### PR TITLE
feat(desktop): show live working state on board cards

### DIFF
--- a/desktop/src/features/workstream-board/lib/activeWorkstreamTurns.test.mjs
+++ b/desktop/src/features/workstream-board/lib/activeWorkstreamTurns.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getActiveWorkstreamTurns } from "./activeWorkstreamTurns.ts";
+
+const boardChannel = { id: "board", name: "loganj-ws-board" };
+const otherBoardChannel = { id: "other-board", name: "loganj-ws-other" };
+const turns = [
+  {
+    channelId: "board",
+    anchorAt: 100,
+    agentCount: 2,
+    agentPubkeys: ["agent-a", "agent-b"],
+  },
+  {
+    channelId: "general",
+    anchorAt: 200,
+    agentCount: 1,
+    agentPubkeys: ["agent-c"],
+  },
+];
+
+test("keeps the store's aggregate for board channels", () => {
+  assert.deepEqual(getActiveWorkstreamTurns([boardChannel], turns), [turns[0]]);
+});
+
+test("does not project unrelated channel turns onto the board", () => {
+  assert.deepEqual(
+    getActiveWorkstreamTurns([boardChannel, otherBoardChannel], turns),
+    [turns[0]],
+  );
+});

--- a/desktop/src/features/workstream-board/lib/activeWorkstreamTurns.ts
+++ b/desktop/src/features/workstream-board/lib/activeWorkstreamTurns.ts
@@ -1,0 +1,15 @@
+import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
+import type { Channel } from "@/shared/api/types";
+
+/**
+ * Restricts the shared liveness projection to cards that exist on this board.
+ * It intentionally does not inspect observer frames or time: the active-turn
+ * store is the only owner of those semantics.
+ */
+export function getActiveWorkstreamTurns(
+  channels: readonly Channel[],
+  activeTurnsByChannel: readonly ActiveChannelTurnSummary[],
+): ActiveChannelTurnSummary[] {
+  const channelIds = new Set(channels.map((channel) => channel.id));
+  return activeTurnsByChannel.filter((turn) => channelIds.has(turn.channelId));
+}

--- a/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
@@ -1,6 +1,11 @@
+import * as React from "react";
+
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { useActiveAgentTurnsByChannel } from "@/features/agents/activeAgentTurnsStore";
 import { useChannelsQuery } from "@/features/channels/hooks";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { filterWorkstreamChannels } from "@/features/workstream-board/lib/discoverWorkstreamChannels";
+import { getActiveWorkstreamTurns } from "@/features/workstream-board/lib/activeWorkstreamTurns";
 import { WorkstreamCard } from "@/features/workstream-board/ui/WorkstreamCard";
 import { Button } from "@/shared/ui/button";
 import { PageHeader } from "@/shared/ui/PageHeader";
