### PR TITLE
docs(architecture): document Desktop's two spawn paths for buzz-acp

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -673,6 +673,14 @@ Buzz Relay ──WS──→ buzz-acp ──stdio (ACP/JSON-RPC)──→ Agent 
 
 **Does NOT:** persist state.
 
+**Desktop's relationship to `buzz-acp` — two independent spawn paths, same wire protocol:**
+
+Desktop (`desktop/src-tauri`) normally spawns `buzz-acp` itself, as an ordinary child process (`std::process::Command::new`, `desktop/src-tauri/src/managed_agents/runtime.rs:521`), passing the agent's credentials as environment variables on that call (`BUZZ_PRIVATE_KEY`, `BUZZ_RELAY_URL`; `runtime.rs:532-533`). A child process inherits the OS user account of whatever launched it — so an agent spawned this way runs under the *same account as Desktop itself* (Desktop's "Agents" panel manages exactly these locally-spawned processes: start/stop/status, one entry per spawned child).
+
+This is not the only valid way to run `buzz-acp`. It is a standalone binary with no dependency on being launched by Desktop, no IPC with Desktop, and no shared memory — it only needs the same three environment variables (`BUZZ_PRIVATE_KEY`, `BUZZ_RELAY_URL`, `BUZZ_AUTH_TAG`) to establish its own outbound WebSocket connection to the relay, authenticate via NIP-42, and begin operating. Any process supervisor capable of setting those env vars and starting the binary is a conforming launcher — a `launchd`/`systemd` unit under a different, more restricted OS account works today, no code change required. Once running, that independently-launched agent is indistinguishable, at the relay/channel level, from a Desktop-spawned one: it shows up as a normal channel member and its messages fan out the same way. It will *not* appear in Desktop's "Agents" panel, since Desktop never spawned it and holds no process handle to it — that panel is scoped to locally-spawned children, not to "every agent visible in this community."
+
+Net: the OS-process relationship (who spawned the agent, what account it inherits) and the relay-level relationship (channel membership, message visibility) are independent. Isolating an agent's OS permissions from Desktop's own account requires the second spawn path, not any change to how the agent participates in channels.
+
 ---
 
 ### buzz-admin — Operator CLI

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -679,6 +679,33 @@ Desktop (`desktop/src-tauri`) normally spawns `buzz-acp` itself, as an ordinary 
 
 This is not the only valid way to run `buzz-acp`. It is a standalone binary with no dependency on being launched by Desktop, no IPC with Desktop, and no shared memory — it only needs the same three environment variables (`BUZZ_PRIVATE_KEY`, `BUZZ_RELAY_URL`, `BUZZ_AUTH_TAG`) to establish its own outbound WebSocket connection to the relay, authenticate via NIP-42, and begin operating. Any process supervisor capable of setting those env vars and starting the binary is a conforming launcher — a `launchd`/`systemd` unit under a different, more restricted OS account works today, no code change required. Once running, that independently-launched agent is indistinguishable, at the relay/channel level, from a Desktop-spawned one: it shows up as a normal channel member and its messages fan out the same way. It will *not* appear in Desktop's "Agents" panel, since Desktop never spawned it and holds no process handle to it — that panel is scoped to locally-spawned children, not to "every agent visible in this community."
 
+**In plain terms:** an agent is not a feature switched on inside Desktop — it's a separate program that happens to be easy to start *from* Desktop. Starting it a different way doesn't change what it is or how it talks to the rest of Buzz, only which computer account owns it.
+
+```mermaid
+graph TB
+    subgraph MacA["Your Mac — account: you"]
+        Desktop["Buzz Desktop<br/>(the app window)"]
+        AgentA["Agent process A<br/>spawned BY Desktop<br/>runs as: you"]
+        Desktop -- "starts it, as a child process" --> AgentA
+    end
+
+    subgraph MacB["Your Mac — account: restricted-agent"]
+        AgentB["Agent process B<br/>spawned by launchd<br/>runs as: restricted-agent"]
+    end
+
+    Relay[("Buzz Relay<br/>(the server)")]
+
+    Desktop == "its own login" ==> Relay
+    AgentA == "its own login" ==> Relay
+    AgentB == "its own login" ==> Relay
+
+    Relay -. "same channel → everyone sees it" .-> Desktop
+    Relay -. "same channel → everyone sees it" .-> AgentA
+    Relay -. "same channel → everyone sees it" .-> AgentB
+```
+
+Three separate logins to the same server, one of them (Desktop) able to start a second one (Agent A) as its own child — but the relay doesn't know or care who started whom. It only sees three independent connections, each with its own credential. Desktop's "Agents" panel can only show Agent A, because Desktop is the one that started it and kept a handle to it; Agent B is just as real and just as visible in shared channels, but Desktop has no record of it — the same way you can see a coworker's messages without your laptop needing to know how their laptop got turned on.
+
 Net: the OS-process relationship (who spawned the agent, what account it inherits) and the relay-level relationship (channel membership, message visibility) are independent. Isolating an agent's OS permissions from Desktop's own account requires the second spawn path, not any change to how the agent participates in channels.
 
 ---


### PR DESCRIPTION
## Summary
- `ARCHITECTURE.md` documents `buzz-acp`'s own internals in detail, but never explains its relationship to the Desktop app that normally launches it.
- Specifically missing: that Desktop spawning `buzz-acp` as a child process (inheriting Desktop's OS account) is one option, and that `buzz-acp` can instead be launched independently (e.g. via `launchd`/`systemd` under a separate, more restricted account) with identical channel-level behavior — it just won't appear in Desktop's "Agents" panel, since that panel only tracks locally-spawned children.
- This surfaced from a real user question about isolating an agent's OS permissions from Desktop's own account — the underlying mechanism already works today, but nothing in the docs said so.

Adds a short, source-cited subsection to the existing `buzz-acp` entry covering both spawn paths, so this doesn't need to be re-derived from source every time it comes up.

## Test plan
- [x] Docs-only change, no code touched
- [x] Every technical claim cited against the actual spawn call and env vars (`desktop/src-tauri/src/managed_agents/runtime.rs:521,532-533`)
- [x] Cross-checked `VISION.md` for any conflicting stance on agent isolation — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)