### PR TITLE
Update Buzz privacy retention to 365 days

### DIFF
--- a/privacy.md
+++ b/privacy.md
@@ -4,7 +4,7 @@ title: "Buzz Privacy Notice"
 
 # Buzz Privacy Notice
 
-*Last Updated: July 15, 2026*
+*Last Updated: August 18, 2026*
 
 [Home](index.html) · [Terms of service](terms.html) · [Support](support.html)
 
@@ -112,7 +112,7 @@ We will keep your personal information only for the period necessary to fulfill 
 
 * your account data for as long as you keep your account open or as needed to provide you with our Services;
 
-* messages, media files and attachments, and other user content are retained for up to 180 days by default, or for a shorter period if you delete them;
+* messages, media files and attachments, and other user content are retained for up to 365 days by default, or for a shorter period if you delete them;
 
 * if you contact our support team (for example, at [help@buzz.xyz](mailto:help@buzz.xyz)), we retain data related to your request for as long as needed to respond to and resolve it; and
 


### PR DESCRIPTION
## Summary
- update the GitHub Pages Buzz privacy notice's default user-content retention period from 180 days to 365 days
- update the privacy notice's Last Updated date to August 18, 2026
- leave the Terms of Service unchanged; the supplied Terms URL links to this privacy notice, which contains the retention clause

## Source trace
- GitHub Pages publishes the `pages` branch at `https://block.github.io/buzz/`
- `terms.md` contains no 180-day retention clause
- `privacy.md` contains the single stale clause and generates `privacy.html`
- 365 days matches merged `squareup/bb-public#384` and the approved/open website sync in `squareup/ext-builderbot-ui#172`

## Validation
- `git diff --check origin/pages...HEAD`
- committed-source assertions: exactly one `up to 365 days by default`, zero `up to 180 days by default`, exactly one `Last Updated: August 18, 2026`
- verified the remote fork commit tree `b6ecf2b7b37e78f4ac206d5461d677f49cc8ef0d` exactly matches the locally checked commit tree
- repository `pages` branch contains Markdown-only legal content and no local build/test configuration; GitHub Pages will render after merge
