### PR TITLE
Allow shared relay agents in mention autocomplete

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -136,8 +136,9 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
 });
 
-test("isAgentIdentityInManagedList: keeps people and only current managed agent identities", () => {
+test("isAgentIdentityInManagedList: keeps people, members, managed agents, and shared relay agents", () => {
   const managedAgentPubkeys = new Set([PUB_A]);
+  const mentionableAgentPubkeys = new Set([PUB_C]);
 
   assert.equal(
     isAgentIdentityInManagedList(
@@ -159,6 +160,21 @@ test("isAgentIdentityInManagedList: keeps people and only current managed agent 
       managedAgentPubkeys,
     ),
     false,
+  );
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
+      managedAgentPubkeys,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: true, pubkey: PUB_C },
+      managedAgentPubkeys,
+      mentionableAgentPubkeys,
+    ),
+    true,
   );
 });
 

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -55,12 +55,15 @@ export function getMentionableAgentPubkeys({
 }
 
 export function isAgentIdentityInManagedList(
-  candidate: { isAgent?: boolean; pubkey: string },
+  candidate: { isAgent?: boolean; isMember?: boolean; pubkey: string },
   managedAgentPubkeys: ReadonlySet<string>,
+  mentionableAgentPubkeys: ReadonlySet<string> = new Set(),
 ) {
   return (
     candidate.isAgent !== true ||
-    managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
+    candidate.isMember === true ||
+    managedAgentPubkeys.has(normalizePubkey(candidate.pubkey)) ||
+    mentionableAgentPubkeys.has(normalizePubkey(candidate.pubkey))
   );
 }
 

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -246,7 +246,13 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (
+        !isAgentIdentityInManagedList(
+          candidate,
+          managedAgentPubkeys,
+          mentionableAgentPubkeys,
+        )
+      ) {
         return;
       }
       if (


### PR DESCRIPTION
## Summary
- keep bot identities that are members of the current channel in mention autocomplete
- allow relay-directory identities when they are invocable by the current user
- preserve the existing filter for unrelated managed-agent identities

## Why
A persistent external agent can be a valid bot member of a shared channel and respond to a teammate, but the teammate cannot select it from `@` autocomplete because the current filter only retains agents managed locally by that viewer. Owners see the agent; other authorized channel members do not.

## Verification
- focused agent-autocomplete unit suite: 18/18 passed
- desktop TypeScript typecheck passed