@@ -13,6 +18,21 @@ export function WorkstreamBoardScreen() {
   const channelsQuery = useChannelsQuery();
   const channels = channelsQuery.data ?? [];
   const workstreamChannels = filterWorkstreamChannels(channels);
+  const activeTurnsByChannel = useActiveAgentTurnsByChannel();
+  const activeWorkstreamTurns = React.useMemo(
+    () => getActiveWorkstreamTurns(workstreamChannels, activeTurnsByChannel),
+    [activeTurnsByChannel, workstreamChannels],
+  );
+  const activeTurnsByChannelId = React.useMemo(
+    () => new Map(activeWorkstreamTurns.map((turn) => [turn.channelId, turn])),
+    [activeWorkstreamTurns],
+  );
+  const activeAgentPubkeys = React.useMemo(
+    () => activeWorkstreamTurns.flatMap((turn) => turn.agentPubkeys),
+    [activeWorkstreamTurns],
+  );
+  const activeProfilesQuery = useUsersBatchQuery(activeAgentPubkeys);
+  const activeProfiles = activeProfilesQuery.data?.profiles;
 
   return (
     <div
@@ -53,8 +73,10 @@ export function WorkstreamBoardScreen() {
             <div className={WORKSTREAM_CARD_GRID_CLASS}>
               {workstreamChannels.map((channel) => (
                 <WorkstreamCard
+                  activeWorking={activeTurnsByChannelId.get(channel.id)}
                   channel={channel}
                   key={channel.id}
+                  profiles={activeProfiles}
                   onSelect={(channelId) => void goChannel(channelId)}
                 />
               ))}

--- a/desktop/src/features/workstream-board/ui/WorkstreamCard.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamCard.tsx
@@ -1,16 +1,26 @@
 import { Hash } from "lucide-react";
 
+import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
 import { useCanvasQuery } from "@/features/channels/hooks";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { buildWorkstreamCardViewModel } from "@/features/workstream-board/lib/workstreamCardViewModel";
 import type { Channel } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
+import { WorkstreamWorkingIndicator } from "@/features/workstream-board/ui/WorkstreamWorkingIndicator";
 
 type WorkstreamCardProps = {
+  activeWorking?: ActiveChannelTurnSummary;
   channel: Channel;
+  profiles?: UserProfileLookup;
   onSelect: (channelId: string) => void;
 };
 
-export function WorkstreamCard({ channel, onSelect }: WorkstreamCardProps) {
+export function WorkstreamCard({
+  activeWorking,
+  channel,
+  onSelect,
+  profiles,
+}: WorkstreamCardProps) {
   const canvasQuery = useCanvasQuery(channel.id);
   const viewModel = buildWorkstreamCardViewModel({
     canvasContent: canvasQuery.data?.content,
@@ -82,6 +92,12 @@ export function WorkstreamCard({ channel, onSelect }: WorkstreamCardProps) {
             ) : null}
           </div>
         )}
+        {activeWorking ? (
+          <WorkstreamWorkingIndicator
+            activeWorking={activeWorking}
+            profiles={profiles}
+          />
+        ) : null}
       </div>
     </div>
   );

--- a/desktop/src/features/workstream-board/ui/WorkstreamWorkingIndicator.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamWorkingIndicator.tsx
@@ -1,0 +1,64 @@
+import { Loader2 } from "lucide-react";
+
+import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
+import { formatElapsed } from "@/features/agents/ui/agentSessionUtils";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
+import { useNow } from "@/shared/lib/useNow";
+import { UserAvatar } from "@/shared/ui/UserAvatar";
+
+type WorkstreamWorkingIndicatorProps = {
+  activeWorking: ActiveChannelTurnSummary;
+  profiles?: UserProfileLookup;
+};
+
+/**
+ * Presentation-only projection of the shared active-turn store for one board
+ * card. Ingestion, ordering, and stall pruning stay owned by
+ * activeAgentTurnsStore.
+ */
+export function WorkstreamWorkingIndicator({
+  activeWorking,
+  profiles,
+}: WorkstreamWorkingIndicatorProps) {
+  const now = useNow(1000);
+  const elapsed = formatElapsed(now - activeWorking.anchorAt);
+
+  return (
+    <section
+      aria-label={`${activeWorking.agentCount} active agent${activeWorking.agentCount === 1 ? "" : "s"}`}
+      className="mt-4 border-t border-border/60 pt-3"
+      data-testid={`workstream-working-${activeWorking.channelId}`}
+    >
+      <div className="flex items-center gap-1.5 text-2xs font-medium text-primary">
+        <Loader2 aria-hidden="true" className="size-3 animate-spin" />
+        <span>
+          {activeWorking.agentCount} working · {elapsed}
+        </span>
+      </div>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {activeWorking.agentPubkeys.map((pubkey) => {
+          const profile = profiles?.[normalizePubkey(pubkey)];
+          const name =
+            profile?.displayName?.trim() || `Agent ${truncatePubkey(pubkey)}`;
+          return (
+            <span
+              className="inline-flex max-w-full items-center gap-1 rounded-full border border-primary/25 bg-primary/10 py-0.5 pl-1 pr-2 text-2xs text-foreground"
+              data-testid={`workstream-working-agent-${pubkey}`}
+              key={pubkey}
+              title={name}
+            >
+              <UserAvatar
+                avatarUrl={profile?.avatarUrl ?? null}
+                className="size-3.5 shrink-0"
+                displayName={name}
+                size="sm"
+              />
+              <span className="truncate">{name}</span>
+            </span>
+          );
+        })}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
🤖

## Summary

Workstream coordinators need to tell at a glance whether a board card is actively being worked, without opening each channel. This adds a passive live-working indicator to Workstream Board cards: active agents and elapsed working time appear on the matching card, and multiple active agents aggregate together.

This is **PR 2 of a four-PR Workstream Board stack**, stacked on [PR 1](https://github.com/block/buzz/pull/6184). It remains an experiment, **off by default**; enable Workstream Board in Settings → Experiments to use it.

### What changes

- Projects the existing shared active-turn observer state onto discovered board channels; active agents and elapsed time render on the corresponding card.
- Preserves inherited completion and stalled-turn pruning behavior from that shared store.
- Keeps unrelated channels from lighting board cards, and aggregates concurrent active agents on one card.
- Does **not** add a second subscription, decryption, event-ordering, terminal-handling, or pruning authority.

The implementation lives on this PR branch in [`activeWorkstreamTurns.ts`](https://github.com/block/buzz/blob/workstream-board/02-live-working/desktop/src/features/workstream-board/lib/activeWorkstreamTurns.ts), [`WorkstreamBoardScreen.tsx`](https://github.com/block/buzz/blob/workstream-board/02-live-working/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx), and [`WorkstreamWorkingIndicator.tsx`](https://github.com/block/buzz/blob/workstream-board/02-live-working/desktop/src/features/workstream-board/ui/WorkstreamWorkingIndicator.tsx).

### Related issue

None found. This is an experiment-gated product spike.

### Testing

- Exact head `2dfbd23581783c54eba52d405593fb00fdabc0d7`:
  - `pnpm check`
  - `pnpm typecheck`
  - full Desktop `pnpm test`: **4,997 passed, 0 failed**
- Continuous relay-backed capture exercises absent → active turn starts → elapsed/liveness → completion clears. Its end-to-end assertions also cover concurrent workers, unrelated-channel exclusion, and silent-turn pruning.
- Two independent Royal reviews cleared the rebased exact head with zero findings (content scores: 9.7/10 and 9.5/10).

**Acceptance gates**

- [x] Board working state is a projection of the existing active-turn observer store.
- [x] Active agents and elapsed time render on matching cards; multiple agents aggregate.
- [x] Completion and stall pruning are inherited; unrelated channels do not light cards.
- [x] Continuous relay-backed demo captured before PR creation.
- [x] Two independent Royal reviews passed at the exact PR head with zero findings.
- [ ] Required CI checks are green.
- [ ] Maintainer review is complete.

> [!NOTE]
> Security may report the known baseline-wide `RUSTSEC-2026-0258` / `h2 0.4.14` advisory. A separate fix lane owns it; it is unrelated to this Desktop-only diff.

### Demo

The qualifying native **36.44-second MP4** is preserved locally and available on request; it is intentionally not uploaded to CloudFront/S3. SHA-256: `6e7fb5bafa8bfe77c9b79c3e763c9aabd330bbf044357598051c8bc81ed5df1b`.

Sampled frames from that uninterrupted relay-backed capture:

| Before active work | Work starts |
| --- | --- |
| ![Board before active work](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6219/frame-5s.png) | ![Board card shows the active worker](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6219/frame-9s.png) |

| Elapsed work | Concurrent workers |
| --- | --- |
| ![Active card shows elapsed working time](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6219/frame-14s.png) | ![Card aggregates concurrent active agents](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6219/frame-19s.png) |

| Unrelated channel excluded | Completion clears card |
| --- | --- |
| ![Unrelated active channel does not light the workstream card](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6219/frame-28s.png) | ![Working indicator clears after completion](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6219/frame-34s.png) |
