### PR TITLE
fix(tooling): create sidecar stubs with the .exe suffix Tauri expects on Windows

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -157,19 +157,32 @@ fmt-all: fmt desktop-tauri-fmt mobile-fmt
 # Fix all formatting and lint issues
 fix-all: fmt desktop-tauri-fmt desktop-fix web-fix mobile-fix
 
-# Ensure sidecar placeholder binaries exist (Tauri validates externalBin at compile time)
-# Sidecar binary list must stay in sync with desktop-release-build below.
-_ensure-sidecar-stubs:
+# Ensure sidecar placeholder binaries exist (Tauri validates externalBin at compile time).
+# Takes an optional target triple; defaults to the host. This is the single
+# definition of the sidecar list — desktop-release-build depends on it rather
+# than repeating it, because the two copies had already drifted apart.
+_ensure-sidecar-stubs target="":
     #!/usr/bin/env bash
     set -euo pipefail
-    TARGET=$(rustc -vV | sed -n 's|host: ||p')
+    TARGET="{{target}}"
+    if [[ -z "$TARGET" ]]; then
+        TARGET=$(rustc -vV | sed -n 's|host: ||p')
+    fi
     mkdir -p desktop/src-tauri/binaries
     SIDECARS=(buzz-acp buzz-agent buzz-dev-mcp git-credential-nostr buzz)
+    # tauri.windows.conf.json overrides externalBin to drop this one on Windows.
     if [[ "$TARGET" != *windows* ]]; then
         SIDECARS+=(buzz-backend-kubernetes)
     fi
+    # Tauri resolves an externalBin as `<name>-<target><exe-suffix>`, so on a
+    # Windows host the stub it validates is `.exe`. Without the suffix the
+    # build script panics on the first sidecar and no Tauri recipe can run.
+    EXE_SUFFIX=""
+    if [[ "$TARGET" == *windows* ]]; then
+        EXE_SUFFIX=".exe"
+    fi
     for bin in "${SIDECARS[@]}"; do
-        touch "desktop/src-tauri/binaries/${bin}-${TARGET}"
+        touch "desktop/src-tauri/binaries/${bin}-${TARGET}${EXE_SUFFIX}"
     done
 
 # Ensure Docker dev services (Postgres, Redis, etc.) are running and healthy
@@ -252,21 +265,10 @@ desktop-tauri-test-compiled-flags: _ensure-sidecar-stubs
     echo "Both compiled states verified."
 
 # Build the full desktop Tauri app locally (unsigned, for testing)
-# Sidecar binary list must stay in sync with _ensure-sidecar-stubs above.
 # pnpm install is unconditional here: release builds must start from a clean dep tree.
-desktop-release-build target="aarch64-apple-darwin":
+desktop-release-build target="aarch64-apple-darwin": (_ensure-sidecar-stubs target)
     #!/usr/bin/env bash
     set -euo pipefail
-    TARGET={{target}}
-    mkdir -p desktop/src-tauri/binaries
-    touch "desktop/src-tauri/binaries/buzz-acp-$TARGET"
-    touch "desktop/src-tauri/binaries/buzz-agent-$TARGET"
-    if [[ "$TARGET" != *windows* ]]; then
-        touch "desktop/src-tauri/binaries/buzz-backend-kubernetes-$TARGET"
-    fi
-    touch "desktop/src-tauri/binaries/buzz-dev-mcp-$TARGET"
-    touch "desktop/src-tauri/binaries/git-credential-nostr-$TARGET"
-    touch "desktop/src-tauri/binaries/buzz-$TARGET"
     pnpm install
     cd {{desktop_dir}} && pnpm tauri build --features mesh-llm --target {{target}}
 


### PR DESCRIPTION
fix(tooling): create sidecar stubs with the .exe suffix Tauri expects on Windows

`_ensure-sidecar-stubs` creates placeholder files named `<name>-<target>`, but
Tauri resolves an `externalBin` as `<name>-<target><exe-suffix>`. On a Windows
host it therefore validates `<name>-<target>.exe`, finds nothing, and the build
script panics on the first sidecar:

    thread 'main' panicked at build.rs:143:6:
    failed to build Tauri application: resource path
    `binaries\buzz-acp-x86_64-pc-windows-msvc.exe` doesn't exist

Every recipe that depends on the stubs — `desktop-tauri-check`,
`desktop-tauri-clippy`, `desktop-tauri-test`, and so `just check` and
`desktop-ci` — is unrunnable on Windows as a result. There is no workaround
short of creating the files by hand, which is what I have been doing.

`desktop-release-build` had the same defect independently, for a target it
explicitly anticipates (it already branches on `*windows*`).

## Also: the two copies had drifted

Both recipes carried their own copy of the sidecar list, each with a comment
telling the reader to keep it in sync with the other. They were not in sync —
the release recipe listed the binaries one `touch` per line while
`_ensure-sidecar-stubs` had moved to an array, and only one of them would have
picked up a future addition.

So `_ensure-sidecar-stubs` now takes an optional target triple, defaulting to
the host, and `desktop-release-build` depends on it instead of repeating it.
One definition, and the Windows suffix is handled once.

The `buzz-backend-kubernetes` exclusion on Windows is preserved — I checked, and
it is deliberate: `tauri.windows.conf.json` overrides `externalBin` to drop that
sidecar, so a stub for it is genuinely not wanted there. That is now stated in a
comment rather than left as an unexplained conditional.

## Verification

On `x86_64-pc-windows-msvc`, against a wiped `desktop/src-tauri/binaries`:

- Reproduced first. Stubs created the old way (no suffix) plus
  `touch desktop/src-tauri/build.rs` to defeat the build-script cache →
  `cargo check --manifest-path desktop/src-tauri/Cargo.toml` exits **101** with
  the panic above. The cache matters: without touching `build.rs` the check
  passes on stale state and the bug looks fixed when it is not.
- With the fix, `just _ensure-sidecar-stubs` then the same forced check exits
  **0**.
- `just _ensure-sidecar-stubs` → 5 stubs, all `.exe`.
- `just _ensure-sidecar-stubs x86_64-pc-windows-msvc` → same 5, all `.exe`.
- `just _ensure-sidecar-stubs x86_64-unknown-linux-gnu` → 6 stubs, no suffix,
  `buzz-backend-kubernetes` included.
- `just --dry-run desktop-tauri-check` still resolves the dependency with no
  argument; `just --dry-run desktop-release-build x86_64-pc-windows-msvc` shows
  the target threaded through.

Non-Windows behaviour is unchanged: `EXE_SUFFIX` is empty for every other
target, so the emitted paths are byte-identical to before.

Signed-off-by: Michael Feth <michael@jira-flow.com>
