### PR TITLE
chore(deps): update h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,9 +3338,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Bumps `h2` from 0.4.14 to 0.4.16 to resolve [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258): unbounded empty HTTP/2 DATA frames can cause unbounded memory growth or a panic when streams are not drained. `0.4.16` is the first patched release.

Lockfile-only change. The `h2` entry was edited in place rather than via `cargo update -p h2 --precise`, because that command also rewrote ~16 unrelated `windows-sys` pins (resolver drift). `h2 0.4.16`'s dependencies are already satisfied by the existing lock, so no transitive changes are required.

Verified locally on the pinned 1.95.0 toolchain: `cargo tree -p h2@0.4.16 --locked` resolves, `cargo deny check advisories` reports `advisories ok`, `just test-unit` (455 passed), `just desktop-tauri-clippy`, and `just desktop-tauri-test` all pass.

Ref: buzz://channel/670a29e9-8631-492f-959b-6bae9003581c