### PR TITLE
fix(pairing): require explicit pairing relay discovery

### DIFF
--- a/crates/buzz-relay/src/nip11.rs
+++ b/crates/buzz-relay/src/nip11.rs
@@ -479,8 +479,7 @@ mod tests {
     fn nip43_not_in_static_supported_nips() {
         // NIP-43 advertisement is conditional on runtime config (stable signing
         // key + membership enforcement) and must NOT live in the static list.
-        // The desktop pairing probe keys off this NIP — advertising it on
-        // open relays misroutes pairing peers to a non-existent /pair sidecar.
+        // Pairing endpoint discovery is independent and uses pairing_relay_url.
         assert!(
             !SUPPORTED_NIPS.contains(&NIP_RELAY_MEMBERSHIP),
             "NIP-43 must be advertised only when advertise_nip43=true is passed to RelayInfo::build"
@@ -508,13 +507,17 @@ mod tests {
         assert!(!info.supported_nips.contains(&NIP_RELAY_MEMBERSHIP));
     }
 
-    /// Membership-enforcing relay: both `self` and NIP-43 advertised.
+    /// Membership enforcement advertises `self` and NIP-43, but does not
+    /// invent a pairing endpoint when none was configured.
     #[test]
-    fn build_membership_relay_advertises_self_and_nip43() {
+    fn build_membership_relay_advertises_nip43_without_inventing_pairing_url() {
         let pk = "0000000000000000000000000000000000000000000000000000000000000001";
         let info = RelayInfo::build(Some(pk), None, true, DEFAULT_MAX_FRAME_BYTES, None);
         assert_eq!(info.relay_self.as_deref(), Some(pk));
         assert!(info.supported_nips.contains(&NIP_RELAY_MEMBERSHIP));
+        assert!(info.pairing_relay_url.is_none());
+        let json = serde_json::to_value(&info).expect("serialize");
+        assert!(json.get("pairing_relay_url").is_none());
     }
 
     /// NIP-43 events are verified against `self`; advertising NIP-43 without

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -209,8 +209,7 @@ extraVolumes: []
 
 # ── Device pairing relay ─────────────────────────────────────────────────────
 # Optional, stateless NIP-AB relay. When enabled, the main relay advertises
-# pairingRelay.url in NIP-11 and Buzz clients use it instead of the legacy
-# same-host /pair convention.
+# pairingRelay.url in NIP-11 and Buzz clients use that explicit endpoint.
 pairingRelay:
   enabled: false
   url: ""

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -8,6 +8,7 @@ BUZZ_IMAGE=ghcr.io/block/buzz:main
 # Public host name. Used by compose.caddy.yml and URL-derived settings below.
 BUZZ_DOMAIN=buzz.example.com
 RELAY_URL=wss://buzz.example.com
+BUZZ_PAIRING_RELAY_URL=wss://buzz.example.com/pair
 BUZZ_MEDIA_BASE_URL=https://buzz.example.com/media
 BUZZ_MEDIA_SERVER_DOMAIN=buzz.example.com
 BUZZ_CORS_ORIGINS=https://buzz.example.com
@@ -36,7 +37,9 @@ BUZZ_S3_BUCKET=buzz-media
 # Bundled MinIO uses path-style URLs; deploy/compose/compose.yml pins this.
 BUZZ_S3_ADDRESSING_STYLE=path
 
-# Optional host ports. Base compose publishes the relay directly on BUZZ_HTTP_PORT.
+# Public gateway bind. Use 127.0.0.1 when a host-level proxy or Cloudflare
+# Tunnel is the only process that should reach the gateway.
+BUZZ_HTTP_BIND_IP=0.0.0.0
 BUZZ_HTTP_PORT=3000
 
 # Caddy host ports. Only used with compose.caddy.yml.

--- a/deploy/compose/Caddyfile
+++ b/deploy/compose/Caddyfile
@@ -1,5 +1,5 @@
 {$BUZZ_DOMAIN} {
-  encode zstd gzip
+	encode zstd gzip
 
-  reverse_proxy relay:3000
+	reverse_proxy gateway:3000
 }

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -26,7 +26,7 @@ keypair.
 ## Production notes
 
 - Requires Docker Compose v2.24.4 or newer; the TLS override uses Compose's
-  `!reset` tag to remove the direct relay port when Caddy terminates HTTPS.
+  `!reset` tag to remove the direct gateway port when Caddy terminates HTTPS.
 - Default `BUZZ_IMAGE` tracks `ghcr.io/block/buzz:main` for early testing. Pin it to `ghcr.io/block/buzz:sha-<7>` or a semver release tag for production once available.
 - Keep `BUZZ_RELAY_PRIVATE_KEY`, `BUZZ_GIT_HOOK_HMAC_SECRET`, database/Redis,
   and S3 secrets stable across restarts.
@@ -43,6 +43,61 @@ keypair.
   `<bucket>.minio`. It is not configurable for an external S3 provider through
   `.env`; use the Helm chart or a custom Compose configuration for providers
   such as new Railway Storage Buckets that require `virtual` addressing.
+
+## Gateway and device pairing
+
+The Compose bundle runs device pairing through Buzz's dedicated, stateless
+`buzz-pair-relay`. Nginx is the single gateway in front of both services:
+
+```text
+public :3000 -> gateway:3000 -> /pair, /pair/* -> pairing-relay:5000
+                              -> everything else -> relay:3000
+```
+
+Only the gateway publishes a host port. The main relay and pairing relay remain
+on the private Compose network, and the pairing relay has no persistent volume,
+database, or identity. Its sessions are ephemeral by design.
+
+NIP-43 advertises relay membership support; it does not advertise a pairing
+endpoint. Keep the explicit public URL in the environment file so the main
+relay publishes it as NIP-11 `pairing_relay_url`:
+
+```dotenv
+BUZZ_PAIRING_RELAY_URL=wss://buzz.example.com/pair
+```
+
+The URL must use `ws://` or `wss://` and include a host. The sample same-host
+`/pair` path is routed by Nginx. A separate pairing hostname can also target the
+gateway when its advertised URL ends in `/pair`; keep external proxies pointed
+at the gateway rather than bypassing it.
+
+### Cloudflare Tunnel
+
+Cloudflare Tunnel can target Nginx directly; Caddy is not required. For a
+host-installed `cloudflared`, bind the gateway to loopback and point the tunnel
+at that port:
+
+```dotenv
+BUZZ_HTTP_BIND_IP=127.0.0.1
+BUZZ_HTTP_PORT=3000
+```
+
+```yaml
+ingress:
+  - hostname: buzz.example.com
+    service: http://127.0.0.1:3000
+  - service: http_status:404
+```
+
+Keep `RELAY_URL=wss://buzz.example.com` and
+`BUZZ_PAIRING_RELAY_URL=wss://buzz.example.com/pair`; Cloudflare terminates TLS
+while Nginx routes both WebSocket upgrades. If `cloudflared` runs as a container
+attached to `buzz-net`, target `http://gateway:3000` instead. Do not target
+`relay:3000`, because that bypasses `/pair` routing.
+
+The optional Caddy overlay follows the same architecture: it removes the
+gateway's host port and proxies all traffic to `gateway:3000`, leaving Nginx as
+the only component that decides between the main and pairing relays.
 
 Run `./run.sh backup-hint` for the backup checklist.
 

--- a/deploy/compose/compose.caddy.yml
+++ b/deploy/compose/compose.caddy.yml
@@ -1,11 +1,11 @@
 services:
-  relay:
+  gateway:
     ports: !reset []
 
   caddy:
     image: caddy:2-alpine
     depends_on:
-      relay:
+      gateway:
         condition: service_healthy
     environment:
       BUZZ_DOMAIN: ${BUZZ_DOMAIN:?set BUZZ_DOMAIN}

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -20,8 +20,6 @@ services:
       BUZZ_GIT_REPO_PATH: /data/git
       BUZZ_AUTO_MIGRATE: ${BUZZ_AUTO_MIGRATE:-false}
       BUZZ_GIT_CONFORMANCE_PROBE: ${BUZZ_GIT_CONFORMANCE_PROBE:-true}
-    ports:
-      - "${BUZZ_HTTP_PORT:-3000}:3000"
     volumes:
       - buzz-git-data:/data/git
     depends_on:
@@ -44,6 +42,43 @@ services:
       timeout: 3s
       retries: 12
       start_period: 30s
+    restart: unless-stopped
+    networks:
+      - buzz-net
+
+  pairing-relay:
+    image: ${BUZZ_IMAGE:-ghcr.io/block/buzz:main}
+    entrypoint: ["/usr/local/bin/buzz-pair-relay"]
+    environment:
+      BUZZ_PAIR_RELAY_BIND_ADDR: 0.0.0.0:5000
+    # The pairing relay is intentionally stateless: no identity, database, or volume.
+    healthcheck:
+      test: ["CMD-SHELL", "bash -ec 'exec 3<>/dev/tcp/127.0.0.1/5000'"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+      - buzz-net
+
+  gateway:
+    image: nginx:1.29-alpine
+    depends_on:
+      relay:
+        condition: service_healthy
+      pairing-relay:
+        condition: service_healthy
+    ports:
+      - "${BUZZ_HTTP_BIND_IP:-0.0.0.0}:${BUZZ_HTTP_PORT:-3000}:3000"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
     restart: unless-stopped
     networks:
       - buzz-net

--- a/deploy/compose/nginx.conf
+++ b/deploy/compose/nginx.conf
@@ -1,0 +1,70 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        "" close;
+    }
+
+    map $http_x_forwarded_proto $forwarded_proto {
+        default $http_x_forwarded_proto;
+        "" $scheme;
+    }
+
+    upstream buzz_relay {
+        server relay:3000;
+    }
+
+    upstream buzz_pairing_relay {
+        server pairing-relay:5000;
+    }
+
+    server {
+        listen 3000;
+        server_name _;
+
+        # Let the relay enforce its own media and WebSocket frame limits.
+        client_max_body_size 0;
+
+        location = /pair {
+            proxy_pass http://buzz_pairing_relay;
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
+            proxy_buffering off;
+            proxy_read_timeout 1h;
+        }
+
+        location ^~ /pair/ {
+            proxy_pass http://buzz_pairing_relay;
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
+            proxy_buffering off;
+            proxy_read_timeout 1h;
+        }
+
+        location / {
+            proxy_pass http://buzz_relay;
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
+            proxy_buffering off;
+            proxy_request_buffering off;
+            proxy_read_timeout 1h;
+        }
+    }
+}

--- a/deploy/compose/run.sh
+++ b/deploy/compose/run.sh
@@ -60,7 +60,7 @@ case "${1:-help}" in
     ;;
   restart)
     require_env
-    compose up -d --wait --force-recreate relay
+    compose up -d --wait --force-recreate relay pairing-relay gateway
     ;;
   pull)
     require_env
@@ -102,7 +102,7 @@ Usage: ./run.sh <command>
 Commands:
   start         Start Buzz with docker compose up -d --wait
   stop          Stop containers without deleting volumes
-  restart       Recreate the relay after env/image changes
+  restart       Recreate the relay, pairing relay, and gateway after changes
   pull          Pull configured images
   upgrade       Pull and restart, then print backup reminders
   logs [svc]    Follow logs (default: relay)

--- a/desktop/src-tauri/src/commands/pairing.rs
+++ b/desktop/src-tauri/src/commands/pairing.rs
@@ -129,7 +129,7 @@ async fn start_pairing_session(
 
     let ws_url = relay_ws_url_with_override(&state);
     let http_url = relay_api_base_url_with_override(&state);
-    let pairing_relay_url = resolve_pairing_relay_url(&ws_url, probe_pairing_relay(&ws_url).await)?;
+    let pairing_relay_url = resolve_pairing_relay_url(&ws_url, probe_pairing_relay(&ws_url).await?);
     let (session, qr_payload) = PairingSession::new_source(pairing_relay_url.clone());
     let mut qr_uri = encode_qr(&qr_payload);
     if mode == PairingMode::RecoverIdentity {
@@ -667,20 +667,19 @@ fn parse_relay_event(text: &str, sub_id: &str) -> Option<nostr::Event> {
 #[derive(Debug, PartialEq, Eq)]
 enum PairingRelay {
     Configured(String),
-    LegacyPath,
     MainRelay,
 }
 
-/// Prefer the relay-advertised dedicated pairing URL. The legacy `/pair`
-/// convention remains as a compatibility fallback for NIP-43 relays that do
-/// not advertise the extension yet.
-async fn probe_pairing_relay(relay_url: &str) -> PairingRelay {
+/// Prefer the relay-advertised dedicated pairing URL. NIP-43 advertises relay
+/// membership support and does not imply that a `/pair` WebSocket endpoint is
+/// available on the main relay.
+async fn probe_pairing_relay(relay_url: &str) -> Result<PairingRelay, String> {
     let http_url = if let Some(rest) = relay_url.strip_prefix("wss://") {
         format!("https://{rest}")
     } else if let Some(rest) = relay_url.strip_prefix("ws://") {
         format!("http://{rest}")
     } else {
-        return PairingRelay::MainRelay;
+        return Ok(PairingRelay::MainRelay);
     };
 
     let client = reqwest::Client::builder()
@@ -695,44 +694,48 @@ async fn probe_pairing_relay(relay_url: &str) -> PairingRelay {
         .await
     {
         Ok(response) => response,
-        Err(_) => return PairingRelay::MainRelay,
+        Err(_) => return Ok(PairingRelay::MainRelay),
     };
 
     let json: serde_json::Value = match resp.json().await {
         Ok(value) => value,
-        Err(_) => return PairingRelay::MainRelay,
+        Err(_) => return Ok(PairingRelay::MainRelay),
     };
 
     pairing_relay_from_nip11(&json)
 }
 
-fn resolve_pairing_relay_url(
-    main_relay_url: &str,
-    pairing_relay: PairingRelay,
-) -> Result<String, String> {
+fn resolve_pairing_relay_url(main_relay_url: &str, pairing_relay: PairingRelay) -> String {
     match pairing_relay {
-        PairingRelay::Configured(url) => Ok(url),
-        PairingRelay::LegacyPath => {
-            let mut url =
-                url::Url::parse(main_relay_url).map_err(|e| format!("invalid relay URL: {e}"))?;
-            let path = url.path().trim_end_matches('/').to_string();
-            url.set_path(&format!("{path}/pair"));
-            Ok(url.to_string())
-        }
-        PairingRelay::MainRelay => Ok(main_relay_url.to_string()),
+        PairingRelay::Configured(url) => url,
+        PairingRelay::MainRelay => main_relay_url.to_string(),
     }
 }
 
-fn pairing_relay_from_nip11(json: &serde_json::Value) -> PairingRelay {
-    if let Some(value) = json
-        .get("pairing_relay_url")
-        .and_then(|value| value.as_str())
-    {
-        if let Ok(url) = url::Url::parse(value) {
-            if matches!(url.scheme(), "ws" | "wss") && url.host_str().is_some() {
-                return PairingRelay::Configured(value.to_string());
-            }
+fn pairing_relay_from_nip11(json: &serde_json::Value) -> Result<PairingRelay, String> {
+    if let Some(configured_value) = json.get("pairing_relay_url") {
+        let value = configured_value.as_str().ok_or_else(|| {
+            "Relay pairing configuration is invalid: NIP-11 pairing_relay_url must be a valid \
+             ws:// or wss:// URL with a host. Configure the stateless buzz-pair-relay through \
+             BUZZ_PAIRING_RELAY_URL."
+                .to_string()
+        })?;
+        let url = url::Url::parse(value).map_err(|error| {
+            format!(
+                "Relay pairing configuration is invalid: NIP-11 pairing_relay_url must be a \
+                 valid ws:// or wss:// URL with a host ({error}). Configure the stateless \
+                 buzz-pair-relay through BUZZ_PAIRING_RELAY_URL."
+            )
+        })?;
+        if !matches!(url.scheme(), "ws" | "wss") || url.host_str().is_none() {
+            return Err(
+                "Relay pairing configuration is invalid: NIP-11 pairing_relay_url must be a \
+                 valid ws:// or wss:// URL with a host. Configure the stateless \
+                 buzz-pair-relay through BUZZ_PAIRING_RELAY_URL."
+                    .to_string(),
+            );
         }
+        return Ok(PairingRelay::Configured(value.to_string()));
     }
 
     if json
@@ -740,9 +743,14 @@ fn pairing_relay_from_nip11(json: &serde_json::Value) -> PairingRelay {
         .and_then(|value| value.as_array())
         .is_some_and(|nips| nips.iter().any(|nip| nip.as_u64() == Some(43)))
     {
-        PairingRelay::LegacyPath
+        Err(
+            "Pairing is not configured for this membership-gated relay. Configure the \
+             stateless buzz-pair-relay through BUZZ_PAIRING_RELAY_URL so NIP-11 advertises \
+             pairing_relay_url."
+                .to_string(),
+        )
     } else {
-        PairingRelay::MainRelay
+        Ok(PairingRelay::MainRelay)
     }
 }
 

--- a/desktop/src-tauri/src/commands/pairing_relay_tests.rs
+++ b/desktop/src-tauri/src/commands/pairing_relay_tests.rs
@@ -3,8 +3,9 @@ use super::{
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-#[tokio::test]
-async fn live_nip11_probe_discovers_configured_pairing_relay() {
+async fn serve_nip11_document(
+    body: &'static str,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind test NIP-11 server");
@@ -19,55 +20,82 @@ async fn live_nip11_probe_discovers_configured_pairing_relay() {
             .to_ascii_lowercase()
             .contains("accept: application/nostr+json"));
 
-        let body = r#"{"pairing_relay_url":"ws://127.0.0.1:5000"}"#;
         let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/nostr+json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-                body.len()
-            );
+            "HTTP/1.1 200 OK\r\nContent-Type: application/nostr+json\r\nContent-Length: \
+             {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
         stream
             .write_all(response.as_bytes())
             .await
             .expect("write response");
     });
+    (addr, server)
+}
+
+#[tokio::test]
+async fn live_nip11_probe_discovers_configured_pairing_relay() {
+    let (addr, server) =
+        serve_nip11_document(r#"{"pairing_relay_url":"ws://127.0.0.1:5000"}"#).await;
 
     assert_eq!(
-        probe_pairing_relay(&format!("ws://{addr}")).await,
+        probe_pairing_relay(&format!("ws://{addr}"))
+            .await
+            .expect("discover configured pairing relay"),
         PairingRelay::Configured("ws://127.0.0.1:5000".to_string())
     );
     server.await.expect("NIP-11 server task");
 }
 
+#[tokio::test]
+async fn live_nip11_probe_rejects_membership_relay_without_pairing_url() {
+    let (addr, server) = serve_nip11_document(r#"{"supported_nips":[1,11,43]}"#).await;
+
+    let error = probe_pairing_relay(&format!("ws://{addr}"))
+        .await
+        .expect_err("NIP-43 alone must not invent a /pair endpoint");
+    assert!(error.contains("membership-gated relay"));
+    assert!(error.contains("buzz-pair-relay"));
+    assert!(error.contains("BUZZ_PAIRING_RELAY_URL"));
+    server.await.expect("NIP-11 server task");
+}
+
 #[test]
-fn configured_pairing_relay_takes_precedence_over_legacy_path() {
+fn configured_pairing_relay_takes_precedence_over_nip43_membership() {
     let document = serde_json::json!({
         "pairing_relay_url": "wss://pairing.buzz.xyz",
         "supported_nips": [43]
     });
 
     assert_eq!(
-        pairing_relay_from_nip11(&document),
+        pairing_relay_from_nip11(&document).expect("valid pairing relay configuration"),
         PairingRelay::Configured("wss://pairing.buzz.xyz".to_string())
     );
 }
 
 #[test]
-fn invalid_pairing_relay_url_falls_back_to_legacy_path() {
-    let document = serde_json::json!({
-        "pairing_relay_url": "https://pairing.buzz.xyz",
-        "supported_nips": [43]
-    });
+fn invalid_pairing_relay_url_returns_actionable_configuration_error() {
+    for value in ["https://pairing.buzz.xyz", "ws://"] {
+        let document = serde_json::json!({
+            "pairing_relay_url": value,
+            "supported_nips": [43]
+        });
 
-    assert_eq!(
-        pairing_relay_from_nip11(&document),
-        PairingRelay::LegacyPath
-    );
+        let error = pairing_relay_from_nip11(&document)
+            .expect_err("invalid explicit pairing URL must be rejected");
+        assert!(error.contains("valid ws:// or wss:// URL with a host"));
+        assert!(error.contains("BUZZ_PAIRING_RELAY_URL"));
+    }
 }
 
 #[test]
 fn document_without_pairing_configuration_uses_main_relay() {
     let document = serde_json::json!({ "supported_nips": [1, 11] });
 
-    assert_eq!(pairing_relay_from_nip11(&document), PairingRelay::MainRelay);
+    assert_eq!(
+        pairing_relay_from_nip11(&document).expect("non-NIP-43 main relay fallback"),
+        PairingRelay::MainRelay
+    );
 }
 
 #[test]
@@ -75,21 +103,21 @@ fn configured_pairing_relay_resolves_to_configured_url() {
     let resolved = resolve_pairing_relay_url(
         "wss://flint.communities.buzz.xyz",
         PairingRelay::Configured("wss://pairing.buzz.xyz".to_string()),
-    )
-    .expect("resolve configured pairing relay");
+    );
 
     assert_eq!(resolved, "wss://pairing.buzz.xyz");
 }
 
 #[test]
-fn legacy_pairing_relay_appends_pair_path() {
-    let resolved = resolve_pairing_relay_url(
-        "wss://flint.communities.buzz.xyz/community",
-        PairingRelay::LegacyPath,
-    )
-    .expect("resolve legacy pairing relay");
+fn same_host_pair_path_is_preserved_when_explicitly_advertised() {
+    let document = serde_json::json!({
+        "pairing_relay_url": "wss://flint.communities.buzz.xyz/pair",
+        "supported_nips": [43]
+    });
+    let discovered = pairing_relay_from_nip11(&document).expect("explicit same-host pairing relay");
+    let resolved = resolve_pairing_relay_url("wss://flint.communities.buzz.xyz", discovered);
 
-    assert_eq!(resolved, "wss://flint.communities.buzz.xyz/community/pair");
+    assert_eq!(resolved, "wss://flint.communities.buzz.xyz/pair");
 }
 
 #[test]
@@ -97,8 +125,7 @@ fn main_relay_pairing_uses_main_relay_url() {
     let resolved = resolve_pairing_relay_url(
         "wss://sprout-oss.stage.blox.sqprod.co",
         PairingRelay::MainRelay,
-    )
-    .expect("resolve main pairing relay");
+    );
 
     assert_eq!(resolved, "wss://sprout-oss.stage.blox.sqprod.co");
 }


### PR DESCRIPTION
## Summary

Fix Desktop pairing discovery so NIP-43 is treated as relay membership support,
not proof that a legacy same-host `/pair` WebSocket endpoint exists.

Desktop now prefers an explicitly advertised, valid `pairing_relay_url`. It
returns an actionable configuration error before opening a WebSocket when that
field is invalid, or when a membership-gated NIP-43 relay does not advertise
one. Non-NIP-43 relays retain their existing main-relay pairing behavior, and a
same-host `/pair` endpoint remains supported when explicitly advertised.

Production Compose now includes the existing stateless `buzz-pair-relay`
binary and an Nginx gateway. The gateway is the only service publishing host
port 3000: `/pair` traffic goes to the pairing relay and all other traffic goes
to the main relay. The optional Caddy overlay proxies through the gateway, and
the documentation includes direct Cloudflare Tunnel routing.

### Related issue

Fixes #2734.

Related open work found before opening this PR: #2736 and #5715 add Compose
pairing sidecars but retain the incorrect NIP-43-to-`/pair` client fallback;
#3424 covers chart routing only. This PR includes the Desktop discovery fix,
regression coverage, and the Compose gateway architecture together.

### Problem and root cause

A membership-gated relay correctly advertises NIP-43 in its NIP-11 document.
Desktop interpreted `supported_nips: [43]` as endpoint discovery, derived
`wss://<relay>/pair`, and attempted to connect. NIP-43 describes relay
membership support and says nothing about a pairing endpoint. Production
Compose exposed only the main relay on port 3000, so the invented endpoint
returned HTTP 404.

### Reproduction

1. Set `BUZZ_REQUIRE_RELAY_MEMBERSHIP=true`.
2. Set a valid `RELAY_OWNER_PUBKEY`.
3. Leave `BUZZ_PAIRING_RELAY_URL` unset.
4. Confirm NIP-11 advertises NIP-43.
5. Open Buzz Desktop → Settings → Mobile.
6. Observe the old client deriving `/pair` and receiving HTTP 404 Not Found.

### Before and after

- Before: any NIP-43 relay without `pairing_relay_url` was treated as if
  `<relay>/pair` existed.
- After: NIP-43 without an explicit pairing URL fails before WebSocket setup
  with guidance to configure the stateless sidecar through
  `BUZZ_PAIRING_RELAY_URL`.
- Before: an invalid explicit pairing URL was ignored and could fall through
  to legacy behavior.
- After: only `ws://` or `wss://` URLs with a host are accepted; invalid values
  return an actionable configuration error.
- Unchanged: relays that do not advertise NIP-43 continue pairing against the
  main relay.
- Unchanged: legacy same-host `/pair` remains usable when it is explicitly
  advertised as `pairing_relay_url`.

### Security and deployment implications

- Discovery fails closed before session creation or WebSocket connection for
  invalid/missing membership-gated pairing configuration.
- Nginx is the single public Compose gateway. The main relay and pairing relay
  have no host ports when the gateway is enabled.
- `BUZZ_HTTP_BIND_IP=127.0.0.1` binds public port 3000 to loopback for a
  host-installed Cloudflare Tunnel or proxy.
- Cloudflare Tunnel can target the gateway directly; Caddy is not required.
  Optional Caddy support routes through the gateway instead of duplicating
  `/pair` behavior.
- `buzz-pair-relay` remains anonymous and ephemeral: it has no identity,
  database, or persistent volume.
- No persistent data or identities are changed or migrated.
- No secret `.env`, `.env.backup*`, backup Compose file, volume contents,
  identity key, or private-host configuration is included. The only environment
  file changed is the public `.env.example`, with
  `BUZZ_PAIRING_RELAY_URL=wss://buzz.example.com/pair`.

### Testing

All commands below ran with the repository Hermit environment activated.

| Command | Result |
| --- | --- |
| `. ./bin/activate-hermit` | Passed; Hermit environment activated (exit 0) |
| `just desktop-tauri-fmt` | Passed (exit 0) |
| `cargo fmt --all` | Passed (exit 0) |
| `just desktop-tauri-fmt-check` | Passed (exit 0) |
| `cargo fmt --all -- --check` | Passed (exit 0) |
| `git diff --check` | Passed, no whitespace errors (exit 0) |
| `just _ensure-sidecar-stubs` | Passed (exit 0) |
| `cargo test --manifest-path desktop/src-tauri/Cargo.toml -p buzz-desktop pairing_relay_tests` | Passed: 8 passed, 0 failed |
| `cargo test -p buzz-relay nip11::tests` | Passed: 15 passed, 0 failed |
| `just desktop-tauri-clippy` | Passed with warnings denied (exit 0) |
| `cargo clippy -p buzz-relay --all-targets -- -D warnings` | Passed (exit 0) |
| `bash -n deploy/compose/run.sh` | Passed (exit 0) |
| `just ci` | Passed end to end (exit 0), including 2,512 Desktop Tauri tests with 17 expected ignores and 1,465 Flutter tests |

Deployment configuration validation:

- Docker Compose v5.5.0 standalone `config --format json` passed for the base
  configuration using an isolated copy of the public sample config and
  `BUZZ_HTTP_BIND_IP=127.0.0.1`. Assertions confirmed that only the gateway
  publishes `127.0.0.1:3000`, the relay and pairing relay publish no host ports,
  and the pairing relay has no volumes.
- The optional Caddy Compose overlay rendered successfully. Assertions
  confirmed that it resets the gateway host port and waits for the healthy
  gateway.
- `BUZZ_DOMAIN=buzz.example.com caddy validate --config deploy/compose/Caddyfile --adapter caddyfile`
  passed with Caddy v2.11.4, and
  the Caddyfile is canonically formatted.
- `nginx -t -c <temporary-config>` passed with Nginx 1.19.4. The temporary
  config changed only the Compose-DNS upstream names to loopback so local Nginx
  could resolve them; the committed config retains `relay:3000` and
  `pairing-relay:5000`.
- A Docker daemon/CLI was not installed on this machine, so container startup
  and a live cross-container WebSocket handshake were not exercised locally.

Screenshots are not applicable; the Desktop change is pairing endpoint
selection and error handling, and the deployment change is proxy routing.
