### PR TITLE
fix(mobile): retry DM membership fetch instead of silently sending with zero recipients

### DIFF
--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -118,24 +118,42 @@ class SendMessage {
     Channel channel,
     String? authorPubkey,
   ) async {
-    List<ChannelMember>? members;
-    try {
-      members = await _fetchMembers(channelId);
-    } catch (_) {
-      // Fall back to metadata below so an unavailable membership query does
-      // not block ordinary DM sends.
-    }
-
+    var members = await _tryFetchMembers(channelId);
     final author = authorPubkey?.toLowerCase();
-    final participants = members != null && members.isNotEmpty
+    var participants = members != null && members.isNotEmpty
         ? members.map((member) => member.pubkey)
         : channel.participantPubkeys;
+
+    // A DM always has at least one other participant besides the sender, so
+    // both the live membership query and the channel-metadata fallback
+    // coming back empty at once means the data isn't available right now —
+    // e.g. a relay reconnect in progress (common on mobile after
+    // backgrounding) — not that the DM genuinely has nobody else in it.
+    // Retry briefly instead of silently sending with zero recipients.
+    for (var attempt = 0; participants.isEmpty && attempt < 3; attempt++) {
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+      members = await _tryFetchMembers(channelId);
+      if (members != null && members.isNotEmpty) {
+        participants = members.map((member) => member.pubkey);
+      }
+    }
+
     return {
       for (final participant in participants)
         if (participant.trim().isNotEmpty &&
             participant.toLowerCase() != author)
           participant.toLowerCase(),
     };
+  }
+
+  Future<List<ChannelMember>?> _tryFetchMembers(String channelId) async {
+    try {
+      return await _fetchMembers(channelId);
+    } catch (_) {
+      // Fall back to metadata below so an unavailable membership query does
+      // not block ordinary DM sends.
+      return null;
+    }
   }
 
   void _ensureDeliveryValid() {

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -213,6 +213,90 @@ void main() {
     await result;
   });
 
