### PR TITLE
fix(acp): expose Cursor non-fast model variants

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -408,7 +408,12 @@ fn build_client_capabilities() -> serde_json::Value {
             // Non-standard extension used by claude-agent-acp to advertise the
             // exact terminal login argv for subscription auth. Unknown `_meta`
             // keys are ignored by other adapters.
-            "terminal-auth": true
+            "terminal-auth": true,
+            // Cursor otherwise collapses model parameters into a single
+            // variant ID and only advertises its fast=true default. Buzz
+            // understands the separate model + fast config options and
+            // composes them back into one persisted model selection.
+            "parameterizedModelPicker": true
         }
     })
 }
@@ -646,8 +651,8 @@ impl AcpClient {
     /// member from a null one. When both `ClaudeMeta` and `session_title` are
     /// present the two `_meta` members are merged into a single object.
     ///
-    /// Callers use [`extract_model_config_options`] and [`extract_model_state`]
-    /// to pull model info from the raw result.
+    /// Callers use [`extract_model_picker_config_options`] and
+    /// [`extract_model_state`] to pull model info from the raw result.
     pub async fn session_new_full(
         &mut self,
         cwd: &str,
@@ -2158,21 +2163,76 @@ pub enum ModelSwitchMethod {
     SetModel { model_id: String },
 }
 
-/// Extract `configOptions` entries with `category == "model"` from a `session/new` result.
+/// A model change plus any parameter config options encoded in its persisted ID.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelSwitchPlan {
+    /// The ACP method used to select the base model.
+    pub model: ModelSwitchMethod,
+    /// Additional `session/set_config_option` values applied after the model.
+    pub parameters: Vec<(String, String)>,
+}
+
+fn config_option_id(option: &serde_json::Value) -> Option<&str> {
+    option
+        .get("configId")
+        .or_else(|| option.get("id"))
+        .and_then(|value| value.as_str())
+}
+
+fn is_fast_config_option(option: &serde_json::Value) -> bool {
+    config_option_id(option) == Some("fast")
+}
+
+/// Extract base-model `configOptions` entries from a `session/new` result.
 ///
 /// Returns the raw JSON array entries. Each entry has `configId` (spelled `id`
 /// by some adapters, e.g. claude-agent-acp), `displayName`,
-/// `options: [{ value, displayName }]`, etc.
+/// `options: [{ value, displayName }]`, etc. Cursor's separate `fast` model
+/// parameter is excluded; use [`extract_model_picker_config_options`] when the
+/// caller needs to reconstruct full model choices.
 pub fn extract_model_config_options(result: &serde_json::Value) -> Vec<serde_json::Value> {
     result["configOptions"]
         .as_array()
         .map(|arr| {
             arr.iter()
-                .filter(|opt| opt.get("category").and_then(|c| c.as_str()) == Some("model"))
+                .filter(|opt| {
+                    opt.get("category").and_then(|c| c.as_str()) == Some("model")
+                        && !is_fast_config_option(opt)
+                })
                 .cloned()
                 .collect()
         })
         .unwrap_or_default()
+}
+
+/// Extract the model selector and the Cursor `fast` parameter needed to
+/// reconstruct a complete persisted model choice during discovery.
+pub fn extract_model_picker_config_options(result: &serde_json::Value) -> Vec<serde_json::Value> {
+    result["configOptions"]
+        .as_array()
+        .map(|options| {
+            options
+                .iter()
+                .filter(|option| {
+                    option.get("category").and_then(|value| value.as_str()) == Some("model")
+                        || is_fast_config_option(option)
+                })
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_fast_model_variant(desired_model: &str) -> (&str, Option<&str>) {
+    for value in ["false", "true"] {
+        let suffix = format!("[fast={value}]");
+        if let Some(model) = desired_model.strip_suffix(&suffix) {
+            if !model.is_empty() {
+                return (model, Some(value));
+            }
+        }
+    }
+    (desired_model, None)
 }
 
 /// Extract `SessionModelState` (unstable path) from a `session/new` result.
@@ -2235,6 +2295,38 @@ pub fn resolve_model_switch_method(
     None
 }
 
+/// Resolve a persisted model ID into the model switch and optional Cursor fast
+/// parameter update required by a parameterized model picker.
+pub fn resolve_model_switch_plan(
+    session_new_result: &serde_json::Value,
+    desired_model: &str,
+) -> Option<ModelSwitchPlan> {
+    let (model_id, fast_value) = parse_fast_model_variant(desired_model);
+    let model = resolve_model_switch_method(session_new_result, model_id)?;
+    let mut parameters = Vec::new();
+
+    if let Some(value) = fast_value {
+        let fast_option = session_new_result["configOptions"]
+            .as_array()?
+            .iter()
+            .find(|option| is_fast_config_option(option))?;
+        let supported = fast_option
+            .get("options")
+            .and_then(|options| options.as_array())
+            .is_some_and(|options| {
+                options.iter().any(|option| {
+                    option.get("value").and_then(|value| value.as_str()) == Some(value)
+                })
+            });
+        if !supported {
+            return None;
+        }
+        parameters.push(("fast".to_string(), value.to_string()));
+    }
+
+    Some(ModelSwitchPlan { model, parameters })
+}
+
 /// Whether `desired_model` appears in pre-extracted catalog halves.
 ///
 /// Mirrors [`resolve_model_switch_method`]'s match, but operates on the
@@ -2246,17 +2338,35 @@ pub fn model_in_catalog(
     available_models: Option<&serde_json::Value>,
     desired_model: &str,
 ) -> bool {
+    let (model_id, fast_value) = parse_fast_model_variant(desired_model);
     let in_config_options = config_options.iter().any(|config_opt| {
+        if is_fast_config_option(config_opt) {
+            return false;
+        }
         config_opt
             .get("options")
             .and_then(|v| v.as_array())
             .is_some_and(|options| {
                 options
                     .iter()
-                    .any(|opt| opt.get("value").and_then(|v| v.as_str()) == Some(desired_model))
+                    .any(|opt| opt.get("value").and_then(|v| v.as_str()) == Some(model_id))
             })
     });
-    if in_config_options {
+    let fast_supported = fast_value.is_none_or(|desired_fast| {
+        config_options.iter().any(|config_opt| {
+            is_fast_config_option(config_opt)
+                && config_opt
+                    .get("options")
+                    .and_then(|value| value.as_array())
+                    .is_some_and(|options| {
+                        options.iter().any(|option| {
+                            option.get("value").and_then(|value| value.as_str())
+                                == Some(desired_fast)
+                        })
+                    })
+        })
+    });
+    if in_config_options && fast_supported {
         return true;
     }
 
@@ -2266,8 +2376,9 @@ pub fn model_in_catalog(
         .is_some_and(|available| {
             available
                 .iter()
-                .any(|model| model.get("modelId").and_then(|v| v.as_str()) == Some(desired_model))
+                .any(|model| model.get("modelId").and_then(|v| v.as_str()) == Some(model_id))
         })
+        && fast_supported
 }
 
 // ─── Drop: kill child process ─────────────────────────────────────────────────
@@ -2497,6 +2608,11 @@ mod tests {
             Some(true),
             "goose customNotifications capability must be advertised"
         );
+        assert_eq!(
+            msg["params"]["clientCapabilities"]["_meta"]["parameterizedModelPicker"].as_bool(),
+            Some(true),
+            "parameterized model picker support must be advertised so Cursor exposes fast=false"
+        );
     }
 
     #[test]
@@ -2713,6 +2829,36 @@ mod tests {
     }
 
     #[test]
+    fn extract_model_picker_config_options_includes_cursor_fast_parameter() {
+        let result = serde_json::json!({
+            "configOptions": [
+                {
+                    "id": "model",
+                    "category": "model",
+                    "options": [{ "value": "grok-4.6" }]
+                },
+                {
+                    "id": "fast",
+                    "options": [
+                        { "value": "false" },
+                        { "value": "true" }
+                    ]
+                },
+                {
+                    "id": "theme",
+                    "category": "appearance",
+                    "options": [{ "value": "dark" }]
+                }
+            ]
+        });
+
+        let options = super::extract_model_picker_config_options(&result);
+        assert_eq!(options.len(), 2);
+        assert_eq!(options[0]["id"].as_str(), Some("model"));
+        assert_eq!(options[1]["id"].as_str(), Some("fast"));
+    }
+
+    #[test]
     fn extract_model_config_options_empty_when_no_config_options() {
         let result = serde_json::json!({ "sessionId": "sess-1" });
         assert!(super::extract_model_config_options(&result).is_empty());
@@ -2877,6 +3023,61 @@ mod tests {
         );
     }
 
+    #[test]
+    fn resolve_parameterized_fast_variant_builds_ordered_switch_plan() {
+        let result = serde_json::json!({
+            "configOptions": [
+                {
+                    "id": "model",
+                    "category": "model",
+                    "options": [{ "value": "grok-4.6" }]
+                },
+                {
+                    "id": "fast",
+                    "category": "model",
+                    "options": [
+                        { "value": "false" },
+                        { "value": "true" }
+                    ]
+                }
+            ]
+        });
+
+        let plan = super::resolve_model_switch_plan(&result, "grok-4.6[fast=false]")
+            .expect("parameterized model should resolve");
+
+        assert_eq!(
+            plan,
+            super::ModelSwitchPlan {
+                model: super::ModelSwitchMethod::ConfigOption {
+                    config_id: "model".to_string(),
+                    option_value: "grok-4.6".to_string(),
+                },
+                parameters: vec![("fast".to_string(), "false".to_string())],
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_parameterized_fast_variant_rejects_unadvertised_value() {
+        let result = serde_json::json!({
+            "configOptions": [
+                {
+                    "id": "model",
+                    "category": "model",
+                    "options": [{ "value": "grok-4.6" }]
+                },
+                {
+                    "id": "fast",
+                    "category": "model",
+                    "options": [{ "value": "true" }]
+                }
+            ]
+        });
+
+        assert!(super::resolve_model_switch_plan(&result, "grok-4.6[fast=false]").is_none());
+    }
+
     // ── model_in_catalog tests ────────────────────────────────────────────
 
     #[test]
@@ -2927,6 +3128,31 @@ mod tests {
     #[test]
     fn model_in_catalog_false_when_both_halves_empty() {
         assert!(!super::model_in_catalog(&[], None, "anything"));
+    }
+
+    #[test]
+    fn model_in_catalog_accepts_parameterized_fast_variant() {
+        let config_options = vec![
+            serde_json::json!({
+                "id": "model",
+                "category": "model",
+                "options": [{ "value": "grok-4.6" }]
+            }),
+            serde_json::json!({
+                "id": "fast",
+                "category": "model",
+                "options": [
+                    { "value": "false" },
+                    { "value": "true" }
+                ]
+            }),
+        ];
+
+        assert!(super::model_in_catalog(
+            &config_options,
+            None,
+            "grok-4.6[fast=false]"
+        ));
     }
 
     // ── Error variant display ─────────────────────────────────────────────

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4984,7 +4984,7 @@ async fn run_authenticate(args: AuthenticateArgs) -> Result<()> {
 /// Flow: spawn → initialize → session/new → print models → shutdown.
 /// No relay connection, no MCP servers, no subscriptions. ~2-5s total.
 async fn run_models(args: ModelsArgs) -> Result<()> {
-    use acp::{extract_model_config_options, extract_model_state};
+    use acp::{extract_model_picker_config_options, extract_model_state};
 
     let agent_args = config::normalize_agent_args(&args.agent.agent_command, args.agent.agent_args);
     let cwd = std::env::current_dir()
@@ -5041,7 +5041,7 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
         .unwrap_or("unknown");
 
     // Extract model info from session/new response.
-    let config_options = extract_model_config_options(&session_resp.raw);
+    let config_options = extract_model_picker_config_options(&session_resp.raw);
     let model_state = extract_model_state(&session_resp.raw);
 
     if args.json {

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -30,9 +30,9 @@ use tokio::time::timeout;
 use uuid::Uuid;
 
 use crate::acp::{
-    extract_model_config_options, extract_model_state, model_in_catalog,
-    resolve_model_switch_method, AcpClient, AcpError, EnvVar, McpServer, ModelSwitchMethod,
-    StopReason, SystemPromptTransport,
+    extract_model_picker_config_options, extract_model_state, model_in_catalog,
+    resolve_model_switch_plan, AcpClient, AcpError, EnvVar, McpServer, ModelSwitchMethod,
+    ModelSwitchPlan, StopReason, SystemPromptTransport,
 };
 use crate::config::{compose_session_title, DedupMode, PermissionMode};
 use crate::observer;
@@ -84,7 +84,7 @@ pub struct TaskMeta {
 /// Fields are read by the desktop's `get_agent_models` Tauri command (Phase 3).
 #[allow(dead_code)] // Scaffolding for desktop integration — fields read via serde.
 pub struct AgentModelCapabilities {
-    /// Stable: configOptions with category "model" from session/new.
+    /// Stable: model-picker configOptions from session/new, including parameters.
     pub config_options_raw: Vec<serde_json::Value>,
     /// Unstable: SessionModelState from session/new.
     pub available_models_raw: Option<serde_json::Value>,
@@ -1042,7 +1042,7 @@ async fn create_session_and_apply_model(
     // Populate model capabilities on first session creation.
     if agent.model_capabilities.is_none() {
         agent.model_capabilities = Some(AgentModelCapabilities {
-            config_options_raw: extract_model_config_options(&resp.raw),
+            config_options_raw: extract_model_picker_config_options(&resp.raw),
             available_models_raw: extract_model_state(&resp.raw),
         });
     }
@@ -1051,9 +1051,9 @@ async fn create_session_and_apply_model(
     // Track whether the switch succeeded so session_config_captured reflects
     // the post-switch state (not the pre-switch desired state).
     let switch_succeeded = if let Some(ref desired) = agent.desired_model {
-        match resolve_model_switch_method(&resp.raw, desired) {
-            Some(method) => {
-                apply_model_switch(&mut agent.acp, &resp.session_id, desired, &method).await?;
+        match resolve_model_switch_plan(&resp.raw, desired) {
+            Some(plan) => {
+                apply_model_switch(&mut agent.acp, &resp.session_id, desired, &plan).await?;
                 true
             }
             None => {
@@ -1149,6 +1149,29 @@ async fn apply_model_switch(
     acp: &mut AcpClient,
     session_id: &str,
     desired: &str,
+    plan: &ModelSwitchPlan,
+) -> Result<(), AcpError> {
+    apply_model_switch_method(acp, session_id, &format!("model {desired}"), &plan.model).await?;
+
+    for (config_id, option_value) in &plan.parameters {
+        apply_model_switch_method(
+            acp,
+            session_id,
+            &format!("model parameter {config_id}={option_value}"),
+            &ModelSwitchMethod::ConfigOption {
+                config_id: config_id.clone(),
+                option_value: option_value.clone(),
+            },
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+async fn apply_model_switch_method(
+    acp: &mut AcpClient,
+    session_id: &str,
+    setting: &str,
     method: &ModelSwitchMethod,
 ) -> Result<(), AcpError> {
     let method_label = match method {
@@ -1178,7 +1201,7 @@ async fn apply_model_switch(
         Ok(Ok(_)) => {
             tracing::info!(
                 target: "pool::model",
-                "applied model {desired} via {method_label} on session {session_id}"
+                "applied {setting} via {method_label} on session {session_id}"
             );
         }
         // Transport-class errors may have corrupted the stdio stream — propagate
@@ -1190,7 +1213,7 @@ async fn apply_model_switch(
         | Ok(Err(e @ AcpError::AgentExited)) => {
             tracing::error!(
                 target: "pool::model",
-                "fatal error setting model {desired} via {method_label}: {e}"
+                "fatal error applying {setting} via {method_label}: {e}"
             );
             return Err(e);
         }
@@ -1198,7 +1221,7 @@ async fn apply_model_switch(
         Ok(Err(e)) => {
             tracing::warn!(
                 target: "pool::model",
-                "failed to set model {desired} via {method_label}: {e} — proceeding with agent default"
+                "failed to apply {setting} via {method_label}: {e} — proceeding with agent default"
             );
         }
         Err(_) => {
@@ -1206,7 +1229,7 @@ async fn apply_model_switch(
             // stream in an unknown state. Treat as transport error.
             tracing::error!(
                 target: "pool::model",
-                "model set via {method_label} timed out ({MODEL_SWITCH_TIMEOUT:?}) — treating as fatal"
+                "applying {setting} via {method_label} timed out ({MODEL_SWITCH_TIMEOUT:?}) — treating as fatal"
             );
             return Err(AcpError::Timeout(MODEL_SWITCH_TIMEOUT));
         }

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -723,26 +723,88 @@ pub(super) fn normalize_agent_models(
 
     let mut models: Vec<AgentModelInfo> = Vec::new();
     let mut seen_ids: HashSet<String> = HashSet::new();
+    let mut stable_base_ids: HashSet<String> = HashSet::new();
+
+    let stable_config_options = raw["stable"]["configOptions"].as_array();
+    let fast_config = stable_config_options.and_then(|options| {
+        options.iter().find(|option| {
+            option
+                .get("configId")
+                .or_else(|| option.get("id"))
+                .and_then(|value| value.as_str())
+                == Some("fast")
+        })
+    });
+    let fast_options = fast_config
+        .and_then(|option| option.get("options"))
+        .and_then(|options| options.as_array())
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    let current_fast = fast_config
+        .and_then(|option| option.get("currentValue"))
+        .and_then(|value| value.as_str());
+    let parameterize_model_id = |model_id: &str, fast: &str| format!("{model_id}[fast={fast}]");
+    let parameterize_current_model = |model_id: &str| {
+        current_fast.map_or_else(
+            || model_id.to_string(),
+            |fast| parameterize_model_id(model_id, fast),
+        )
+    };
 
     // 1. Stable configOptions (preferred). Only entries with category "model"
-    //    are model options — the CLI pre-filters, but we're defensive here.
-    if let Some(config_options) = raw["stable"]["configOptions"].as_array() {
+    //    are model options. Cursor also categorizes its separate `fast`
+    //    parameter as model config, so keep it out of the base-model pass and
+    //    expand its choices into the composite IDs Buzz already persists.
+    if let Some(config_options) = stable_config_options {
         for opt in config_options {
             if opt.get("category").and_then(|c| c.as_str()) != Some("model") {
+                continue;
+            }
+            if opt
+                .get("configId")
+                .or_else(|| opt.get("id"))
+                .and_then(|value| value.as_str())
+                == Some("fast")
+            {
                 continue;
             }
             if let Some(options) = opt.get("options").and_then(|v| v.as_array()) {
                 for o in options {
                     if let Some(value) = o.get("value").and_then(|v| v.as_str()) {
-                        if seen_ids.insert(value.to_string()) {
-                            models.push(AgentModelInfo {
-                                id: value.to_string(),
-                                name: o
+                        stable_base_ids.insert(value.to_string());
+                        let base_name = o
+                            .get("displayName")
+                            .or_else(|| o.get("name"))
+                            .and_then(|name| name.as_str());
+                        if fast_options.is_empty() {
+                            if seen_ids.insert(value.to_string()) {
+                                models.push(AgentModelInfo {
+                                    id: value.to_string(),
+                                    name: base_name.map(str::to_string),
+                                    description: None,
+                                });
+                            }
+                            continue;
+                        }
+                        for fast_option in fast_options {
+                            let Some(fast_value) =
+                                fast_option.get("value").and_then(|value| value.as_str())
+                            else {
+                                continue;
+                            };
+                            let id = parameterize_model_id(value, fast_value);
+                            if seen_ids.insert(id.clone()) {
+                                let fast_name = fast_option
                                     .get("displayName")
-                                    .and_then(|v| v.as_str())
-                                    .map(str::to_string),
-                                description: None,
-                            });
+                                    .or_else(|| fast_option.get("name"))
+                                    .and_then(|name| name.as_str())
+                                    .unwrap_or(fast_value);
+                                models.push(AgentModelInfo {
+                                    id,
+                                    name: base_name.map(|name| format!("{name} ({fast_name})")),
+                                    description: None,
+                                });
+                            }
                         }
                     }
                 }
@@ -753,10 +815,15 @@ pub(super) fn normalize_agent_models(
     // 2. Unstable availableModels (fallback — skip duplicates from stable).
     let mut agent_default_model: Option<String> = None;
     if let Some(unstable) = raw.get("unstable") {
-        agent_default_model = unstable["currentModelId"].as_str().map(str::to_string);
+        agent_default_model = unstable["currentModelId"]
+            .as_str()
+            .map(&parameterize_current_model);
         if let Some(available) = unstable["availableModels"].as_array() {
             for m in available {
                 if let Some(id) = m.get("modelId").and_then(|v| v.as_str()) {
+                    if stable_base_ids.contains(id) {
+                        continue;
+                    }
                     if seen_ids.insert(id.to_string()) {
                         models.push(AgentModelInfo {
                             id: id.to_string(),

--- a/desktop/src-tauri/src/commands/agent_models_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_models_tests.rs
@@ -1,6 +1,59 @@
 use super::*;
 
 #[test]
+fn parameterized_fast_options_expand_into_selectable_model_variants() {
+    let raw = serde_json::json!({
+        "agent": { "name": "cursor", "version": "2026.08" },
+        "stable": {
+            "configOptions": [
+                {
+                    "id": "model",
+                    "category": "model",
+                    "currentValue": "grok-4.6",
+                    "options": [
+                        { "value": "grok-4.6", "name": "Grok 4.6" }
+                    ]
+                },
+                {
+                    "id": "fast",
+                    "category": "model",
+                    "currentValue": "false",
+                    "options": [
+                        { "value": "false", "name": "Off" },
+                        { "value": "true", "name": "Fast" }
+                    ]
+                }
+            ]
+        },
+        "unstable": {
+            "currentModelId": "grok-4.6",
+            "availableModels": [
+                { "modelId": "grok-4.6", "name": "Grok 4.6" }
+            ]
+        }
+    });
+
+    let response = normalize_agent_models(&raw, None);
+    let ids = response
+        .models
+        .iter()
+        .map(|model| model.id.as_str())
+        .collect::<Vec<_>>();
+    let names = response
+        .models
+        .iter()
+        .map(|model| model.name.as_deref())
+        .collect::<Vec<_>>();
+
+    assert_eq!(ids, vec!["grok-4.6[fast=false]", "grok-4.6[fast=true]"]);
+    assert_eq!(names, vec![Some("Grok 4.6 (Off)"), Some("Grok 4.6 (Fast)")]);
+    assert_eq!(
+        response.agent_default_model.as_deref(),
+        Some("grok-4.6[fast=false]")
+    );
+}
+
+#[test]
 fn access_policy_change_requires_runtime_refresh_for_effective_gate_changes() {
     use crate::managed_agents::RespondTo;
 

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -201,6 +201,16 @@ with a TypeScript lookup table or an id comparison in a component.
    fields, and profile-wide activity selection. Caller context may control the
    panel shell or return navigation, but must not filter or replace profile
    content.
+14. **Parameterized model choices stay compatible with the persisted model
+    field.** ACP discovery advertises Cursor's `parameterizedModelPicker`
+    capability and folds its separate `model` + `fast` options into composite
+    IDs such as `grok-4.6[fast=false]`. All model selectors continue to consume
+    the same discovered model list and persist the same normalized `model`
+    field; do not add a Cursor-only render branch. `buzz-acp` is responsible
+    for validating that both pieces were advertised and applying the base
+    model before the `fast` config option. Thought-level options remain a
+    separate harness-native effort concern and must not be folded into this
+    compatibility path.
 
 ## The tests that enforce this
 


### PR DESCRIPTION
## Summary

- advertise ACP's parameterized model picker capability so Cursor exposes both fast modes
- present Cursor's `fast=false` and `fast=true` choices as model variants in the existing selectors
- validate and apply the base model before setting the Cursor fast parameter

### Related issue

Fixes #6114.

### Testing

- `just ci`
- `cargo test -p buzz-acp --lib acp::tests::`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml commands::agent_models::tests::`

Cursor CLI was not available locally, so this was verified with protocol fixtures rather than a live Cursor session.

_Generated with Codex._