### PR TITLE
feat(tooling): Windows bootstrap, fork-aware screenshot hosting, mobile golden helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -599,6 +599,16 @@ removes stale worktree-suffixed installs from simulators/emulators. See
 [mobile/README.md](mobile/README.md) for direct Xcode / Android Studio
 usage.
 
+### Windows (no hermit)
+
+hermit publishes no Windows build — `bin/flutter` 404s fetching
+`hermit-mingw64_nt-10.0-<build>-amd64.gz`, and `source bin/activate-hermit`
+leaves you with `flutter: command not found`. On Windows run `pwsh -File
+scripts/bootstrap-windows.ps1` instead: it installs the pinned SDK and prints
+the `PATH` / `PUB_CACHE` lines to set. `flutter test`, `flutter analyze`, and
+`dart format` all work from there; iOS simulator work stays macOS-only. See
+[docs/windows-dev-setup.md](docs/windows-dev-setup.md).
+
 ### Testing Conventions
 
 - Prefer **widget tests** over unit tests for UI components — test the

--- a/docs/windows-dev-setup.md
+++ b/docs/windows-dev-setup.md
@@ -1,0 +1,166 @@
+# Windows Dev Setup
+
+How to get a working Flutter/Dart toolchain for this repo on Windows, where
+hermit does not run.
+
+## Why hermit does not work here
+
+Every toolchain in `bin/` is a hermit shim: `bin/flutter` is a symlink to
+`bin/.flutter-3.41.7.pkg`, which is a symlink to `bin/hermit`. Running either
+`bin/flutter` or `source bin/activate-hermit` first bootstraps hermit itself,
+and that is where Windows falls over. `bin/hermit` derives the download name
+from `uname -s`, which on Windows under Git Bash / MSYS is:
+
+```
+$ uname -s
+MINGW64_NT-10.0-26200
+```
+
+so it asks for
+
+```
+https://github.com/cashapp/hermit/releases/download/stable/hermit-mingw64_nt-10.0-26200-amd64.gz
+```
+
+and gets **HTTP 404** — cashapp/hermit publishes `darwin` and `linux` archives
+only, no Windows build at any version. The bootstrap fails, `bin/flutter` never
+runs, and after `source bin/activate-hermit` the shell reports:
+
+```
+flutter: command not found
+```
+
+That is a packaging gap, not a broken checkout. The mobile code itself is
+perfectly testable on Windows — you just need the SDK installed directly
+instead of through hermit. (An automated verifier has already misread this
+404 as "mobile is unverifiable on this machine". It isn't.)
+
+## Bootstrap
+
+`scripts/bootstrap-windows.ps1` installs exactly the Flutter version this repo
+pins, without hermit:
+
+```powershell
+pwsh -File scripts/bootstrap-windows.ps1
+```
+
+What it does:
+
+1. Reads the pinned version out of `bin/.flutter-<version>.pkg` — it never
+   hardcodes a version, so it follows the repo when the pin moves. It fails
+   loudly if that marker is missing or ambiguous.
+2. Resolves the matching Windows archive from
+   `https://storage.googleapis.com/flutter_infra_release/releases/releases_windows.json`,
+   failing if that exact version has no Windows build. Flutter publishes no
+   arm64 Windows SDK (that manifest has zero arm64 entries), so on Windows on
+   ARM the script says so and uses the x64 archive, which runs under emulation.
+3. Downloads the archive into the install root and **always** verifies its
+   SHA256 against the manifest before extracting. A mismatch aborts.
+4. Extracts, then runs `flutter --version` and asserts the reported version
+   equals the pinned one.
+5. Prints the `PATH` / `PUB_CACHE` lines to set.
+
+It is idempotent and non-destructive: an archive that is already downloaded is
+re-verified but not refetched, an SDK that is already extracted at the pinned
+version is left alone, and the script never deletes a directory. Any failure
+exits non-zero. There are no prompts, so it is safe to run from CI or from an
+agent.
+
+Options:
+
+| Flag | Meaning |
+|------|---------|
+| `-InstallRoot <dir>` | Where the SDK and pub cache live. Default `E:\flutter-sdk`. |
+| `-PrintEnvOnly` | Skip install, just print the environment lines for an existing install. |
+
+```powershell
+pwsh -File scripts/bootstrap-windows.ps1 -InstallRoot C:\sdks\flutter-sdk
+pwsh -File scripts/bootstrap-windows.ps1 -PrintEnvOnly
+```
+
+If the SDK at `-InstallRoot` is a *different* version than the repo pins, the
+script stops and tells you to move it aside or pick another root — it will not
+silently overwrite or delete an existing SDK.
+
+## Environment
+
+The script does not touch your persistent `PATH`. Set these per shell (adjust
+if you used a custom `-InstallRoot`):
+
+```powershell
+# PowerShell
+$env:PATH = "E:\flutter-sdk\flutter\bin;$env:PATH"
+$env:PUB_CACHE = "E:\flutter-sdk\pub-cache"
+```
+
+```bash
+# Git Bash
+export PATH="/e/flutter-sdk/flutter/bin:$PATH"
+export PUB_CACHE='E:\flutter-sdk\pub-cache'
+```
+
+`PUB_CACHE` always stays a Windows-style path — Dart resolves it itself and
+does not understand MSYS `/e/...` paths.
+
+Or skip `PATH` entirely and call the binaries directly, which is the most
+reliable option for scripted/agent use:
+
+```
+E:\flutter-sdk\flutter\bin\flutter.bat --version
+E:\flutter-sdk\flutter\bin\dart.bat format .
+```
+
+Never use `bin/flutter`, `bin/dart`, or `bin/activate-hermit` on Windows.
+
+## What works on Windows, and what does not
+
+Works, using the SDK installed above:
+
+- `flutter test` — the full `mobile/` widget and unit test suite.
+- `flutter analyze` — static analysis.
+- `dart format` (and `dart format --output=none --set-exit-if-changed .` for
+  the CI-style check).
+
+So the mobile quality gate is fully runnable here:
+
+```powershell
+$env:PATH = "E:\flutter-sdk\flutter\bin;$env:PATH"
+$env:PUB_CACHE = "E:\flutter-sdk\pub-cache"
+cd mobile
+dart format --output=none --set-exit-if-changed .
+flutter analyze
+flutter test
+```
+
+Does **not** work on Windows:
+
+- **iOS simulator work — anything involving the iOS simulator, `xcodebuild`,
+  CocoaPods, or iOS screenshots is macOS-only.** `just mobile-dev` starts an
+  iOS simulator and cannot run here.
+- `just mobile-*` recipes in general, and any other `just` recipe that shells
+  out to a `bin/` hermit shim — those go through hermit and will fail the same
+  way. Run the underlying `flutter` / `dart` commands directly instead.
+- Per repo policy, agents must not run `flutter run`, `flutter build`,
+  `flutter clean`, or `flutter upgrade` on any platform.
+
+## Scope
+
+This script covers Flutter/Dart only, because that is the toolchain the mobile
+gate needs. The other hermit-pinned tools (`node`, `pnpm`, `rust`, `just`,
+`biome`, …) hit the same hermit gap on Windows and have to be installed
+natively, from their own installers, at the versions pinned in `bin/`.
+
+## Troubleshooting
+
+**`flutter: command not found` after `source bin/activate-hermit`** — expected;
+see above. Use the bootstrap script.
+
+**`Bootstrapping ... 404`** — expected; hermit has no Windows release.
+
+**SHA256 mismatch** — the download is corrupt or tampered with. The script
+refuses to extract and leaves the file in place; delete it yourself and re-run.
+
+**`Get-FileHash` takes a while** — the archive is ~1.8 GB, and it is verified
+whenever the script has to extract, including when the download itself was
+skipped because the archive was already on disk. That is deliberate. Runs that
+find the SDK already extracted skip the archive entirely and finish in seconds.

--- a/mobile/test/helpers/README.md
+++ b/mobile/test/helpers/README.md
@@ -1,0 +1,169 @@
+# Mobile test helpers
+
+Shared scaffolding for the Flutter widget tests.
+
+| File | What it is |
+|------|------------|
+| `widget_helpers.dart` | `WidgetHelpers.testable()` — wraps a widget in `ProviderScope` + `MaterialApp` + `Scaffold` with the app theme. |
+| `golden_shot.dart` | Golden-screenshot helper: render any widget at a phone surface with the real app fonts and write a PNG. |
+
+---
+
+## Golden screenshots (`golden_shot.dart`)
+
+PR screenshots for the mobile app normally mean a Mac, Xcode, and a booted
+simulator. `golden_shot.dart` removes all three: a widget test rendered at a
+phone surface with the real fonts loaded is good enough for review, and
+`flutter test` runs everywhere — including Windows.
+
+### Writing a shot
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../helpers/golden_shot.dart';
+import '../../helpers/widget_helpers.dart';
+
+void main() {
+  testWidgets('channel list', (tester) async {
+    await loadAppFonts();
+    setPhoneSurface(tester);
+
+    await tester.pumpWidget(WidgetHelpers.testable(child: const ChannelList()));
+
+    await captureShot(tester, find.byType(ChannelList), '01-channel-list');
+  });
+}
+```
+
+### Producing the PNGs
+
+```sh
+cd mobile
+flutter test --update-goldens test/features/channels
+```
+
+The PNGs are written to a `goldens/` directory next to the test file, named
+after the second argument to `captureShot`. Prefix names with `01-`, `02-`, …
+so they sort into the order you want them read.
+
+A plain `flutter test` (no flag) compares against whatever was written, so once
+a shot exists it doubles as a visual regression test.
+
+To post the results on a PR, use the repo-root helper — **never** `buzz upload`
+or a relay media URL, which fail through GitHub's camo proxy:
+
+```sh
+./scripts/post-screenshots.sh <PR-number> mobile/test/features/channels/goldens
+```
+
+### Two shots that are byte-identical
+
+`captureShot` throws when two shots in the same run produce identical bytes.
+That is nearly always a real bug rather than a coincidence: both captures
+rendered the *same* state, because the test never actually drove the UI into
+the second state, or because the finder was scoped to a whole page that looks
+the same in both. It is the most common screenshot mistake there is, and it is
+almost impossible to spot by eye in a wall of thumbnails.
+
+Fix the test. Only pass `failOnDuplicate: false` when two states really are
+meant to be pixel-identical.
+
+Outside this helper, the same check by hand is:
+
+```sh
+shasum -a 256 mobile/test/**/goldens/*.png   # every hash should be unique
+```
+
+---
+
+## The two font traps
+
+`flutter_test` renders with a stub font that draws every glyph as a filled
+square. Screenshots taken without registering real fonts are walls of tofu
+boxes, and nothing warns you — the test passes, the PNG is just wrong. This is
+what `loadAppFonts()` exists to prevent, and there are two ways to get it wrong.
+
+**1. The app font.** `Inter` lives at `mobile/assets/fonts/InterVariable.ttf`
+and has to be handed to `FontLoader` explicitly; `pubspec.yaml`'s `fonts:`
+section only covers the real app, not the test host.
+
+**2. `fontPackage` (the subtle one).** Icons come from the
+`lucide_icons_flutter` package, and every one of its `IconData` constants
+carries `fontPackage: 'lucide_icons_flutter'`. Flutter turns that into the
+family name:
+
+```
+packages/lucide_icons_flutter/Lucide
+```
+
+Registering the bare family `Lucide` *succeeds*, logs nothing, and leaves
+**every icon in the app** as a tofu box. `loadAppFonts()` registers the
+package-qualified names, including the `Lucide100`…`Lucide600` weight variants
+behind `LucideIcons.<name><weight>`.
+
+`golden_shot_test.dart` guards both traps by rendering pairs that are identical
+under the stub font and obviously different under the real ones (`MMMM` vs
+`llll`; two different Lucide icons).
+
+Pairwise inequality is enough for the *base* families — with no font registered
+both glyphs collapse to the same box, so the two captures match. It is **not**
+enough for the `Lucide100`…`Lucide600` variants: an unregistered `Lucide100`
+draws a box, and a box differs from a real bell just as much as a thin bell
+does, so the comparison stays green while the icon is broken. Those are checked
+by shade count instead — a solid tofu box is 2 flat colours, an antialiased
+glyph is ~17. `registeredFontFamilies` is likewise recorded as fonts actually
+register, not restated as a literal list, so it cannot report a family that a
+later edit stopped registering.
+
+### Two more traps, for whoever edits the helper next
+
+**Font bytes are read synchronously.** `FontLoader.load()` awaits the futures it
+was given, and a future that completed with an *error* wedges the run forever
+instead of failing it — a missing font file turns into a hung test suite with
+no output. `_readFontSync` checks `existsSync()` and throws a message naming
+the missing path before any future is created. Keep it that way.
+
+**The golden comparison runs inside `runAsync`.** `captureShot` hands raw bytes
+to `matchesGoldenFile`, and on that path flutter_test awaits the golden
+comparator *outside* `runAsync` (the early `List<int>` branch of
+`MatchesGoldenFile.matchAsync`). `LocalFileComparator` reads and writes with
+real `dart:io` futures, and a real I/O future never completes inside the
+fake-async zone a widget test runs in. Unwrap that call and
+`flutter test --update-goldens` hangs forever with no output rather than
+writing a PNG.
+
+Nothing cheap catches this: an in-memory comparator completes synchronously and
+looks perfectly healthy, which is why the self-test also drives a comparator
+that does real file I/O (`_RealIoGoldens`) under an explicit `Timeout`.
+flutter_test disables per-test timeouts by default, so without that timeout a
+regression hangs CI instead of failing it.
+
+### Paths
+
+Nothing is hardcoded. The mobile package, the icon package (whatever version
+the lockfile pins), and the Flutter SDK are all resolved from
+`.dart_tool/package_config.json`, `FLUTTER_ROOT`/`PUB_CACHE`, or the running
+executable, so the helper works on macOS, Linux, Windows, and inside git
+worktrees.
+
+---
+
+## API
+
+| Function | Purpose |
+|----------|---------|
+| `loadAppFonts()` | Register Inter, GeistMono, the Lucide icon families, MaterialIcons and Roboto. Idempotent; call it per test. |
+| `setPhoneSurface(tester, {logical, dpr})` | Size the view to 390×844 @2x, pin text scale to 1.0, zero the safe-area padding. Restores everything via `addTearDown`. |
+| `captureShot(tester, finder, name)` | Settle, rasterise, reject byte-identical duplicates, compare against `goldens/<name>.png`. |
+| `rasterize(tester, finder)` | Encoded PNG bytes for a finder, with no golden file involved. |
+| `isVisuallyBlank(tester, finder)` | `true` when every pixel is the same colour — the signature of a render that produced nothing. |
+| `distinctColorCount(tester, finder)` | Number of distinct colours; a cheap "did the glyphs rasterise" probe. |
+
+### Why there are no committed goldens for the helper itself
+
+`golden_shot_test.dart` is assertion-based, not golden-based. Binary PNGs in
+the repo would need refreshing on every font or engine bump and could not
+explain *why* a shot broke; the pairwise assertions can. The self-test
+therefore passes under a plain `flutter test` with no `--update-goldens` step
+and no PNGs checked in.

--- a/mobile/test/helpers/golden_shot.dart
+++ b/mobile/test/helpers/golden_shot.dart
@@ -1,0 +1,621 @@
+/// Golden-screenshot helpers for the Buzz mobile widget tests.
+///
+/// The point of this file is to make it possible to produce PR-quality mobile
+/// screenshots from a plain `flutter test` run — no Mac, no simulator, no
+/// device farm. A widget test rendered at a phone surface with the real app
+/// fonts loaded is visually indistinguishable from a simulator capture for
+/// review purposes, and it runs on every contributor's machine including
+/// Windows.
+///
+/// Typical use:
+///
+/// ```dart
+/// testWidgets('channel list', (tester) async {
+///   await loadAppFonts();
+///   setPhoneSurface(tester);
+///   await tester.pumpWidget(WidgetHelpers.testable(child: const MyPage()));
+///   await captureShot(tester, find.byType(MyPage), '01-channel-list');
+/// });
+/// ```
+///
+/// Then generate/refresh the PNGs with:
+///
+/// ```sh
+/// flutter test --update-goldens test/features/my_feature
+/// ```
+///
+/// The PNGs land in a `goldens/` directory next to the test file and can be
+/// posted straight to a PR (see `scripts/post-screenshots.sh` at the repo
+/// root).
+///
+/// See `test/helpers/README.md` for the full runbook and the font traps this
+/// file exists to encode.
+library;
+
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Logical size of the default capture surface (iPhone 14 / 15 class device).
+const Size kPhoneLogicalSize = Size(390, 844);
+
+/// Device pixel ratio of the default capture surface.
+const double kPhoneDevicePixelRatio = 2.0;
+
+/// The font family the app's text theme asks for.
+const String _kAppFontFamily = 'Inter';
+
+/// The monospace family used by code blocks in message bodies.
+const String _kMonoFontFamily = 'GeistMono';
+
+/// The pub package that ships the icon font used across the app.
+const String _kIconPackage = 'lucide_icons_flutter';
+
+/// Weight variants shipped by the icon package, as `Lucide<weight>` families.
+const List<int> _kIconWeights = <int>[100, 200, 300, 400, 500, 600];
+
+// ---------------------------------------------------------------------------
+// Fonts
+// ---------------------------------------------------------------------------
+
+bool _fontsLoaded = false;
+
+/// Registers the real app fonts with the test font collection.
+///
+/// `flutter_test` ships with a single stub font ("Ahem") that draws every
+/// glyph as a filled box, so **any** widget-test screenshot is unreadable tofu
+/// until the real fonts are registered. Call this at the top of every test
+/// that captures a shot. It is idempotent and cheap after the first call.
+///
+/// What gets registered, and why each one matters:
+///
+/// * `Inter` — the app's text family (`lib/shared/theme/text_theme.dart`).
+///   Without it every string renders as boxes.
+/// * `GeistMono` — the monospace family used for code.
+/// * `packages/lucide_icons_flutter/Lucide` (plus the `Lucide100`..`Lucide600`
+///   weight variants) — the icon font. Note the `packages/<pkg>/` prefix: the
+///   `IconData` constants in `lucide_icons_flutter` carry
+///   `fontPackage: 'lucide_icons_flutter'`, and Flutter resolves that to the
+///   family name `packages/lucide_icons_flutter/Lucide`. Registering the bare
+///   name `Lucide` "succeeds" and still leaves **every icon in the app** as a
+///   tofu box, which is the easiest way there is to ship a broken screenshot.
+/// * `MaterialIcons` and `Roboto` — shipped by the Flutter SDK and used by
+///   framework widgets (back buttons, dropdown chevrons, unstyled text).
+///
+/// Throws a [StateError] with an actionable message if a font file cannot be
+/// located. It never hangs: every font file is read **synchronously** before
+/// being handed to [FontLoader]. `FontLoader.load()` awaits the futures it was
+/// given, and a future that completes with an error there wedges the test run
+/// forever rather than failing it — so the read must not be async.
+Future<void> loadAppFonts() async {
+  if (_fontsLoaded) {
+    return;
+  }
+
+  final appFonts = '${mobilePackageRoot()}/assets/fonts';
+  await _registerFont(_kAppFontFamily, <String>[
+    '$appFonts/InterVariable.ttf',
+    '$appFonts/InterVariable-Italic.ttf',
+  ]);
+  await _registerFont(_kMonoFontFamily, <String>[
+    '$appFonts/GeistMono-Variable.ttf',
+    '$appFonts/GeistMono-Italic-Variable.ttf',
+  ]);
+
+  // The family names MUST carry the `packages/<pkg>/` prefix — see above.
+  // `Lucide` is the fixed-weight font; `Lucide100`..`Lucide600` are the
+  // variable-weight builds behind `LucideIcons.<name><weight>`.
+  final iconRoot = iconPackageRoot();
+  await _registerFont('packages/$_kIconPackage/Lucide', <String>[
+    '$iconRoot/assets/lucide.ttf',
+  ]);
+  for (final weight in _kIconWeights) {
+    await _registerFont('packages/$_kIconPackage/Lucide$weight', <String>[
+      '$iconRoot/assets/build_font/LucideVariable-w$weight.ttf',
+    ]);
+  }
+
+  final sdkFonts = '${flutterSdkRoot()}/bin/cache/artifacts/material_fonts';
+  await _registerFont('MaterialIcons', <String>[
+    '$sdkFonts/materialicons-regular.otf',
+  ]);
+  await _registerFont('Roboto', <String>[
+    '$sdkFonts/roboto-regular.ttf',
+    '$sdkFonts/roboto-medium.ttf',
+    '$sdkFonts/roboto-bold.ttf',
+  ]);
+
+  _fontsLoaded = true;
+}
+
+/// Family names [loadAppFonts] has actually registered, in registration order.
+///
+/// Recorded by [_registerFont] as each family goes in, rather than restated as
+/// a literal list: a hardcoded list keeps happily reporting families that a
+/// later edit stopped registering, which is precisely the silent breakage this
+/// helper exists to catch. Empty until [loadAppFonts] has been awaited.
+List<String> get registeredFontFamilies =>
+    List<String>.unmodifiable(_registeredFamilies);
+
+final List<String> _registeredFamilies = <String>[];
+
+Future<void> _registerFont(String family, List<String> paths) async {
+  final loader = FontLoader(family);
+  for (final path in paths) {
+    // Synchronous read on purpose: see loadAppFonts' doc comment.
+    loader.addFont(Future<ByteData>.value(_readFontSync(path, family)));
+  }
+  await loader.load();
+  if (!_registeredFamilies.contains(family)) {
+    _registeredFamilies.add(family);
+  }
+}
+
+ByteData _readFontSync(String path, String family) {
+  final file = File(path);
+  if (!file.existsSync()) {
+    throw StateError(
+      'golden_shot: cannot register font family "$family" — file not found:\n'
+      '  $path\n'
+      'If this is a pub package font, run `flutter pub get` in mobile/ and '
+      'retry. If it is an SDK font, check that FLUTTER_ROOT points at a '
+      'Flutter checkout with a populated bin/cache/artifacts.',
+    );
+  }
+  return ByteData.sublistView(file.readAsBytesSync());
+}
+
+// ---------------------------------------------------------------------------
+// Surface
+// ---------------------------------------------------------------------------
+
+/// Sizes the test view to a phone surface so captures look like a real device.
+///
+/// The default `flutter_test` surface is 800x600 at DPR 1 — a squat landscape
+/// tablet that makes every mobile layout look wrong. This sets a portrait
+/// phone surface, pins the text scale factor to 1.0 so host accessibility
+/// settings cannot drift the output, and zeroes the safe-area padding so shots
+/// are not offset by a simulated notch.
+///
+/// Everything it changes is restored via `addTearDown`, so it is safe to call
+/// once per test.
+void setPhoneSurface(
+  WidgetTester tester, {
+  Size logical = kPhoneLogicalSize,
+  double dpr = kPhoneDevicePixelRatio,
+}) {
+  final view = tester.view;
+
+  view.devicePixelRatio = dpr;
+  view.physicalSize = Size(logical.width * dpr, logical.height * dpr);
+  view.padding = FakeViewPadding.zero;
+  view.viewPadding = FakeViewPadding.zero;
+  view.viewInsets = FakeViewPadding.zero;
+  tester.platformDispatcher.textScaleFactorTestValue = 1.0;
+
+  addTearDown(() {
+    view.resetDevicePixelRatio();
+    view.resetPhysicalSize();
+    view.resetPadding();
+    view.resetViewPadding();
+    view.resetViewInsets();
+    tester.platformDispatcher.clearTextScaleFactorTestValue();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Capture
+// ---------------------------------------------------------------------------
+
+/// Digest -> shot name, so identical captures inside one run are caught.
+final Map<int, String> _shotDigests = <int, String>{};
+
+/// Renders [finder] and compares it against `goldens/<name>.png`.
+///
+/// Run `flutter test --update-goldens <path>` to write the PNGs, then commit
+/// or post them. A subsequent plain `flutter test` compares against what was
+/// written, which is what keeps the screenshots honest over time.
+///
+/// [name] should sort in the order you want the shots to appear in the PR
+/// comment, e.g. `01-empty-state`, `02-with-messages`.
+///
+/// If two shots in the same run produce byte-identical images this throws by
+/// default. That is almost never a coincidence: it means both captures
+/// rendered the *same* state — the most common screenshot bug there is, and
+/// one that is easy to miss when eyeballing a wall of thumbnails. Fix the test
+/// rather than silencing it; pass `failOnDuplicate: false` only when two
+/// states are genuinely expected to be pixel-identical.
+Future<void> captureShot(
+  WidgetTester tester,
+  Finder finder,
+  String name, {
+  String goldenDir = 'goldens',
+  bool failOnDuplicate = true,
+  bool settle = true,
+}) async {
+  if (settle) {
+    await tester.pumpAndSettle();
+  }
+
+  final png = await rasterize(tester, finder);
+
+  final digest = _digest(png);
+  final previous = _shotDigests[digest];
+  if (previous != null && previous != name) {
+    if (failOnDuplicate) {
+      throw StateError(
+        'golden_shot: shot "$name" is byte-identical to "$previous".\n'
+        'Two captures rendered the same state. Check that the test actually '
+        'drove the UI into a different state between the two shots, and that '
+        'the finder is scoped to the subject rather than the whole page. Pass '
+        'failOnDuplicate: false if they are genuinely meant to match.',
+      );
+    }
+    debugPrint(
+      'golden_shot: warning — shot "$name" is byte-identical to "$previous".',
+    );
+  }
+  _shotDigests[digest] = name;
+
+  // The golden comparison MUST run inside runAsync, and that is not a
+  // stylistic choice. When the value handed to matchesGoldenFile is a
+  // List<int>, flutter_test's matcher awaits the golden comparator *outside*
+  // runAsync — see the early byte path in MatchesGoldenFile.matchAsync
+  // (flutter_test/lib/src/_matchers_io.dart). LocalFileComparator reads and
+  // writes with real dart:io futures, and a real I/O future never completes
+  // inside the fake-async zone a widget test runs in. Without this wrapper,
+  // `flutter test --update-goldens` hangs forever with no output instead of
+  // writing a PNG, and nothing surfaces the cause: a stubbed in-memory
+  // comparator completes synchronously and looks perfectly healthy.
+  await TestWidgetsFlutterBinding.instance.runAsync(
+    () => expectLater(png, matchesGoldenFile('$goldenDir/$name.png')),
+  );
+}
+
+/// Renders [finder]'s nearest repaint boundary and returns encoded PNG bytes.
+///
+/// Useful on its own for assertions about what was drawn (see
+/// [isVisuallyBlank] and [distinctColorCount]) without involving a golden file
+/// at all.
+Future<Uint8List> rasterize(WidgetTester tester, Finder finder) {
+  return _withCapturedImage(finder, (image) async {
+    final data = await image.toByteData(format: ui.ImageByteFormat.png);
+    if (data == null) {
+      throw StateError('golden_shot: could not encode the captured image.');
+    }
+    return Uint8List.fromList(data.buffer.asUint8List());
+  });
+}
+
+/// Whether every pixel of [finder]'s capture is the same colour.
+///
+/// A uniform capture is the signature of a render that produced nothing — most
+/// often because the fonts were never loaded and the widget under test is pure
+/// text, or because the finder resolved to an offstage subtree. Use it to
+/// assert that a shot has actual content in it.
+Future<bool> isVisuallyBlank(WidgetTester tester, Finder finder) {
+  return _withCapturedImage(finder, (image) async {
+    final pixels = await _rawPixels(image);
+    if (pixels.isEmpty) {
+      return true;
+    }
+    final first = pixels.first;
+    for (final pixel in pixels) {
+      if (pixel != first) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+/// Number of distinct colours in [finder]'s capture.
+///
+/// A crude but effective "did the glyphs actually rasterise" probe: antialiased
+/// text and icon strokes produce dozens of intermediate shades, whereas tofu
+/// boxes and empty surfaces produce a handful of flat colours.
+Future<int> distinctColorCount(WidgetTester tester, Finder finder) {
+  return _withCapturedImage(finder, (image) async {
+    final pixels = await _rawPixels(image);
+    return pixels.toSet().length;
+  });
+}
+
+Future<Uint32List> _rawPixels(ui.Image image) async {
+  final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  if (data == null) {
+    throw StateError('golden_shot: could not read the captured pixels.');
+  }
+  return data.buffer.asUint32List();
+}
+
+Future<T> _withCapturedImage<T>(
+  Finder finder,
+  Future<T> Function(ui.Image image) body,
+) async {
+  final elements = finder.evaluate();
+  if (elements.isEmpty) {
+    throw StateError('golden_shot: finder matched no widgets: $finder');
+  }
+  if (elements.length > 1) {
+    throw StateError(
+      'golden_shot: finder matched ${elements.length} widgets, expected '
+      'exactly one: $finder',
+    );
+  }
+
+  // captureImage() must be *called* outside runAsync (it walks the live layer
+  // tree) and *awaited* inside it — this mirrors what matchesGoldenFile does.
+  final imageFuture = captureImage(elements.single);
+  final result = await TestWidgetsFlutterBinding.instance.runAsync(() async {
+    final image = await imageFuture;
+    try {
+      return await body(image);
+    } finally {
+      image.dispose();
+    }
+  });
+
+  if (result == null) {
+    throw StateError('golden_shot: image capture did not complete.');
+  }
+  return result;
+}
+
+/// Clears the duplicate-shot registry. Only useful in this helper's own tests.
+@visibleForTesting
+void resetShotDigests() => _shotDigests.clear();
+
+/// FNV-1a over the encoded bytes. Not cryptographic — just a cheap identity
+/// check for "did these two captures produce the same image".
+int _digest(Uint8List bytes) {
+  var hash = 0xcbf29ce484222325;
+  for (final byte in bytes) {
+    hash = (hash ^ byte) * 0x100000001b3;
+    hash &= 0xFFFFFFFFFFFFFFFF;
+  }
+  return hash;
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution
+//
+// Everything below resolves paths from the environment rather than hardcoding
+// them, so the helper works on macOS, Linux and Windows, inside git worktrees,
+// and against whatever icon-package version the lockfile happens to pin.
+// ---------------------------------------------------------------------------
+
+String? _cachedMobileRoot;
+String? _cachedIconRoot;
+String? _cachedFlutterRoot;
+
+/// Absolute path to the `mobile/` package root, with `/` separators.
+String mobilePackageRoot() {
+  final cached = _cachedMobileRoot;
+  if (cached != null) {
+    return cached;
+  }
+
+  // Primary: ask the package resolver where `package:buzz` lives. Independent
+  // of whatever working directory the test runner happened to start in.
+  final resolved = _packageRootFromConfig('buzz');
+  if (resolved != null && Directory('$resolved/assets/fonts').existsSync()) {
+    return _cachedMobileRoot = resolved;
+  }
+
+  // Fallback: walk up from the working directory looking for the app's fonts.
+  var dir = Directory.current.absolute;
+  for (var i = 0; i < 8; i++) {
+    final candidate = _stripTrailingSlash(_posix(dir.path));
+    if (Directory('$candidate/assets/fonts').existsSync() &&
+        File('$candidate/pubspec.yaml').existsSync()) {
+      return _cachedMobileRoot = candidate;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) {
+      break;
+    }
+    dir = parent;
+  }
+
+  throw StateError(
+    'golden_shot: could not locate the mobile package root (the directory '
+    'holding pubspec.yaml and assets/fonts). Run the tests from mobile/ with '
+    '`flutter test`.',
+  );
+}
+
+/// Absolute path to the resolved `lucide_icons_flutter` package.
+String iconPackageRoot() {
+  final cached = _cachedIconRoot;
+  if (cached != null) {
+    return cached;
+  }
+
+  final resolved = _packageRootFromConfig(_kIconPackage);
+  if (resolved != null && File('$resolved/assets/lucide.ttf').existsSync()) {
+    return _cachedIconRoot = resolved;
+  }
+
+  // Fallback: glob the pub cache. The version is never hardcoded — take the
+  // highest-sorting `lucide_icons_flutter-*` directory that is present.
+  final cacheDir = Directory('${_pubCacheRoot()}/hosted/pub.dev');
+  if (cacheDir.existsSync()) {
+    final matches =
+        cacheDir
+            .listSync()
+            .whereType<Directory>()
+            .map((entry) => _stripTrailingSlash(_posix(entry.path)))
+            .where((path) => path.split('/').last.startsWith('$_kIconPackage-'))
+            .toList()
+          ..sort();
+    if (matches.isNotEmpty) {
+      return _cachedIconRoot = matches.last;
+    }
+  }
+
+  throw StateError(
+    'golden_shot: could not locate the $_kIconPackage package. Run '
+    '`flutter pub get` in mobile/, or point PUB_CACHE at your pub cache.',
+  );
+}
+
+/// Absolute path to the Flutter SDK checkout that owns the bundled fonts.
+String flutterSdkRoot() {
+  final cached = _cachedFlutterRoot;
+  if (cached != null) {
+    return cached;
+  }
+
+  bool hasFonts(String path) =>
+      Directory('$path/bin/cache/artifacts/material_fonts').existsSync();
+
+  final fromEnv = Platform.environment['FLUTTER_ROOT'];
+  if (fromEnv != null && fromEnv.isNotEmpty) {
+    final normalized = _stripTrailingSlash(_posix(fromEnv));
+    if (hasFonts(normalized)) {
+      return _cachedFlutterRoot = normalized;
+    }
+  }
+
+  // `package:flutter` resolves to <sdk>/packages/flutter.
+  final flutterPackage = _packageRootFromConfig('flutter');
+  if (flutterPackage != null) {
+    final sdk = _parentOf(_parentOf(flutterPackage));
+    if (hasFonts(sdk)) {
+      return _cachedFlutterRoot = sdk;
+    }
+  }
+
+  // Last resort: the test runner binary lives under <sdk>/bin/cache/...
+  var dir = File(Platform.resolvedExecutable).parent;
+  for (var i = 0; i < 10; i++) {
+    final candidate = _stripTrailingSlash(_posix(dir.path));
+    if (hasFonts(candidate)) {
+      return _cachedFlutterRoot = candidate;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) {
+      break;
+    }
+    dir = parent;
+  }
+
+  throw StateError(
+    'golden_shot: could not locate the Flutter SDK. Set FLUTTER_ROOT to your '
+    'Flutter checkout and retry.',
+  );
+}
+
+/// Reads `.dart_tool/package_config.json` and returns [package]'s root dir.
+///
+/// Uses [Isolate.packageConfigSync] first so it works regardless of the
+/// working directory, then falls back to walking up from the CWD.
+String? _packageRootFromConfig(String package) {
+  for (final configUri in _packageConfigCandidates()) {
+    final file = File.fromUri(configUri);
+    if (!file.existsSync()) {
+      continue;
+    }
+    final String contents;
+    try {
+      contents = file.readAsStringSync();
+    } on FileSystemException {
+      continue;
+    }
+    final rootUri = _rootUriFor(contents, package);
+    if (rootUri == null) {
+      continue;
+    }
+    final resolved = configUri.resolve(rootUri);
+    if (!resolved.isScheme('file')) {
+      continue;
+    }
+    return _stripTrailingSlash(_posix(File.fromUri(resolved).path));
+  }
+  return null;
+}
+
+Iterable<Uri> _packageConfigCandidates() sync* {
+  final fromIsolate = _isolatePackageConfig();
+  if (fromIsolate != null) {
+    yield fromIsolate;
+  }
+  var dir = Directory.current.absolute;
+  for (var i = 0; i < 8; i++) {
+    yield Uri.file(
+      '${_stripTrailingSlash(_posix(dir.path))}/.dart_tool/package_config.json',
+    );
+    final parent = dir.parent;
+    if (parent.path == dir.path) {
+      break;
+    }
+    dir = parent;
+  }
+}
+
+/// The package config the isolate was launched with, when it will tell us.
+///
+/// `flutter_tester` throws `Unsupported operation: Isolate.packageConfig`, so
+/// this is strictly a best-effort shortcut — callers fall back to walking up
+/// from the working directory.
+Uri? _isolatePackageConfig() {
+  try {
+    final uri = Isolate.packageConfigSync;
+    return uri != null && uri.isScheme('file') ? uri : null;
+  } on Object {
+    return null;
+  }
+}
+
+/// Pulls `rootUri` for [package] out of a package_config.json body.
+///
+/// Deliberately regex-based rather than `dart:convert` plus a pile of casts:
+/// the file is machine-generated and flat, and this keeps a malformed entry
+/// from throwing where a clean "not found" is the useful answer.
+String? _rootUriFor(String json, String package) {
+  final entry = RegExp(
+    '\\{[^{}]*"name"\\s*:\\s*"${RegExp.escape(package)}"[^{}]*\\}',
+  ).firstMatch(json);
+  if (entry == null) {
+    return null;
+  }
+  final rootUri = RegExp(
+    r'"rootUri"\s*:\s*"([^"]*)"',
+  ).firstMatch(entry.group(0)!);
+  return rootUri?.group(1);
+}
+
+String _pubCacheRoot() {
+  final fromEnv = Platform.environment['PUB_CACHE'];
+  if (fromEnv != null && fromEnv.isNotEmpty) {
+    return _stripTrailingSlash(_posix(fromEnv));
+  }
+  if (Platform.isWindows) {
+    final localAppData = Platform.environment['LOCALAPPDATA'];
+    if (localAppData != null && localAppData.isNotEmpty) {
+      return '${_stripTrailingSlash(_posix(localAppData))}/Pub/Cache';
+    }
+  }
+  final home =
+      Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'] ?? '';
+  return '${_stripTrailingSlash(_posix(home))}/.pub-cache';
+}
+
+String _parentOf(String path) {
+  final index = path.lastIndexOf('/');
+  return index <= 0 ? path : path.substring(0, index);
+}
+
+String _stripTrailingSlash(String path) => path.length > 1 && path.endsWith('/')
+    ? path.substring(0, path.length - 1)
+    : path;
+
+/// Normalises Windows backslashes so the rest of the file can join with '/'.
+/// `dart:io` accepts forward slashes on every platform Flutter supports.
+String _posix(String path) => path.replaceAll(r'\', '/');

--- a/mobile/test/helpers/golden_shot_test.dart
+++ b/mobile/test/helpers/golden_shot_test.dart
@@ -1,0 +1,337 @@
+// Self-test for the golden-screenshot helper.
+//
+// This deliberately does NOT compare against a committed golden PNG: binary
+// goldens in the repo would need refreshing on every font or engine bump, and
+// they cannot tell you *why* a shot broke. Instead it asserts the two things
+// the helper exists to guarantee — that the text font and the package-scoped
+// icon font actually rasterise — by rendering pairs of inputs that are
+// indistinguishable when the fonts are missing and obviously different when
+// they are present.
+//
+// It passes under a plain `flutter test`; no `--update-goldens` needed.
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import 'golden_shot.dart';
+
+const Key _shotKey = ValueKey<String>('golden-shot-self-test');
+
+/// A fixed-size white swatch with a repaint boundary, so every capture in this
+/// file is the same geometry and only the glyphs differ.
+Widget _swatch(Widget child) {
+  return MaterialApp(
+    debugShowCheckedModeBanner: false,
+    home: Scaffold(
+      backgroundColor: Colors.white,
+      body: Center(
+        child: RepaintBoundary(
+          key: _shotKey,
+          child: Container(
+            width: 200,
+            height: 90,
+            color: Colors.white,
+            alignment: Alignment.center,
+            child: child,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<Uint8List> _render(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(_swatch(child));
+  await tester.pumpAndSettle();
+  return rasterize(tester, find.byKey(_shotKey));
+}
+
+/// Accepts every comparison so `captureShot` can be exercised end to end
+/// without a PNG on disk.
+class _AcceptAllGoldens extends GoldenFileComparator {
+  @override
+  Future<bool> compare(Uint8List imageBytes, Uri golden) async => true;
+
+  @override
+  Future<void> update(Uri golden, Uint8List imageBytes) async {}
+}
+
+/// Accepts every comparison too, but only after doing the same **real**
+/// `dart:io` work `LocalFileComparator` does — the part an in-memory stub
+/// silently skips.
+///
+/// A real I/O future never completes inside the fake-async zone a widget test
+/// runs in, so this comparator hangs forever unless `captureShot` awaits the
+/// golden comparison inside `runAsync`. That is the whole point of it: the
+/// accept-all stub above completes synchronously and cannot tell you whether
+/// the real workflow works at all.
+class _RealIoGoldens extends GoldenFileComparator {
+  _RealIoGoldens(this.baseDir);
+
+  final Directory baseDir;
+
+  File fileFor(Uri golden) => File(
+    '${baseDir.path}${Platform.pathSeparator}'
+    '${golden.path.replaceAll('/', Platform.pathSeparator)}',
+  );
+
+  @override
+  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
+    await update(golden, imageBytes);
+    return true;
+  }
+
+  @override
+  Future<void> update(Uri golden, Uint8List imageBytes) async {
+    final file = fileFor(golden);
+    await file.parent.create(recursive: true);
+    await file.writeAsBytes(imageBytes, flush: true);
+  }
+}
+
+void main() {
+  setUp(() async {
+    // Idempotent: the first test pays for the font registration, the rest are
+    // free. Calling it per test is the pattern the README tells contributors
+    // to follow, so the self-test follows it too.
+    await loadAppFonts();
+  });
+
+  test('loadAppFonts registers the package-qualified icon families', () {
+    // The trap this guards: LucideIcons' IconData carries
+    // fontPackage: 'lucide_icons_flutter', so the family Flutter looks up is
+    // 'packages/lucide_icons_flutter/Lucide'. Registering bare 'Lucide'
+    // silently leaves every icon as a tofu box.
+    expect(
+      registeredFontFamilies,
+      contains('packages/lucide_icons_flutter/Lucide'),
+    );
+    expect(
+      registeredFontFamilies.where((family) => family.contains('Lucide')),
+      everyElement(startsWith('packages/lucide_icons_flutter/')),
+    );
+    for (final weight in const <int>[100, 200, 300, 400, 500, 600]) {
+      expect(
+        registeredFontFamilies,
+        contains('packages/lucide_icons_flutter/Lucide$weight'),
+        reason: 'The Lucide$weight weight variant was never registered.',
+      );
+    }
+    expect(registeredFontFamilies, contains('Inter'));
+    expect(registeredFontFamilies, contains('MaterialIcons'));
+  });
+
+  testWidgets('setPhoneSurface sizes the view to a phone', (tester) async {
+    final defaultSize = tester.view.physicalSize;
+
+    setPhoneSurface(tester);
+    expect(tester.view.physicalSize, isNot(defaultSize));
+    expect(tester.view.devicePixelRatio, kPhoneDevicePixelRatio);
+    expect(
+      tester.view.physicalSize,
+      Size(
+        kPhoneLogicalSize.width * kPhoneDevicePixelRatio,
+        kPhoneLogicalSize.height * kPhoneDevicePixelRatio,
+      ),
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: SizedBox.expand())),
+    );
+    // The app really lays out at phone logical size, not the 800x600 default.
+    expect(tester.getSize(find.byType(MaterialApp)), kPhoneLogicalSize);
+    // setPhoneSurface registers its own addTearDown to undo all of the above,
+    // which is why it is safe to call once per test.
+  });
+
+  testWidgets('text renders with real glyphs, not tofu boxes', (tester) async {
+    setPhoneSurface(tester);
+
+    const style = TextStyle(
+      fontFamily: 'Inter',
+      fontSize: 34,
+      color: Colors.black,
+    );
+    final wide = await _render(tester, const Text('MMMM', style: style));
+    final narrow = await _render(tester, const Text('llll', style: style));
+
+    // Every glyph in the stub test font is an identical filled square, so
+    // 'MMMM' and 'llll' rasterise identically when no real font is loaded.
+    expect(
+      wide,
+      isNot(equals(narrow)),
+      reason:
+          'Identical captures for different glyphs means the Inter font never '
+          'registered and text is rendering as tofu boxes.',
+    );
+
+    // Antialiased curves produce many intermediate greys; a blank surface or a
+    // run of solid tofu boxes produces a handful of flat colours.
+    await _render(tester, const Text('Buzz', style: style));
+    final shades = await distinctColorCount(tester, find.byKey(_shotKey));
+    expect(shades, greaterThan(8), reason: 'Capture has $shades colours.');
+    expect(await isVisuallyBlank(tester, find.byKey(_shotKey)), isFalse);
+  });
+
+  testWidgets('lucide icons render with real glyphs', (tester) async {
+    setPhoneSurface(tester);
+
+    const size = 56.0;
+    final bell = await _render(
+      tester,
+      const Icon(LucideIcons.bell, size: size, color: Colors.black),
+    );
+    final house = await _render(
+      tester,
+      const Icon(LucideIcons.house, size: size, color: Colors.black),
+    );
+    final weighted = await _render(
+      tester,
+      const Icon(LucideIcons.bell100, size: size, color: Colors.black),
+    );
+
+    // Unregistered icon fonts collapse every codepoint to the same tofu box.
+    expect(
+      bell,
+      isNot(equals(house)),
+      reason:
+          'Two different Lucide icons rasterised identically — the icon font '
+          'family is almost certainly registered without its '
+          'packages/lucide_icons_flutter/ prefix.',
+    );
+    expect(
+      bell,
+      isNot(equals(weighted)),
+      reason: 'LucideIcons.bell100 rasterised the same bytes as bell.',
+    );
+
+    // The tree still holds the weighted render. Byte inequality alone is NOT
+    // enough for the weight variants: an unregistered Lucide100 draws a tofu
+    // box, and a box differs from a real bell just as much as a thin bell does.
+    // Only the shade count separates them — a solid box is 2 flat colours, an
+    // antialiased glyph is well over a dozen.
+    final weightedShades = await distinctColorCount(
+      tester,
+      find.byKey(_shotKey),
+    );
+    expect(
+      weightedShades,
+      greaterThan(8),
+      reason:
+          'LucideIcons.bell100 rasterised to $weightedShades colours — that is '
+          'a tofu box, so packages/lucide_icons_flutter/Lucide100 never '
+          'registered.',
+    );
+
+    expect(await isVisuallyBlank(tester, find.byKey(_shotKey)), isFalse);
+  });
+
+  testWidgets('captureShot rejects byte-identical shots', (tester) async {
+    final previousComparator = goldenFileComparator;
+    goldenFileComparator = _AcceptAllGoldens();
+    resetShotDigests();
+    addTearDown(() {
+      goldenFileComparator = previousComparator;
+      resetShotDigests();
+    });
+
+    setPhoneSurface(tester);
+    await tester.pumpWidget(
+      _swatch(
+        const Text(
+          'Buzz',
+          style: TextStyle(
+            fontFamily: 'Inter',
+            fontSize: 28,
+            color: Colors.black,
+          ),
+        ),
+      ),
+    );
+
+    // First shot goes through the full matchesGoldenFile path.
+    await captureShot(tester, find.byKey(_shotKey), '01-first');
+
+    // Re-capturing the unchanged tree under a new name is the classic
+    // "two screenshots of the same state" bug, and the helper must catch it.
+    await expectLater(
+      () => captureShot(tester, find.byKey(_shotKey), '02-duplicate'),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          contains('byte-identical'),
+        ),
+      ),
+    );
+
+    // ...and the escape hatch still works for genuinely identical states.
+    await captureShot(
+      tester,
+      find.byKey(_shotKey),
+      '03-duplicate-allowed',
+      failOnDuplicate: false,
+    );
+  });
+
+  testWidgets(
+    'captureShot survives a comparator that does real file I/O',
+    (tester) async {
+      // Regression guard for a bug this file used to be blind to. Handed raw
+      // bytes, matchesGoldenFile awaits the golden comparator OUTSIDE runAsync,
+      // and the real LocalFileComparator reads and writes with dart:io futures
+      // that never complete inside a widget test's fake-async zone — so
+      // `flutter test --update-goldens` hung forever instead of writing a PNG,
+      // while every assertion here stayed green against the in-memory stub.
+      //
+      // The explicit timeout matters as much as the assertions: flutter_test
+      // disables per-test timeouts by default, so a regression would otherwise
+      // hang CI indefinitely rather than fail it.
+      final tempDir = Directory.systemTemp.createTempSync(
+        'golden_shot_selftest',
+      );
+      final previousComparator = goldenFileComparator;
+      final comparator = _RealIoGoldens(tempDir);
+      goldenFileComparator = comparator;
+      resetShotDigests();
+      addTearDown(() {
+        goldenFileComparator = previousComparator;
+        resetShotDigests();
+        tempDir.deleteSync(recursive: true);
+      });
+
+      setPhoneSurface(tester);
+      await tester.pumpWidget(
+        _swatch(
+          const Text(
+            'Buzz',
+            style: TextStyle(
+              fontFamily: 'Inter',
+              fontSize: 28,
+              color: Colors.black,
+            ),
+          ),
+        ),
+      );
+
+      await captureShot(tester, find.byKey(_shotKey), 'real-comparator');
+
+      final written = comparator.fileFor(
+        Uri.parse('goldens/real-comparator.png'),
+      );
+      expect(
+        written.existsSync(),
+        isTrue,
+        reason: 'captureShot produced no PNG at ${written.path}',
+      );
+      // PNG magic number — proves a real image landed, not a truncated write.
+      expect(written.readAsBytesSync().take(4), <int>[0x89, 0x50, 0x4e, 0x47]);
+      expect(written.lengthSync(), greaterThan(500));
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+}

--- a/scripts/bootstrap-windows.ps1
+++ b/scripts/bootstrap-windows.ps1
@@ -1,0 +1,355 @@
+<#
+.SYNOPSIS
+    Installs the Flutter SDK version pinned by this repo, on Windows, without hermit.
+
+.DESCRIPTION
+    The repo vendors its toolchains with hermit (bin/flutter -> bin/.flutter-<version>.pkg).
+    hermit publishes no Windows release: bootstrapping it fetches
+    hermit-mingw64_nt-10.0-<build>-amd64.gz and gets HTTP 404, after which
+    `source bin/activate-hermit` leaves you with `flutter: command not found`.
+
+    This script closes that gap. It reads the pinned Flutter version straight out of
+    bin/.flutter-<version>.pkg, resolves the matching Windows archive from Google's
+    release manifest, downloads and SHA256-verifies it, extracts it, and prints the
+    PATH / PUB_CACHE lines to export. It is idempotent: an already-downloaded archive
+    is verified but not refetched, an already-extracted SDK of the pinned version is
+    left alone, and nothing is ever deleted.
+
+.PARAMETER InstallRoot
+    Directory holding the SDK and its pub cache. The SDK lands in <InstallRoot>\flutter
+    and PUB_CACHE points at <InstallRoot>\pub-cache. Defaults to E:\flutter-sdk.
+
+.PARAMETER PrintEnvOnly
+    Skip install entirely and just print the environment lines for an existing install.
+
+.EXAMPLE
+    pwsh -File scripts/bootstrap-windows.ps1
+
+.EXAMPLE
+    pwsh -File scripts/bootstrap-windows.ps1 -InstallRoot C:\sdks\flutter-sdk
+
+.EXAMPLE
+    pwsh -File scripts/bootstrap-windows.ps1 -PrintEnvOnly
+#>
+
+[CmdletBinding()]
+param(
+    [string]$InstallRoot = 'E:\flutter-sdk',
+    [switch]$PrintEnvOnly
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$ManifestUrl = 'https://storage.googleapis.com/flutter_infra_release/releases/releases_windows.json'
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "==> $Message"
+}
+
+function Fail {
+    param([string]$Message)
+    [Console]::Error.WriteLine('')
+    [Console]::Error.WriteLine("ERROR: $Message")
+    exit 1
+}
+
+# --- 1. Pinned version, read from the repo -------------------------------------------
+
+function Get-PinnedFlutterVersion {
+    param([string]$BinDir)
+
+    if (-not (Test-Path -LiteralPath $BinDir -PathType Container)) {
+        Fail "No bin/ directory at '$BinDir'. Run this script from inside the buzz checkout."
+    }
+
+    $pkgs = @(Get-ChildItem -Force -LiteralPath $BinDir -Filter '.flutter-*.pkg' | Sort-Object Name)
+
+    if ($pkgs.Count -eq 0) {
+        Fail "No bin/.flutter-<version>.pkg found in '$BinDir'. Cannot determine the pinned Flutter version."
+    }
+    if ($pkgs.Count -gt 1) {
+        $names = ($pkgs | ForEach-Object { $_.Name }) -join ', '
+        Fail "Ambiguous Flutter pin: found $($pkgs.Count) marker files in '$BinDir' ($names). Exactly one is expected."
+    }
+
+    $name = $pkgs[0].Name
+    $parsed = [regex]::Match($name, '^\.flutter-(?<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.\-]+)?)\.pkg$')
+    if (-not $parsed.Success) {
+        Fail "Could not parse a version out of '$name' (expected .flutter-<version>.pkg)."
+    }
+
+    return $parsed.Groups['version'].Value
+}
+
+# --- 2. Windows archive, resolved from the release manifest ---------------------------
+
+function Get-WindowsRelease {
+    param([string]$Version)
+
+    Write-Step "Resolving the Windows archive for Flutter $Version from the release manifest"
+
+    $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64' -or $env:PROCESSOR_ARCHITEW6432 -eq 'ARM64') {
+        'arm64'
+    }
+    else {
+        'x64'
+    }
+
+    try {
+        $manifest = Invoke-RestMethod -Uri $ManifestUrl -UseBasicParsing
+    }
+    catch {
+        Fail "Failed to fetch the Flutter Windows release manifest from $ManifestUrl : $($_.Exception.Message)"
+    }
+
+    $candidates = @($manifest.releases | Where-Object { $_.version -eq $Version })
+    if ($candidates.Count -eq 0) {
+        Fail @"
+Flutter $Version has no Windows build in $ManifestUrl.
+The repo pins that version via bin/.flutter-$Version.pkg, but Google publishes no matching
+Windows archive for it. Raise the pin, or install that version from source by hand.
+"@
+    }
+
+    # dart_sdk_arch only appears once multi-arch builds existed; absent means x64.
+    $pickArch = {
+        param([string]$Want)
+        @($candidates | Where-Object {
+                $relArch = if ($_.PSObject.Properties.Name -contains 'dart_sdk_arch') { $_.dart_sdk_arch } else { 'x64' }
+                $relArch -eq $Want
+            })
+    }
+
+    $forArch = @(& $pickArch $arch)
+    if ($forArch.Count -eq 0 -and $arch -ne 'x64') {
+        # Flutter publishes no arm64 Windows SDK at all - releases_windows.json has
+        # zero arm64 entries. Windows on ARM runs the x64 build under emulation,
+        # which is what flutter.dev tells you to install there.
+        $forArch = @(& $pickArch 'x64')
+        if ($forArch.Count -gt 0) {
+            Write-Host "    note: no arm64 Windows archive exists for Flutter $Version; using the x64 one (Windows on ARM runs it under emulation)."
+            $arch = 'x64'
+        }
+    }
+    if ($forArch.Count -eq 0) {
+        $channels = ($candidates | ForEach-Object { $_.channel }) -join ', '
+        Fail "Flutter $Version has a Windows build, but none usable on $arch (channels found: $channels)."
+    }
+
+    $release = $forArch | Where-Object { $_.channel -eq 'stable' } | Select-Object -First 1
+    if (-not $release) { $release = $forArch | Select-Object -First 1 }
+
+    $distinct = @($forArch | Select-Object -ExpandProperty archive -Unique)
+    if ($distinct.Count -gt 1) {
+        Write-Host "    note: $($distinct.Count) $arch archives claim version $Version; using the $($release.channel) one."
+    }
+
+    foreach ($field in @('archive', 'sha256')) {
+        if (-not ($release.PSObject.Properties.Name -contains $field) -or [string]::IsNullOrWhiteSpace($release.$field)) {
+            Fail "The manifest entry for Flutter $Version is missing '$field'."
+        }
+    }
+
+    return [pscustomobject]@{
+        Version = $Version
+        Channel = $release.channel
+        Arch    = $arch
+        Url     = "$($manifest.base_url)/$($release.archive)"
+        Sha256  = $release.sha256.ToLowerInvariant()
+        File    = Split-Path -Leaf $release.archive.Replace('/', '\')
+    }
+}
+
+# --- 3. Download + verify -------------------------------------------------------------
+
+function Get-VerifiedArchive {
+    param($Release, [string]$Root)
+
+    $archivePath = Join-Path $Root $Release.File
+
+    if (Test-Path -LiteralPath $archivePath -PathType Leaf) {
+        Write-Step "Archive already present, skipping download: $archivePath"
+    }
+    else {
+        Write-Step "Downloading $($Release.Url)"
+        $partial = "$archivePath.partial"
+        $previousProgress = $ProgressPreference
+        $ProgressPreference = 'SilentlyContinue'
+        try {
+            Invoke-WebRequest -Uri $Release.Url -OutFile $partial -UseBasicParsing
+        }
+        catch {
+            Fail "Download failed: $($_.Exception.Message)"
+        }
+        finally {
+            $ProgressPreference = $previousProgress
+        }
+        Move-Item -LiteralPath $partial -Destination $archivePath -Force
+    }
+
+    Write-Step 'Verifying SHA256 against the manifest (reads the whole archive)'
+    $actual = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -ne $Release.Sha256) {
+        Fail @"
+SHA256 mismatch for $archivePath
+  expected $($Release.Sha256)
+  actual   $actual
+Refusing to extract. Move or delete that file yourself, then re-run this script.
+"@
+    }
+    Write-Host "    ok: $actual"
+
+    return $archivePath
+}
+
+# --- 4. Extract -----------------------------------------------------------------------
+
+function Get-InstalledVersion {
+    param([string]$FlutterExe)
+
+    if (-not (Test-Path -LiteralPath $FlutterExe -PathType Leaf)) { return $null }
+
+    $output = (& $FlutterExe --version 2>&1 | Out-String)
+    if ($LASTEXITCODE -ne 0) {
+        Fail "'$FlutterExe --version' exited with $LASTEXITCODE.`n$output"
+    }
+
+    $parsed = [regex]::Match($output, 'Flutter\s+(?<version>\d+\.\d+\.\d+[0-9A-Za-z.\-+]*)')
+    if (-not $parsed.Success) {
+        Fail "Could not parse a version from '$FlutterExe --version' output:`n$output"
+    }
+
+    return $parsed.Groups['version'].Value
+}
+
+function Install-Sdk {
+    param($Release, [string]$Root, [string]$SdkDir)
+
+    $flutterExe = Join-Path $SdkDir 'bin\flutter.bat'
+
+    if (Test-Path -LiteralPath $SdkDir -PathType Container) {
+        $installed = Get-InstalledVersion -FlutterExe $flutterExe
+        if ($null -eq $installed) {
+            Fail @"
+'$SdkDir' exists but has no bin\flutter.bat, so it is not a usable Flutter SDK.
+Move it aside (this script never deletes anything) or pass a different -InstallRoot, then re-run.
+"@
+        }
+        if ($installed -ne $Release.Version) {
+            Fail @"
+'$SdkDir' holds Flutter $installed but this repo pins $($Release.Version).
+Move it aside (this script never deletes anything) or pass a different -InstallRoot, then re-run.
+"@
+        }
+        Write-Step "Flutter $installed already extracted at $SdkDir, skipping download and extraction"
+        return
+    }
+
+    $archivePath = Get-VerifiedArchive -Release $Release -Root $Root
+
+    Write-Step "Extracting to $SdkDir (a few minutes; the archive is ~1.8 GB)"
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    try {
+        # The archive contains a single top-level flutter/ directory, so extract into the root.
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($archivePath, $Root)
+    }
+    catch {
+        Fail "Extraction failed: $($_.Exception.Message)"
+    }
+
+    if (-not (Test-Path -LiteralPath $flutterExe -PathType Leaf)) {
+        Fail "Extraction finished but '$flutterExe' is missing. The archive layout is not what was expected."
+    }
+}
+
+# --- 5. Environment -------------------------------------------------------------------
+
+function Show-Env {
+    param([string]$SdkDir, [string]$PubCache)
+
+    $binDir = Join-Path $SdkDir 'bin'
+    # E:\flutter-sdk\flutter\bin -> /e/flutter-sdk/flutter/bin for Git Bash / MSYS.
+    $bashBin = '/' + ($binDir -replace '^(?<drive>[A-Za-z]):\\', '${drive}/' -replace '\\', '/')
+    $bashBin = $bashBin.Substring(0, 2).ToLowerInvariant() + $bashBin.Substring(2)
+
+    Write-Host ''
+    Write-Host 'This script does not change PATH permanently. Set these per shell:'
+    Write-Host ''
+    Write-Host '  # PowerShell'
+    Write-Host "  `$env:PATH = `"$binDir;`$env:PATH`""
+    Write-Host "  `$env:PUB_CACHE = `"$PubCache`""
+    Write-Host ''
+    Write-Host '  # Git Bash'
+    Write-Host "  export PATH=`"${bashBin}:`$PATH`""
+    Write-Host "  export PUB_CACHE='$PubCache'"
+    Write-Host ''
+    Write-Host '  # Or call the binaries directly, no PATH change needed:'
+    Write-Host "  $(Join-Path $binDir 'flutter.bat') test"
+    Write-Host "  $(Join-Path $binDir 'dart.bat') format ."
+    Write-Host ''
+    Write-Host '  # Optional, persist PUB_CACHE for your user (affects new shells only):'
+    Write-Host "  [Environment]::SetEnvironmentVariable('PUB_CACHE', '$PubCache', 'User')"
+    Write-Host ''
+    Write-Host 'Do not use bin/flutter or bin/activate-hermit on Windows - hermit ships no Windows'
+    Write-Host 'build and its bootstrap 404s. See docs/windows-dev-setup.md.'
+}
+
+# --- main -----------------------------------------------------------------------------
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$binDir = Join-Path $repoRoot 'bin'
+
+$pinned = Get-PinnedFlutterVersion -BinDir $binDir
+Write-Step "Repo pins Flutter $pinned (from bin\.flutter-$pinned.pkg)"
+
+# [IO.Path]::Combine, not Join-Path: Join-Path resolves the drive qualifier and
+# throws a raw "Cannot find drive" exception when -InstallRoot names a drive this
+# machine does not have (the default root is E:\, which is not universal).
+$sdkDir = [IO.Path]::Combine($InstallRoot, 'flutter')
+$pubCache = [IO.Path]::Combine($InstallRoot, 'pub-cache')
+$flutterExe = [IO.Path]::Combine($sdkDir, 'bin\flutter.bat')
+
+if ($PrintEnvOnly) {
+    if (-not (Test-Path -LiteralPath $flutterExe -PathType Leaf)) {
+        Fail "-PrintEnvOnly was passed but '$flutterExe' does not exist. Run this script without -PrintEnvOnly first."
+    }
+    Show-Env -SdkDir $sdkDir -PubCache $pubCache
+    exit 0
+}
+
+$release = Get-WindowsRelease -Version $pinned
+Write-Host "    $($release.Channel)/$($release.Arch): $($release.Url)"
+
+try {
+    if (-not (Test-Path -LiteralPath $InstallRoot -PathType Container)) {
+        New-Item -ItemType Directory -Path $InstallRoot -ErrorAction Stop | Out-Null
+    }
+    if (-not (Test-Path -LiteralPath $pubCache -PathType Container)) {
+        New-Item -ItemType Directory -Path $pubCache -ErrorAction Stop | Out-Null
+    }
+}
+catch {
+    Fail @"
+Could not create the install root '$InstallRoot': $($_.Exception.Message)
+The default root is E:\flutter-sdk, which does not exist on every machine.
+Pass -InstallRoot <dir> to pick a location that exists here.
+"@
+}
+
+Install-Sdk -Release $release -Root $InstallRoot -SdkDir $sdkDir
+
+Write-Step 'Verifying the install'
+$installed = Get-InstalledVersion -FlutterExe $flutterExe
+if ($installed -ne $pinned) {
+    Fail "The installed Flutter reports $installed but the repo pins $pinned."
+}
+$dartExe = Join-Path $sdkDir 'bin\dart.bat'
+if (-not (Test-Path -LiteralPath $dartExe -PathType Leaf)) {
+    Fail "Flutter $installed is installed but '$dartExe' is missing."
+}
+Write-Host "    ok: Flutter $installed at $sdkDir"
+
+Show-Env -SdkDir $sdkDir -PubCache $pubCache
+exit 0

--- a/scripts/post-screenshots.sh
+++ b/scripts/post-screenshots.sh
@@ -1,8 +1,354 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Host PR screenshots as blobs on a GitHub branch and post them to a PR.
+#
+# Images are pushed to a per-developer branch (agent-screenshots/<login>) on a
+# remote the caller can actually push to — which is NOT necessarily the repo
+# the PR lives in. Fork contributors have no push access to block/buzz, so the
+# hosting remote is auto-detected (or picked with --remote) and the raw image
+# base URL is derived from that remote's owner/repo. The PR comment always
+# targets the PR repo (block/buzz by default).
+#
+# macOS ships bash 3.2: no mapfile, no associative arrays, and empty arrays
+# must be expanded with the ${arr[@]+"${arr[@]}"} guard so `set -u` is happy.
+
+PR_REPO_DEFAULT="block/buzz"
+MAX_PUSH_ATTEMPTS=5
+
+usage() {
+  cat <<USAGE
+Usage: $0 [options] <pr-number> <png-dir> [comment-body-file]
+
+Options:
+  --remote <name>    Git remote to host the screenshot blobs on.
+                     Default: auto-detected (first pushable of origin, fork,
+                     a remote owned by your gh login, any other remote).
+  --pr-repo <o/r>    Repo the PR lives in (default: ${PR_REPO_DEFAULT}).
+  --dry-run          Do everything except 'git push' and 'gh pr comment'.
+                     Prints the resolved remote, owner/repo, RAW_BASE, image
+                     URLs and the rendered comment body.
+  --self-test        Run the URL-parsing / remote-detection unit tests and exit.
+                     Needs no repo and no network.
+  -h, --help         Show this help.
+
+Environment:
+  POST_SCREENSHOTS_GH_USER  Override the gh login used for the branch name.
+USAGE
+}
+
+# ---------------------------------------------------------------------------
+# URL parsing
+# ---------------------------------------------------------------------------
+
+# Parse "owner/repo" out of a git remote URL.
+# Handles https://github.com/o/r(.git), git@github.com:o/r(.git),
+# ssh://git@github.com[:22]/o/r.git, git://…, and userinfo in the authority.
+parse_owner_repo() {
+  local url="${1:-}" path=""
+
+  case "$url" in
+    ssh://* | https://* | http://* | git+ssh://* | git://*)
+      path="${url#*://}" # [user[:pass]@]host[:port]/owner/repo(.git)
+      path="${path#*@}"  # strip userinfo, if any
+      path="${path#*/}"  # strip host[:port]
+      ;;
+    *:*)
+      # scp-like syntax: [user@]host:owner/repo(.git)
+      path="${url#*:}"
+      ;;
+    *)
+      path="$url"
+      ;;
+  esac
+
+  path="${path#/}"
+  path="${path%/}"
+  path="${path%.git}"
+  path="${path%/}"
+
+  if [[ "$path" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+    printf '%s\n' "$path"
+    return 0
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Remote detection (these four are the seams the self-test stubs out)
+# ---------------------------------------------------------------------------
+
+list_remotes() {
+  git remote
+}
+
+remote_push_url() {
+  git remote get-url --push "$1" 2>/dev/null && return 0
+  # git < 2.7 has no `remote get-url`.
+  git config --get "remote.$1.pushurl" 2>/dev/null && return 0
+  git config --get "remote.$1.url" 2>/dev/null
+}
+
+gh_login() {
+  if [[ -n "${POST_SCREENSHOTS_GH_USER:-}" ]]; then
+    printf '%s\n' "$POST_SCREENSHOTS_GH_USER"
+    return 0
+  fi
+  gh api user --jq .login 2>/dev/null
+}
+
+# Can we push to this remote? Ask GitHub first (cheap and definitive), then
+# fall back to a dry-run push probe against a ref that cannot already exist.
+remote_is_pushable() {
+  local remote="$1" url owner_repo perm probe_ref
+  url="$(remote_push_url "$remote")" || return 1
+  [[ -n "$url" ]] || return 1
+
+  if owner_repo="$(parse_owner_repo "$url")" && command -v gh >/dev/null 2>&1; then
+    perm="$(gh repo view "$owner_repo" --json viewerPermission --jq .viewerPermission 2>/dev/null || true)"
+    case "$perm" in
+      ADMIN | MAINTAIN | WRITE) return 0 ;;
+      READ | TRIAGE | NONE) return 1 ;;
+    esac
+  fi
+
+  # The probe runs unattended during auto-detection, so it must never block on
+  # an interactive prompt — git's own, a GUI credential helper (e.g. Git
+  # Credential Manager), or ssh asking for a passphrase. Cached credentials
+  # still work; only the interactive fallback is switched off.
+  probe_ref="refs/heads/agent-screenshots-pushcheck/$$"
+  GIT_TERMINAL_PROMPT=0 \
+    GIT_ASKPASS=echo \
+    SSH_ASKPASS=echo \
+    GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh} -o BatchMode=yes" \
+    git -c credential.interactive=false \
+    push --dry-run "$remote" "HEAD:${probe_ref}" >/dev/null 2>&1
+}
+
+# Prefer origin, then a remote literally named "fork", then a remote owned by
+# the gh login, then anything else that accepts a push.
+detect_remote() {
+  local login remote url owner_repo
+  local fallbacks=""
+
+  for remote in $(list_remotes); do
+    case "$remote" in
+      origin)
+        if remote_is_pushable "$remote"; then
+          printf '%s\n' "$remote"
+          return 0
+        fi
+        ;;
+      *) fallbacks="${fallbacks}${remote} " ;;
+    esac
+  done
+
+  for remote in $fallbacks; do
+    if [[ "$remote" == "fork" ]] && remote_is_pushable "$remote"; then
+      printf '%s\n' "$remote"
+      return 0
+    fi
+  done
+
+  login="$(gh_login || true)"
+  if [[ -n "$login" ]]; then
+    for remote in $fallbacks; do
+      url="$(remote_push_url "$remote")" || continue
+      owner_repo="$(parse_owner_repo "$url")" || continue
+      if [[ "${owner_repo%%/*}" == "$login" ]] && remote_is_pushable "$remote"; then
+        printf '%s\n' "$remote"
+        return 0
+      fi
+    done
+  fi
+
+  for remote in $fallbacks; do
+    if remote_is_pushable "$remote"; then
+      printf '%s\n' "$remote"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Self-test: exercises URL parsing and remote detection with stubbed seams.
+# ---------------------------------------------------------------------------
+
+SELF_TEST_FAILURES=0
+
+expect_parse() {
+  local url="$1" want="$2" got
+  got="$(parse_owner_repo "$url" || echo '<none>')"
+  if [[ "$got" == "$want" ]]; then
+    echo "ok   parse_owner_repo '$url' -> $got"
+  else
+    echo "FAIL parse_owner_repo '$url' -> '$got' (want '$want')"
+    SELF_TEST_FAILURES=$((SELF_TEST_FAILURES + 1))
+  fi
+}
+
+expect_remote() {
+  local want="$1" got
+  got="$(detect_remote || echo '<none>')"
+  if [[ "$got" == "$want" ]]; then
+    echo "ok   detect_remote [${TEST_REMOTES}] pushable=[${TEST_PUSHABLE}] -> $got"
+  else
+    echo "FAIL detect_remote [${TEST_REMOTES}] pushable=[${TEST_PUSHABLE}] -> '$got' (want '$want')"
+    SELF_TEST_FAILURES=$((SELF_TEST_FAILURES + 1))
+  fi
+}
+
+run_self_test() {
+  echo "-- parse_owner_repo --"
+  expect_parse "https://github.com/block/buzz.git" "block/buzz"
+  expect_parse "https://github.com/block/buzz" "block/buzz"
+  expect_parse "https://github.com/block/buzz/" "block/buzz"
+  expect_parse "git@github.com:mfethe1/buzz.git" "mfethe1/buzz"
+  expect_parse "git@github.com:mfethe1/buzz" "mfethe1/buzz"
+  expect_parse "ssh://git@github.com/block/buzz.git" "block/buzz"
+  expect_parse "ssh://git@github.com:22/block/buzz.git" "block/buzz"
+  expect_parse "git://github.com/block/buzz.git" "block/buzz"
+  expect_parse "https://user:token@github.com/block/buzz.git" "block/buzz"
+  expect_parse "https://github.com/block/buzz-releases.git" "block/buzz-releases"
+  expect_parse "/local/path/to/repo" "<none>"
+  expect_parse "" "<none>"
+
+  echo
+  echo "-- detect_remote --"
+  # Stub the seams. Redefining a function is bash-3.2 safe.
+  # shellcheck disable=SC2086 # intentional word splitting: one remote per line
+  list_remotes() { printf '%s\n' $TEST_REMOTES; }
+  remote_push_url() {
+    local pair
+    for pair in $TEST_URLS; do
+      case "$pair" in
+        "$1="*)
+          printf '%s\n' "${pair#*=}"
+          return 0
+          ;;
+      esac
+    done
+    return 1
+  }
+  remote_is_pushable() {
+    local name
+    for name in $TEST_PUSHABLE; do
+      if [[ "$name" == "$1" ]]; then
+        return 0
+      fi
+    done
+    return 1
+  }
+  gh_login() { printf '%s\n' "$TEST_LOGIN"; }
+
+  TEST_LOGIN="mfethe1"
+  TEST_URLS="origin=https://github.com/block/buzz.git fork=git@github.com:mfethe1/buzz.git mine=https://github.com/mfethe1/buzz-two.git other=https://github.com/someone/buzz.git"
+
+  # Maintainer: origin wins.
+  TEST_REMOTES="origin fork"
+  TEST_PUSHABLE="origin fork"
+  expect_remote "origin"
+
+  # Fork contributor: origin is read-only, so "fork" wins.
+  TEST_REMOTES="origin fork mine"
+  TEST_PUSHABLE="fork mine"
+  expect_remote "fork"
+
+  # No remote named fork: owner-matches-login beats an unrelated remote.
+  TEST_REMOTES="origin other mine"
+  TEST_PUSHABLE="other mine"
+  expect_remote "mine"
+
+  # "fork" exists but is not pushable: fall through to the owner match.
+  TEST_REMOTES="origin fork mine"
+  TEST_PUSHABLE="mine"
+  expect_remote "mine"
+
+  # Nothing owned by the login: any pushable remote beats nothing.
+  TEST_REMOTES="origin other"
+  TEST_PUSHABLE="other"
+  expect_remote "other"
+
+  # Nothing is pushable at all.
+  TEST_REMOTES="origin other"
+  TEST_PUSHABLE=""
+  expect_remote "<none>"
+
+  echo
+  if [[ $SELF_TEST_FAILURES -eq 0 ]]; then
+    echo "self-test: all checks passed"
+    return 0
+  fi
+  echo "self-test: ${SELF_TEST_FAILURES} check(s) failed" >&2
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+REMOTE=""
+PR_REPO="$PR_REPO_DEFAULT"
+DRY_RUN=0
+SELF_TEST=0
+POSITIONAL=()
+
+require_value() {
+  if [[ -z "${2:-}" ]]; then
+    echo "error: $1 requires a value" >&2
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --remote)
+      require_value --remote "${2:-}"
+      REMOTE="$2"
+      shift
+      ;;
+    --remote=*) REMOTE="${1#*=}" ;;
+    --pr-repo)
+      require_value --pr-repo "${2:-}"
+      PR_REPO="$2"
+      shift
+      ;;
+    --pr-repo=*) PR_REPO="${1#*=}" ;;
+    --dry-run) DRY_RUN=1 ;;
+    --self-test) SELF_TEST=1 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do
+        POSITIONAL+=("$1")
+        shift
+      done
+      break
+      ;;
+    -*)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *) POSITIONAL+=("$1") ;;
+  esac
+  shift
+done
+
+if [[ $SELF_TEST -eq 1 ]]; then
+  run_self_test
+  exit $?
+fi
+
+set -- ${POSITIONAL[@]+"${POSITIONAL[@]}"}
+
 if [[ $# -lt 2 ]]; then
-  echo "Usage: $0 <pr-number> <png-dir> [comment-body-file]" >&2
+  usage >&2
   exit 1
 fi
 
@@ -15,9 +361,37 @@ if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-GH_USER=$(gh api user --jq .login)
+# ---------------------------------------------------------------------------
+# Resolve the hosting remote and its owner/repo
+# ---------------------------------------------------------------------------
+
+if [[ -n "$REMOTE" ]]; then
+  if ! git remote get-url "$REMOTE" >/dev/null 2>&1; then
+    echo "error: no such git remote: $REMOTE" >&2
+    exit 1
+  fi
+else
+  if ! REMOTE="$(detect_remote)"; then
+    echo "error: could not find a git remote you can push to." >&2
+    echo "       Add a fork remote (git remote add fork git@github.com:<you>/buzz.git)" >&2
+    echo "       or pass --remote <name> explicitly." >&2
+    exit 1
+  fi
+  echo "Auto-detected hosting remote: ${REMOTE}"
+fi
+
+REMOTE_URL="$(remote_push_url "$REMOTE")"
+if ! HOST_REPO="$(parse_owner_repo "$REMOTE_URL")"; then
+  echo "error: could not parse owner/repo from remote '${REMOTE}' url: ${REMOTE_URL}" >&2
+  exit 1
+fi
+
+if ! GH_USER="$(gh_login)" || [[ -z "$GH_USER" ]]; then
+  echo "error: could not determine your GitHub login (gh api user)." >&2
+  echo "       Run 'gh auth login' or set POST_SCREENSHOTS_GH_USER." >&2
+  exit 1
+fi
 BRANCH="agent-screenshots/${GH_USER}"
-REPO="block/buzz"
 
 # macOS ships bash 3.2, which lacks mapfile — build the array with read.
 PNGS=()
@@ -27,11 +401,6 @@ done < <(find "$PNG_DIR" -maxdepth 1 -name "*.png" -type f | sort)
 if [[ ${#PNGS[@]} -eq 0 ]]; then
   echo "error: no PNGs found in $PNG_DIR" >&2
   exit 1
-fi
-
-EXISTING_ENTRIES=""
-if git fetch origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null; then
-  EXISTING_ENTRIES=$(git ls-tree "origin/${BRANCH}" | grep -v $'\t'"\"\\{0,1\\}pr-${PR}--" || true)
 fi
 
 NEW_ENTRIES=""
@@ -48,18 +417,67 @@ for PNG in "${PNGS[@]}"; do
   TREE_PATHS+=("$TREE_PATH")
 done
 
-COMBINED=$(printf '%s\n' "$EXISTING_ENTRIES" "$NEW_ENTRIES" | grep -v '^$')
-TREE=$(echo "$COMBINED" | git mktree)
+# ---------------------------------------------------------------------------
+# Build the tree on the current branch tip, then push (retrying on races)
+# ---------------------------------------------------------------------------
 
-PARENT_ARGS=()
-if git rev-parse "origin/${BRANCH}" >/dev/null 2>&1; then
-  PARENT_ARGS=(-p "origin/${BRANCH}")
-fi
-# ${arr[@]+...} guards the empty-array case, which trips set -u on bash 3.2.
-COMMIT=$(git commit-tree "$TREE" ${PARENT_ARGS[@]+"${PARENT_ARGS[@]}"} -m "screenshots: PR #${PR}")
-git push --force-with-lease origin "${COMMIT}:refs/heads/${BRANCH}"
+TIP=""
+TREE=""
+COMMIT=""
+LEASE=""
 
-RAW_BASE="https://raw.githubusercontent.com/${REPO}/${COMMIT}"
+# Re-read the remote branch tip and rebuild the commit on top of it, keeping
+# every entry that exists there now (another session may have added images for
+# other PRs since we last looked) except this PR's, which we replace.
+build_commit_on_tip() {
+  local existing="" combined
+  local parent_args=()
+
+  TIP=""
+  if git fetch --quiet "$REMOTE" "+refs/heads/${BRANCH}:refs/remotes/${REMOTE}/${BRANCH}" 2>/dev/null; then
+    TIP="$(git rev-parse --verify --quiet "refs/remotes/${REMOTE}/${BRANCH}" || true)"
+  fi
+
+  if [[ -n "$TIP" ]]; then
+    existing=$(git ls-tree "$TIP" | grep -v $'\t'"\"\\{0,1\\}pr-${PR}--" || true)
+    parent_args=(-p "$TIP")
+    LEASE="refs/heads/${BRANCH}:${TIP}"
+  else
+    # No branch on the remote yet — the lease demands it still not exist.
+    LEASE="refs/heads/${BRANCH}:"
+  fi
+
+  combined=$(printf '%s\n' "$existing" "$NEW_ENTRIES" | grep -v '^$')
+  TREE=$(printf '%s\n' "$combined" | git mktree)
+  # ${arr[@]+...} guards the empty-array case, which trips set -u on bash 3.2.
+  COMMIT=$(git commit-tree "$TREE" ${parent_args[@]+"${parent_args[@]}"} -m "screenshots: PR #${PR}")
+}
+
+ATTEMPT=1
+while :; do
+  build_commit_on_tip
+
+  if [[ $DRY_RUN -eq 1 ]]; then
+    break
+  fi
+
+  if PUSH_OUT=$(git push --force-with-lease="$LEASE" "$REMOTE" "${COMMIT}:refs/heads/${BRANCH}" 2>&1); then
+    break
+  fi
+
+  if [[ $ATTEMPT -ge $MAX_PUSH_ATTEMPTS ]] ||
+    ! printf '%s\n' "$PUSH_OUT" | grep -qiE 'stale info|non-fast-forward|fetch first|rejected'; then
+    printf '%s\n' "$PUSH_OUT" >&2
+    echo "error: failed to push screenshots to ${REMOTE} (${HOST_REPO}) after ${ATTEMPT} attempt(s)." >&2
+    exit 1
+  fi
+
+  echo "note: ${BRANCH} moved on ${REMOTE} — rebuilding on the new tip (attempt ${ATTEMPT}/${MAX_PUSH_ATTEMPTS})" >&2
+  ATTEMPT=$((ATTEMPT + 1))
+  sleep 1
+done
+
+RAW_BASE="https://raw.githubusercontent.com/${HOST_REPO}/${COMMIT}"
 
 # Parallel name/url arrays instead of an associative array (bash 4+ only).
 IMAGE_NAMES=()
@@ -68,6 +486,11 @@ for i in "${!PNGS[@]}"; do
   IMAGE_NAMES+=("$(basename "${PNGS[$i]}" .png)")
   IMAGE_URLS+=("${RAW_BASE}/${TREE_PATHS[$i]}")
 done
+
+HOSTED_ELSEWHERE=0
+if [[ "$HOST_REPO" != "$PR_REPO" ]]; then
+  HOSTED_ELSEWHERE=1
+fi
 
 if [[ -n "$BODY_FILE" ]]; then
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -98,5 +521,38 @@ else
   done
 fi
 
-gh pr comment "$PR" --repo "$REPO" --body "$COMMENT_BODY"
+if [[ $HOSTED_ELSEWHERE -eq 1 ]]; then
+  COMMENT_BODY+=$'\n'"<sub>Images hosted on \`${HOST_REPO}\` (branch \`${BRANCH}\`, commit \`${COMMIT}\`) — the author has no push access to \`${PR_REPO}\`.</sub>"$'\n'
+fi
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "--- dry run: nothing pushed, no comment posted ---"
+  echo "hosting remote : ${REMOTE}"
+  echo "hosting url    : ${REMOTE_URL}"
+  echo "hosting repo   : ${HOST_REPO}"
+  echo "pr repo        : ${PR_REPO} (PR #${PR})"
+  echo "branch         : ${BRANCH}"
+  echo "remote tip     : ${TIP:-<none - branch would be created>}"
+  echo "push lease     : ${LEASE}"
+  echo "tree           : ${TREE}"
+  echo "commit         : ${COMMIT}"
+  echo "RAW_BASE       : ${RAW_BASE}"
+  if [[ $HOSTED_ELSEWHERE -eq 1 ]]; then
+    echo "note           : images would be hosted on ${HOST_REPO}, not ${PR_REPO}"
+  fi
+  echo "images:"
+  for URL in "${IMAGE_URLS[@]}"; do
+    echo "  ${URL}"
+  done
+  echo "--- comment body ---"
+  printf '%s\n' "$COMMENT_BODY"
+  echo "--- end comment body ---"
+  exit 0
+fi
+
+if [[ $HOSTED_ELSEWHERE -eq 1 ]]; then
+  echo "note: images hosted on ${HOST_REPO} (remote '${REMOTE}'), not ${PR_REPO} — the comment still goes to ${PR_REPO}#${PR}"
+fi
+
+gh pr comment "$PR" --repo "$PR_REPO" --body "$COMMENT_BODY"
 echo "Posted ${#PNGS[@]} screenshot(s) to PR #${PR}"


### PR DESCRIPTION
## Summary

Three independent developer-tooling gaps, each hit while contributing to this repo from a
Windows host without push access. They are separable — happy to split into three PRs if that
reviews better.

**`scripts/bootstrap-windows.ps1`** — hermit publishes no Windows build, so `bin/flutter` 404s
fetching `hermit-mingw64_nt-<build>-amd64.gz` and `source bin/activate-hermit` leaves
`flutter: command not found`. AGENTS.md states the hooks and toolchain are available, which is
not true on Windows, and at least one automated verifier concluded the mobile code was
*unverifiable on this host* as a result — it is not; it runs fine with a directly installed SDK.

The script reads the pinned version from `bin/.flutter-<version>.pkg` rather than hardcoding it,
resolves the archive from the official release manifest, **verifies SHA256 before extracting**,
and is idempotent. Windows publishes no arm64 Flutter SDK at all, so arm64 hosts fall back to
the x64 archive under emulation rather than failing outright.

**`scripts/post-screenshots.sh`** — previously pushed blobs to `origin` and built raw URLs from
a hardcoded `block/buzz`, both of which fail for fork contributors: the push is rejected, and
even if it were not, the image URLs would 404. The hosting remote is now auto-detected (or set
with `--remote`), raw URLs follow the remote actually pushed to, the PR comment still targets
`block/buzz`, and a rejected non-fast-forward rebuilds the tree on the new tip and retries
instead of clobbering a concurrent push. Adds `--dry-run`.

**`mobile/test/helpers/golden_shot.dart`** — the repo has no golden infrastructure. This
produces PR-quality mobile screenshots with no Mac and no simulator. It encodes the two traps
that cost the most time: `flutter_test` renders tofu without real fonts, and Lucide's `IconData`
carries `fontPackage`, so the family must be registered as
`packages/lucide_icons_flutter/Lucide` or **every** glyph is silently blank. Font bytes are read
synchronously because `FontLoader.load()` awaiting an errored future hangs indefinitely rather
than throwing.

## Evidence

No user-observable change. Developer tooling only, with no user-observable surface. scripts/bootstrap-windows.ps1 installs the repo-pinned Flutter SDK on Windows (hermit publishes no Windows build); scripts/post-screenshots.sh hosts PR screenshots for contributors without push access to block/buzz; mobile/test/helpers/golden_shot.dart is a test-only helper that is not compiled into the app; plus AGENTS.md and docs/windows-dev-setup.md. No product code paths, no UI, and no runtime behaviour change for any user of the desktop or mobile app.

<sub>Base `main` at `78cbffeb` â†’ head `f63c91c7`.</sub>

### Related issue

No existing issue. Searched open and closed PRs for prior art on a Windows bootstrap, fork-aware
screenshot hosting, and Flutter goldens — `grep -rn golden_toolkit`/`matchesGoldenFile` over the
repo returns nothing, and `scripts/post-screenshots.sh` has had no fork handling since it was
added. Nothing duplicated.

### Testing

Verified on Windows with the repo-pinned toolchain (Flutter 3.41.7 / Dart 3.11.5):

- `flutter analyze` — No issues found
- `dart format --output=none --set-exit-if-changed .` — 0 changed
- `flutter test` — 1423 passed, including 6 new tests for the golden helper, each run
  individually to confirm it executes rather than silently skipping
- `bootstrap-windows.ps1` executed end to end: happy path, idempotent re-run (install root
  byte-identical), a deliberately corrupted archive (SHA256 mismatch aborts, exit 1, no
  extraction), and eight distinct failure paths each exiting 1 with a single actionable `ERROR:`
  line
- `post-screenshots.sh` — `bash -n` clean; `--dry-run` verified to resolve the hosting remote,
  owner/repo and `RAW_BASE` correctly against a fork, pushing nothing and commenting nothing

**One caveat, stated rather than buried:** those gates were run at this branch's base, and the
branch is currently ~18 commits behind `main`. Say the word and I will merge `main` in and re-run
before you spend time on it.

The golden helper's own tests assert the two traps directly — that text renders real glyphs
rather than tofu, and that the package-qualified icon family resolves — so a regression in font
loading fails the suite instead of silently producing blank screenshots.
