### PR TITLE
fix(relay): keep the NIP-11 document readable under a CORS allowlist

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -331,6 +331,17 @@ test-unit:
         # `cargo test --workspace`; without this step a manifest edit that
         # diverges Rust from the corpus ships green.
         cargo nextest run -p buzz-agent --lib
+        # buzz-relay router/NIP-11 unit tests: infra-free in-process axum +
+        # tower coverage — CORS conformance on the NIP-11 relay information
+        # document (it stays readable cross-origin under a BUZZ_CORS_ORIGINS
+        # allowlist without widening the authenticated surface), trace-span
+        # propagation, and the WebSocket frame limit. The rest of buzz-relay's
+        # --lib set is Postgres/Redis-backed and is selected explicitly by the
+        # backend integration job, so select the infra-free modules here rather
+        # than the whole package. Without this step the archive builds these
+        # tests and nothing executes them.
+        cargo nextest run -p buzz-relay --lib \
+            -E 'test(/^router::tests/) or test(/^nip11::tests/)'
     else
         ./scripts/run-tests.sh unit
     fi

--- a/crates/buzz-relay/src/nip11.rs
+++ b/crates/buzz-relay/src/nip11.rs
@@ -177,12 +177,46 @@ impl RelayInfo {
 pub async fn relay_info_handler(
     axum::extract::State(state): axum::extract::State<std::sync::Arc<crate::state::AppState>>,
     headers: axum::http::HeaderMap,
-) -> axum::response::Json<RelayInfo> {
+) -> axum::response::Response {
     let raw_host = headers
         .get(axum::http::header::HOST)
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
-    axum::response::Json(nip11_document(&state, raw_host).await)
+    relay_info_response(nip11_document(&state, raw_host).await)
+}
+
+/// Serialise the relay information document with the CORS headers NIP-11
+/// requires on it.
+///
+/// NIP-11 makes cross-origin readability a MUST: the document is how a browser
+/// client discovers a relay's capabilities before it has any credentials, so it
+/// has to be readable from an origin the operator never enumerated. Every
+/// route, this one included, sits under the relay-wide layer built from
+/// `BUZZ_CORS_ORIGINS`, which narrows responses to the configured allowlist —
+/// and the deployment guide tells operators to set that variable, so the
+/// documented VPS path would otherwise ship a relay that fails the MUST.
+///
+/// Setting the headers on the response conforms without widening the allowlist
+/// that protects `/events`, `/query`, `/count`, and the media surface:
+/// `tower_http`'s CORS layer overwrites only the header names it emits, so an
+/// allowlisted origin still gets its own value echoed back and every other
+/// origin keeps the permissive one set here. The document carries no private
+/// data — capabilities, limits, and the relay's public key — and
+/// `auth_required`/`restricted_writes` continue to gate everything that
+/// matters. Same pattern as the NIP-05 document in [`crate::api::nip05`].
+pub(crate) fn relay_info_response(info: RelayInfo) -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+
+    let mut response = axum::response::Json(info).into_response();
+    let headers = response.headers_mut();
+    for (name, value) in [
+        (axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
+        (axum::http::header::ACCESS_CONTROL_ALLOW_HEADERS, "*"),
+        (axum::http::header::ACCESS_CONTROL_ALLOW_METHODS, "*"),
+    ] {
+        headers.insert(name, axum::http::HeaderValue::from_static(value));
+    }
+    response
 }
 
 fn push_descriptor(

--- a/crates/buzz-relay/src/router.rs
+++ b/crates/buzz-relay/src/router.rs
@@ -23,7 +23,7 @@ use crate::api;
 use crate::audio;
 use crate::connection::handle_connection;
 use crate::metrics::track_metrics;
-use crate::nip11::{nip11_document, relay_info_handler};
+use crate::nip11::{nip11_document, relay_info_handler, relay_info_response};
 use crate::state::AppState;
 
 /// Build the axum [`Router`] with all relay routes, middleware, and CORS configuration.
@@ -295,7 +295,7 @@ async fn nip11_or_ws_handler(
     }
 
     if accept.contains("application/nostr+json") {
-        return Json(nip11_document(&state, raw_host).await).into_response();
+        return relay_info_response(nip11_document(&state, raw_host).await);
     }
 
     // Row zero: bind the connection to its community from the request host
@@ -463,6 +463,10 @@ fn build_cors_layer(cors_origins: &[String]) -> CorsLayer {
 
 #[cfg(test)]
 mod tests {
+    use axum::http::header::{
+        HeaderName, ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS,
+        ACCESS_CONTROL_ALLOW_ORIGIN,
+    };
     use axum::{routing::get, Router};
     use futures_util::SinkExt;
     use opentelemetry::trace::TracerProvider as _;
@@ -475,6 +479,119 @@ mod tests {
     use tracing_subscriber::prelude::*;
 
     use super::*;
+
+    /// The two CORS-relevant halves of the relay surface behind the real
+    /// `build_cors_layer`: the public NIP-11 document and one authenticated
+    /// bridge route that the allowlist must keep narrowing.
+    fn nip11_and_bridge_router(cors_origins: &[String]) -> Router {
+        Router::new()
+            .route(
+                "/info",
+                get(|| async {
+                    relay_info_response(crate::nip11::RelayInfo::build(
+                        None,
+                        None,
+                        false,
+                        crate::config::DEFAULT_MAX_FRAME_BYTES,
+                        None,
+                    ))
+                }),
+            )
+            .route("/query", post(|| async { StatusCode::OK }))
+            .layer(build_cors_layer(cors_origins))
+    }
+
+    async fn header_values(
+        app: Router,
+        path: &str,
+        origin: &str,
+        header: HeaderName,
+    ) -> Vec<String> {
+        let response = app
+            .oneshot(
+                Request::get(path)
+                    .header(axum::http::header::ORIGIN, origin)
+                    .body(Body::empty())
+                    .expect("build test request"),
+            )
+            .await
+            .expect("router should answer the test request");
+
+        response
+            .headers()
+            .get_all(header)
+            .iter()
+            .map(|value| value.to_str().expect("header is valid UTF-8").to_string())
+            .collect()
+    }
+
+    /// A relay whose CORS allowlist is configured (`BUZZ_CORS_ORIGINS`, which
+    /// the deployment guide tells operators to set) must still serve the NIP-11
+    /// relay information document to any origin — the spec makes that a MUST,
+    /// and a browser client hosted elsewhere has no other way to discover the
+    /// relay's capabilities.
+    #[tokio::test]
+    async fn nip11_document_stays_readable_from_any_origin_under_a_cors_allowlist() {
+        let allowlist = vec!["https://buzz.example.com".to_string()];
+
+        assert_eq!(
+            header_values(
+                nip11_and_bridge_router(&allowlist),
+                "/info",
+                "https://some-web-client.example",
+                ACCESS_CONTROL_ALLOW_ORIGIN,
+            )
+            .await,
+            vec!["*".to_string()],
+            "NIP-11 requires the relay information document to be readable cross-origin"
+        );
+
+        for header in [ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS] {
+            assert_eq!(
+                header_values(
+                    nip11_and_bridge_router(&allowlist),
+                    "/info",
+                    "https://some-web-client.example",
+                    header.clone(),
+                )
+                .await,
+                vec!["*".to_string()],
+                "NIP-11 requires {header} on the relay information document"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn allowlisted_origin_gets_exactly_one_allow_origin_on_the_nip11_document() {
+        // The relay-wide layer overwrites the permissive value rather than
+        // appending to it — two `Access-Control-Allow-Origin` values would be
+        // rejected by every browser.
+        assert_eq!(
+            header_values(
+                nip11_and_bridge_router(&["https://buzz.example.com".to_string()]),
+                "/info",
+                "https://buzz.example.com",
+                ACCESS_CONTROL_ALLOW_ORIGIN,
+            )
+            .await,
+            vec!["https://buzz.example.com".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_allowlist_still_narrows_the_authenticated_surface() {
+        assert!(
+            header_values(
+                nip11_and_bridge_router(&["https://buzz.example.com".to_string()]),
+                "/query",
+                "https://some-web-client.example",
+                ACCESS_CONTROL_ALLOW_ORIGIN,
+            )
+            .await
+            .is_empty(),
+            "exempting the NIP-11 document must not widen CORS on the rest of the surface"
+        );
+    }
 
     #[test]
     fn invite_landing_path_requires_exactly_one_nonempty_code_segment() {

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -90,6 +90,16 @@ run_unit_tests() {
   run_test_step "buzz-cli tests" \
     cargo test -p buzz-cli -- --nocapture
 
+  # buzz-relay router/NIP-11 unit tests (no infra): NIP-11 CORS conformance,
+  # trace-span propagation, and the WebSocket frame limit. The rest of the
+  # package's --lib set needs Postgres/Redis, so select the infra-free modules
+  # rather than the whole package — see the `test-unit` recipe in the Justfile.
+  run_test_step "buzz-relay router unit tests" \
+    cargo test -p buzz-relay --lib router::tests -- --nocapture
+
+  run_test_step "buzz-relay NIP-11 unit tests" \
+    cargo test -p buzz-relay --lib nip11::tests -- --nocapture
+
   # buzz-db migrator/lint unit tests (no infra): guard the embedded-migrator
   # invariant (exactly the consolidated 0001; cutover/backfill stays an operator
   # script, not startup state) and the tenant-scoping lints. The Postgres-backed


### PR DESCRIPTION
Fixes #5550.

## Problem

NIP-11 makes cross-origin readability of the relay information document a MUST:

> Relays MUST accept CORS requests by sending `Access-Control-Allow-Origin`, `Access-Control-Allow-Headers`, and `Access-Control-Allow-Methods` headers.

`build_cors_layer` is applied to the whole merged router (`router.rs:200`), so when `BUZZ_CORS_ORIGINS` is set the allowlist that (correctly) protects the authenticated REST surface also narrows the relay information document — `GET /` with `Accept: application/nostr+json` and `GET /info`. Browser-based clients hosted anywhere else can no longer read it.

This is on the documented path, not an exotic config: `deploy/compose/.env.example` ships `BUZZ_CORS_ORIGINS=https://buzz.example.com`, so following the deployment guide produces a relay that fails the MUST. The response is `200` either way and only the header differs, so it fails silently from the server's perspective.

## Fix

Serve the document with permissive CORS headers set on the response (`relay_info_response` in `nip11.rs`), used by both the `/info` handler and the content-negotiated `/` branch.

I did not split the document into its own permissively-layered `Router` as the issue suggested, because `/` is content-negotiated with the WebSocket upgrade — the NIP-11 branch is selected by `Accept`, not by path, so it cannot be routed away from the WS handler. Setting the headers on the response covers both entry points and composes correctly with the existing layer: `tower_http`'s CORS layer overwrites only the header names it emits, so

- a non-allowlisted origin keeps the permissive value set here, and
- an allowlisted origin still gets its own value echoed back — exactly one `Access-Control-Allow-Origin`, never two.

This is the same pattern the NIP-05 document already uses (`api/nip05.rs`), so the two public documents now behave alike.

Nothing else is widened: `BUZZ_CORS_ORIGINS` keeps governing `/events`, `/query`, `/count`, the media endpoints and the rest of the surface. The document carries no private data — capabilities, limits, and the relay's public key — and `auth_required`/`restricted_writes` continue to gate everything that matters.

## Tests

Three tests in `router::tests`, driving the real `build_cors_layer` with a configured allowlist:

- `nip11_document_stays_readable_from_any_origin_under_a_cors_allowlist` — a foreign origin gets all three headers on `/info`. **Fails on `main`** (`left: []`, `right: ["*"]`), which is the reported symptom.
- `allowlisted_origin_gets_exactly_one_allow_origin_on_the_nip11_document` — guards the duplicate-header hazard.
- `cors_allowlist_still_narrows_the_authenticated_surface` — a bridge route still gets no `Access-Control-Allow-Origin` for a foreign origin, so the exemption cannot silently widen.

### Second commit: making those tests actually run

While checking which job would execute them, I found that nothing does. `just test-unit` enumerates packages explicitly (because nothing in CI runs `cargo test --workspace`) and buzz-relay is not on the list; the backend integration job archives the package's lib tests but only ever selects `api::invites::tests` and `handlers::relay_admin::tests`. So `router::tests` and `nip11::tests` are compiled by clippy and the archive build, then executed by nothing — a regression test that never runs would not have guarded this fix.

The second commit selects those two modules in the unit job, where they belong: both are pure in-process axum + tower coverage needing no Postgres or Redis (23 tests, verified passing with no services up). The rest of the package's lib set is infra-backed and stays where it is. Mirrored into `scripts/run-tests.sh`, the recipe's fallback when cargo-nextest is absent, since the surrounding comments there ask for the two lists to stay in step.

I put this in `just test-unit` rather than adding a step to `ci.yml` on purpose: these tests need no infra, and `.github/workflows/ci.yml` is in the `hashFiles` key for the relay-artifacts cache, so editing it would invalidate that cache for everyone. Happy to move it if you'd rather have it elsewhere — or to drop the commit entirely if the coverage gap is deliberate.

```
cargo test -p buzz-relay --lib router::tests    # 8 passed
cargo test -p buzz-relay --lib                  # 886 passed; the 8 failures (api::admin, api::media)
                                                # are pre-existing on a clean tree here — they need Postgres/Redis
cargo clippy -p buzz-relay --all-targets -- -D warnings   # clean (the `just clippy` gate)
cargo fmt --all -- --check                      # clean (the `just fmt-check` gate)
cargo nextest run -p buzz-relay --lib -E 'test(/^router::tests/) or test(/^nip11::tests/)'
                                                # 23 passed, no infra — the new unit-job selection
```

Manual check against the issue's repro, with `BUZZ_CORS_ORIGINS=https://relay.example.com` set:

```console
$ curl -sSI -H 'Origin: https://some-web-client.example' -H 'Accept: application/nostr+json' <relay>/ | grep -i access-control
access-control-allow-origin: *
access-control-allow-headers: *
access-control-allow-methods: *
```

## Related

Searched open PRs before starting — no PR referenced #5550. Closest in the area: none touching `build_cors_layer` or `nip11.rs`.

One adjacent observation, not changed here: NIP-05 requires `Access-Control-Allow-Origin: *` on `/.well-known/nostr.json` and the handler already sets it, so that one is conformant today — it just gets there by the same mechanism this PR now uses for NIP-11.
