### PR TITLE
fix(mobile): resolve thread-reply channel before send instead of trusting a null snapshot

### DIFF
--- a/mobile/lib/features/channels/resolve_thread_reply_channel.dart
+++ b/mobile/lib/features/channels/resolve_thread_reply_channel.dart
@@ -1,0 +1,21 @@
+import 'channel.dart';
+
+/// Resolves the channel to send a thread reply against.
+///
+/// [channel] is normally already available (from `ref.watch(channelsProvider)`
+/// at build time), but it can still be `null` right when the user sends — a
+/// cold start or a notification/deep-link tap straight into a thread, before
+/// the channel list has finished loading. Falling back to `null` in that case
+/// would silently skip DM auto-mention (`SendMessage.call` only adds
+/// DM-recipient `p` tags when a non-null, `isDm` channel is passed), so this
+/// waits for [loadChannels] to resolve instead of sending with a channel
+/// that's known to be missing.
+Future<Channel?> resolveThreadReplyChannel({
+  required Channel? channel,
+  required String channelId,
+  required Future<List<Channel>> Function() loadChannels,
+}) async {
+  if (channel != null) return channel;
+  final channels = await loadChannels();
+  return channels.where((c) => c.id == channelId).firstOrNull;
+}

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -35,6 +35,7 @@ import 'message_content.dart';
 import 'reaction_row.dart';
 import '../../shared/read_state/read_state_format.dart';
 import '../../shared/read_state/read_state_provider.dart';
+import 'resolve_thread_reply_channel.dart';
 import 'send_message_provider.dart';
 import 'small_avatar.dart';
 import 'timeline_message.dart';
@@ -759,15 +760,24 @@ class ThreadDetailPage extends HookConsumerWidget {
                               content,
                               mentionPubkeys, {
                               mediaTags = const <List<String>>[],
-                            }) => sendMessage.call(
-                              channelId: channelId,
-                              content: content,
-                              mentionPubkeys: mentionPubkeys,
-                              channel: channel,
-                              parentEventId: threadHead.id,
-                              rootEventId: effectiveRootId,
-                              mediaTags: mediaTags,
-                            ),
+                            }) async {
+                              final resolvedChannel =
+                                  await resolveThreadReplyChannel(
+                                    channel: channel,
+                                    channelId: channelId,
+                                    loadChannels: () =>
+                                        ref.read(channelsProvider.future),
+                                  );
+                              await sendMessage.call(
+                                channelId: channelId,
+                                content: content,
+                                mentionPubkeys: mentionPubkeys,
+                                channel: resolvedChannel,
+                                parentEventId: threadHead.id,
+                                rootEventId: effectiveRootId,
+                                mediaTags: mediaTags,
+                              );
+                            },
                       ),
                     ],
                   ),

--- a/mobile/test/features/channels/resolve_thread_reply_channel_test.dart
+++ b/mobile/test/features/channels/resolve_thread_reply_channel_test.dart
@@ -1,0 +1,60 @@
+import 'package:buzz/features/channels/channel.dart';
+import 'package:buzz/features/channels/resolve_thread_reply_channel.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('returns the given channel without loading the list', () async {
+    final given = _channel(id: 'general');
+    var loadCalls = 0;
+
+    final resolved = await resolveThreadReplyChannel(
+      channel: given,
+      channelId: 'general',
+      loadChannels: () async {
+        loadCalls++;
+        return [given];
+      },
+    );
+
+    expect(resolved, same(given));
+    expect(loadCalls, 0);
+  });
+
+  test(
+    'awaits the channel list and resolves by id when channel is null',
+    () async {
+      final wanted = _channel(id: 'general');
+
+      final resolved = await resolveThreadReplyChannel(
+        channel: null,
+        channelId: 'general',
+        loadChannels: () async => [_channel(id: 'random'), wanted],
+      );
+
+      expect(resolved, same(wanted));
+    },
+  );
+
+  test('returns null when the loaded list has no matching channel', () async {
+    final resolved = await resolveThreadReplyChannel(
+      channel: null,
+      channelId: 'missing',
+      loadChannels: () async => [_channel(id: 'general')],
+    );
+
+    expect(resolved, isNull);
+  });
+}
+
+Channel _channel({required String id}) => Channel(
+  id: id,
+  name: id,
+  channelType: 'dm',
+  visibility: 'private',
+  description: '',
+  createdBy: 'self',
+  createdAt: DateTime(2025),
+  memberCount: 1,
+  participantPubkeys: const ['self'],
+  isMember: true,
+);


### PR DESCRIPTION
## Problem

Closes #6199.

In the mobile app, a thread reply in a group DM can go out with **zero** `p` tags — same visible symptom as #6027, but a distinct root cause in a different (Flutter) codebase, not the desktop bug recurring.

`SendMessage.call()` (`mobile/lib/features/channels/send_message_provider.dart:62-72`) only adds DM-recipient auto-mentions when a non-null `channel` object is passed in *and* `channel.isDm == true`:

```dart
final dmRecipientPubkeys = channel?.isDm == true
    ? await _fetchDmRecipientPubkeys(channelId, channel!, authorPubkey)
    : null;
final resolvedMentions = dmRecipientPubkeys != null
    ? messageMentionPubkeys(...)
    : explicitMentions;   // <-- silent fallback, no DM auto-mention at all
```

`ThreadDetailPage` derived `channel` from a nullable async provider:

```dart
final channelsAsync = ref.watch(channelsProvider);
final channel = channelsAsync.value
    ?.where((candidate) => candidate.id == channelId)
    .firstOrNull;
```

`channelsAsync.value` is `null` whenever the channel list hasn't loaded yet in this session — cold start, a notification/deep-link tap straight into a thread, or any brief loading window. When that happens, the old `onSend` callback passed `channel: channel` (i.e. `null`) straight into `SendMessage.call()`, which silently fell back to `explicitMentions` only. A plain-text reply with no `@name` in it (the common case) then went out with no `p` tags at all.

`ChannelDetailPage` doesn't have this gap — its `channel` is a required, always-non-null constructor field, passed in directly by the caller rather than re-derived from a nullable provider. This is why the bug is specifically a **thread-reply** issue, matching the live incident it was found from.

## Fix

Bundle- and mobile-only. No relay/desktop changes.

- Added `resolveThreadReplyChannel()` (`mobile/lib/features/channels/resolve_thread_reply_channel.dart`): returns the already-loaded `channel` immediately when present, otherwise awaits `channelsProvider.future` and resolves by id — closing the race instead of silently sending with a channel known to be stale.
- Wired it into `ThreadDetailPage`'s `onSend` callback (`thread_detail_page.dart`), which is now `async` and awaits resolution before calling `sendMessage.call()`.
- Extracted as a small, pure-ish function with its own unit tests (`resolve_thread_reply_channel_test.dart`), following the existing `messageMentionPubkeys.dart` pattern rather than burying the logic in the widget's closure.

## Tests / Validation

```
$ flutter test test/features/channels/resolve_thread_reply_channel_test.dart
00:00 +3: All tests passed!

$ flutter analyze
Analyzing mobile...
No issues found!

$ flutter test
...
01:00 +1468: All tests passed!

$ dart format --output=none --set-exit-if-changed <changed files>
Formatted 3 files (0 changed)

$ node mobile/scripts/check-file-sizes.mjs
(no output — passes)
```

## Checklist

- [x] Mobile-only — no relay/desktop source changed
- [x] `flutter analyze` clean
- [x] Full `flutter test` suite passes (1468 tests)
- [x] `dart format` clean
- [x] File-size guard passes
- [x] New logic covered by unit tests, not just relied on for coverage elsewhere
