### PR TITLE
chore(hooks): keep mobile analysis out of pre-commit

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -36,9 +36,9 @@ pre-commit:
       glob: ["web/**", "pnpm-lock.yaml"]
       run: just web-fix
       stage_fixed: true
-    mobile-fix:
+    mobile-fmt:
       glob: ["mobile/**"]
-      run: just mobile-fix
+      run: just mobile-fmt
       stage_fixed: true
 
 # Appends the DCO Signed-off-by trailer the required "DCO Check" enforces.
@@ -79,6 +79,9 @@ pre-push:
       # serially so parallel pre-push hooks do not contend for Cargo's lock.
       glob: ["desktop/src-tauri/**", "crates/**", "migrations/**", "schema/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "deny.toml", "scripts/run-tests.sh", "justfile"]
       run: just desktop-tauri-clippy && just desktop-tauri-test
+    mobile-check:
+      glob: ["mobile/**"]
+      run: just mobile-check
     mobile-test:
       glob: ["mobile/**"]
       run: just mobile-test

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -28,12 +28,14 @@ pre-commit:
       run: just desktop-tauri-fmt
       stage_fixed: true
     desktop-fix:
-      glob: ["desktop/**", "pnpm-lock.yaml"]
+      # A lockfile-only change has no desktop source for Biome to rewrite.
+      glob: ["desktop/**"]
       exclude: ["desktop/src-tauri/**"]
       run: just desktop-fix
       stage_fixed: true
     web-fix:
-      glob: ["web/**", "pnpm-lock.yaml"]
+      # A lockfile-only change has no web source for Biome to rewrite.
+      glob: ["web/**"]
       run: just web-fix
       stage_fixed: true
     mobile-fmt:
@@ -59,7 +61,7 @@ pre-push:
       # would only duplicate policy and create another place for coverage drift.
       run: just file-size-check
     rust-tests:
-      glob: ["crates/**", "migrations/**", "schema/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "deny.toml", "scripts/run-tests.sh", "justfile"]
+      glob: ["crates/**", "migrations/**", "schema/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "deny.toml", "scripts/run-tests.sh", "Justfile"]
       run: just test-unit
     desktop-check:
       glob: ["desktop/**", "pnpm-lock.yaml"]
@@ -77,7 +79,7 @@ pre-push:
       # Keep local lint parity with Desktop Core CI for every path that can
       # affect the Tauri crate or its path dependencies. Run clippy and tests
       # serially so parallel pre-push hooks do not contend for Cargo's lock.
-      glob: ["desktop/src-tauri/**", "crates/**", "migrations/**", "schema/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "deny.toml", "scripts/run-tests.sh", "justfile"]
+      glob: ["desktop/src-tauri/**", "crates/**", "migrations/**", "schema/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "deny.toml", "scripts/run-tests.sh", "Justfile"]
       run: just desktop-tauri-clippy && just desktop-tauri-test
     mobile-check:
       glob: ["mobile/**"]


### PR DESCRIPTION
## Summary

- run only Dart formatting for mobile changes during pre-commit
- move Flutter static analysis to the path-scoped pre-push graph
- fix case-sensitive `Justfile` triggers for the Rust and Tauri pre-push gates
- skip whole-tree desktop/web formatting for lockfile-only commits while retaining every lockfile-triggered pre-push check

No test suite was removed or narrowed. Cargo formatting remains workspace-scoped; frontend and mobile source changes still select their existing formatters.

## Benchmark

Warm isolated timings on an M2 Max:

- `dart format .`: 1.92–2.23s
- `flutter analyze`: 5.58–7.51s
- old forced full pre-commit: 10.16–18.40s
- current forced full pre-commit at `f18d9b5`: 5.42–7.09s, median 6.29s (45% lower)
- current forced full pre-push at `f18d9b5`: 2m45s, effectively unchanged from the prior warm 2m41s run
- lockfile-only pre-commit after the follow-up: 0.18–0.19s across three runs

The new mobile analysis lane finishes before the existing mobile test lane, so it added no observed full-push wall time.

## Validation

At pushed head `79626be60d89ba34e0fe136f254cc38cf1f1c2b8`:

- `lefthook validate`
- isolated temporary-repository selection test:
  - `Justfile` selects both Rust and Tauri pre-push gates
  - `pnpm-lock.yaml` selects neither mutating frontend formatter
  - desktop/web source files still select their formatter
- lockfile-only pre-commit: 0.19s, 0.19s, 0.18s
- pre-push hook passed on the exact pushed head

Earlier full-cycle validation at `f18d9b5802f11543e8afbef3cd54c5928817e32b`:

- forced full pre-commit: 5.42s, 6.29s, 7.09s
- forced full pre-push: 2m45s; all lanes passed
- mobile tests: 1,465 passed
