### PR TITLE
fix(desktop): bound remote agent mention authorization

### DIFF
--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -1033,7 +1033,7 @@ pub async fn discover_managed_agent_prereqs(
 mod relay_directory;
 #[cfg(test)]
 use relay_directory::advance_relay_cursor;
-pub use relay_directory::list_relay_agents;
+pub use relay_directory::{list_relay_agents, revalidate_relay_agents};
 
 #[cfg(test)]
 mod tests {

--- a/desktop/src-tauri/src/commands/agent_discovery/relay_directory.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/relay_directory.rs
@@ -91,6 +91,14 @@ fn retain_verified_owner(
 pub(crate) async fn list_relay_agents_for_state(
     state: &AppState,
 ) -> Result<Vec<RelayAgentInfo>, String> {
+    list_relay_agents_for_selection(state, None, None).await
+}
+
+async fn list_relay_agents_for_selection(
+    state: &AppState,
+    requested_pubkeys: Option<&std::collections::HashSet<String>>,
+    channel_id: Option<&str>,
+) -> Result<Vec<RelayAgentInfo>, String> {
     let viewer_pubkey = current_user_pubkey(state)?;
     let owner_only = owner_only_relay_directory();
     let relay_pubkey = identity_archive::fetch_relay_self(state)
@@ -100,18 +108,22 @@ pub(crate) async fn list_relay_agents_for_state(
     // Membership is the authoritative and bounded candidate source. Only
     // channels visible to this identity are read, and only bot-role p-tags can
     // drive the downstream managed-policy and owner-profile lookups.
-    let membership_events = query_all_relay_pages(
-        state,
-        serde_json::json!({
-            "kinds": [39002],
-            "authors": [&relay_pubkey],
-            "#p": [&viewer_pubkey],
-        }),
-    )
-    .await
-    .map_err(|error| format!("relay agent channel-membership query failed: {error}"))?;
-    let member_agent_channel_ids =
+    let mut membership_filter = serde_json::json!({
+        "kinds": [39002],
+        "authors": [&relay_pubkey],
+        "#p": [&viewer_pubkey],
+    });
+    if let Some(channel_id) = channel_id {
+        membership_filter["#d"] = serde_json::json!([channel_id]);
+    }
+    let membership_events = query_all_relay_pages(state, membership_filter)
+        .await
+        .map_err(|error| format!("relay agent channel-membership query failed: {error}"))?;
+    let mut member_agent_channel_ids =
         nostr_convert::member_agent_channel_ids_from_events(&membership_events, &relay_pubkey);
+    if let Some(requested_pubkeys) = requested_pubkeys {
+        member_agent_channel_ids.retain(|pubkey, _| requested_pubkeys.contains(pubkey));
+    }
     let candidate_pubkeys: Vec<String> = member_agent_channel_ids.keys().cloned().collect();
     if candidate_pubkeys.is_empty() {
         return Ok(Vec::new());
@@ -184,6 +196,27 @@ pub(crate) async fn list_relay_agents_for_state(
 #[tauri::command]
 pub async fn list_relay_agents(state: State<'_, AppState>) -> Result<Vec<RelayAgentInfo>, String> {
     list_relay_agents_for_state(&state).await
+}
+
+/// Revalidate only the selected relay agents in the target channel.
+///
+/// This preserves the full directory command for autocomplete while keeping
+/// send-time authorization bounded by the actual mention set and destination.
+#[tauri::command]
+pub async fn revalidate_relay_agents(
+    pubkeys: Vec<String>,
+    channel_id: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<Vec<RelayAgentInfo>, String> {
+    let requested_pubkeys = pubkeys
+        .into_iter()
+        .filter_map(|pubkey| nostr::PublicKey::from_hex(&pubkey).ok())
+        .map(|pubkey| pubkey.to_hex())
+        .collect::<std::collections::HashSet<_>>();
+    if requested_pubkeys.is_empty() {
+        return Ok(Vec::new());
+    }
+    list_relay_agents_for_selection(&state, Some(&requested_pubkeys), channel_id.as_deref()).await
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -146,7 +146,6 @@ pub fn run() {
                     if webview.label() != "main" {
                         return;
                     }
-
                     // Linux/WebKitGTK needs media-stream settings and a
                     // permission-request handler for getUserMedia; no-op
                     // on macOS/Windows.
@@ -763,6 +762,7 @@ pub fn run() {
             get_relay_self,
             resolve_oa_owner,
             list_relay_agents,
+            revalidate_relay_agents,
             list_managed_agents,
             list_managed_agent_runtimes,
             start_managed_agent_runtime,

--- a/desktop/src/features/messages/lib/agentMentionRevalidation.test.mjs
+++ b/desktop/src/features/messages/lib/agentMentionRevalidation.test.mjs
@@ -19,17 +19,14 @@ function options(refetchOwnerProfiles) {
     ownerOnly: true,
     ownerPolicyError: null,
     refetchManagedAgents: async () => ({ data: [], error: null }),
-    refetchRelayAgents: async () => ({
-      data: [
-        {
-          pubkey: AGENT,
-          respondTo: "anyone",
-          respondToAllowlist: [],
-          channelIds: ["general"],
-        },
-      ],
-      error: null,
-    }),
+    fetchRelayAgents: async () => [
+      {
+        pubkey: AGENT,
+        respondTo: "anyone",
+        respondToAllowlist: [],
+        channelIds: ["general"],
+      },
+    ],
     refetchOwnerProfiles,
   };
 }
@@ -61,10 +58,9 @@ test("fresh managed evidence survives unrelated relay authorization errors", asy
       data: [{ pubkey: LOCAL_AGENT }],
       error: null,
     }),
-    refetchRelayAgents: async () => ({
-      data: undefined,
-      error: new Error("relay directory unavailable"),
-    }),
+    fetchRelayAgents: async () => {
+      throw new Error("relay directory unavailable");
+    },
   });
 
   assert.deepEqual(result, [HUMAN, LOCAL_AGENT]);
@@ -76,10 +72,9 @@ test("relay-only agents still fail closed when relay discovery fails", async () 
       profiles: { [AGENT]: { ownerPubkey: CURRENT } },
       missing: [],
     })),
-    refetchRelayAgents: async () => ({
-      data: undefined,
-      error: new Error("relay directory unavailable"),
-    }),
+    fetchRelayAgents: async () => {
+      throw new Error("relay directory unavailable");
+    },
   });
 
   assert.deepEqual(result, [HUMAN]);
@@ -97,10 +92,9 @@ test("mixed evidence preserves only fresh managed agents and humans", async () =
       data: [{ pubkey: LOCAL_AGENT }],
       error: null,
     }),
-    refetchRelayAgents: async () => ({
-      data: undefined,
-      error: new Error("relay directory unavailable"),
-    }),
+    fetchRelayAgents: async () => {
+      throw new Error("relay directory unavailable");
+    },
   });
 
   assert.deepEqual(result, [HUMAN, LOCAL_AGENT]);

