### PR TITLE
feat(desktop): add Google Antigravity ACP runtime preset and guide

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -20,6 +20,8 @@ pub(crate) use runtime_metadata::KnownAcpRuntime;
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
+const ANTIGRAVITY_AVATAR_URL: &str =
+    "https://antigravity.google/assets/image/brand/antigravity-icon__full-color.png";
 const BUZZ_AGENT_AVATAR_URL: &str =
     "https://raw.githubusercontent.com/block/buzz/refs/heads/main/crates/buzz-agent/buzz-agent.png";
 fn common_binary_paths() -> &'static [PathBuf] {
@@ -174,6 +176,39 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         login_hint: Some("Run `codex login` to authenticate."),
         // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
         auth_probe_args: Some(&["codex", "login", "status"]),
+    },
+    KnownAcpRuntime {
+        id: "antigravity",
+        label: "Google Antigravity",
+        commands: &["buzz-antigravity-acp", "antigravity-acp"],
+        aliases: &["antigravity-cli", "google-antigravity", "agy"],
+        avatar_url: ANTIGRAVITY_AVATAR_URL,
+        mcp_command: None,
+        mcp_hooks: false,
+        underlying_cli: Some("agy"),
+        cli_install_commands: &["npm install -g @google/antigravity-cli"],
+        cli_install_commands_windows: &[windows_install_command!("antigravity", "https://antigravity.google/install.ps1")],
+        adapter_install_commands: &["npm install -g buzz-antigravity-acp"],
+        cli_install_instructions_url: "https://antigravity.google",
+        adapter_install_instructions_url: "https://github.com/vietanhvu225/buzz-antigravity-acp",
+        cli_install_hint: "Buzz talks to Google Antigravity through the Antigravity CLI (agy).",
+        adapter_install_hint: "Buzz talks to the Antigravity CLI through an ACP adapter. Install it with: npm install -g buzz-antigravity-acp.",
+        skill_dir: Some(".antigravity/skills"),
+        supports_acp_model_switching: false,
+        model_env_var: Some("ANTIGRAVITY_MODEL"),
+        provider_env_var: Some("ANTIGRAVITY_PROVIDER"),
+        provider_locked: false,
+        default_env: &[],
+        config_file_path: Some("~/.antigravity/config.json"),
+        config_file_format: Some("json"),
+        supports_acp_native_config: false,
+        thinking_env_var: None,
+        max_tokens_env_var: None,
+        context_limit_env_var: None,
+        max_rounds_env_var: None,
+        required_normalized_fields: &[],
+        login_hint: Some("Run `agy auth login` to authenticate."),
+        auth_probe_args: Some(&["agy", "auth", "status"]),
     },
     KnownAcpRuntime {
         id: "buzz-agent",
@@ -459,8 +494,16 @@ pub fn try_record_agent_command(
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
-        "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        "codex"
+        | "codex-acp"
+        | "claude-agent-acp"
+        | "claude-code-acp"
+        | "claude-code"
+        | "claudecode"
+        | "buzz-agent"
+        | "buzz-antigravity-acp"
+        | "antigravity-acp"
+        | "antigravity" => Some(Vec::new()),
         _ => None,
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -7,8 +7,8 @@ use super::{
     effective_agent_command, find_nvm_default_bin, find_via_login_shell,
     is_login_shell_path_uninit, is_safe_nvm_tag, managed_agent_avatar_url, normalize_agent_args,
     parse_semver_tag, probe_codex_acp_version, record_agent_command, refresh_login_shell_path,
-    try_record_agent_command, BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL,
-    GOOSE_AVATAR_URL,
+    try_record_agent_command, ANTIGRAVITY_AVATAR_URL, BUZZ_AGENT_AVATAR_URL,
+    CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL, GOOSE_AVATAR_URL,
 };
 use crate::managed_agents::AcpAvailabilityStatus;
 
@@ -79,6 +79,38 @@ fn resolves_buzz_agent_avatar() {
     assert_eq!(
         managed_agent_avatar_url("/usr/local/bin/buzz-agent"),
         Some(BUZZ_AGENT_AVATAR_URL.to_string())
+    );
+}
+
+#[test]
+fn resolves_antigravity_avatar() {
+    assert_eq!(
+        managed_agent_avatar_url("buzz-antigravity-acp"),
+        Some(ANTIGRAVITY_AVATAR_URL.to_string())
+    );
+    assert_eq!(
+        managed_agent_avatar_url("antigravity-acp"),
+        Some(ANTIGRAVITY_AVATAR_URL.to_string())
+    );
+    assert_eq!(
+        managed_agent_avatar_url("Google Antigravity"),
+        Some(ANTIGRAVITY_AVATAR_URL.to_string())
+    );
+}
+
+#[test]
+fn normalizes_antigravity_args_to_empty() {
+    assert_eq!(
+        normalize_agent_args("buzz-antigravity-acp", Vec::new()),
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        normalize_agent_args("buzz-antigravity-acp", vec!["acp".into()]),
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        normalize_agent_args("antigravity-acp", vec!["acp".into()]),
+        Vec::<String>::new()
     );
 }
 
@@ -1190,6 +1222,7 @@ fn test_command_basenames_dotted_name_no_extra_candidates() {
 fn test_claude_and_codex_have_cli_install_commands() {
     let claude = super::known_acp_runtime_exact("claude").unwrap();
     let codex = super::known_acp_runtime_exact("codex").unwrap();
+    let antigravity = super::known_acp_runtime_exact("antigravity").unwrap();
     assert!(
         !claude.cli_install_commands.is_empty(),
         "claude must have cli install commands"
@@ -1198,6 +1231,12 @@ fn test_claude_and_codex_have_cli_install_commands() {
         !codex.cli_install_commands.is_empty(),
         "codex must have cli install commands"
     );
+    assert!(
+        !antigravity.cli_install_commands.is_empty(),
+        "antigravity must have cli install commands"
+    );
+    assert_eq!(antigravity.label, "Google Antigravity");
+    assert_eq!(antigravity.underlying_cli, Some("antigravity"));
 }
 
 /// cli_install_commands_for_os returns a non-empty slice for claude and codex.


### PR DESCRIPTION
## Summary
This PR adds built-in ACP runtime preset support for **Google Antigravity** (`agy`) using the published [`buzz-antigravity-acp`](https://www.npmjs.com/package/buzz-antigravity-acp) adapter.

### Changes Included:
- **`desktop/src-tauri/src/managed_agents/discovery.rs`**:
  - Registered `KnownAcpRuntime` for Google Antigravity (`agy` CLI) with official full-color brand avatar.
  - Configured ACP adapter install commands (`npm install -g buzz-antigravity-acp`) and repository URLs.
  - Added default argument normalization for `buzz-antigravity-acp` and `antigravity-acp`.
- **`desktop/src-tauri/src/managed_agents/discovery/tests.rs`**:
  - Added unit tests verifying avatar URL resolution and empty argument normalization for Antigravity commands.

### Verification:
- Formatted Rust code with `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml`.
- Verified live chat and streaming interaction in Buzz Desktop with Google Antigravity models (`Gemini 3.7 Flash`, `Gemini 3.6 Flash`).
