### PR TITLE
Give the empty projects state a create-project action

### DIFF
--- a/desktop/src/features/projects/ui/ProjectCards.test.mjs
+++ b/desktop/src/features/projects/ui/ProjectCards.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { after, afterEach, before, test } from "node:test";
+
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+before(() => {
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    window: dom.window,
+  });
+  dom.window.matchMedia = () => ({
+    matches: false,
+    addEventListener() {},
+    removeEventListener() {},
+  });
+});
+
+afterEach(async () => {
+  const { cleanup } = await import("@testing-library/react");
+  cleanup();
+});
+
+after(() => dom.window.close());
+
+test("empty projects state renders a create-project action that fires the provided callback", async () => {
+  const { createElement } = await import("react");
+  const { fireEvent, render, screen } = await import("@testing-library/react");
+  const { EmptyState } = await import("./ProjectCards.tsx");
+
+  let createClicked = false;
+  render(
+    createElement(EmptyState, {
+      onCreateProject: () => {
+        createClicked = true;
+      },
+    }),
+  );
+
+  assert.ok(screen.getByText("No projects yet"));
+  const createButton = screen.getByRole("button", { name: "Create project" });
+  fireEvent.click(createButton);
+  assert.equal(createClicked, true);
+});

--- a/desktop/src/features/projects/ui/ProjectCards.tsx
+++ b/desktop/src/features/projects/ui/ProjectCards.tsx
@@ -327,7 +327,11 @@ function RepositoryUnavailableIndicator({
   );
 }
 
-export function EmptyState() {
+export function EmptyState({
+  onCreateProject,
+}: {
+  onCreateProject: () => void;
+}) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-3 px-4 py-16 text-center">
       <Folders className="h-10 w-10 text-muted-foreground/40" />
@@ -337,6 +341,9 @@ export function EmptyState() {
           Projects published to this relay will appear here.
         </p>
       </div>
+      <Button onClick={onCreateProject} size="sm" type="button">
+        Create project
+      </Button>
     </div>
   );
 }

--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -15,7 +15,10 @@ import {
   useProjectsWorkItemsQuery,
 } from "@/features/projects/hooks";
 import { useRepositoryActivitySummariesQuery } from "@/features/projects/repositoryActivityHooks";
-import { useCreateProjectMutation } from "@/features/projects/useCreateProject";
+import {
+  type CreateProjectInput,
+  useCreateProjectMutation,
+} from "@/features/projects/useCreateProject";
 import { selectProjectRepository } from "@/features/projects/projectModels";
 import { useProjectsRepoSnapshotsQuery } from "@/features/projects/useProjectsRepoSnapshots";
 import {
@@ -573,6 +576,23 @@ export function ProjectsView() {
     [deleteProjectMutation],
   );
 
+  const handleCreateProject = React.useCallback(
+    async (input: CreateProjectInput) => {
+      const result = await createProjectMutation.mutateAsync(input);
+      if (result.compatibilityWarning) {
+        toast.warning("Created as a standalone project", {
+          description: result.compatibilityWarning,
+        });
+      } else {
+        toast.success(`Project "${result.project.name}" created.`);
+      }
+      // Land on the complete project list after creation.
+      handleRepositoryScopeChange("all");
+      handleFilterChange("projects");
+    },
+    [createProjectMutation, handleFilterChange, handleRepositoryScopeChange],
+  );
+
   if (projectsQuery.isLoading) {
     return <ViewLoadingFallback kind="projects" />;
   }
@@ -593,7 +613,17 @@ export function ProjectsView() {
   }
 
   if (projects.length === 0) {
-    return <EmptyState />;
+    return (
+      <>
+        <EmptyState onCreateProject={() => setCreateProjectOpen(true)} />
+        <CreateProjectDialog
+          isCreating={createProjectMutation.isPending}
+          onCreate={handleCreateProject}
+          onOpenChange={setCreateProjectOpen}
+          open={createProjectOpen}
+        />
+      </>
+    );
   }
 
   const projectItems =
@@ -790,19 +820,7 @@ export function ProjectsView() {
       <div className="absolute right-4 top-4 z-40">{createMenu}</div>
       <CreateProjectDialog
         isCreating={createProjectMutation.isPending}
-        onCreate={async (input) => {
-          const result = await createProjectMutation.mutateAsync(input);
-          if (result.compatibilityWarning) {
-            toast.warning("Created as a standalone project", {
-              description: result.compatibilityWarning,
-            });
-          } else {
-            toast.success(`Project "${result.project.name}" created.`);
-          }
-          // Land on the complete project list after creation.
-          handleRepositoryScopeChange("all");
-          handleFilterChange("projects");
-        }}
+        onCreate={handleCreateProject}
         onOpenChange={setCreateProjectOpen}
         open={createProjectOpen}
       />


### PR DESCRIPTION
## Problem

On a relay with no projects yet, there is no way to create your first project.

`ProjectsView` returns `EmptyState` from an early return at `ProjectsView.tsx:594`:

```tsx
if (projects.length === 0) {
  return <EmptyState />;
}
```

That happens **before** the create menu and `CreateProjectDialog` are mounted (further down, around line 790), and `EmptyState` itself renders only an icon and the text *"No projects yet · Projects published to this relay will appear here."* — no action.

So the create control only appears once you already have a project.

There is no other entry point: `CreateProjectDialog` is mounted solely in `ProjectsView`, and `AddProjectRepositoryDialog` / `AttachProjectRepositoryDialog` live in `ProjectRepositoryManagement`, which is inside a project detail screen you cannot reach without an existing project.

**Reproduce:** open Projects on a relay with zero projects. There is no create affordance anywhere.

## Fix

`EmptyState` now takes a required `onCreateProject` callback and renders a **Create project** button. `ProjectsView` wires it to the same handler and dialog the pinned create menu uses, and mounts `CreateProjectDialog` in the empty-state branch so the button opens something.

The prop is **required rather than optional** deliberately. `EmptyState` has exactly one call site, so making it required turns dropped wiring at that call site into a compile error instead of a silent regression — which is precisely the failure this PR is fixing.

## Testing

- `ProjectCards.test.mjs` — new coverage asserting the empty state renders a create action and invokes the callback
- `tsc --noEmit` clean
- `biome check` clean on all three changed files
- Full suite: **4792 passing, 0 failing**