--- a/desktop/src/features/messages/lib/agentMentionRevalidation.ts
+++ b/desktop/src/features/messages/lib/agentMentionRevalidation.ts
@@ -6,6 +6,7 @@ import {
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import { evictUsersBatchEntries } from "@/features/profile/hooks";
 import { getUsersBatch } from "@/shared/api/tauriProfiles";
+import { revalidateRelayAgents } from "@/shared/api/tauriRelayAgents";
 import type {
   ManagedAgent,
   RelayAgent,
@@ -29,7 +30,7 @@ export async function revalidateAgentMentionPubkeys({
   ownerOnly,
   ownerPolicyError,
   refetchManagedAgents,
-  refetchRelayAgents,
+  fetchRelayAgents,
   refetchOwnerProfiles,
 }: {
   pubkeys: readonly string[];
@@ -40,7 +41,7 @@ export async function revalidateAgentMentionPubkeys({
   ownerOnly: boolean | undefined;
   ownerPolicyError: Error | null;
   refetchManagedAgents: () => Promise<DirectoryResult<ManagedAgent[]>>;
-  refetchRelayAgents: () => Promise<DirectoryResult<RelayAgent[]>>;
+  fetchRelayAgents: (pubkeys: string[]) => Promise<RelayAgent[]>;
   refetchOwnerProfiles: (pubkeys: string[]) => Promise<UsersBatchResponse>;
 }) {
   const requestedAgentPubkeys = new Set(
@@ -50,15 +51,14 @@ export async function revalidateAgentMentionPubkeys({
     return [...pubkeys];
   }
 
-  const [managedResult, relayResult, ownerProfiles] = await Promise.all([
+  const [managedResult, relayAgents, ownerProfiles] = await Promise.all([
     refetchManagedAgents(),
-    refetchRelayAgents(),
+    fetchRelayAgents([...requestedAgentPubkeys]).catch(() => null),
     ownerOnly
       ? refetchOwnerProfiles([...requestedAgentPubkeys]).catch(() => null)
       : Promise.resolve(null),
   ]);
-  const relayDirectoryReady =
-    relayResult.error === null && relayResult.data !== undefined;
+  const relayDirectoryReady = relayAgents !== null;
   if (
     ownerOnly === undefined ||
     ownerPolicyError !== null ||
@@ -75,7 +75,7 @@ export async function revalidateAgentMentionPubkeys({
     currentPubkey,
     eligibilityScope,
     managedAgentPubkeys: managedPubkeys,
-    relayAgents: relayDirectoryReady ? relayResult.data : [],
+    relayAgents: relayDirectoryReady ? relayAgents : [],
     sharedChannelIds,
   });
   const admittedPubkeys = new Set(
@@ -110,7 +110,6 @@ export function useAgentMentionRevalidation({
   ownerOnly,
   ownerPolicyError,
   refetchManagedAgents,
-  refetchRelayAgents,
 }: {
   agentPubkeys: ReadonlySet<string>;
   getSelectedAgentPubkeys: () => ReadonlySet<string>;
@@ -120,7 +119,6 @@ export function useAgentMentionRevalidation({
   ownerOnly: boolean | undefined;
   ownerPolicyError: Error | null;
   refetchManagedAgents: () => Promise<DirectoryResult<ManagedAgent[]>>;
-  refetchRelayAgents: () => Promise<DirectoryResult<RelayAgent[]>>;
 }) {
   const queryClient = useQueryClient();
   const refetchOwnerProfiles = React.useCallback(
@@ -141,7 +139,13 @@ export function useAgentMentionRevalidation({
         ownerOnly,
         ownerPolicyError,
         refetchManagedAgents,
-        refetchRelayAgents,
+        fetchRelayAgents: (requestedPubkeys) =>
+          revalidateRelayAgents(
+            requestedPubkeys,
+            eligibilityScope.type === "channel"
+              ? eligibilityScope.channelId
+              : undefined,
+          ),
         refetchOwnerProfiles,
       }),
     [
@@ -153,7 +157,6 @@ export function useAgentMentionRevalidation({
       ownerPolicyError,
       refetchManagedAgents,
       refetchOwnerProfiles,
-      refetchRelayAgents,
       sharedChannelIds,
     ],
   );

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -827,7 +827,6 @@ export function useMentions(
     ownerOnly: agentAccessOwnerOnlyQuery.data,
     ownerPolicyError: agentAccessOwnerOnlyQuery.error,
     refetchManagedAgents: managedAgentsQuery.refetch,
-    refetchRelayAgents: relayAgentsQuery.refetch,
   });
 
   const extractMentionPersonas = React.useCallback(

--- a/desktop/src/features/messages/ui/useMentionSendFlow.ts
+++ b/desktop/src/features/messages/ui/useMentionSendFlow.ts
@@ -401,9 +401,9 @@ export function useMentionSendFlow({
       };
       let uploadStarted = false;
       try {
-        // Use selection-time identity only for non-publishing preparation;
-        // finishSend authorizes once more at publication.
-        const admittedMentionPubkeys = uniqueNormalizedPubkeys(mentionPubkeys);
+        const admittedMentionPubkeys = uniqueNormalizedPubkeys(
+          await mentions.revalidateMentionPubkeys(mentionPubkeys),
+        );
         if (isSendCancelled()) return;
         if (!isMountedRef.current) return persistPreflightDraft();
         const admittedMentionPubkeySet = new Set(admittedMentionPubkeys);

--- a/desktop/src/features/messages/ui/useMentionSendFlow.ts
+++ b/desktop/src/features/messages/ui/useMentionSendFlow.ts
@@ -401,9 +401,9 @@ export function useMentionSendFlow({
       };
       let uploadStarted = false;
       try {
-        const admittedMentionPubkeys = uniqueNormalizedPubkeys(
-          await mentions.revalidateMentionPubkeys(mentionPubkeys),
-        );
+        // Use selection-time identity only for non-publishing preparation;
+        // finishSend authorizes once more at publication.
+        const admittedMentionPubkeys = uniqueNormalizedPubkeys(mentionPubkeys);
         if (isSendCancelled()) return;
         if (!isMountedRef.current) return persistPreflightDraft();
         const admittedMentionPubkeySet = new Set(admittedMentionPubkeys);

--- a/desktop/src/shared/api/tauriRelayAgents.ts
+++ b/desktop/src/shared/api/tauriRelayAgents.ts
@@ -1,0 +1,37 @@
+import { invokeTauri } from "@/shared/api/tauri";
+import type { RelayAgent } from "@/shared/api/types";
+
+type RawRelayAgent = {
+  pubkey: string;
+  owner_pubkey?: string | null;
+  name: string;
+  agent_type: string;
+  channels: string[];
+  channel_ids: string[];
+  capabilities: string[];
+  status: RelayAgent["status"];
+  respond_to?: RelayAgent["respondTo"];
+  respond_to_allowlist?: string[];
+};
+
+export async function revalidateRelayAgents(
+  pubkeys: string[],
+  channelId?: string,
+): Promise<RelayAgent[]> {
+  const agents = await invokeTauri<RawRelayAgent[]>("revalidate_relay_agents", {
+    pubkeys,
+    channelId,
+  });
+  return agents.map((agent) => ({
+    pubkey: agent.pubkey,
+    ownerPubkey: agent.owner_pubkey ?? null,
+    name: agent.name,
+    agentType: agent.agent_type,
+    channels: agent.channels,
+    channelIds: agent.channel_ids ?? [],
+    capabilities: agent.capabilities,
+    status: agent.status,
+    respondTo: agent.respond_to ?? null,
+    respondToAllowlist: agent.respond_to_allowlist ?? [],
+  }));
+}

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -298,6 +298,8 @@ type E2eConfig = {
     relayAgents?: MockRelayAgentSeed[];
     /** Reject successive relay-agent directory reads, then resume. */
     relayAgentListErrors?: (string | null)[];
+    /** Pubkeys omitted only from targeted send-time authorization checks. */
+    relayAgentRevalidationRevokedPubkeys?: string[];
     /** Native-like huddle state seeded from authoritative role-bearing membership. */
     huddle?: MockHuddleSeed;
     agentListDelayMs?: number;
@@ -12222,9 +12224,15 @@ export function maybeInstallE2eTauriMocks() {
         const requested = new Set(
           pubkeys.map((pubkey) => pubkey.toLowerCase()),
         );
+        const revoked = new Set(
+          (activeConfig?.mock?.relayAgentRevalidationRevokedPubkeys ?? []).map(
+            (pubkey) => pubkey.toLowerCase(),
+          ),
+        );
         return agents.filter(
           (agent) =>
             requested.has(agent.pubkey.toLowerCase()) &&
+            !revoked.has(agent.pubkey.toLowerCase()) &&
             (!channelId || agent.channel_ids.includes(channelId)),
         );
       }

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -12213,6 +12213,21 @@ export function maybeInstallE2eTauriMocks() {
         );
       case "list_relay_agents":
         return handleListRelayAgents(activeConfig);
+      case "revalidate_relay_agents": {
+        const agents = await handleListRelayAgents(activeConfig);
+        const { pubkeys, channelId } = payload as {
+          pubkeys: string[];
+          channelId?: string;
+        };
+        const requested = new Set(
+          pubkeys.map((pubkey) => pubkey.toLowerCase()),
+        );
+        return agents.filter(
+          (agent) =>
+            requested.has(agent.pubkey.toLowerCase()) &&
+            (!channelId || agent.channel_ids.includes(channelId)),
+        );
+      }
       case "list_personas":
         return handleListPersonas();
       case "create_persona":

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -1286,7 +1286,7 @@ test("managed agents keep their p tag when relay discovery fails before send", a
     .toContain(ALLOWLIST_RELAY_AGENT_PUBKEY);
 });
 
-test("selected relay agents revoked before send emit no p tag", async ({
+test("targeted revocation before send causes no agent side effects", async ({
   page,
 }) => {
   await installMockBridge(page, {
@@ -1302,6 +1302,24 @@ test("selected relay agents revoked before send emit no p tag", async ({
   });
   await page.goto("/");
   await page.getByTestId("channel-general").click();
+  await page.evaluate(
+    async ({ channelId, pubkey }) => {
+      const invoke = window.__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
+      if (!invoke) throw new Error("Mock bridge is not installed.");
+      await invoke("add_channel_members", {
+        channelId,
+        pubkeys: [pubkey],
+        role: "bot",
+      });
+      await window.__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries({
+        queryKey: ["channels"],
+      });
+    },
+    {
+      channelId: GENERAL_CHANNEL_ID,
+      pubkey: ALLOWLIST_RELAY_AGENT_PUBKEY,
+    },
+  );
   const input = page.getByTestId("message-input");
   await input.fill("@quinn");
   const quinnRow = autocomplete(page).locator("button", { hasText: "quinn" });
@@ -1309,26 +1327,10 @@ test("selected relay agents revoked before send emit no p tag", async ({
   await quinnRow.click();
   await page.keyboard.type("hello");
 
-  await page.evaluate(async () => {
+  await page.evaluate((pubkey) => {
     window.__BUZZ_E2E__.mock ??= {};
-    window.__BUZZ_E2E__.mock.relayAgentListErrors = Array(5).fill(
-      "mock directory revoked",
-    );
-    const queryClient = window.__BUZZ_E2E_QUERY_CLIENT__ as unknown as {
-      invalidateQueries: (filters: {
-        queryKey: readonly unknown[];
-      }) => Promise<void>;
-      getQueryState: (
-        queryKey: readonly unknown[],
-      ) => { status?: string } | undefined;
-    };
-    await queryClient.invalidateQueries({ queryKey: ["relay-agents"] });
-    if (queryClient.getQueryState(["relay-agents"])?.status !== "error") {
-      throw new Error(
-        "relay-agent directory refetch did not enter error state",
-      );
-    }
-  });
+    window.__BUZZ_E2E__.mock.relayAgentRevalidationRevokedPubkeys = [pubkey];
+  }, ALLOWLIST_RELAY_AGENT_PUBKEY);
   const baselineCommands = await readCommandLog(page);
   await page.getByTestId("send-message").click();
 
@@ -1339,6 +1341,12 @@ test("selected relay agents revoked before send emit no p tag", async ({
     .poll(() => readOutgoingMentionPubkeys(page, "@quinn hello"))
     .not.toContain(ALLOWLIST_RELAY_AGENT_PUBKEY);
   const commands = await readCommandLog(page);
+  expect(commandCount(commands, "revalidate_relay_agents")).toBe(
+    commandCount(baselineCommands, "revalidate_relay_agents") + 2,
+  );
+  expect(commandCount(commands, "list_relay_agents")).toBe(
+    commandCount(baselineCommands, "list_relay_agents"),
+  );
   for (const command of [
     "add_channel_members",
     "start_managed_agent",

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -1233,7 +1233,7 @@ test("relay-only allowlisted agents emit a p tag when sent", async ({
 
   const commands = await readCommandLog(page);
   expect(commandCount(commands, "revalidate_relay_agents")).toBe(
-    commandCount(baselineCommands, "revalidate_relay_agents") + 1,
+    commandCount(baselineCommands, "revalidate_relay_agents") + 2,
   );
   expect(commandCount(commands, "list_relay_agents")).toBe(
     commandCount(baselineCommands, "list_relay_agents"),

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -1198,6 +1198,24 @@ test("relay-only allowlisted agents emit a p tag when sent", async ({
   });
   await page.goto("/");
   await page.getByTestId("channel-general").click();
+  await page.evaluate(
+    async ({ channelId, pubkey }) => {
+      const invoke = window.__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
+      if (!invoke) throw new Error("Mock bridge is not installed.");
+      await invoke("add_channel_members", {
+        channelId,
+        pubkeys: [pubkey],
+        role: "bot",
+      });
+      await window.__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries({
+        queryKey: ["channels"],
+      });
+    },
+    {
+      channelId: GENERAL_CHANNEL_ID,
+      pubkey: ALLOWLIST_RELAY_AGENT_PUBKEY,
+    },
+  );
 
   const input = page.getByTestId("message-input");
   await input.fill("@quinn");
@@ -1206,12 +1224,20 @@ test("relay-only allowlisted agents emit a p tag when sent", async ({
   await quinnRow.click();
   await page.keyboard.type("hello");
   await expect(input).toHaveText("@quinn hello");
+  const baselineCommands = await readCommandLog(page);
   await page.getByTestId("send-message").click();
-  await page.getByRole("button", { name: "Invite", exact: true }).click();
 
   await expect
     .poll(() => readOutgoingMentionPubkeys(page, "@quinn hello"))
     .toContain(ALLOWLIST_RELAY_AGENT_PUBKEY);
+
+  const commands = await readCommandLog(page);
+  expect(commandCount(commands, "revalidate_relay_agents")).toBe(
+    commandCount(baselineCommands, "revalidate_relay_agents") + 1,
+  );
+  expect(commandCount(commands, "list_relay_agents")).toBe(
+    commandCount(baselineCommands, "list_relay_agents"),
+  );
 });
 
 test("managed agents keep their p tag when relay discovery fails before send", async ({


### PR DESCRIPTION
## Summary

- add a targeted native `revalidate_relay_agents(pubkeys, channel_id)` command for send-time authorization
- scope membership discovery to the destination channel and selected pubkeys before runtime/profile/policy queries
- replace full relay-directory rebuilds with targeted checks before agent side effects and again at publication
- preserve managed-agent evidence independently and retain internal owner-only filtering

## Security and trust boundary

The targeted command reuses the existing authoritative chain:

1. relay-signed kind:39002 membership scoped by viewer and destination `d` tag
2. agent runtime directory event
3. agent-signed owner profile verification
4. owner-signed managed policy
5. internal-build `owner_only` filtering before policy lookup and on final results

Relay-only agents are dropped on any targeted directory failure. Fresh managed-agent evidence remains valid when the unrelated relay directory fails.

## Validation

- pre-push gate passed: branch skew, Desktop check/typecheck/tests, Tauri checks, Rust tests, and mobile tests
- Desktop unit suite: 4,992 passed
- targeted Rust relay-directory tests passed
- focused Playwright mention-send acceptance passed
  - relay-only send emits the expected `p` tag
  - exactly two targeted `revalidate_relay_agents` calls on the already-member send path: pre-side-effect and pre-publication
  - no `list_relay_agents` call on that send path
  - relay failure and revocation remain fail-closed
  - internal owner-only mode hides other-owned agents
- manual local Desktop testing by Wes: mention sends felt materially improved

## Notes

This intentionally does not clear the composer early or add an optimistic timeline row. Publication still waits for fresh authorization.