+  test(
+    'retries membership fetch when both membership and metadata are empty',
+    () async {
+      final session = _PendingPublishRelaySession();
+      final signingKey = nostr.Keys.generate().nsec;
+      final sender = nostr.Keys(
+        nostr.Nip19.decode(payload: signingKey).data,
+      ).public;
+      final recipient = 'b' * 64;
+      var fetchCount = 0;
+      final send = SendMessage(
+        signedEventRelay: SignedEventRelay(session: session, nsec: signingKey),
+        fetchMembers: (_) async {
+          fetchCount++;
+          // Simulate a relay reconnect resolving after a couple of attempts.
+          if (fetchCount < 3) return const [];
+          return [_member(sender), _member(recipient)];
+        },
+        readUserCache: () => const {},
+        addLocalMessage: (_, _) {},
+        completeLocalMessage: (_, _) {},
+        removeLocalMessage: (_, _) {},
+      );
+
+      final result = send(
+        channelId: _channelId,
+        content: 'hello after a flaky membership fetch',
+        // Metadata fallback is empty too, so the first attempt alone can't
+        // resolve a recipient — only the retry can.
+        channel: _dmChannel(const []),
+        mentionPubkeys: const [],
+      );
+      await session.published;
+
+      expect(session.event.tags.where((tag) => tag.first == 'p').toList(), [
+        ['p', recipient],
+      ]);
+      expect(fetchCount, greaterThanOrEqualTo(3));
+
+      session.accept();
+      await result;
+    },
+    timeout: const Timeout(Duration(seconds: 5)),
+  );
+
+  test(
+    'gives up after bounded retries and sends without recipients rather than hanging',
+    () async {
+      final session = _PendingPublishRelaySession();
+      final signingKey = nostr.Keys.generate().nsec;
+      var fetchCount = 0;
+      final send = SendMessage(
+        signedEventRelay: SignedEventRelay(session: session, nsec: signingKey),
+        fetchMembers: (_) async {
+          fetchCount++;
+          return const [];
+        },
+        readUserCache: () => const {},
+        addLocalMessage: (_, _) {},
+        completeLocalMessage: (_, _) {},
+        removeLocalMessage: (_, _) {},
+      );
+
+      final result = send(
+        channelId: _channelId,
+        content: 'hello into the void',
+        channel: _dmChannel(const []),
+        mentionPubkeys: const [],
+      );
+      await session.published;
+
+      expect(
+        session.event.tags.where((tag) => tag.first == 'p').toList(),
+        isEmpty,
+      );
+      // Initial attempt + 3 retries, not unbounded.
+      expect(fetchCount, 4);
+
+      session.accept();
+      await result;
+    },
+    timeout: const Timeout(Duration(seconds: 5)),
+  );
+
   test('cancels delivery after the active community changes', () async {
     final container = ProviderContainer();
     addTearDown(container.dispose);
@@ -246,7 +330,7 @@ Channel _dmChannel(List<String> participantPubkeys) => Channel(
   channelType: 'dm',
   visibility: 'private',
   description: '',
-  createdBy: participantPubkeys.first,
+  createdBy: participantPubkeys.firstOrNull ?? 'unknown',
   createdAt: DateTime(2025),
   memberCount: participantPubkeys.length,
   participantPubkeys: participantPubkeys,


### PR DESCRIPTION
## Problem

Closes #6206.

A plain, top-level DM message can go out with zero `p` tags — confirmed live tonight: checked the raw event on the relay directly against `buzz channels members` for the same channel at the same moment, and the member list was correct and complete. The recipients existed; the app just didn't attach them.

`SendMessage._fetchDmRecipientPubkeys()` (`mobile/lib/features/channels/send_message_provider.dart`) resolves DM recipients from a live membership query, falling back to the channel metadata's `participantPubkeys` when that query fails — a fallback that's already covered by existing tests. The gap is when **both** sources come back empty at once. `channelMembersProvider` returns a plain empty list (not an error) whenever the relay session isn't `connected` and there's no cached snapshot — and mobile reconnects far more often than desktop (iOS backgrounding suspends the socket, same pattern already confirmed in #6200's presence gap). If a send lands during one of those windows and the in-memory `Channel` object's `participantPubkeys` also isn't populated, both fallback layers come up empty and the message ships with no recipients, silently.

A DM always has at least one other participant besides the sender by construction, so "both sources empty" is never a legitimate answer — it means the data isn't available yet, not that the DM has nobody in it.

## Fix

Mobile-only, no relay/desktop changes.

- `_fetchDmRecipientPubkeys()`: when both the live query and the metadata fallback come back empty, retry the membership fetch up to 3 times with a 400ms delay between attempts, instead of concluding the DM has zero recipients. Bounded, so a genuinely persistent failure still resolves (same zero-recipient outcome as before) rather than hanging the send indefinitely.
- Extracted the try/catch into `_tryFetchMembers()` so the retry loop can reuse it without duplicating the swallow-and-fall-back logic.

## Scope note

`channelMembersProvider`'s silent-empty-on-disconnect behavior is shared by 7 other consumers across the app (member sheets, mention autocomplete, compose bar, agent activity). Changing that provider's own error contract would touch all of them and deserves real review on its own — this PR intentionally stays scoped to the DM-mention send path only, not the shared provider.

## Tests / Validation

```
$ flutter test test/features/channels/send_message_provider_test.dart
00:02 +9: All tests passed!
  (includes 2 new tests: recovers after a flaky membership fetch,
   and gives up after bounded retries rather than hanging)

$ flutter analyze
No issues found!

$ flutter test
01:00 +1467: All tests passed!

$ dart format --output=none --set-exit-if-changed <changed files>
Formatted 2 files (0 changed)

$ node mobile/scripts/check-file-sizes.mjs
(no output — passes)
```

## Checklist

- [x] Mobile-only — no relay/desktop source changed
- [x] `flutter analyze` clean
- [x] Full `flutter test` suite passes (1467 tests)
- [x] `dart format` clean
- [x] File-size guard passes
- [x] New logic covered by unit tests, including the bounded-retry edge case
