### PR TITLE
fix(desktop): bind presence retry timers

### DIFF
--- a/desktop/src/features/presence/lib/presenceSubscriptionReconciler.test.mjs
+++ b/desktop/src/features/presence/lib/presenceSubscriptionReconciler.test.mjs
@@ -75,6 +75,41 @@ test("a stale async open is closed and never installed", async () => {
   reconciler.dispose();
 });
 
+test("default timers preserve their global receiver when scheduling retries", async () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const timers = [];
+  const cleared = [];
+
+  globalThis.setTimeout = function (callback) {
+    assert.equal(this, globalThis);
+    timers.push(callback);
+    return timers.length;
+  };
+  globalThis.clearTimeout = function (timer) {
+    assert.equal(this, globalThis);
+    cleared.push(timer);
+  };
+
+  try {
+    const reconciler = new PresenceSubscriptionReconciler({
+      open: async () => {
+        throw new Error("relay unavailable");
+      },
+    });
+
+    reconciler.setAuthors([A]);
+    await Promise.resolve();
+    assert.equal(timers.length, 1);
+
+    reconciler.dispose();
+    assert.deepEqual(cleared, [1]);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
 test("failed replacement preserves the previous subscription and retries", async () => {
   const timers = [];
   const actions = [];

--- a/desktop/src/features/presence/lib/presenceSubscriptionReconciler.ts
+++ b/desktop/src/features/presence/lib/presenceSubscriptionReconciler.ts
@@ -41,8 +41,11 @@ export class PresenceSubscriptionReconciler {
     this.retryDelay =
       options.retryDelay ??
       ((attempt) => Math.min(1000 * 2 ** attempt, 30_000));
-    this.setTimer = options.setTimer ?? setTimeout;
-    this.clearTimer = options.clearTimer ?? clearTimeout;
+    this.setTimer =
+      options.setTimer ??
+      ((callback, delayMs) => globalThis.setTimeout(callback, delayMs));
+    this.clearTimer =
+      options.clearTimer ?? ((timer) => globalThis.clearTimeout(timer));
   }
 
   setAuthors(authors: string[]) {


### PR DESCRIPTION
## Summary
- preserve the WebKit-required `Window` receiver when scheduling and clearing presence subscription retries
- add a receiver-sensitive regression test covering both retry creation and disposal

## Impact
When subscription opening failed, WebKit rejected the detached timer call before `retryTimer` could be set. The reconciler's `finally` block then immediately started another reconciliation because demand was still unsatisfied and no retry appeared pending. This bypassed the intended exponential backoff and could repeatedly reopen subscription work during startup, so the impact was more than console noise.

With the timer receiver fixed, a failed open schedules one bounded retry at a time (1s exponential backoff, capped at 30s), and disposal cancels it correctly.

## Validation
- `cd desktop && node --import ./test-loader.mjs --experimental-strip-types --test src/features/presence/lib/presenceSubscriptionReconciler.test.mjs` (11 passed)
- `cd desktop && pnpm test` (4,993 passed)
- `cd desktop && pnpm typecheck`
- `cd desktop && pnpm check` (passes with existing unrelated warnings)
- pre-push hook on `578b9a0b5c851b21de0b8746238b04dc69032e78` (desktop check/typecheck/tests, Rust tests, Tauri checks, mobile tests all passed)
