### PR TITLE
feat(workflows): reply in-thread from send_message action

### DIFF
--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -875,47 +875,30 @@ pub struct ThreadTags {
 
 /// Parse NIP-10 thread tags from a Nostr event.
 ///
-/// Detection logic (per research doc §4c):
-/// - Find an `e` tag with `root` marker → its value is `root_event_id`
-/// - Find an `e` tag with `reply` marker → its value is `parent_event_id`
-/// - If only `reply` marker found (direct reply to root), root == parent
-/// - `p` tags → mentioned pubkeys
+/// Marker parsing and the (root, reply) → (root, parent) collapse are delegated
+/// to [`buzz_core::nip10`] so ACP anchoring reads ancestry exactly as relay
+/// ingest does. Only `p`-tag mention collection is local to ACP.
 ///
-/// NOTE: Only handles NIP-10 marker-based format (preferred). The deprecated
-/// positional format (no markers, `["e", id, relay_url]`) is not supported —
-/// Buzz always generates marker-based tags (see relay messages.rs:762-783).
+/// Consequences of sharing the resolver:
+/// - A malformed (non-64-hex) marker id is ignored, never a thread link —
+///   restoring parity with ingest (ACP previously counted it).
+/// - A lone `root` marker (no `reply`) is top-level, not a reply — again
+///   matching ingest.
 pub fn parse_thread_tags(event: &Event) -> ThreadTags {
-    let mut root = None;
-    let mut reply = None;
-    let mut mentions = Vec::new();
-
-    for tag in event.tags.iter() {
-        let parts = tag.as_slice();
-        match parts.first().map(|s| s.as_str()) {
-            Some("e") if parts.len() >= 4 => {
-                let id = &parts[1];
-                let marker = &parts[3];
-                match marker.as_str() {
-                    "root" => root = Some(id.clone()),
-                    "reply" => reply = Some(id.clone()),
-                    _ => {}
-                }
-            }
-            Some("p") if parts.len() >= 2 => {
-                mentions.push(parts[1].clone());
-            }
-            _ => {}
-        }
-    }
-
-    // For direct replies to root: single "reply" tag, no "root" tag.
-    // In that case, root == parent.
-    let (root_event_id, parent_event_id) = match (root, reply) {
-        (Some(r), Some(p)) => (Some(r), Some(p)),
-        (Some(r), None) => (Some(r.clone()), Some(r)),
-        (None, Some(p)) => (Some(p.clone()), Some(p)),
-        (None, None) => (None, None),
+    let markers = buzz_core::nip10::parse_thread_markers(&event.tags);
+    let (root_event_id, parent_event_id) = match markers.resolve() {
+        Some((root, parent)) => (Some(root), Some(parent)),
+        None => (None, None),
     };
+
+    let mentions = event
+        .tags
+        .iter()
+        .filter_map(|tag| {
+            let parts = tag.as_slice();
+            (parts.len() >= 2 && parts[0] == "p").then(|| parts[1].clone())
+        })
+        .collect();
 
     ThreadTags {
         root_event_id,
@@ -3192,28 +3175,31 @@ mod tests {
     #[test]
     fn test_parse_thread_tags_direct_reply() {
         // Direct reply to root: single "reply" tag.
+        let root = "a".repeat(64);
         let event = make_event_with_tags(
             "reply to root",
-            vec![vec!["e".into(), "abc123".into(), "".into(), "reply".into()]],
+            vec![vec!["e".into(), root.clone(), "".into(), "reply".into()]],
         );
         let tags = parse_thread_tags(&event);
-        assert_eq!(tags.root_event_id.as_deref(), Some("abc123"));
-        assert_eq!(tags.parent_event_id.as_deref(), Some("abc123"));
+        assert_eq!(tags.root_event_id.as_deref(), Some(root.as_str()));
+        assert_eq!(tags.parent_event_id.as_deref(), Some(root.as_str()));
     }
 
     #[test]
     fn test_parse_thread_tags_nested_reply() {
         // Nested reply: root + reply tags.
+        let root = "a".repeat(64);
+        let parent = "b".repeat(64);
         let event = make_event_with_tags(
             "nested reply",
             vec![
-                vec!["e".into(), "root123".into(), "".into(), "root".into()],
-                vec!["e".into(), "parent456".into(), "".into(), "reply".into()],
+                vec!["e".into(), root.clone(), "".into(), "root".into()],
+                vec!["e".into(), parent.clone(), "".into(), "reply".into()],
             ],
         );
         let tags = parse_thread_tags(&event);
-        assert_eq!(tags.root_event_id.as_deref(), Some("root123"));
-        assert_eq!(tags.parent_event_id.as_deref(), Some("parent456"));
+        assert_eq!(tags.root_event_id.as_deref(), Some(root.as_str()));
+        assert_eq!(tags.parent_event_id.as_deref(), Some(parent.as_str()));
     }
 
     #[test]
@@ -3231,15 +3217,36 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_thread_tags_root_only() {
-        // Only root marker, no reply marker — root == parent.
+    fn test_parse_thread_tags_root_only_is_top_level() {
+        // Only a `root` marker, no `reply` — top-level, matching ingest. A lone
+        // `root` tag does not anchor a reply (behavior change from the old
+        // hand-rolled parser, which treated root == parent here).
+        let root = "a".repeat(64);
         let event = make_event_with_tags(
-            "reply",
-            vec![vec!["e".into(), "root123".into(), "".into(), "root".into()]],
+            "root only",
+            vec![vec!["e".into(), root, "".into(), "root".into()]],
         );
         let tags = parse_thread_tags(&event);
-        assert_eq!(tags.root_event_id.as_deref(), Some("root123"));
-        assert_eq!(tags.parent_event_id.as_deref(), Some("root123"));
+        assert!(tags.root_event_id.is_none());
+        assert!(tags.parent_event_id.is_none());
+    }
+
+    #[test]
+    fn test_parse_thread_tags_malformed_id_is_not_a_thread_link() {
+        // A non-64-hex marker id is ignored — parity with relay ingest, which
+        // never treats a malformed id as a thread link.
+        let event = make_event_with_tags(
+            "malformed marker",
+            vec![vec![
+                "e".into(),
+                "garbage".into(),
+                "".into(),
+                "reply".into(),
+            ]],
+        );
+        let tags = parse_thread_tags(&event);
+        assert!(tags.root_event_id.is_none());
+        assert!(tags.parent_event_id.is_none());
     }
 
     #[test]
@@ -3312,7 +3319,7 @@ mod tests {
             "yes go ahead",
             vec![vec![
                 "e".into(),
-                "root123".into(),
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
                 "".into(),
                 "reply".into(),
             ]],
@@ -3330,7 +3337,9 @@ mod tests {
 
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
         assert!(prompt.contains("Scope: thread"));
-        assert!(prompt.contains("Thread root: root123"));
+        assert!(prompt.contains(
+            "Thread root: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ));
     }
 
     #[test]
@@ -3340,7 +3349,7 @@ mod tests {
             "yes go ahead",
             vec![vec![
                 "e".into(),
-                "root123".into(),
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
                 "".into(),
                 "reply".into(),
             ]],
@@ -3645,7 +3654,7 @@ mod tests {
             "sounds good, do it",
             vec![vec![
                 "e".into(),
-                "root123".into(),
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
                 "".into(),
                 "reply".into(),
             ]],
@@ -3698,7 +3707,9 @@ mod tests {
         );
         // Thread structural info should be present.
         assert!(
-            prompt.contains("Thread root: root123"),
+            prompt.contains(
+                "Thread root: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
             "DM reply should include thread root"
         );
         // Thread context should be included.
@@ -3712,7 +3723,7 @@ mod tests {
             "follow up",
             vec![vec![
                 "e".into(),
-                "root123".into(),
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
                 "".into(),
                 "reply".into(),
             ]],
@@ -5310,7 +5321,7 @@ mod tests {
             "reply in thread",
             vec![vec![
                 "e".into(),
-                "root123".into(),
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
                 "".into(),
                 "reply".into(),
             ]],

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -14,36 +14,29 @@ use buzz_sdk::mentions::{
 
 /// Extract the thread root event ID from a Nostr tag array.
 ///
-/// Parses `"e"` tags with NIP-10 markers:
-/// - If a `"root"` marker exists, returns that event ID.
-/// - Otherwise, if only a `"reply"` marker exists, returns the reply target
+/// Delegates marker parsing to [`buzz_core::nip10`] (shared with relay ingest
+/// and ACP) so id-validity and marker selection cannot drift:
+/// - If a `root` marker exists, returns that event ID.
+/// - Otherwise, if only a `reply` marker exists, returns the reply target
 ///   (a direct reply's parent IS the root, and nested replies need that root
 ///   to thread correctly).
-/// - If no thread markers exist, returns `None` (parent is a top-level message,
-///   so it is itself the root).
+/// - If no valid thread markers exist, returns `None` (parent is a top-level
+///   message, so it is itself the root).
 fn find_root_from_tags(tags: &serde_json::Value) -> Option<String> {
-    fn valid_event_id(s: &str) -> bool {
-        s.len() == 64 && s.chars().all(|c| c.is_ascii_hexdigit())
-    }
-    let arr = tags.as_array()?;
-    let mut root = None;
-    let mut reply = None;
-    for tag in arr {
-        let Some(parts) = tag.as_array() else {
-            continue;
-        };
-        if parts.len() >= 4 && parts[0].as_str() == Some("e") {
-            // Defensively ignore malformed marker values so a bad tag on the
-            // parent event can't block the reply — fall back to root == parent.
-            let id = parts[1].as_str().filter(|s| valid_event_id(s));
-            match (parts[3].as_str(), id) {
-                (Some("root"), Some(id)) => root = Some(id.to_string()),
-                (Some("reply"), Some(id)) => reply = Some(id.to_string()),
-                _ => {}
-            }
-        }
-    }
-    root.or(reply)
+    let parts: Vec<Vec<String>> = tags
+        .as_array()?
+        .iter()
+        .filter_map(|tag| {
+            tag.as_array().map(|a| {
+                a.iter()
+                    .map(|v| v.as_str().unwrap_or("").to_string())
+                    .collect()
+            })
+        })
+        .collect();
+    let markers =
+        buzz_core::nip10::parse_thread_markers_from_parts(parts.iter().map(Vec::as_slice));
+    markers.root.or(markers.reply)
 }
 
 /// Build a `ThreadRef` for a reply, given the immediate parent's event ID.

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -14,14 +14,14 @@ use buzz_sdk::mentions::{
 
 /// Extract the thread root event ID from a Nostr tag array.
 ///
-/// Delegates marker parsing to [`buzz_core::nip10`] (shared with relay ingest
-/// and ACP) so id-validity and marker selection cannot drift:
-/// - If a `root` marker exists, returns that event ID.
-/// - Otherwise, if only a `reply` marker exists, returns the reply target
-///   (a direct reply's parent IS the root, and nested replies need that root
-///   to thread correctly).
-/// - If no valid thread markers exist, returns `None` (parent is a top-level
-///   message, so it is itself the root).
+/// Delegates marker parsing and collapse to [`buzz_core::nip10`] (shared with
+/// relay ingest and ACP) so id-validity, marker selection, and top-level
+/// classification cannot drift:
+/// - A `root`+`reply` parent returns its root event ID.
+/// - A `reply`-only parent returns the reply target (a direct reply's parent IS
+///   the root).
+/// - A root-only or marker-less parent returns `None` (it is top-level and its
+///   own root).
 fn find_root_from_tags(tags: &serde_json::Value) -> Option<String> {
     let parts: Vec<Vec<String>> = tags
         .as_array()?
@@ -34,9 +34,25 @@ fn find_root_from_tags(tags: &serde_json::Value) -> Option<String> {
             })
         })
         .collect();
-    let markers =
-        buzz_core::nip10::parse_thread_markers_from_parts(parts.iter().map(Vec::as_slice));
-    markers.root.or(markers.reply)
+    buzz_core::nip10::parse_thread_markers_from_parts(parts.iter().map(Vec::as_slice))
+        .resolve()
+        .map(|(root, _)| root)
+}
+
+fn thread_ref_from_parent_tags(
+    parent_eid: nostr::EventId,
+    parent_event_id: &str,
+    tags: &serde_json::Value,
+) -> Result<ThreadRef, CliError> {
+    let root_eid = match find_root_from_tags(tags) {
+        Some(root_hex) if root_hex != parent_event_id => parse_event_id(&root_hex)?,
+        _ => parent_eid,
+    };
+
+    Ok(ThreadRef {
+        root_event_id: root_eid,
+        parent_event_id: parent_eid,
+    })
 }
 
 /// Build a `ThreadRef` for a reply, given the immediate parent's event ID.
@@ -73,14 +89,7 @@ fn thread_ref_from_event(event_id: &str, event: &serde_json::Value) -> Result<Th
         .get("tags")
         .cloned()
         .unwrap_or(serde_json::Value::Null);
-    let root_event_id = match find_root_from_tags(&tags) {
-        Some(root_hex) if root_hex != event_id => parse_event_id(&root_hex)?,
-        _ => parent_eid,
-    };
-    Ok(ThreadRef {
-        root_event_id,
-        parent_event_id: parent_eid,
-    })
+    thread_ref_from_parent_tags(parent_eid, event_id, &tags)
 }
 
 /// Resolve the channel UUID for an event by querying for it via POST /query.
@@ -1050,7 +1059,8 @@ mod tests {
         channel_id_from_event, cmd_get_thread, event_mention_pubkeys, find_root_from_tags,
         match_profiles_by_name, merge_message_mentions, missing_members,
         normalize_explicit_mentions, parse_member_pubkeys, resolve_names_to_pubkeys,
-        resolve_thread_target, thread_ref_from_event, BuzzClient, CliError, Uuid,
+        resolve_thread_target, thread_ref_from_event, thread_ref_from_parent_tags, BuzzClient,
+        CliError, Uuid,
     };
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
@@ -1125,7 +1135,7 @@ mod tests {
         let channel = "123e4567-e89b-12d3-a456-426614174000";
         let other_channel = "123e4567-e89b-12d3-a456-426614174001";
         let selected = json!({
-            "tags": [["h", channel], ["e", ID_A, "", "root"]]
+            "tags": [["h", channel], ["e", ID_A, "", "root"], ["e", ID_B, "", "reply"]]
         });
 
         assert!(resolve_thread_target(
@@ -1165,6 +1175,23 @@ mod tests {
     }
 
     #[test]
+    fn root_marker_without_reply_is_top_level() {
+        let tags = json!([["e", ID_A, "", "root"], ["p", PUBKEY],]);
+        assert!(find_root_from_tags(&tags).is_none());
+    }
+
+    #[test]
+    fn root_only_parent_starts_cli_reply_thread_at_parent() {
+        let tags = json!([["e", ID_A, "", "root"]]);
+        let parent = nostr::EventId::from_hex(ID_B).expect("valid parent id");
+
+        let thread_ref = thread_ref_from_parent_tags(parent, ID_B, &tags).expect("thread ref");
+
+        assert_eq!(thread_ref.parent_event_id, parent);
+        assert_eq!(thread_ref.root_event_id, parent);
+    }
+
+    #[test]
     fn reply_only_falls_back_to_reply_target() {
         // Direct reply to a top-level message — the parent's only e-tag is a
         // "reply" marker pointing at it; treat the reply target as the root.
@@ -1187,14 +1214,16 @@ mod tests {
     }
 
     #[test]
-    fn malformed_tags_are_skipped() {
+    fn malformed_tags_are_skipped_and_root_only_is_top_level() {
+        // Invalid entries are ignored, leaving a valid root-only marker; the
+        // shared collapse rule still classifies that parent as top-level.
         let tags = json!([
             "not-an-array",
             ["e"],
             ["e", "short"],
             ["e", ID_A, "", "root"],
         ]);
-        assert_eq!(find_root_from_tags(&tags).as_deref(), Some(ID_A));
+        assert!(find_root_from_tags(&tags).is_none());
     }
 
     #[test]

--- a/crates/buzz-core/src/lib.rs
+++ b/crates/buzz-core/src/lib.rs
@@ -26,6 +26,8 @@ pub mod invite;
 pub mod kind;
 /// Network utilities — SSRF-safe IP classification.
 pub mod network;
+/// NIP-10 thread-marker parsing — shared `root`/`reply` marker resolver.
+pub mod nip10;
 /// Agent observer frame helpers.
 pub mod observer;
 /// NIP-AB device pairing — crypto primitives, message types, and errors.

--- a/crates/buzz-core/src/nip10.rs
+++ b/crates/buzz-core/src/nip10.rs
@@ -23,6 +23,26 @@ pub struct ThreadMarkers {
     pub reply: Option<String>,
 }
 
+impl ThreadMarkers {
+    /// Collapse the `root`/`reply` markers into a reply's `(root_id, parent_id)`.
+    ///
+    /// This is the single definition of the NIP-10 resolution rule that every
+    /// consumer (relay ingest, ACP anchoring, CLI reply threading) shares:
+    ///
+    /// - `root` + `reply` → `(root, reply)` — a nested reply names both.
+    /// - `reply` only → `(reply, reply)` — a direct reply to the root; the
+    ///   reply target is itself the thread root.
+    /// - `root` only or neither → `None` — no `reply` marker means the event is
+    ///   top-level, matching ingest (a lone `root` tag never anchors a reply).
+    pub fn resolve(&self) -> Option<(String, String)> {
+        match (&self.root, &self.reply) {
+            (Some(root), Some(reply)) => Some((root.clone(), reply.clone())),
+            (None, Some(reply)) => Some((reply.clone(), reply.clone())),
+            (Some(_), None) | (None, None) => None,
+        }
+    }
+}
+
 /// Return true when `id` is exactly 64 ASCII-hex characters — the shape a
 /// Nostr event id must have to be a real thread link.
 fn is_event_id_hex(id: &str) -> bool {
@@ -34,13 +54,24 @@ fn is_event_id_hex(id: &str) -> bool {
 /// Only `e` tags with a marker (`parts.len() >= 4`) and a valid 64-hex event id
 /// are considered; everything else is ignored.
 pub fn parse_thread_markers(tags: &nostr::Tags) -> ThreadMarkers {
+    parse_thread_markers_from_parts(tags.iter().map(nostr::Tag::as_slice))
+}
+
+/// Same parser as [`parse_thread_markers`], for consumers that hold raw tag
+/// arrays (e.g. decoded JSON `tags`) rather than a [`nostr::Tags`].
+///
+/// Each tag is a slice of string-like parts (`["e", <id>, <relay>, <marker>]`).
+pub fn parse_thread_markers_from_parts<'a, S, I>(tags: I) -> ThreadMarkers
+where
+    S: AsRef<str> + 'a,
+    I: IntoIterator<Item = &'a [S]>,
+{
     let mut markers = ThreadMarkers::default();
-    for tag in tags.iter() {
-        let parts = tag.as_slice();
-        if parts.len() >= 4 && parts[0] == "e" && is_event_id_hex(&parts[1]) {
-            match parts[3].as_str() {
-                "root" => markers.root = Some(parts[1].to_string()),
-                "reply" => markers.reply = Some(parts[1].to_string()),
+    for parts in tags {
+        if parts.len() >= 4 && parts[0].as_ref() == "e" && is_event_id_hex(parts[1].as_ref()) {
+            match parts[3].as_ref() {
+                "root" => markers.root = Some(parts[1].as_ref().to_string()),
+                "reply" => markers.reply = Some(parts[1].as_ref().to_string()),
                 _ => {}
             }
         }
@@ -114,5 +145,52 @@ mod tests {
         ]);
         assert_eq!(m.root.as_deref(), Some(id().as_str()));
         assert!(m.reply.is_none());
+    }
+
+    #[test]
+    fn resolve_root_and_reply_keeps_both() {
+        let m = ThreadMarkers {
+            root: Some("r".repeat(64)),
+            reply: Some("p".repeat(64)),
+        };
+        assert_eq!(m.resolve(), Some(("r".repeat(64), "p".repeat(64))));
+    }
+
+    #[test]
+    fn resolve_reply_only_is_direct_reply_to_root() {
+        let m = ThreadMarkers {
+            root: None,
+            reply: Some(id()),
+        };
+        assert_eq!(m.resolve(), Some((id(), id())));
+    }
+
+    #[test]
+    fn resolve_root_only_is_top_level() {
+        let m = ThreadMarkers {
+            root: Some(id()),
+            reply: None,
+        };
+        assert_eq!(m.resolve(), None);
+    }
+
+    #[test]
+    fn resolve_no_markers_is_top_level() {
+        assert_eq!(ThreadMarkers::default().resolve(), None);
+    }
+
+    #[test]
+    fn parse_from_parts_matches_tags_path() {
+        // The slice-based entry point must gate id validity and select markers
+        // identically to the `nostr::Tags` path.
+        let tags: Vec<Vec<String>> = vec![
+            vec!["e".into(), id(), "".into(), "root".into()],
+            vec!["e".into(), "b".repeat(64), "".into(), "reply".into()],
+            vec!["e".into(), "bad".into(), "".into(), "reply".into()],
+            vec!["p".into(), "abc".into()],
+        ];
+        let m = parse_thread_markers_from_parts(tags.iter().map(Vec::as_slice));
+        assert_eq!(m.root.as_deref(), Some(id().as_str()));
+        assert_eq!(m.reply.as_deref(), Some("b".repeat(64).as_str()));
     }
 }

--- a/crates/buzz-core/src/nip10.rs
+++ b/crates/buzz-core/src/nip10.rs
@@ -1,0 +1,118 @@
+//! Shared NIP-10 thread-marker parsing.
+//!
+//! One parser for the `root`/`reply` markers on an event's `e` tags, so every
+//! consumer reads ancestry the same way. The relay ingest resolver
+//! (`resolve_nip10_thread_meta`) and the workflow `trigger_is_reply` predicate
+//! both call this — a second hand-rolled copy is exactly how the two drifted on
+//! marker semantics and on id-validity.
+//!
+//! Validity mirrors ingest: a marker counts only when its event id is exactly
+//! 64 ASCII-hex characters. A malformed id (e.g. `["e","bad","","reply"]`) is
+//! ignored, never treated as a thread link.
+
+/// The `root` and `reply` event ids parsed from an event's NIP-10 `e` tags.
+///
+/// Each is `Some(id_hex)` only when a marker of that kind carried a valid
+/// 64-hex event id. The last valid occurrence of each marker wins, matching
+/// the relay resolver's single-pass overwrite.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ThreadMarkers {
+    /// Event id from a valid `["e", <64-hex>, <relay>, "root"]` tag.
+    pub root: Option<String>,
+    /// Event id from a valid `["e", <64-hex>, <relay>, "reply"]` tag.
+    pub reply: Option<String>,
+}
+
+/// Return true when `id` is exactly 64 ASCII-hex characters — the shape a
+/// Nostr event id must have to be a real thread link.
+fn is_event_id_hex(id: &str) -> bool {
+    id.len() == 64 && id.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Parse the NIP-10 `root`/`reply` markers from an event's tags.
+///
+/// Only `e` tags with a marker (`parts.len() >= 4`) and a valid 64-hex event id
+/// are considered; everything else is ignored.
+pub fn parse_thread_markers(tags: &nostr::Tags) -> ThreadMarkers {
+    let mut markers = ThreadMarkers::default();
+    for tag in tags.iter() {
+        let parts = tag.as_slice();
+        if parts.len() >= 4 && parts[0] == "e" && is_event_id_hex(&parts[1]) {
+            match parts[3].as_str() {
+                "root" => markers.root = Some(parts[1].to_string()),
+                "reply" => markers.reply = Some(parts[1].to_string()),
+                _ => {}
+            }
+        }
+    }
+    markers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr::{EventBuilder, Keys, Kind, Tag};
+
+    fn markers_for(tags: Vec<Tag>) -> ThreadMarkers {
+        let event = EventBuilder::new(Kind::Custom(9), "")
+            .tags(tags)
+            .sign_with_keys(&Keys::generate())
+            .expect("sign");
+        parse_thread_markers(&event.tags)
+    }
+
+    fn id() -> String {
+        "a".repeat(64)
+    }
+
+    #[test]
+    fn no_e_tags_yields_no_markers() {
+        assert_eq!(markers_for(vec![]), ThreadMarkers::default());
+    }
+
+    #[test]
+    fn root_and_reply_both_parsed() {
+        let m = markers_for(vec![
+            Tag::parse(["e", &id(), "", "root"]).unwrap(),
+            Tag::parse(["e", &"b".repeat(64), "", "reply"]).unwrap(),
+        ]);
+        assert_eq!(m.root.as_deref(), Some(id().as_str()));
+        assert_eq!(m.reply.as_deref(), Some("b".repeat(64).as_str()));
+    }
+
+    #[test]
+    fn reply_only_marker_parsed() {
+        let m = markers_for(vec![Tag::parse(["e", &id(), "", "reply"]).unwrap()]);
+        assert_eq!(m.reply.as_deref(), Some(id().as_str()));
+        assert!(m.root.is_none());
+    }
+
+    #[test]
+    fn bare_e_tag_without_marker_is_ignored() {
+        let m = markers_for(vec![Tag::parse(["e", &id()]).unwrap()]);
+        assert_eq!(m, ThreadMarkers::default());
+    }
+
+    #[test]
+    fn malformed_id_is_ignored_for_both_markers() {
+        // Ingest gates the marker on a valid 64-hex id; a malformed id is not a
+        // thread link, so neither marker is set.
+        let m = markers_for(vec![
+            Tag::parse(["e", "bad", "", "reply"]).unwrap(),
+            Tag::parse(["e", "also-bad", "", "root"]).unwrap(),
+        ]);
+        assert_eq!(m, ThreadMarkers::default());
+    }
+
+    #[test]
+    fn valid_root_with_malformed_reply_is_top_level() {
+        // A valid root but a malformed reply id: reply is ignored, so this is
+        // top-level to ingest (root-only) and must be so here too.
+        let m = markers_for(vec![
+            Tag::parse(["e", &id(), "", "root"]).unwrap(),
+            Tag::parse(["e", "bad", "", "reply"]).unwrap(),
+        ]);
+        assert_eq!(m.root.as_deref(), Some(id().as_str()));
+        assert!(m.reply.is_none());
+    }
+}

--- a/crates/buzz-core/src/nip10.rs
+++ b/crates/buzz-core/src/nip10.rs
@@ -26,8 +26,10 @@ pub struct ThreadMarkers {
 impl ThreadMarkers {
     /// Collapse the `root`/`reply` markers into a reply's `(root_id, parent_id)`.
     ///
-    /// This is the single definition of the NIP-10 resolution rule that every
-    /// consumer (relay ingest, ACP anchoring, CLI reply threading) shares:
+    /// This is the single definition of the NIP-10 resolution rule shared by
+    /// the consumers that classify a reply's own root/parent (relay ingest, ACP
+    /// anchoring). The CLI does not use it — it derives a *parent's* ancestry
+    /// via `root.or(reply)`, which is a different question.
     ///
     /// - `root` + `reply` → `(root, reply)` — a nested reply names both.
     /// - `reply` only → `(reply, reply)` — a direct reply to the root; the

--- a/crates/buzz-core/src/nip10.rs
+++ b/crates/buzz-core/src/nip10.rs
@@ -27,9 +27,8 @@ impl ThreadMarkers {
     /// Collapse the `root`/`reply` markers into a reply's `(root_id, parent_id)`.
     ///
     /// This is the single definition of the NIP-10 resolution rule shared by
-    /// the consumers that classify a reply's own root/parent (relay ingest, ACP
-    /// anchoring). The CLI does not use it — it derives a *parent's* ancestry
-    /// via `root.or(reply)`, which is a different question.
+    /// consumers that classify a reply's own root/parent or recover a parent's
+    /// ancestry (relay ingest, ACP anchoring, and the CLI).
     ///
     /// - `root` + `reply` → `(root, reply)` — a nested reply names both.
     /// - `reply` only → `(reply, reply)` — a direct reply to the root; the

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -872,6 +872,128 @@ pub(crate) async fn resolve_nip10_thread_meta(
     }))
 }
 
+/// Resolved thread ancestry for a relay-built reply (workflow path).
+///
+/// Carries the parent and root identifiers plus the reply's depth, so the
+/// caller can both emit matching NIP-10 `root`/`reply` tags and persist thread
+/// metadata for the signed reply event.
+pub(crate) struct ReplyAncestry {
+    pub parent_event_id: Vec<u8>,
+    pub parent_event_created_at: chrono::DateTime<Utc>,
+    pub root_event_id: Vec<u8>,
+    pub root_event_created_at: chrono::DateTime<Utc>,
+    pub depth: i32,
+}
+
+impl ReplyAncestry {
+    /// Root event ID as lowercase hex, for the NIP-10 `root` tag.
+    pub fn root_hex(&self) -> String {
+        hex::encode(&self.root_event_id)
+    }
+
+    /// Parent event ID as lowercase hex, for the NIP-10 `reply` tag.
+    pub fn parent_hex(&self) -> String {
+        hex::encode(&self.parent_event_id)
+    }
+
+    /// Build the DB thread-metadata params for the signed reply event.
+    pub fn into_thread_meta(
+        self,
+        reply_event_id: Vec<u8>,
+        reply_created_at: chrono::DateTime<Utc>,
+        channel_id: Uuid,
+    ) -> ThreadMetadataOwned {
+        ThreadMetadataOwned {
+            event_id: reply_event_id,
+            event_created_at: reply_created_at,
+            channel_id,
+            parent_event_id: self.parent_event_id,
+            parent_event_created_at: self.parent_event_created_at,
+            root_event_id: self.root_event_id,
+            root_event_created_at: self.root_event_created_at,
+            depth: self.depth,
+            broadcast: false,
+        }
+    }
+}
+
+/// Resolve thread ancestry for a reply built by the relay (workflow path).
+///
+/// Unlike [`resolve_nip10_thread_meta`], which validates client-supplied NIP-10
+/// `e` tags, this derives ancestry from a known `parent_hex` (the triggering
+/// event) and *computes* the correct root and depth. Enforces the same-channel
+/// invariant and the depth limit that the ingest path applies.
+pub(crate) async fn resolve_relay_reply_thread_meta(
+    community_id: CommunityId,
+    parent_hex: &str,
+    channel_id: Uuid,
+    state: &AppState,
+) -> Result<ReplyAncestry, String> {
+    let parent_bytes =
+        hex::decode(parent_hex).map_err(|_| "invalid parent event ID hex".to_string())?;
+
+    let (parent_event_result, parent_meta_result) = tokio::join!(
+        state.db.get_event_by_id(community_id, &parent_bytes),
+        state
+            .db
+            .get_thread_metadata_by_event(community_id, &parent_bytes),
+    );
+
+    let parent_event = parent_event_result
+        .map_err(|e| format!("db error looking up parent: {e}"))?
+        .ok_or_else(|| "reply parent not found".to_string())?;
+
+    match parent_event.channel_id {
+        Some(parent_ch) if parent_ch != channel_id => {
+            return Err("parent event belongs to a different channel".to_string());
+        }
+        None => return Err("parent event has no channel association".to_string()),
+        _ => {}
+    }
+
+    let parent_created =
+        chrono::DateTime::from_timestamp(parent_event.event.created_at.as_secs() as i64, 0)
+            .unwrap_or_else(Utc::now);
+
+    let parent_meta =
+        parent_meta_result.map_err(|e| format!("db error looking up thread metadata: {e}"))?;
+
+    // Root = parent's root if the parent is itself a reply, else the parent.
+    // Depth = parent depth + 1 (a direct reply to a top-level message is depth 1).
+    let (root_bytes, root_created, depth) = match parent_meta {
+        Some(meta) => {
+            let effective_root = meta.root_event_id.unwrap_or_else(|| parent_bytes.clone());
+            let root_ts = if effective_root == parent_bytes {
+                parent_created
+            } else if let Ok(Some(root_ev)) = state
+                .db
+                .get_event_by_id(community_id, &effective_root)
+                .await
+            {
+                chrono::DateTime::from_timestamp(root_ev.event.created_at.as_secs() as i64, 0)
+                    .unwrap_or(parent_created)
+            } else {
+                parent_created
+            };
+            (effective_root, root_ts, meta.depth + 1)
+        }
+        // No metadata row ⇒ parent is a top-level message; it is its own root.
+        None => (parent_bytes.clone(), parent_created, 1),
+    };
+
+    if depth > 100 {
+        return Err("thread depth limit exceeded".to_string());
+    }
+
+    Ok(ReplyAncestry {
+        parent_event_id: parent_bytes,
+        parent_event_created_at: parent_created,
+        root_event_id: root_bytes,
+        root_event_created_at: root_created,
+        depth,
+    })
+}
+
 /// Count all `e` tags regardless of content validity.
 fn count_e_tags(event: &Event) -> usize {
     event

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -724,23 +724,9 @@ pub(crate) async fn resolve_nip10_thread_meta(
     channel_id: Uuid,
     state: &AppState,
 ) -> Result<Option<ThreadMetadataOwned>, String> {
-    let mut root_hex: Option<String> = None;
-    let mut reply_hex: Option<String> = None;
-
-    for tag in event.tags.iter() {
-        let parts = tag.as_slice();
-        if parts.len() >= 4 && parts[0] == "e" {
-            let hex_val = &parts[1];
-            let marker = &parts[3];
-            if hex_val.len() == 64 && hex_val.chars().all(|c| c.is_ascii_hexdigit()) {
-                match marker.as_str() {
-                    "root" => root_hex = Some(hex_val.to_string()),
-                    "reply" => reply_hex = Some(hex_val.to_string()),
-                    _ => {}
-                }
-            }
-        }
-    }
+    let markers = buzz_core::nip10::parse_thread_markers(&event.tags);
+    let root_hex = markers.root;
+    let reply_hex = markers.reply;
 
     if root_hex.is_none() && reply_hex.is_none() {
         return Ok(None);

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -807,46 +807,18 @@ pub(crate) async fn resolve_nip10_thread_meta(
             (effective_root, root_ts, depth)
         }
         None => {
-            let parent_root = parent_event
-                .event
-                .tags
-                .iter()
-                .find_map(|t| {
-                    let parts = t.as_slice();
-                    if parts.len() >= 4 && parts[0] == "e" && parts[3] == "root" {
-                        hex::decode(&parts[1]).ok().filter(|b| b.len() == 32)
-                    } else {
-                        None
-                    }
-                })
-                .or_else(|| {
-                    parent_event.event.tags.iter().find_map(|t| {
-                        let parts = t.as_slice();
-                        if parts.len() >= 4 && parts[0] == "e" && parts[3] == "reply" {
-                            hex::decode(&parts[1]).ok().filter(|b| b.len() == 32)
-                        } else {
-                            None
-                        }
-                    })
-                })
-                .unwrap_or_else(|| parent_bytes.clone());
+            let (parent_root, root_created, depth) = derive_ancestry_from_parent_tags(
+                community_id,
+                &parent_event.event,
+                &parent_bytes,
+                parent_created,
+                state,
+            )
+            .await;
 
             if client_root_bytes != parent_root {
                 return Err("root tag does not match thread ancestry".to_string());
             }
-            let depth = if parent_root == parent_bytes { 1 } else { 2 };
-            let root_created = if parent_root != parent_bytes {
-                if let Ok(Some(root_ev)) =
-                    state.db.get_event_by_id(community_id, &parent_root).await
-                {
-                    chrono::DateTime::from_timestamp(root_ev.event.created_at.as_secs() as i64, 0)
-                        .unwrap_or(parent_created)
-                } else {
-                    parent_created
-                }
-            } else {
-                parent_created
-            };
             (parent_root, root_created, depth)
         }
     };
@@ -870,6 +842,52 @@ pub(crate) async fn resolve_nip10_thread_meta(
         depth,
         broadcast,
     }))
+}
+
+/// Recover a reply's thread ancestry from its *parent's* NIP-10 tags when the
+/// parent has **no** `thread_metadata` row (legacy or not-yet-indexed events).
+///
+/// The parent's own marked `root` (else `reply`) `e` tag names the thread root;
+/// absent both, the parent is itself top-level and is its own root. Depth is 1
+/// when the parent is the root and 2 otherwise — a reply to a nested-but-
+/// unindexed parent must not be mistaken for a top-level reply.
+///
+/// Shared by [`resolve_nip10_thread_meta`] (client path) and
+/// [`resolve_relay_reply_thread_meta`] (workflow path) so the two cannot
+/// diverge. Returns `(root_event_id, root_event_created_at, depth)`.
+async fn derive_ancestry_from_parent_tags(
+    community_id: CommunityId,
+    parent_event: &Event,
+    parent_bytes: &[u8],
+    parent_created: chrono::DateTime<Utc>,
+    state: &AppState,
+) -> (Vec<u8>, chrono::DateTime<Utc>, i32) {
+    let marked_ancestor = |marker: &str| {
+        parent_event.tags.iter().find_map(|t| {
+            let parts = t.as_slice();
+            if parts.len() >= 4 && parts[0] == "e" && parts[3] == marker {
+                hex::decode(&parts[1]).ok().filter(|b| b.len() == 32)
+            } else {
+                None
+            }
+        })
+    };
+    let parent_root = marked_ancestor("root")
+        .or_else(|| marked_ancestor("reply"))
+        .unwrap_or_else(|| parent_bytes.to_vec());
+
+    if parent_root.as_slice() == parent_bytes {
+        (parent_root, parent_created, 1)
+    } else {
+        let root_created =
+            if let Ok(Some(root_ev)) = state.db.get_event_by_id(community_id, &parent_root).await {
+                chrono::DateTime::from_timestamp(root_ev.event.created_at.as_secs() as i64, 0)
+                    .unwrap_or(parent_created)
+            } else {
+                parent_created
+            };
+        (parent_root, root_created, 2)
+    }
 }
 
 /// Resolved thread ancestry for a relay-built reply (workflow path).
@@ -977,8 +995,19 @@ pub(crate) async fn resolve_relay_reply_thread_meta(
             };
             (effective_root, root_ts, meta.depth + 1)
         }
-        // No metadata row ⇒ parent is a top-level message; it is its own root.
-        None => (parent_bytes.clone(), parent_created, 1),
+        // No metadata row ⇒ recover the parent's ancestry from its own NIP-10
+        // tags. A marked (but not-yet-indexed) nested parent yields depth 2, not
+        // a false top-level depth 1.
+        None => {
+            derive_ancestry_from_parent_tags(
+                community_id,
+                &parent_event.event,
+                &parent_bytes,
+                parent_created,
+                state,
+            )
+            .await
+        }
     };
 
     if depth > 100 {

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -725,17 +725,10 @@ pub(crate) async fn resolve_nip10_thread_meta(
     state: &AppState,
 ) -> Result<Option<ThreadMetadataOwned>, String> {
     let markers = buzz_core::nip10::parse_thread_markers(&event.tags);
-    let root_hex = markers.root;
-    let reply_hex = markers.reply;
 
-    if root_hex.is_none() && reply_hex.is_none() {
-        return Ok(None);
-    }
-
-    let (root_hex, parent_hex) = match (root_hex, reply_hex) {
-        (Some(r), Some(p)) => (r, p),
-        (None, Some(p)) => (p.clone(), p),
-        (Some(_), None) | (None, None) => return Ok(None),
+    let (root_hex, parent_hex) = match markers.resolve() {
+        Some(pair) => pair,
+        None => return Ok(None),
     };
 
     let parent_bytes =
@@ -848,18 +841,13 @@ async fn derive_ancestry_from_parent_tags(
     parent_created: chrono::DateTime<Utc>,
     state: &AppState,
 ) -> (Vec<u8>, chrono::DateTime<Utc>, i32) {
-    let marked_ancestor = |marker: &str| {
-        parent_event.tags.iter().find_map(|t| {
-            let parts = t.as_slice();
-            if parts.len() >= 4 && parts[0] == "e" && parts[3] == marker {
-                hex::decode(&parts[1]).ok().filter(|b| b.len() == 32)
-            } else {
-                None
-            }
-        })
-    };
-    let parent_root = marked_ancestor("root")
-        .or_else(|| marked_ancestor("reply"))
+    let marked_ancestor = |id_hex: &str| hex::decode(id_hex).ok().filter(|b| b.len() == 32);
+    let markers = buzz_core::nip10::parse_thread_markers(&parent_event.tags);
+    let parent_root = markers
+        .root
+        .as_deref()
+        .and_then(marked_ancestor)
+        .or_else(|| markers.reply.as_deref().and_then(marked_ancestor))
         .unwrap_or_else(|| parent_bytes.to_vec());
 
     if parent_root.as_slice() == parent_bytes {

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -826,10 +826,12 @@ pub(crate) async fn resolve_nip10_thread_meta(
 /// Recover a reply's thread ancestry from its *parent's* NIP-10 tags when the
 /// parent has **no** `thread_metadata` row (legacy or not-yet-indexed events).
 ///
-/// The parent's own marked `root` (else `reply`) `e` tag names the thread root;
-/// absent both, the parent is itself top-level and is its own root. Depth is 1
-/// when the parent is the root and 2 otherwise — a reply to a nested-but-
-/// unindexed parent must not be mistaken for a top-level reply.
+/// The parent's markers are first collapsed through `ThreadMarkers::resolve()`:
+/// a `root`+`reply` parent carries its marked root, a `reply`-only parent carries
+/// its reply target as root, and a root-only/malformed/unmarked parent is itself
+/// top-level and its own root. Depth is 1 when the parent is the root and 2
+/// otherwise — a reply to a nested-but-unindexed parent must not be mistaken for
+/// a top-level reply.
 ///
 /// Shared by [`resolve_nip10_thread_meta`] (client path) and
 /// [`resolve_relay_reply_thread_meta`] (workflow path) so the two cannot
@@ -844,10 +846,10 @@ async fn derive_ancestry_from_parent_tags(
     let marked_ancestor = |id_hex: &str| hex::decode(id_hex).ok().filter(|b| b.len() == 32);
     let markers = buzz_core::nip10::parse_thread_markers(&parent_event.tags);
     let parent_root = markers
-        .root
+        .resolve()
+        .map(|(root, _)| root)
         .as_deref()
         .and_then(marked_ancestor)
-        .or_else(|| markers.reply.as_deref().and_then(marked_ancestor))
         .unwrap_or_else(|| parent_bytes.to_vec());
 
     if parent_root.as_slice() == parent_bytes {

--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -286,19 +286,30 @@ impl ActionSink for RelayActionSink {
             };
 
             // NIP-10 e-tags for the thread. Marked `root`/`reply` so clients and
-            // the ingest resolver read the ancestry the same way. When the reply
-            // is directly under the root, both markers point at the same event.
+            // the ingest resolver read the ancestry the same way. A direct reply
+            // (parent == root) emits a single `reply` tag; a nested reply emits
+            // the `root` + `reply` pair — matching `buzz_sdk::builders::thread_tags`
+            // so every writer produces one wire shape per reply kind.
             if let Some(ancestry) = &reply_ancestry {
                 let root_hex = ancestry.root_hex();
                 let parent_hex = ancestry.parent_hex();
-                tags.push(
-                    Tag::parse(["e", &root_hex, "", "root"])
-                        .map_err(|e| ActionSinkError::EventBuild(format!("root e tag: {e}")))?,
-                );
-                tags.push(
-                    Tag::parse(["e", &parent_hex, "", "reply"])
-                        .map_err(|e| ActionSinkError::EventBuild(format!("reply e tag: {e}")))?,
-                );
+                if root_hex == parent_hex {
+                    tags.push(
+                        Tag::parse(["e", &root_hex, "", "reply"]).map_err(|e| {
+                            ActionSinkError::EventBuild(format!("reply e tag: {e}"))
+                        })?,
+                    );
+                } else {
+                    tags.push(
+                        Tag::parse(["e", &root_hex, "", "root"])
+                            .map_err(|e| ActionSinkError::EventBuild(format!("root e tag: {e}")))?,
+                    );
+                    tags.push(
+                        Tag::parse(["e", &parent_hex, "", "reply"]).map_err(|e| {
+                            ActionSinkError::EventBuild(format!("reply e tag: {e}"))
+                        })?,
+                    );
+                }
             }
 
             // Resolve `@Name` mentions to channel-member pubkeys and append a
@@ -846,8 +857,16 @@ mod integration_tests {
                 }
             })
         };
-        assert_eq!(marker("root").as_deref(), Some(root_hex.as_str()));
-        assert_eq!(marker("reply").as_deref(), Some(root_hex.as_str()));
+        assert_eq!(
+            marker("reply").as_deref(),
+            Some(root_hex.as_str()),
+            "direct reply emits a single reply marker at the root"
+        );
+        assert_eq!(
+            marker("root"),
+            None,
+            "direct reply omits the root marker (matches SDK thread_tags)"
+        );
 
         // Thread metadata reflects a depth-1 reply parented on the root.
         let meta = state

--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -399,6 +399,20 @@ impl ActionSink for RelayActionSink {
                     None,
                 )
                 .await;
+
+                // A threaded reply changed its thread's counters — push a fresh
+                // relay-signed kind:39005 so subscribed clients update badge
+                // counts without refetching the head window, exactly as the
+                // ingest path does after a reply insert. Fan-out-only and
+                // best-effort; skipped for top-level (non-reply) messages.
+                if let Some(owned) = &thread_meta_owned {
+                    crate::handlers::side_effects::emit_live_thread_summary(
+                        &tenant,
+                        &state,
+                        channel_uuid,
+                        owned.root_event_id.clone(),
+                    );
+                }
             }
 
             Ok(event_id_hex)
@@ -852,6 +866,148 @@ mod integration_tests {
             .to_vec();
         assert_eq!(meta.parent_event_id.as_deref(), Some(root_bytes.as_slice()));
         assert_eq!(meta.root_event_id.as_deref(), Some(root_bytes.as_slice()));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn workflow_reply_to_metadata_less_nested_parent_recovers_depth_2() {
+        // A parent that carries NIP-10 root/reply markers but has NO
+        // thread_metadata row (legacy or not-yet-indexed) must be recognized as
+        // nested: the workflow reply threads at depth 2 onto the parent's own
+        // root, not a false top-level depth 1.
+        let state = test_state().await;
+
+        let author = nostr::Keys::generate();
+        let author_hex = author.public_key().to_hex();
+
+        let host = format!("wf-legacy-{}.example", uuid::Uuid::new_v4().simple());
+        let community = match state
+            .db
+            .create_community_with_owner(&host, &author_hex)
+            .await
+            .expect("create community")
+        {
+            CreateCommunityWithOwnerResult::Created(rec) => rec.id,
+            other => panic!("expected fresh community, got {other:?}"),
+        };
+
+        let channel = state
+            .db
+            .create_channel(
+                community,
+                "wf-legacy",
+                ChannelType::Stream,
+                ChannelVisibility::Open,
+                None,
+                &author.public_key().to_bytes(),
+                None,
+            )
+            .await
+            .expect("create channel");
+
+        let channel_hex = channel.id.to_string();
+
+        // A top-level root message, inserted WITHOUT any thread metadata row.
+        let root_event = EventBuilder::new(Kind::from(KIND_STREAM_MESSAGE as u16), "root")
+            .tags([Tag::parse(["h", &channel_hex]).expect("h tag")])
+            .sign_with_keys(&author)
+            .expect("sign root");
+        let root_hex = root_event.id.to_hex();
+        state
+            .db
+            .insert_event(community, &root_event, Some(channel.id))
+            .await
+            .expect("insert root");
+
+        // A nested parent that marks its root/reply — but, crucially, is stored
+        // with NO thread_metadata row (the legacy/unindexed case F1 addresses).
+        let parent_event =
+            EventBuilder::new(Kind::from(KIND_STREAM_MESSAGE as u16), "nested parent")
+                .tags([
+                    Tag::parse(["h", &channel_hex]).expect("h tag"),
+                    Tag::parse(["e", &root_hex, "", "root"]).expect("root tag"),
+                    Tag::parse(["e", &root_hex, "", "reply"]).expect("reply tag"),
+                ])
+                .sign_with_keys(&author)
+                .expect("sign parent");
+        let parent_hex = parent_event.id.to_hex();
+        state
+            .db
+            .insert_event(community, &parent_event, Some(channel.id))
+            .await
+            .expect("insert parent");
+        assert!(
+            state
+                .db
+                .get_thread_metadata_by_event(community, parent_event.id.as_bytes())
+                .await
+                .expect("query parent meta")
+                .is_none(),
+            "test premise: the nested parent must have no thread_metadata row"
+        );
+
+        // A workflow reply onto the metadata-less nested parent.
+        let reply_hex = RelayActionSink::new(&state)
+            .send_message(
+                community,
+                &channel_hex,
+                "workflow reply",
+                &author_hex,
+                Some(&parent_hex),
+            )
+            .await
+            .expect("send reply");
+
+        let reply_id_bytes = nostr::EventId::from_hex(&reply_hex)
+            .expect("reply id")
+            .as_bytes()
+            .to_vec();
+        let meta = state
+            .db
+            .get_thread_metadata_by_event(community, &reply_id_bytes)
+            .await
+            .expect("query meta")
+            .expect("reply has thread metadata");
+
+        assert_eq!(
+            meta.depth, 2,
+            "reply to a marked-but-unindexed nested parent is depth 2, not top-level"
+        );
+        let root_bytes = nostr::EventId::from_hex(&root_hex)
+            .expect("root id")
+            .as_bytes()
+            .to_vec();
+        let parent_bytes = parent_event.id.as_bytes().to_vec();
+        assert_eq!(
+            meta.root_event_id.as_deref(),
+            Some(root_bytes.as_slice()),
+            "root recovered from the parent's own NIP-10 markers"
+        );
+        assert_eq!(
+            meta.parent_event_id.as_deref(),
+            Some(parent_bytes.as_slice())
+        );
+
+        // The reply's own NIP-10 e-tags point root→the recovered root,
+        // reply→the immediate parent (matching the ingest resolver).
+        let stored = state
+            .db
+            .get_event_by_id(community, &reply_id_bytes)
+            .await
+            .expect("query reply")
+            .expect("reply persisted");
+        let marker = |m: &str| -> Option<String> {
+            stored.event.tags.iter().find_map(|t| {
+                let p = t.as_slice();
+                if p.len() >= 4 && p[0] == "e" && p[3] == m {
+                    Some(p[1].clone())
+                } else {
+                    None
+                }
+            })
+        };
+        assert_eq!(marker("root").as_deref(), Some(root_hex.as_str()));
+        assert_eq!(marker("reply").as_deref(), Some(parent_hex.as_str()));
     }
 
     #[tokio::test]

--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -890,7 +890,7 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore = "requires Postgres"]
-    async fn workflow_reply_to_metadata_less_nested_parent_recovers_depth_2() {
+    async fn workflow_replies_recover_metadata_less_parent_ancestry() {
         // A parent that carries NIP-10 root/reply markers but has NO
         // thread_metadata row (legacy or not-yet-indexed) must be recognized as
         // nested: the workflow reply threads at depth 2 onto the parent's own
@@ -1028,6 +1028,55 @@ mod integration_tests {
         };
         assert_eq!(marker("root").as_deref(), Some(root_hex.as_str()));
         assert_eq!(marker("reply").as_deref(), Some(parent_hex.as_str()));
+
+        // A root-only parent is top-level under the shared collapse rule, even
+        // without metadata. A workflow reply therefore starts a thread at P,
+        // rather than incorrectly inheriting the marker's unrelated root R.
+        let root_only_parent =
+            EventBuilder::new(Kind::from(KIND_STREAM_MESSAGE as u16), "root-only parent")
+                .tags([
+                    Tag::parse(["h", &channel_hex]).expect("h tag"),
+                    Tag::parse(["e", &root_hex, "", "root"]).expect("root tag"),
+                ])
+                .sign_with_keys(&author)
+                .expect("sign root-only parent");
+        let root_only_parent_hex = root_only_parent.id.to_hex();
+        let root_only_parent_bytes = root_only_parent.id.as_bytes().to_vec();
+        state
+            .db
+            .insert_event(community, &root_only_parent, Some(channel.id))
+            .await
+            .expect("insert root-only parent");
+
+        let root_only_reply_hex = RelayActionSink::new(&state)
+            .send_message(
+                community,
+                &channel_hex,
+                "workflow reply to root-only parent",
+                &author_hex,
+                Some(&root_only_parent_hex),
+            )
+            .await
+            .expect("send root-only reply");
+        let root_only_reply_bytes = nostr::EventId::from_hex(&root_only_reply_hex)
+            .expect("reply id")
+            .as_bytes()
+            .to_vec();
+        let root_only_meta = state
+            .db
+            .get_thread_metadata_by_event(community, &root_only_reply_bytes)
+            .await
+            .expect("query root-only reply meta")
+            .expect("root-only reply has thread metadata");
+        assert_eq!(root_only_meta.depth, 1);
+        assert_eq!(
+            root_only_meta.parent_event_id.as_deref(),
+            Some(root_only_parent_bytes.as_slice())
+        );
+        assert_eq!(
+            root_only_meta.root_event_id.as_deref(),
+            Some(root_only_parent_bytes.as_slice())
+        );
     }
 
     #[tokio::test]

--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -176,10 +176,12 @@ impl ActionSink for RelayActionSink {
         channel_id: &str,
         text: &str,
         author_pubkey: &str,
+        reply_to: Option<&str>,
     ) -> Pin<Box<dyn Future<Output = Result<String, ActionSinkError>> + Send + '_>> {
         let channel_id = channel_id.to_owned();
         let text = text.to_owned();
         let author_pubkey = author_pubkey.to_owned();
+        let reply_to = reply_to.map(str::to_owned);
 
         Box::pin(async move {
             // 0. Upgrade weak reference — fails only during shutdown.
@@ -266,6 +268,39 @@ impl ActionSink for RelayActionSink {
                     .map_err(|e| ActionSinkError::EventBuild(format!("workflow tag: {e}")))?,
             ];
 
+            // Resolve thread ancestry when this is a threaded reply, so the
+            // built event carries NIP-10 `root`/`reply` e-tags and persists real
+            // thread metadata (matching the ingest path) instead of top-level.
+            let reply_ancestry = match reply_to.as_deref() {
+                Some(parent_hex) => Some(
+                    crate::handlers::ingest::resolve_relay_reply_thread_meta(
+                        tenant.community(),
+                        parent_hex,
+                        channel_uuid,
+                        &state,
+                    )
+                    .await
+                    .map_err(ActionSinkError::InvalidInput)?,
+                ),
+                None => None,
+            };
+
+            // NIP-10 e-tags for the thread. Marked `root`/`reply` so clients and
+            // the ingest resolver read the ancestry the same way. When the reply
+            // is directly under the root, both markers point at the same event.
+            if let Some(ancestry) = &reply_ancestry {
+                let root_hex = ancestry.root_hex();
+                let parent_hex = ancestry.parent_hex();
+                tags.push(
+                    Tag::parse(["e", &root_hex, "", "root"])
+                        .map_err(|e| ActionSinkError::EventBuild(format!("root e tag: {e}")))?,
+                );
+                tags.push(
+                    Tag::parse(["e", &parent_hex, "", "reply"])
+                        .map_err(|e| ActionSinkError::EventBuild(format!("reply e tag: {e}")))?,
+                );
+            }
+
             // Resolve `@Name` mentions to channel-member pubkeys and append a
             // `p` tag for each (skipping the author, already tagged above). A
             // resolution failure must not drop the message, so log and proceed
@@ -321,17 +356,24 @@ impl ActionSink for RelayActionSink {
             );
 
             // 4. Persist event with thread metadata (matches REST handler path).
-            //    Workflow messages are always top-level: depth=0, no parent/root.
-            let thread_meta = Some(buzz_db::event::ThreadMetadataParams {
-                event_id: &event_id_bytes,
-                event_created_at,
-                channel_id: channel_uuid,
-                parent_event_id: None,
-                parent_event_created_at: None,
-                root_event_id: None,
-                root_event_created_at: None,
-                depth: 0,
-                broadcast: false,
+            //    Threaded replies persist the resolved parent/root/depth; a
+            //    non-reply workflow message stays top-level (depth=0, no parent).
+            let thread_meta_owned = reply_ancestry.map(|ancestry| {
+                ancestry.into_thread_meta(event_id_bytes.clone(), event_created_at, channel_uuid)
+            });
+            let thread_meta = Some(match &thread_meta_owned {
+                Some(owned) => owned.as_params(),
+                None => buzz_db::event::ThreadMetadataParams {
+                    event_id: &event_id_bytes,
+                    event_created_at,
+                    channel_id: channel_uuid,
+                    parent_event_id: None,
+                    parent_event_created_at: None,
+                    root_event_id: None,
+                    root_event_created_at: None,
+                    depth: 0,
+                    broadcast: false,
+                },
             });
 
             let (stored_event, was_inserted) = state
@@ -676,6 +718,7 @@ mod integration_tests {
                 &channel.id.to_string(),
                 "heads up @Robby — please take a look",
                 &author_hex,
+                None,
             )
             .await
             .expect("send_message");
@@ -706,6 +749,155 @@ mod integration_tests {
         assert!(
             p_tag_targets.contains(&agent_hex.as_str()),
             "mentioned member {agent_hex} must be p-tagged so it wakes; got {p_tag_targets:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn workflow_reply_in_thread_threads_onto_parent() {
+        let state = test_state().await;
+
+        let author = nostr::Keys::generate();
+        let author_hex = author.public_key().to_hex();
+
+        let host = format!("wf-thread-{}.example", uuid::Uuid::new_v4().simple());
+        let community = match state
+            .db
+            .create_community_with_owner(&host, &author_hex)
+            .await
+            .expect("create community")
+        {
+            CreateCommunityWithOwnerResult::Created(rec) => rec.id,
+            other => panic!("expected fresh community, got {other:?}"),
+        };
+
+        let channel = state
+            .db
+            .create_channel(
+                community,
+                "wf-thread",
+                ChannelType::Stream,
+                ChannelVisibility::Open,
+                None,
+                &author.public_key().to_bytes(),
+                None,
+            )
+            .await
+            .expect("create channel");
+
+        let sink = RelayActionSink::new(&state);
+
+        // 1. A top-level workflow message becomes the thread root.
+        let root_hex = sink
+            .send_message(
+                community,
+                &channel.id.to_string(),
+                "root message",
+                &author_hex,
+                None,
+            )
+            .await
+            .expect("send root");
+
+        // 2. A reply_in_thread message threads onto it.
+        let reply_hex = sink
+            .send_message(
+                community,
+                &channel.id.to_string(),
+                "threaded reply",
+                &author_hex,
+                Some(&root_hex),
+            )
+            .await
+            .expect("send reply");
+
+        // The reply event carries NIP-10 root+reply e-tags pointing at the root.
+        let reply_id_bytes = nostr::EventId::from_hex(&reply_hex)
+            .expect("reply id")
+            .as_bytes()
+            .to_vec();
+        let stored = state
+            .db
+            .get_event_by_id(community, &reply_id_bytes)
+            .await
+            .expect("query reply")
+            .expect("reply persisted");
+        let marker = |m: &str| -> Option<String> {
+            stored.event.tags.iter().find_map(|t| {
+                let p = t.as_slice();
+                if p.len() >= 4 && p[0] == "e" && p[3] == m {
+                    Some(p[1].clone())
+                } else {
+                    None
+                }
+            })
+        };
+        assert_eq!(marker("root").as_deref(), Some(root_hex.as_str()));
+        assert_eq!(marker("reply").as_deref(), Some(root_hex.as_str()));
+
+        // Thread metadata reflects a depth-1 reply parented on the root.
+        let meta = state
+            .db
+            .get_thread_metadata_by_event(community, &reply_id_bytes)
+            .await
+            .expect("query meta")
+            .expect("reply has thread metadata");
+        assert_eq!(
+            meta.depth, 1,
+            "direct reply to a top-level message is depth 1"
+        );
+        let root_bytes = nostr::EventId::from_hex(&root_hex)
+            .expect("root id")
+            .as_bytes()
+            .to_vec();
+        assert_eq!(meta.parent_event_id.as_deref(), Some(root_bytes.as_slice()));
+        assert_eq!(meta.root_event_id.as_deref(), Some(root_bytes.as_slice()));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn workflow_reply_to_missing_parent_errors() {
+        let state = test_state().await;
+        let author = nostr::Keys::generate();
+        let author_hex = author.public_key().to_hex();
+        let host = format!("wf-missing-{}.example", uuid::Uuid::new_v4().simple());
+        let community = match state
+            .db
+            .create_community_with_owner(&host, &author_hex)
+            .await
+            .expect("create community")
+        {
+            CreateCommunityWithOwnerResult::Created(rec) => rec.id,
+            other => panic!("expected fresh community, got {other:?}"),
+        };
+        let channel = state
+            .db
+            .create_channel(
+                community,
+                "wf-missing",
+                ChannelType::Stream,
+                ChannelVisibility::Open,
+                None,
+                &author.public_key().to_bytes(),
+                None,
+            )
+            .await
+            .expect("create channel");
+
+        let unknown = nostr::Keys::generate().public_key().to_hex();
+        let err = RelayActionSink::new(&state)
+            .send_message(
+                community,
+                &channel.id.to_string(),
+                "orphan reply",
+                &author_hex,
+                Some(&unknown),
+            )
+            .await
+            .expect_err("reply to a non-existent parent must fail");
+        assert!(
+            matches!(err, ActionSinkError::InvalidInput(_)),
+            "expected InvalidInput, got {err:?}"
         );
     }
 }

--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -836,7 +836,8 @@ mod integration_tests {
             .await
             .expect("send reply");
 
-        // The reply event carries NIP-10 root+reply e-tags pointing at the root.
+        // A direct reply carries a single NIP-10 reply e-tag at the root (no
+        // root marker), matching SDK `thread_tags`.
         let reply_id_bytes = nostr::EventId::from_hex(&reply_hex)
             .expect("reply id")
             .as_bytes()

--- a/crates/buzz-test-client/tests/e2e_relay.rs
+++ b/crates/buzz-test-client/tests/e2e_relay.rs
@@ -2661,6 +2661,113 @@ async fn test_reply_ingest_pushes_live_thread_summary() {
     client.disconnect().await.expect("disconnect");
 }
 
+/// F3 (workflow path): a `message_posted` workflow whose `send_message` action
+/// has `reply_in_thread: true` posts a threaded reply to the triggering
+/// top-level message — and that relay-built reply must push the same live
+/// kind:39005 thread-summary overlay the human ingest path does, so desktops
+/// update the root's badge without refetching. Also exercises F2's semantics:
+/// the `trigger_is_reply == false` filter must fire on the top-level message.
+#[tokio::test]
+#[ignore]
+async fn test_workflow_reply_in_thread_pushes_live_thread_summary() {
+    let url = relay_url();
+    let http = relay_http_url();
+    let keys = Keys::generate();
+    let pubkey_hex = keys.public_key().to_hex();
+    let channel = create_test_channel(&keys).await;
+
+    // A message_posted workflow that replies in-thread, but only to NEW
+    // top-level messages (`trigger_is_reply == false`) — so it cannot recurse
+    // on the reply it just posted.
+    let yaml = format!(
+        "name: reply-bot\n\
+         description: F3 live probe\n\
+         trigger:\n\
+         \x20 on: message_posted\n\
+         \x20 filter: \"trigger_is_reply == false\"\n\
+         steps:\n\
+         \x20 - id: step1\n\
+         \x20   name: Reply\n\
+         \x20   action: send_message\n\
+         \x20   text: \"auto-reply\"\n\
+         \x20   reply_in_thread: true\n"
+    );
+    let def = EventBuilder::new(Kind::Custom(30620), yaml)
+        .tags([
+            Tag::parse(["d", &Uuid::new_v4().to_string()]).unwrap(),
+            Tag::parse(["h", channel.as_str()]).unwrap(),
+            Tag::parse(["name", "reply-bot"]).unwrap(),
+        ])
+        .sign_with_keys(&keys)
+        .expect("sign workflow def");
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{http}/events"))
+        .header("X-Pubkey", &pubkey_hex)
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&def).unwrap())
+        .send()
+        .await
+        .expect("submit workflow def");
+    let body: serde_json::Value = resp.json().await.expect("parse def response");
+    assert!(
+        body["accepted"].as_bool().unwrap_or(false),
+        "workflow def not accepted: {body}"
+    );
+
+    // Live 39005 subscription for the channel, shaped like the desktop window
+    // store's.
+    let mut ws = BuzzTestClient::connect(&url, &keys).await.expect("connect");
+    let sid = sub_id("wf-live-summary");
+    let filter = Filter::new()
+        .kind(Kind::Custom(39005))
+        .custom_tags(SingleLetterTag::lowercase(Alphabet::H), [channel.as_str()]);
+    ws.subscribe(&sid, vec![filter]).await.expect("subscribe");
+    ws.collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("EOSE");
+
+    // Post a top-level message — the workflow fires and posts a threaded reply.
+    let root = EventBuilder::new(Kind::Custom(9), "trigger me")
+        .tags([Tag::parse(["h", channel.as_str()]).unwrap()])
+        .sign_with_keys(&keys)
+        .expect("sign root");
+    let root_id = root.id;
+    let ok = ws.send_event(root).await.expect("send root");
+    assert!(ok.accepted, "root rejected: {}", ok.message);
+
+    // The workflow reply's 39005 overlay must arrive and target the root with a
+    // reply_count of 1 — proving the relay-built reply pushed the live summary.
+    let summary = loop {
+        match ws
+            .recv_event(Duration::from_secs(10))
+            .await
+            .expect("recv 39005 for workflow reply")
+        {
+            RelayMessage::Event { event, .. } if event.kind == Kind::Custom(39005) => break *event,
+            _ => continue,
+        }
+    };
+    let root_tag_val = summary
+        .tags
+        .iter()
+        .find(|t| t.as_slice().first().map(String::as_str) == Some("e"))
+        .and_then(|t| t.content().map(str::to_string))
+        .expect("summary carries root e-tag");
+    assert_eq!(
+        root_tag_val,
+        root_id.to_hex(),
+        "workflow-reply summary targets the triggering top-level message as root"
+    );
+    let content: serde_json::Value = serde_json::from_str(&summary.content).expect("JSON");
+    assert_eq!(
+        content["reply_count"], 1,
+        "workflow threaded reply counted up: {content}"
+    );
+
+    ws.disconnect().await.expect("disconnect");
+}
+
 /// Read a member's authoritative role from the relay-signed kind:39002 member
 /// list. The relay's own view of membership, not the client's — a kind:9000 can
 /// be `accepted` (stored) while its membership side effect fails, so asserting

--- a/crates/buzz-test-client/tests/e2e_relay.rs
+++ b/crates/buzz-test-client/tests/e2e_relay.rs
@@ -2679,8 +2679,7 @@ async fn test_workflow_reply_in_thread_pushes_live_thread_summary() {
     // A message_posted workflow that replies in-thread, but only to NEW
     // top-level messages (`trigger_is_reply == false`) — so it cannot recurse
     // on the reply it just posted.
-    let yaml = format!(
-        "name: reply-bot\n\
+    let yaml = "name: reply-bot\n\
          description: F3 live probe\n\
          trigger:\n\
          \x20 on: message_posted\n\
@@ -2691,7 +2690,7 @@ async fn test_workflow_reply_in_thread_pushes_live_thread_summary() {
          \x20   action: send_message\n\
          \x20   text: \"auto-reply\"\n\
          \x20   reply_in_thread: true\n"
-    );
+        .to_string();
     let def = EventBuilder::new(Kind::Custom(30620), yaml)
         .tags([
             Tag::parse(["d", &Uuid::new_v4().to_string()]).unwrap(),

--- a/crates/buzz-workflow/src/action_sink.rs
+++ b/crates/buzz-workflow/src/action_sink.rs
@@ -57,6 +57,9 @@ pub trait ActionSink: Send + Sync {
     /// - `text`: message body (must not be empty/whitespace-only)
     /// - `author_pubkey`: hex-encoded pubkey of the workflow owner (used for
     ///   the `p` attribution tag; the relay keypair signs the event)
+    /// - `reply_to`: when `Some(event_id_hex)`, the message is posted as a
+    ///   threaded reply to that event (NIP-10 root/reply tags + real thread
+    ///   metadata); when `None`, it is a top-level channel message.
     ///
     /// Returns the event ID hex string on success.
     fn send_message(
@@ -65,5 +68,6 @@ pub trait ActionSink: Send + Sync {
         channel_id: &str,
         text: &str,
         author_pubkey: &str,
+        reply_to: Option<&str>,
     ) -> Pin<Box<dyn Future<Output = Result<String, ActionSinkError>> + Send + '_>>;
 }

--- a/crates/buzz-workflow/src/executor.rs
+++ b/crates/buzz-workflow/src/executor.rs
@@ -37,6 +37,10 @@ pub struct TriggerContext {
     pub emoji: String,
     /// Event ID of the triggering message (hex string).
     pub message_id: String,
+    /// True when the triggering event is itself a threaded reply (carries a
+    /// NIP-10 `reply`/`root` marker e-tag). Lets a `message_posted` filter
+    /// select only top-level messages via `trigger_is_reply == false`.
+    pub is_reply: bool,
     /// Arbitrary webhook body fields (webhook trigger).
     pub webhook_fields: HashMap<String, String>,
 }
@@ -213,6 +217,7 @@ fn apply_filter(value: String, filter: &str) -> Result<String, WorkflowError> {
 /// | `trigger.timestamp`               | `trigger_timestamp`       |
 /// | `trigger.emoji`                   | `trigger_emoji`           |
 /// | `trigger.message_id`              | `trigger_message_id`      |
+/// | `trigger.is_reply`                | `trigger_is_reply` (bool) |
 /// | `steps.STEP_ID.output.FIELD`      | `steps_STEP_ID_output_FIELD` |
 ///
 /// Also registers string helper functions that the `cron` crate's `evalexpr` v11
@@ -299,6 +304,14 @@ pub fn build_eval_context(
         ctx.set_value((*name).into(), Value::String((*val).to_owned()))
             .map_err(|e| WorkflowError::ConditionError(e.to_string()))?;
     }
+
+    // `trigger_is_reply` is boolean (not a string field), so a filter can read
+    // `trigger_is_reply == false` to fire only on top-level messages.
+    ctx.set_value(
+        "trigger_is_reply".into(),
+        Value::Boolean(trigger_ctx.is_reply),
+    )
+    .map_err(|e| WorkflowError::ConditionError(e.to_string()))?;
 
     for (step_id, output) in step_outputs {
         if let JsonValue::Object(map) = output {
@@ -403,9 +416,14 @@ pub fn resolve_step_templates(
     };
 
     match &step.action {
-        SendMessage { text, channel } => Ok(SendMessage {
+        SendMessage {
+            text,
+            channel,
+            reply_in_thread,
+        } => Ok(SendMessage {
             text: t(text)?,
             channel: t_opt(channel)?,
+            reply_in_thread: *reply_in_thread,
         }),
         SendDm { to, text } => Ok(SendDm {
             to: t(to)?,
@@ -546,7 +564,11 @@ pub async fn dispatch_action(
     let result = serving_write
         .protect(async {
             match action {
-                SendMessage { text, channel } => {
+                SendMessage {
+                    text,
+                    channel,
+                    reply_in_thread,
+                } => {
                     // Look up workflow metadata for destination validation and
                     // attribution, scoped to the run's community — the same run/workflow
                     // UUID may exist in another community, so a bare-id lookup could
@@ -577,16 +599,38 @@ pub async fn dispatch_action(
                     )?;
                     let owner_pubkey_hex = hex::encode(&workflow.owner_pubkey);
 
+                    // Thread the reply onto the triggering message when requested.
+                    // The trigger must carry the event to reply to; schema
+                    // validation already forbids `reply_in_thread` on triggers
+                    // that have no message, so an empty id here is a real fault.
+                    let reply_to = if *reply_in_thread {
+                        if trigger_ctx.message_id.is_empty() {
+                            return Err(WorkflowError::InvalidDefinition(
+                                "SendMessage: reply_in_thread is set but the trigger has no message_id to reply to".into(),
+                            ));
+                        }
+                        Some(trigger_ctx.message_id.as_str())
+                    } else {
+                        None
+                    };
+
                     info!(
                         run_id = %run_id,
                         step = step_id,
                         channel = %channel_id,
+                        reply_in_thread = *reply_in_thread,
                         "SendMessage → {channel_id}: {text}"
                     );
 
                     let event_id = engine
                         .action_sink()?
-                        .send_message(community_id, &channel_id, text, &owner_pubkey_hex)
+                        .send_message(
+                            community_id,
+                            &channel_id,
+                            text,
+                            &owner_pubkey_hex,
+                            reply_to,
+                        )
                         .await
                         .map_err(WorkflowError::from)?;
 
@@ -1266,6 +1310,7 @@ mod tests {
             timestamp: "1700000000".to_owned(),
             emoji: "fire".to_owned(),
             message_id: "event-id-hex".to_owned(),
+            is_reply: false,
             webhook_fields: HashMap::new(),
         }
     }
@@ -1383,6 +1428,56 @@ mod tests {
                 .await
                 .unwrap();
         assert!(!result);
+    }
+
+    #[tokio::test]
+    async fn condition_trigger_is_reply_selects_top_level_only() {
+        // The top-level-only filter from the feature's use case.
+        let mut ctx = make_trigger();
+
+        ctx.is_reply = false;
+        assert!(
+            evaluate_condition("trigger_is_reply == false", &ctx, &HashMap::new())
+                .await
+                .unwrap(),
+            "top-level message should pass the filter"
+        );
+
+        ctx.is_reply = true;
+        assert!(
+            !evaluate_condition("trigger_is_reply == false", &ctx, &HashMap::new())
+                .await
+                .unwrap(),
+            "threaded reply should be filtered out"
+        );
+    }
+
+    #[test]
+    fn resolve_step_templates_carries_reply_in_thread() {
+        let ctx = make_trigger();
+        let step = Step {
+            id: "reply".to_owned(),
+            name: None,
+            if_expr: None,
+            timeout_secs: None,
+            action: ActionDef::SendMessage {
+                text: "hi {{trigger.author}}".to_owned(),
+                channel: None,
+                reply_in_thread: true,
+            },
+        };
+        let resolved = resolve_step_templates(&step, &ctx, &HashMap::new()).unwrap();
+        match resolved {
+            ActionDef::SendMessage {
+                text,
+                reply_in_thread,
+                ..
+            } => {
+                assert_eq!(text, "hi abc123def456");
+                assert!(reply_in_thread, "reply_in_thread must survive resolution");
+            }
+            other => panic!("unexpected action: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/buzz-workflow/src/lib.rs
+++ b/crates/buzz-workflow/src/lib.rs
@@ -1002,16 +1002,17 @@ pub fn build_trigger_context(event: &buzz_core::StoredEvent) -> executor::Trigge
     }
 }
 
-/// True when an event is a threaded reply — it carries a NIP-10 `e` tag marked
-/// `reply`. A `root` marker alone is not enough: the ingest resolver treats
-/// `(root=Some, reply=None)` as top-level (see `resolve_nip10_thread_meta`), so
-/// a `message_posted` filter of `trigger_is_reply == false` fires on those and
-/// on messages with no NIP-10 markers at all.
+/// True when an event is a threaded reply — it carries a valid NIP-10 `reply`
+/// marker. Delegates to the shared [`buzz_core::nip10`] parser so this stays in
+/// lockstep with ingest's `resolve_nip10_thread_meta`: a `root` marker alone is
+/// top-level, and a marker with a malformed (non-64-hex) event id is ignored by
+/// ingest, so it must not flip `trigger_is_reply` either — else a
+/// `trigger_is_reply == false` workflow would skip a message ingest stored as a
+/// new top-level post.
 fn event_is_reply(event: &nostr::Event) -> bool {
-    event.tags.iter().any(|tag| {
-        let parts = tag.as_slice();
-        parts.len() >= 4 && parts[0] == "e" && parts[3] == "reply"
-    })
+    buzz_core::nip10::parse_thread_markers(&event.tags)
+        .reply
+        .is_some()
 }
 
 /// Pure authority decision for [`WorkflowEngine::check_owner_authority`].
@@ -1692,6 +1693,53 @@ steps:
         let stored = buzz_core::StoredEvent::new(event, Some(Uuid::new_v4()));
         let ctx = build_trigger_context(&stored);
         assert!(!ctx.is_reply, "unmarked e-tag must not count as a reply");
+    }
+
+    #[test]
+    fn build_trigger_context_is_reply_false_for_malformed_reply_id() {
+        // Ingest gates a marker on a valid 64-hex event id; a malformed reply
+        // id is not a thread link, so ingest stores the event top-level. The
+        // predicate must agree, or `trigger_is_reply == false` would skip it.
+        use nostr::{EventBuilder, Keys, Kind, Tag};
+        use uuid::Uuid;
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(9), "malformed reply marker")
+            .tags([Tag::parse(["e", "bad", "", "reply"]).expect("reply tag")])
+            .sign_with_keys(&keys)
+            .expect("sign");
+        let stored = buzz_core::StoredEvent::new(event, Some(Uuid::new_v4()));
+        let ctx = build_trigger_context(&stored);
+        assert!(
+            !ctx.is_reply,
+            "a malformed reply id is ignored by ingest, so it is top-level"
+        );
+    }
+
+    #[test]
+    fn build_trigger_context_is_reply_false_for_valid_root_malformed_reply() {
+        // A valid `root` marker but a malformed `reply` id: ingest ignores the
+        // reply and stores the event as root-only, i.e. top-level. The predicate
+        // must not flip to reply on the malformed marker.
+        use nostr::{EventBuilder, Keys, Kind, Tag};
+        use uuid::Uuid;
+        let root = Keys::generate();
+        let root_event = EventBuilder::new(Kind::Custom(9), "root")
+            .sign_with_keys(&root)
+            .expect("sign root");
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(9), "valid root, malformed reply")
+            .tags([
+                Tag::parse(["e", &root_event.id.to_hex(), "", "root"]).expect("root tag"),
+                Tag::parse(["e", "bad", "", "reply"]).expect("reply tag"),
+            ])
+            .sign_with_keys(&keys)
+            .expect("sign");
+        let stored = buzz_core::StoredEvent::new(event, Some(Uuid::new_v4()));
+        let ctx = build_trigger_context(&stored);
+        assert!(
+            !ctx.is_reply,
+            "a valid root with a malformed reply id is top-level to ingest"
+        );
     }
 
     #[test]

--- a/crates/buzz-workflow/src/lib.rs
+++ b/crates/buzz-workflow/src/lib.rs
@@ -997,8 +997,19 @@ pub fn build_trigger_context(event: &buzz_core::StoredEvent) -> executor::Trigge
         timestamp: event.event.created_at.as_secs().to_string(),
         emoji,
         message_id,
+        is_reply: event_is_reply(&event.event),
         webhook_fields: HashMap::new(),
     }
+}
+
+/// True when an event is a threaded reply — it carries a NIP-10 `e` tag marked
+/// `reply` or `root`. A top-level message has neither, so a `message_posted`
+/// filter of `trigger_is_reply == false` fires only on new top-level messages.
+fn event_is_reply(event: &nostr::Event) -> bool {
+    event.tags.iter().any(|tag| {
+        let parts = tag.as_slice();
+        parts.len() >= 4 && parts[0] == "e" && (parts[3] == "reply" || parts[3] == "root")
+    })
 }
 
 /// Pure authority decision for [`WorkflowEngine::check_owner_authority`].
@@ -1588,6 +1599,53 @@ steps:
         // Non-reaction events have empty emoji.
         assert_eq!(ctx.emoji, "");
         assert!(ctx.webhook_fields.is_empty());
+        // A top-level message (no e-tags) is not a reply.
+        assert!(!ctx.is_reply);
+    }
+
+    #[test]
+    fn build_trigger_context_is_reply_true_for_threaded_message() {
+        use nostr::{EventBuilder, Keys, Kind, Tag};
+        use uuid::Uuid;
+        let root = Keys::generate();
+        let root_event = EventBuilder::new(Kind::Custom(9), "root")
+            .tags([])
+            .sign_with_keys(&root)
+            .expect("sign root");
+        let root_hex = root_event.id.to_hex();
+
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(9), "a threaded reply")
+            .tags([
+                Tag::parse(["e", &root_hex, "", "root"]).expect("root tag"),
+                Tag::parse(["e", &root_hex, "", "reply"]).expect("reply tag"),
+            ])
+            .sign_with_keys(&keys)
+            .expect("sign");
+        let stored = buzz_core::StoredEvent::new(event, Some(Uuid::new_v4()));
+        let ctx = build_trigger_context(&stored);
+        assert!(ctx.is_reply, "message with reply/root e-tags is a reply");
+    }
+
+    #[test]
+    fn build_trigger_context_is_reply_false_for_unmarked_e_tag() {
+        // A bare `e` tag with no NIP-10 marker (e.g. a plain mention/quote) is
+        // not treated as a thread reply — only `reply`/`root` markers count.
+        use nostr::{EventBuilder, Keys, Kind, Tag};
+        use uuid::Uuid;
+        let other = Keys::generate();
+        let other_event = EventBuilder::new(Kind::Custom(9), "other")
+            .tags([])
+            .sign_with_keys(&other)
+            .expect("sign");
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(9), "quotes another")
+            .tags([Tag::parse(["e", &other_event.id.to_hex()]).expect("bare e tag")])
+            .sign_with_keys(&keys)
+            .expect("sign");
+        let stored = buzz_core::StoredEvent::new(event, Some(Uuid::new_v4()));
+        let ctx = build_trigger_context(&stored);
+        assert!(!ctx.is_reply, "unmarked e-tag must not count as a reply");
     }
 
     #[test]

--- a/crates/buzz-workflow/src/lib.rs
+++ b/crates/buzz-workflow/src/lib.rs
@@ -1003,12 +1003,14 @@ pub fn build_trigger_context(event: &buzz_core::StoredEvent) -> executor::Trigge
 }
 
 /// True when an event is a threaded reply — it carries a NIP-10 `e` tag marked
-/// `reply` or `root`. A top-level message has neither, so a `message_posted`
-/// filter of `trigger_is_reply == false` fires only on new top-level messages.
+/// `reply`. A `root` marker alone is not enough: the ingest resolver treats
+/// `(root=Some, reply=None)` as top-level (see `resolve_nip10_thread_meta`), so
+/// a `message_posted` filter of `trigger_is_reply == false` fires on those and
+/// on messages with no NIP-10 markers at all.
 fn event_is_reply(event: &nostr::Event) -> bool {
     event.tags.iter().any(|tag| {
         let parts = tag.as_slice();
-        parts.len() >= 4 && parts[0] == "e" && (parts[3] == "reply" || parts[3] == "root")
+        parts.len() >= 4 && parts[0] == "e" && parts[3] == "reply"
     })
 }
 
@@ -1625,6 +1627,50 @@ steps:
         let stored = buzz_core::StoredEvent::new(event, Some(Uuid::new_v4()));
         let ctx = build_trigger_context(&stored);
         assert!(ctx.is_reply, "message with reply/root e-tags is a reply");
+    }
+
+    #[test]
+    fn build_trigger_context_is_reply_true_for_reply_only_marker() {
+        // A NIP-10 `reply` marker without a `root` marker (the fallback ingest
+        // treats as `root == reply`) is still a threaded reply.
+        use nostr::{EventBuilder, Keys, Kind, Tag};
+        use uuid::Uuid;
+        let parent = Keys::generate();
+        let parent_event = EventBuilder::new(Kind::Custom(9), "parent")
+            .sign_with_keys(&parent)
+            .expect("sign parent");
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(9), "reply only")
+            .tags([Tag::parse(["e", &parent_event.id.to_hex(), "", "reply"]).expect("reply tag")])
+            .sign_with_keys(&keys)
+            .expect("sign");
+        let stored = buzz_core::StoredEvent::new(event, Some(Uuid::new_v4()));
+        let ctx = build_trigger_context(&stored);
+        assert!(ctx.is_reply, "a lone `reply` marker is a reply");
+    }
+
+    #[test]
+    fn build_trigger_context_is_reply_false_for_root_only_marker() {
+        // Ingest treats `(root=Some, reply=None)` as top-level, so
+        // `event_is_reply` must too — otherwise `trigger_is_reply == false`
+        // would skip a message the relay stored as a new top-level post.
+        use nostr::{EventBuilder, Keys, Kind, Tag};
+        use uuid::Uuid;
+        let root = Keys::generate();
+        let root_event = EventBuilder::new(Kind::Custom(9), "root")
+            .sign_with_keys(&root)
+            .expect("sign root");
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(9), "root marker only")
+            .tags([Tag::parse(["e", &root_event.id.to_hex(), "", "root"]).expect("root tag")])
+            .sign_with_keys(&keys)
+            .expect("sign");
+        let stored = buzz_core::StoredEvent::new(event, Some(Uuid::new_v4()));
+        let ctx = build_trigger_context(&stored);
+        assert!(
+            !ctx.is_reply,
+            "a lone `root` marker is top-level to ingest, not a reply"
+        );
     }
 
     #[test]

--- a/crates/buzz-workflow/src/schema.rs
+++ b/crates/buzz-workflow/src/schema.rs
@@ -100,6 +100,11 @@ pub enum ActionDef {
         /// Optional channel UUID override. Must be a valid UUID string.
         #[serde(default)]
         channel: Option<String>,
+        /// Reply to the triggering message in its thread instead of posting a
+        /// new top-level message. Only valid for message-based triggers, which
+        /// carry a triggering event to reply to.
+        #[serde(default)]
+        reply_in_thread: bool,
     },
     /// Send a direct message to a user.
     SendDm {
@@ -205,6 +210,34 @@ impl WorkflowDef {
                     "duplicate step id: {}",
                     step.id
                 )));
+            }
+        }
+
+        // `reply_in_thread` requires a triggering message to reply to. Schedule
+        // and webhook triggers have none, so reject the combination at
+        // definition time rather than failing silently at run time.
+        let trigger_has_message = matches!(
+            self.trigger,
+            TriggerDef::MessagePosted { .. }
+                | TriggerDef::ReactionAdded { .. }
+                | TriggerDef::DiffPosted { .. }
+        );
+        if !trigger_has_message {
+            for step in &self.steps {
+                if matches!(
+                    step.action,
+                    ActionDef::SendMessage {
+                        reply_in_thread: true,
+                        ..
+                    }
+                ) {
+                    return Err(WorkflowError::InvalidDefinition(format!(
+                        "step '{}': reply_in_thread requires a message-based trigger \
+                         (message_posted, reaction_added, or diff_posted); \
+                         schedule and webhook triggers have no message to reply to",
+                        step.id
+                    )));
+                }
             }
         }
 
@@ -456,6 +489,78 @@ mod tests {
         let yaml = "name: Empty Schedule\ntrigger:\n  on: schedule\nsteps:\n  - id: s1\n    action: send_message\n    text: hi\n";
         let err = parse_yaml(yaml).unwrap_err();
         assert!(matches!(err, WorkflowError::InvalidDefinition(_)));
+    }
+
+    #[test]
+    fn reply_in_thread_defaults_false_and_round_trips() {
+        // Absent field defaults to false.
+        let yaml = "name: Auto Reply\ntrigger:\n  on: message_posted\nsteps:\n  - id: s1\n    action: send_message\n    text: hi\n";
+        let (def, _) = parse_yaml(yaml).expect("parse failed");
+        match &def.steps[0].action {
+            ActionDef::SendMessage {
+                reply_in_thread, ..
+            } => assert!(!reply_in_thread, "should default to false"),
+            other => panic!("unexpected action: {other:?}"),
+        }
+
+        // Explicit true parses, and survives a JSON round-trip.
+        let yaml = "name: Auto Reply\ntrigger:\n  on: message_posted\nsteps:\n  - id: s1\n    action: send_message\n    text: hi\n    reply_in_thread: true\n";
+        let (def, _) = parse_yaml(yaml).expect("parse failed");
+        match &def.steps[0].action {
+            ActionDef::SendMessage {
+                reply_in_thread, ..
+            } => assert!(reply_in_thread),
+            other => panic!("unexpected action: {other:?}"),
+        }
+        let json = serde_json::to_string(&def).expect("serialize");
+        let reparsed: WorkflowDef = serde_json::from_str(&json).expect("json round-trip");
+        assert!(matches!(
+            &reparsed.steps[0].action,
+            ActionDef::SendMessage {
+                reply_in_thread: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn validate_accepts_reply_in_thread_on_message_triggers() {
+        for on in ["message_posted", "reaction_added", "diff_posted"] {
+            let yaml = format!(
+                "name: Auto Reply\ntrigger:\n  on: {on}\nsteps:\n  - id: s1\n    action: send_message\n    text: hi\n    reply_in_thread: true\n"
+            );
+            parse_yaml(&yaml)
+                .unwrap_or_else(|e| panic!("reply_in_thread should be valid on {on}: {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_rejects_reply_in_thread_on_schedule_trigger() {
+        let yaml = "name: Bad\ntrigger:\n  on: schedule\n  cron: '0 9 * * 1-5'\nsteps:\n  - id: s1\n    action: send_message\n    text: hi\n    reply_in_thread: true\n";
+        let err = parse_yaml(yaml).unwrap_err();
+        match &err {
+            WorkflowError::InvalidDefinition(msg) => {
+                assert!(
+                    msg.contains("reply_in_thread"),
+                    "expected reply_in_thread in: {msg}"
+                );
+            }
+            other => panic!("expected InvalidDefinition, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_reply_in_thread_on_webhook_trigger() {
+        let yaml = "name: Bad\ntrigger:\n  on: webhook\nsteps:\n  - id: s1\n    action: send_message\n    text: hi\n    channel: 00000000-0000-0000-0000-000000000000\n    reply_in_thread: true\n";
+        let err = parse_yaml(yaml).unwrap_err();
+        assert!(matches!(err, WorkflowError::InvalidDefinition(_)));
+    }
+
+    #[test]
+    fn validate_allows_reply_in_thread_false_on_schedule() {
+        // Explicit `false` on a schedule trigger is fine — no message needed.
+        let yaml = "name: OK\ntrigger:\n  on: schedule\n  cron: '0 9 * * 1-5'\nsteps:\n  - id: s1\n    action: send_message\n    text: hi\n    reply_in_thread: false\n";
+        parse_yaml(yaml).expect("reply_in_thread: false on schedule should be valid");
     }
 
     #[test]

--- a/desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx
@@ -39,6 +39,7 @@ import {
   formStateToYaml,
   nextStepId,
   supportsMessageTextCondition,
+  withTriggerType,
   yamlToFormState,
 } from "./workflowFormTypes";
 import { defaultScheduleTrigger } from "./workflowSchedule";
@@ -744,23 +745,27 @@ export const WorkflowFormBuilder = React.forwardRef<
                                 ariaLabel="Trigger event"
                                 disabled={disabled}
                                 labels={TRIGGER_LABELS}
-                                onChange={(triggerType) =>
+                                onChange={(triggerType) => {
+                                  const next = withTriggerType(
+                                    formState,
+                                    triggerType,
+                                  );
                                   updateFormState({
-                                    ...formState,
+                                    ...next,
                                     steps: supportsMessageTextCondition(
                                       triggerType,
                                     )
-                                      ? formState.steps
-                                      : formState.steps.map((step) => ({
+                                      ? next.steps
+                                      : next.steps.map((step) => ({
                                           ...step,
                                           condition: undefined,
                                         })),
                                     trigger:
                                       triggerType === "schedule"
                                         ? defaultScheduleTrigger()
-                                        : { on: triggerType },
-                                  })
-                                }
+                                        : next.trigger,
+                                  });
+                                }}
                                 options={SELECTABLE_TRIGGER_TYPES}
                                 value={formState.trigger.on}
                               />

--- a/desktop/src/features/workflows/ui/WorkflowStepCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowStepCard.tsx
@@ -11,6 +11,7 @@ import { WorkflowMessageTextCondition } from "./WorkflowMessageTextConditionEdit
 import { FieldLabel, FormSelect } from "./workflowFormPrimitives";
 import { WorkflowWebhookHeadersEditor } from "./WorkflowWebhookHeadersEditor";
 import {
+  isThreadReplyEligibleTrigger,
   supportsMessageTextCondition,
   type StepFormState,
   type TriggerType,
@@ -184,7 +185,7 @@ function StepConfigFields({
               ) : null}
             </div>
           )}
-          {triggerType !== "webhook" && triggerType !== "schedule" ? (
+          {isThreadReplyEligibleTrigger(triggerType) ? (
             <div className="flex items-center gap-2">
               <Checkbox
                 checked={step.replyInThread === true}

--- a/desktop/src/features/workflows/ui/WorkflowStepCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowStepCard.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, useState } from "react";
 
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
+import { Checkbox } from "@/shared/ui/checkbox";
 import { Input } from "@/shared/ui/input";
 import { Textarea } from "@/shared/ui/textarea";
 import { WorkflowDurationField } from "./WorkflowDurationField";
@@ -183,6 +184,21 @@ function StepConfigFields({
               ) : null}
             </div>
           )}
+          {triggerType !== "webhook" && triggerType !== "schedule" ? (
+            <div className="flex items-center gap-2">
+              <Checkbox
+                checked={step.replyInThread === true}
+                disabled={disabled}
+                id={`${prefix}-reply-in-thread`}
+                onCheckedChange={(checked) =>
+                  onUpdate({ ...step, replyInThread: checked === true })
+                }
+              />
+              <label className="text-xs" htmlFor={`${prefix}-reply-in-thread`}>
+                Reply to triggering message in thread
+              </label>
+            </div>
+          ) : null}
         </div>
       );
     case "send_dm":

--- a/desktop/src/features/workflows/ui/workflowFormTypes.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowFormTypes.test.mjs
@@ -240,6 +240,51 @@ test("switching from Message Posted clears reply_in_thread before save", () => {
   }
 });
 
+test("an ineligible trigger cannot resurrect reply_in_thread through an action change", () => {
+  // Full repro: Message Posted → Send Message → enable Reply → switch action to
+  // Delay → switch trigger to an ineligible one → switch action back to Send
+  // Message. The action picker changes only `action` (a plain spread, mirrored
+  // here), so `withTriggerType` must clear the hidden flag on every step, not
+  // just the ones whose current action is send_message.
+  for (const triggerType of ["schedule", "webhook"]) {
+    const enabled = sendMessageState({ replyInThread: true });
+    const asDelay = {
+      ...enabled,
+      steps: [{ ...enabled.steps[0], action: "delay", duration: "5m" }],
+    };
+    const switched = withTriggerType(asDelay, triggerType);
+    const backToSend = {
+      ...switched,
+      steps: [{ ...switched.steps[0], action: "send_message" }],
+    };
+
+    assert.equal(backToSend.steps[0].replyInThread, false, triggerType);
+    assert.doesNotMatch(formStateToYaml(backToSend), /reply_in_thread/);
+  }
+});
+
+test("invalid reply_in_thread values are refused rather than normalized", () => {
+  const original = (yaml) => {
+    const result = yamlToFormState(yaml);
+    assert.equal(result.ok, false);
+    assert.match(result.error, /YAML editor/);
+    return result;
+  };
+
+  // Non-boolean would be silently deleted on serialization.
+  const nonBoolean = `name: Coerced\ntrigger: { on: message_posted }\nsteps: [{ id: s1, action: send_message, text: hi, reply_in_thread: "yes" }]\n`;
+  assert.match(original(nonBoolean).error, /reply_in_thread must be a boolean/);
+
+  // true under an ineligible trigger would round-trip a backend-invalid definition.
+  for (const trigger of ["schedule, cron: '0 9 * * *'", "webhook"]) {
+    const yaml = `name: Ineligible\ntrigger: { on: ${trigger} }\nsteps: [{ id: s1, action: send_message, text: hi, reply_in_thread: true }]\n`;
+    assert.match(
+      original(yaml).error,
+      /reply_in_thread is not supported for (schedule|webhook) triggers/,
+    );
+  }
+});
+
 test("reply_in_thread eligibility follows trigger capability", () => {
   assert.equal(isThreadReplyEligibleTrigger("message_posted"), true);
   assert.equal(isThreadReplyEligibleTrigger("schedule"), false);

--- a/desktop/src/features/workflows/ui/workflowFormTypes.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowFormTypes.test.mjs
@@ -6,6 +6,7 @@ import {
   formStateToYaml,
   supportsMessageTextCondition,
   yamlToFormState,
+  DEFAULT_FORM_STATE,
 } from "./workflowFormTypes.ts";
 
 function accepted(yaml) {
@@ -23,6 +24,22 @@ function normalizeBackendDefaults(value) {
     }
   }
   return copy;
+}
+
+function sendMessageState(overrides) {
+  return {
+    ...DEFAULT_FORM_STATE,
+    name: "Auto Reply",
+    trigger: { on: "message_posted", filter: "trigger_is_reply == false" },
+    steps: [
+      {
+        id: "step_1",
+        action: "send_message",
+        text: "pre-written reply",
+        ...overrides,
+      },
+    ],
+  };
 }
 
 test("message-text conditions are limited to message-bearing triggers", () => {
@@ -195,4 +212,43 @@ test("values the Form serializer would normalize are refused", () => {
   ];
 
   for (const yaml of fixtures) assert.equal(yamlToFormState(yaml).ok, false);
+});
+
+test("reply_in_thread is emitted only when the checkbox is on", () => {
+  const withReply = formStateToYaml(sendMessageState({ replyInThread: true }));
+  assert.match(withReply, /reply_in_thread: true/);
+
+  const withoutReply = formStateToYaml(
+    sendMessageState({ replyInThread: false }),
+  );
+  assert.doesNotMatch(withoutReply, /reply_in_thread/);
+
+  const unset = formStateToYaml(sendMessageState({}));
+  assert.doesNotMatch(unset, /reply_in_thread/);
+});
+
+test("reply_in_thread round-trips YAML -> form -> YAML", () => {
+  const yaml = formStateToYaml(sendMessageState({ replyInThread: true }));
+  const parsed = yamlToFormState(yaml);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.state.steps[0].replyInThread, true);
+
+  const reserialized = formStateToYaml(parsed.state);
+  assert.match(reserialized, /reply_in_thread: true/);
+});
+
+test("absent reply_in_thread parses as false", () => {
+  const yaml = [
+    "name: No Reply",
+    "trigger:",
+    "  on: message_posted",
+    "steps:",
+    "  - id: step_1",
+    "    action: send_message",
+    "    text: hi",
+    "",
+  ].join("\n");
+  const parsed = yamlToFormState(yaml);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.state.steps[0].replyInThread, false);
 });

--- a/desktop/src/features/workflows/ui/workflowFormTypes.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowFormTypes.test.mjs
@@ -4,7 +4,9 @@ import { parse as parseYaml } from "yaml";
 
 import {
   formStateToYaml,
+  isThreadReplyEligibleTrigger,
   supportsMessageTextCondition,
+  withTriggerType,
   yamlToFormState,
   DEFAULT_FORM_STATE,
 } from "./workflowFormTypes.ts";
@@ -227,6 +229,22 @@ test("reply_in_thread is emitted only when the checkbox is on", () => {
   assert.doesNotMatch(unset, /reply_in_thread/);
 });
 
+test("switching from Message Posted clears reply_in_thread before save", () => {
+  const messagePosted = sendMessageState({ replyInThread: true });
+
+  for (const triggerType of ["schedule", "webhook"]) {
+    const switched = withTriggerType(messagePosted, triggerType);
+    assert.equal(switched.trigger.on, triggerType);
+    assert.equal(switched.steps[0].replyInThread, false);
+    assert.doesNotMatch(formStateToYaml(switched), /reply_in_thread/);
+  }
+});
+
+test("reply_in_thread eligibility follows trigger capability", () => {
+  assert.equal(isThreadReplyEligibleTrigger("message_posted"), true);
+  assert.equal(isThreadReplyEligibleTrigger("schedule"), false);
+  assert.equal(isThreadReplyEligibleTrigger("webhook"), false);
+});
 test("reply_in_thread round-trips YAML -> form -> YAML", () => {
   const yaml = formStateToYaml(sendMessageState({ replyInThread: true }));
   const parsed = yamlToFormState(yaml);

--- a/desktop/src/features/workflows/ui/workflowFormTypes.ts
+++ b/desktop/src/features/workflows/ui/workflowFormTypes.ts
@@ -207,12 +207,13 @@ export function withTriggerType(
   return {
     ...state,
     trigger: { on: triggerType },
+    // Clear threaded-reply state on every step, not just send_message ones:
+    // a hidden `replyInThread` on a step whose action was changed away from
+    // send_message would otherwise resurrect when the action is switched back.
     steps: isThreadReplyEligibleTrigger(triggerType)
       ? state.steps
       : state.steps.map((step) =>
-          step.action === "send_message" && step.replyInThread
-            ? { ...step, replyInThread: false }
-            : step,
+          step.replyInThread ? { ...step, replyInThread: false } : step,
         ),
   };
 }
@@ -592,6 +593,21 @@ export function yamlToFormState(
             ok: false,
             error:
               "Webhook header names cannot be empty or have surrounding whitespace in Form mode",
+          };
+        }
+      }
+
+      if (step.reply_in_thread !== undefined) {
+        if (typeof step.reply_in_thread !== "boolean") {
+          return {
+            ok: false,
+            error: `Step ${number} reply_in_thread must be a boolean — use the YAML editor`,
+          };
+        }
+        if (step.reply_in_thread && !isThreadReplyEligibleTrigger(triggerOn)) {
+          return {
+            ok: false,
+            error: `reply_in_thread is not supported for ${triggerOn} triggers — use the YAML editor`,
           };
         }
       }

--- a/desktop/src/features/workflows/ui/workflowFormTypes.ts
+++ b/desktop/src/features/workflows/ui/workflowFormTypes.ts
@@ -196,6 +196,27 @@ function actionFieldsForStep(step: StepFormState): Record<string, unknown> {
   return fields;
 }
 
+export function isThreadReplyEligibleTrigger(trigger: TriggerType): boolean {
+  return trigger !== "webhook" && trigger !== "schedule";
+}
+
+export function withTriggerType(
+  state: WorkflowFormState,
+  triggerType: TriggerType,
+): WorkflowFormState {
+  return {
+    ...state,
+    trigger: { on: triggerType },
+    steps: isThreadReplyEligibleTrigger(triggerType)
+      ? state.steps
+      : state.steps.map((step) =>
+          step.action === "send_message" && step.replyInThread
+            ? { ...step, replyInThread: false }
+            : step,
+        ),
+  };
+}
+
 export function formStateToYaml(state: WorkflowFormState): string {
   const trigger: Record<string, unknown> = { on: state.trigger.on };
   if (
@@ -270,7 +291,12 @@ const TRIGGER_KEYS: Record<TriggerType, ReadonlySet<string>> = {
 const COMMON_STEP_KEYS = ["id", "name", "action", "if", "timeout_secs"];
 const ACTION_STEP_KEYS: Record<ActionType, ReadonlySet<string>> = {
   delay: new Set([...COMMON_STEP_KEYS, "duration"]),
-  send_message: new Set([...COMMON_STEP_KEYS, "text", "channel"]),
+  send_message: new Set([
+    ...COMMON_STEP_KEYS,
+    "text",
+    "channel",
+    "reply_in_thread",
+  ]),
   send_dm: new Set([...COMMON_STEP_KEYS, "to", "text"]),
   call_webhook: new Set([
     ...COMMON_STEP_KEYS,

--- a/desktop/src/features/workflows/ui/workflowFormTypes.ts
+++ b/desktop/src/features/workflows/ui/workflowFormTypes.ts
@@ -69,6 +69,7 @@ export type StepFormState = {
   duration?: string;
   text?: string;
   channel?: string;
+  replyInThread?: boolean;
   to?: string;
   url?: string;
   method?: string;
@@ -165,6 +166,7 @@ function actionFieldsForStep(step: StepFormState): Record<string, unknown> {
     case "send_message":
       if (step.text) fields.text = step.text;
       if (step.channel) fields.channel = step.channel;
+      if (step.replyInThread) fields.reply_in_thread = true;
       break;
     case "send_dm":
       if (step.to) fields.to = step.to;
@@ -579,6 +581,7 @@ export function yamlToFormState(
         duration: step.duration as string | undefined,
         text: step.text as string | undefined,
         channel: step.channel as string | undefined,
+        replyInThread: step.reply_in_thread === true,
         to: step.to as string | undefined,
         url: step.url as string | undefined,
         method: step.method as string | undefined,


### PR DESCRIPTION
The `send_message` workflow action could only post new top-level channel messages. This adds a `reply_in_thread` option so a `message_posted` workflow can reply in the triggering message's thread, plus a `trigger_is_reply` filter variable so a workflow can fire only on top-level messages.

Every NIP-10 thread-marker reader in the tree now routes through one shared parser and one collapse rule in `buzz-core`, deleting four hand-rolled copies that had drifted on id-validity and marker semantics.

## What changed

- **Schema** (`crates/buzz-workflow/src/schema.rs`): new `reply_in_thread: bool` (serde default `false`) on `ActionDef::SendMessage`. `validate()` rejects `reply_in_thread: true` on `schedule`/`webhook` triggers — they carry no message to reply to.
- **Executor** (`crates/buzz-workflow/src/executor.rs`): threads `reply_to: Option<&str>` (the trigger `message_id`) through `ActionSink::send_message` when `reply_in_thread` is set; errors clearly if the trigger has no `message_id`. `resolve_step_templates` carries the new field. Adds `trigger_is_reply` (boolean) to the eval context.
- **Relay sink** (`crates/buzz-relay/src/workflow_sink.rs`): when `reply_to` is set, resolves parent/root/depth from the known trigger event, persists real thread metadata instead of the hardcoded top-level `depth: 0`, and pushes the live kind:39005 thread-summary overlay after insert so subscribed desktops update the root's reply badge without refetching — matching the human ingest path. Emits the same NIP-10 `e`-tag shape as `buzz_sdk::builders::thread_tags`: a single `["e", id, "", "reply"]` tag for a direct reply (parent == root), and the `root` + `reply` pair only when nested — so every writer produces one wire shape per reply kind.
- **Ingest resolver** (`crates/buzz-relay/src/handlers/ingest.rs`): new `resolve_relay_reply_thread_meta` + `ReplyAncestry`. Unlike the client-facing `resolve_nip10_thread_meta` (which validates client-supplied tags), this computes root/depth from the known parent and enforces the same same-channel and depth-limit invariants. When the parent has no `thread_metadata` row, both resolvers share `derive_ancestry_from_parent_tags`, which applies `ThreadMarkers::resolve()`: a marked nested parent remains depth 2, while a root-only, malformed, or unmarked parent is top-level and starts its reply thread at itself. Both the client resolver and the parent-ancestor fallback now read markers via the shared parser instead of hand-scanning `e`-tags.
- **Shared NIP-10 parser** (`crates/buzz-core/src/nip10.rs`): `parse_thread_markers` reads an event's `root`/`reply` markers, honoring a marker only when its event id is exactly 64 ASCII-hex characters. `ThreadMarkers::resolve()` is the single definition of the (root, reply) → (root_id, parent_id) collapse: `root`+`reply` as-is, `reply`-only → `(reply, reply)`, a lone `root` or neither → top-level. A slice-based `parse_thread_markers_from_parts` entry point serves consumers holding raw JSON tag arrays. Relay ingest, the workflow `trigger_is_reply` predicate, ACP anchoring, and the CLI reply resolver all call these, so they cannot drift on marker, id-validity, or collapse semantics.
- **ACP** (`crates/buzz-acp/src/queue.rs`): `parse_thread_tags` delegates marker parsing and collapse to `buzz_core::nip10`, keeping only its local `p`-tag mention collection. This fixes a parity gap with ingest: a malformed non-64-hex marker id is no longer counted as a thread link, and a lone `root` marker is now top-level rather than being treated as root == parent.
- **CLI** (`crates/buzz-cli/src/commands/messages.rs`): `find_root_from_tags` routes its JSON tags through the shared slice parser and collapse rule. CLI replies to root-only, malformed, or unmarked parents now correctly start at that immediate parent; reply-only and root+reply parent ancestry remain intact.
- **Trigger context** (`crates/buzz-workflow/src/lib.rs`): `build_trigger_context` derives `is_reply` solely from a valid NIP-10 `reply` marker (no DB hit). A lone `root` marker is top-level to ingest, so it does not count; neither does a `reply` marker whose event id is malformed, nor a bare/unmarked `e`-tag (mentions, quotes).
- **Desktop** (`workflowFormTypes.ts`, `WorkflowStepCard.tsx`): `replyInThread` form field with YAML round-trip, and a "Reply to triggering message in thread" checkbox shown only for message-based triggers. Switching to `schedule` or `webhook` clears the option on every step before serialization, so a value hidden behind an action change cannot resurrect when the action is switched back. The form parser also requires `reply_in_thread` to be a boolean and refuses `reply_in_thread: true` under an ineligible trigger, falling back to YAML mode rather than silently normalizing a backend-invalid definition.

## Usage

```yaml
trigger:
  on: message_posted
  filter: trigger_is_reply == false
steps:
  - id: auto_reply
    action: send_message
    text: "pre-written reply text"
    reply_in_thread: true
```


