### PR TITLE
Show live Workstream Board PR status

### DIFF
--- a/desktop/playwright.b3-pr-capture.config.ts
+++ b/desktop/playwright.b3-pr-capture.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  outputDir: "test-results-b3-pr-demo",
+  timeout: 120_000,
+  retries: 0,
+  workers: 1,
+  reporter: [["list"]],
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    ...devices["Desktop Chrome"],
+    viewport: { width: 1440, height: 900 },
+    video: { mode: "on", size: { width: 1440, height: 900 } },
+    screenshot: "on",
+    trace: "off",
+  },
+  projects: [
+    {
+      name: "relay-b3-pr-capture",
+      testMatch: "**/workstream-board-b3-pr.capture.spec.ts",
+    },
+    {
+      name: "canvas-bridge-regression",
+      testMatch: "**/get-canvas-bridge.spec.ts",
+    },
+  ],
+  webServer: {
+    command: "python3 -m http.server 4173 -d dist",
+    cwd: ".",
+    reuseExistingServer: false,
+    url: "http://127.0.0.1:4173",
+  },
+});

--- a/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.test.mjs
+++ b/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createWorkstreamPollingRegistry,
+  fetchBuzzPullRequestStatus,
+  fetchGithubPullRequestStatus,
+  parseWorkstreamPullRequestReference,
+  parseWorkstreamPullRequestReferences,
+} from "./workstreamPullRequestStatus.ts";
+
+const OWNER = "a".repeat(64);
+const EVENT = "b".repeat(64);
+const buzz = `buzz://pr?id=${EVENT}&owner=${OWNER}&d=buzz`;
+
+function response(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+test("parses canonical Buzz, GitHub, malformed, and unsupported references", () => {
+  const refs = parseWorkstreamPullRequestReferences([
+    buzz,
+    "https://github.com/Block/Buzz/pull/42",
+    "https://github.com/block/buzz/issues/42",
+    "https://example.com/pr/1",
+    "not a url",
+    null,
+  ]);
+  assert.equal(refs[0].kind, "buzz");
+  assert.equal(refs[0].identity, `buzz:${OWNER}:buzz:${EVENT}`);
+  assert.equal(refs[1].kind, "github");
+  assert.equal(refs[1].href, "https://github.com/block/buzz/pull/42");
+  assert.equal(refs[2].kind, "unsupported");
+  assert.equal(refs[2].reason, "malformed");
+  assert.equal(refs[3].reason, "unsupported-provider");
+  assert.equal(refs[4].reason, "malformed");
+  assert.equal(refs[5].reason, "invalid-field");
+});
+
+test("GitHub status reports lifecycle and latest review state", async () => {
+  const ref = parseWorkstreamPullRequestReference(
+    "https://github.com/block/buzz/pull/42",
+  );
+  assert.equal(ref.kind, "github");
+  const result = await fetchGithubPullRequestStatus(ref, {
+    fetcher: async (url) =>
+      String(url).endsWith("/reviews?per_page=100")
+        ? response([
+            {
+              user: { login: "reviewer" },
+              state: "APPROVED",
+              submitted_at: "2026-08-18T00:00:00Z",
+            },
+          ])
+        : response({
+            number: 42,
+            title: "Board PR",
+            state: "closed",
+            draft: false,
+            merged_at: "2026-08-18T01:00:00Z",
+            requested_reviewers: [],
+          }),
+  });
+  assert.deepEqual(result, {
+    status: "live",
+    provider: "github",
+    href: "https://github.com/block/buzz/pull/42",
+    repository: "block/buzz",
+    number: 42,
+    title: "Board PR",
+    lifecycle: "merged",
+    reviewState: "approved",
+  });
+});
+
+test("Buzz status consumes root and existing NIP-34 status events", async () => {
+  const ref = parseWorkstreamPullRequestReference(buzz);
+  assert.equal(ref.kind, "buzz");
+  const root = {
+    id: EVENT,
+    pubkey: OWNER,
+    kind: 1618,
+    created_at: 10,
+    content: "Wire board",
+    tags: [
+      ["a", `30617:${OWNER}:buzz`],
+      ["d", "pr-1"],
+      ["subject", "Wire board"],
+      ["p", "c".repeat(64)],
+    ],
+  };
+  const status = {
+    id: "c".repeat(64),
+    pubkey: OWNER,
+    kind: 1631,
+    created_at: 20,
+    content: "",
+    tags: [
+      ["e", EVENT],
+      ["a", `30617:${OWNER}:buzz`],
+    ],
+  };
+  const result = await fetchBuzzPullRequestStatus(ref, async (filter) =>
+    filter.kinds[0] === 1618 ? [root] : [status],
+  );
+  assert.equal(result.status, "live");
+  assert.equal(result.lifecycle, "merged");
+  assert.equal(result.title, "Wire board");
+  assert.equal(result.reviewState, "review-requested");
+});
+
+test("polling deduplicates canonical identities and tears down", async () => {
+  let requests = 0;
+  let aborted = false;
+  let resolveRequest;
+  const pending = new Promise((resolve) => {
+    resolveRequest = resolve;
+  });
+  const reference = parseWorkstreamPullRequestReference(
+    "https://github.com/block/buzz/pull/42",
+  );
+  assert.equal(reference.kind, "github");
+  const registry = createWorkstreamPollingRegistry({
+    fetcher: async (_url, init) => {
+      requests += 1;
+      init.signal.addEventListener("abort", () => {
+        aborted = true;
+      });
+      await pending;
+      return response({
+        number: 42,
+        title: "Board",
+        state: "open",
+        draft: false,
+      });
+    },
+    intervalMs: 1000,
+  });
+  const listener = () => {};
+  const unsubscribeOne = registry.subscribe(reference, listener);
+  const unsubscribeTwo = registry.subscribe(reference, () => {});
+  assert.equal(registry.entryCount(), 1);
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(requests, 2);
+  unsubscribeOne();
+  assert.equal(registry.entryCount(), 1);
+  unsubscribeTwo();
+  assert.equal(registry.entryCount(), 0);
+  assert.equal(aborted, true);
+  resolveRequest();
+});

--- a/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.test.mjs
+++ b/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.test.mjs
@@ -23,6 +23,7 @@ function response(body, status = 200) {
 test("parses canonical Buzz, GitHub, malformed, and unsupported references", () => {
   const refs = parseWorkstreamPullRequestReferences([
     buzz,
+    { url: "https://github.com/Block/Buzz/pull/42", label: "labeled PR" },
     "https://github.com/Block/Buzz/pull/42",
     "https://github.com/block/buzz/issues/42",
     "https://example.com/pr/1",
@@ -33,11 +34,12 @@ test("parses canonical Buzz, GitHub, malformed, and unsupported references", () 
   assert.equal(refs[0].identity, `buzz:${OWNER}:buzz:${EVENT}`);
   assert.equal(refs[1].kind, "github");
   assert.equal(refs[1].href, "https://github.com/block/buzz/pull/42");
-  assert.equal(refs[2].kind, "unsupported");
-  assert.equal(refs[2].reason, "malformed");
-  assert.equal(refs[3].reason, "unsupported-provider");
-  assert.equal(refs[4].reason, "malformed");
-  assert.equal(refs[5].reason, "invalid-field");
+  assert.equal(refs[2].kind, "github");
+  assert.equal(refs[3].kind, "unsupported");
+  assert.equal(refs[3].reason, "malformed");
+  assert.equal(refs[4].reason, "unsupported-provider");
+  assert.equal(refs[5].reason, "malformed");
+  assert.equal(refs[6].reason, "invalid-field");
 });
 
 test("GitHub status reports lifecycle and latest review state", async () => {

--- a/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.test.mjs
+++ b/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.test.mjs
@@ -1,5 +1,21 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { after, before, test } from "node:test";
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+before(() => {
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    window: dom.window,
+  });
+});
+
+after(() => dom.window.close());
 
 import {
   createWorkstreamPollingRegistry,
@@ -154,4 +170,102 @@ test("polling deduplicates canonical identities and tears down", async () => {
   assert.equal(registry.entryCount(), 0);
   assert.equal(aborted, true);
   resolveRequest();
+});
+
+test("workstream status hook exposes loading before a supported PR resolves", async () => {
+  const { cleanup, renderHook } = await import("@testing-library/react");
+  const { useWorkstreamPullRequestStatuses } = await import(
+    "./workstreamPullRequestStatus.ts"
+  );
+  const reference = parseWorkstreamPullRequestReference(
+    "https://github.com/block/buzz/pull/42",
+  );
+  const registry = createWorkstreamPollingRegistry({
+    fetcher: () => new Promise(() => {}),
+  });
+  const references = [reference];
+  const { result, unmount } = renderHook(() =>
+    useWorkstreamPullRequestStatuses(references, registry),
+  );
+  assert.deepEqual(result.current.get(reference.identity), {
+    status: "loading",
+  });
+  unmount();
+  cleanup();
+});
+
+test("workstream status hook preserves a synchronous live callback", async () => {
+  const { act, cleanup, renderHook } = await import("@testing-library/react");
+  const { useWorkstreamPullRequestStatuses } = await import(
+    "./workstreamPullRequestStatus.ts"
+  );
+  const reference = parseWorkstreamPullRequestReference(
+    "https://github.com/block/buzz/pull/42",
+  );
+  const registry = createWorkstreamPollingRegistry({
+    fetcher: async (url) =>
+      String(url).endsWith("/reviews?per_page=100")
+        ? response([])
+        : response({ number: 42, title: "Board", state: "open", draft: false }),
+    maxPolls: 1,
+  });
+  const prime = registry.subscribe(reference, () => {});
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  const references = [reference];
+  const { result, unmount } = renderHook(() =>
+    useWorkstreamPullRequestStatuses(references, registry),
+  );
+  await act(async () => {
+    await Promise.resolve();
+  });
+  assert.deepEqual(result.current.get(reference.identity), {
+    status: "live",
+    provider: "github",
+    href: "https://github.com/block/buzz/pull/42",
+    repository: "block/buzz",
+    number: 42,
+    title: "Board",
+    lifecycle: "open",
+    reviewState: "no-reviews",
+  });
+  unmount();
+  prime();
+  cleanup();
+});
+
+test("workstream status hook removes stale references and preserves unsupported state", async () => {
+  const { act, cleanup, renderHook } = await import("@testing-library/react");
+  const { useWorkstreamPullRequestStatuses } = await import(
+    "./workstreamPullRequestStatus.ts"
+  );
+  const supported = parseWorkstreamPullRequestReference(
+    "https://github.com/block/buzz/pull/42",
+  );
+  const unsupported = parseWorkstreamPullRequestReference(
+    "https://example.com/pr/1",
+  );
+  const registry = createWorkstreamPollingRegistry({
+    fetcher: () => new Promise(() => {}),
+  });
+  const { result, rerender, unmount } = renderHook(
+    ({ refs }) => useWorkstreamPullRequestStatuses(refs, registry),
+    { initialProps: { refs: [supported, unsupported] } },
+  );
+  assert.deepEqual(
+    result.current.get(unsupported.identity)?.status,
+    "unsupported",
+  );
+  await act(async () => {
+    rerender({ refs: [unsupported] });
+  });
+  assert.equal(result.current.has(supported.identity), false);
+  assert.deepEqual(
+    result.current.get(unsupported.identity)?.status,
+    "unsupported",
+  );
+  unmount();
+  cleanup();
 });

--- a/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.ts
+++ b/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.ts
@@ -507,8 +507,14 @@ export function createWorkstreamPollingRegistry(
 
 const defaultWorkstreamPollingRegistry = createWorkstreamPollingRegistry();
 
+type WorkstreamPollingRegistry = Pick<
+  ReturnType<typeof createWorkstreamPollingRegistry>,
+  "subscribe"
+>;
+
 export function useWorkstreamPullRequestStatuses(
   references: readonly WorkstreamPullRequestReference[],
+  pollingRegistry: WorkstreamPollingRegistry = defaultWorkstreamPollingRegistry,
 ): ReadonlyMap<string, WorkstreamPullRequestDisplayState> {
   const [states, setStates] = React.useState<
     ReadonlyMap<string, WorkstreamPullRequestDisplayState>
@@ -520,34 +526,37 @@ export function useWorkstreamPullRequestStatuses(
   }, [references]);
 
   React.useEffect(() => {
-    const next = new Map<string, WorkstreamPullRequestDisplayState>();
+    const initial = new Map<string, WorkstreamPullRequestDisplayState>();
+    for (const reference of referencesByIdentity.values()) {
+      initial.set(
+        reference.identity,
+        reference.kind === "unsupported"
+          ? {
+              status: "unsupported",
+              href: reference.href,
+              reason: reference.reason,
+            }
+          : { status: "loading" },
+      );
+    }
+    setStates(initial);
+
     const unsubscribers: Array<() => void> = [];
     for (const reference of referencesByIdentity.values()) {
-      if (reference.kind === "unsupported") {
-        next.set(reference.identity, {
-          status: "unsupported",
-          href: reference.href,
-          reason: reference.reason,
+      if (reference.kind === "unsupported") continue;
+      const unsubscribe = pollingRegistry.subscribe(reference, (state) => {
+        setStates((current) => {
+          const updated = new Map(current);
+          updated.set(reference.identity, state);
+          return updated;
         });
-        continue;
-      }
-      const unsubscribe = defaultWorkstreamPollingRegistry.subscribe(
-        reference,
-        (state) => {
-          setStates((current) => {
-            const updated = new Map(current);
-            updated.set(reference.identity, state);
-            return updated;
-          });
-        },
-      );
+      });
       unsubscribers.push(unsubscribe);
     }
-    setStates(next);
     return () => {
       for (const unsubscribe of unsubscribers) unsubscribe();
     };
-  }, [referencesByIdentity]);
+  }, [pollingRegistry, referencesByIdentity]);
 
   return states;
 }

--- a/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.ts
+++ b/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.ts
@@ -1,0 +1,554 @@
+import * as React from "react";
+
+import { eventToProjectPullRequest } from "@/features/projects/projectPullRequests.mjs";
+import { relayClient } from "@/shared/api/relayClient";
+import type { RelayEvent } from "@/shared/api/types";
+import {
+  KIND_GIT_PULL_REQUEST,
+  KIND_GIT_STATUS_CLOSED,
+  KIND_GIT_STATUS_DRAFT,
+  KIND_GIT_STATUS_MERGED,
+  KIND_GIT_STATUS_OPEN,
+} from "@/shared/constants/kinds";
+import { buildPullRequestLink, parseEntityLink } from "@/shared/lib/entityLink";
+
+export type WorkstreamPullRequestReference =
+  | {
+      kind: "buzz";
+      rawUrl: string;
+      href: string;
+      identity: string;
+      repoAddress: string;
+      eventId: string;
+      repository: string;
+    }
+  | {
+      kind: "github";
+      rawUrl: string;
+      href: string;
+      identity: string;
+      owner: string;
+      repository: string;
+      number: number;
+    }
+  | {
+      kind: "unsupported";
+      rawUrl: string;
+      href: string;
+      identity: string;
+      reason: "malformed" | "unsupported-provider" | "invalid-field";
+    };
+
+export type WorkstreamReviewState =
+  | "approved"
+  | "changes-requested"
+  | "review-requested"
+  | "no-reviews";
+
+export type WorkstreamPullRequestStatus = {
+  status: "live";
+  provider: "buzz" | "github";
+  href: string;
+  repository: string;
+  number: number | null;
+  title: string;
+  lifecycle: "draft" | "open" | "merged" | "closed";
+  reviewState: WorkstreamReviewState;
+};
+
+export type WorkstreamPullRequestUnknown = {
+  status: "unknown";
+  href: string;
+  reason: "not-found";
+};
+
+export type WorkstreamPullRequestDisplayState =
+  | { status: "loading" }
+  | { status: "error"; href: string }
+  | {
+      status: "unsupported";
+      href: string;
+      reason: "malformed" | "unsupported-provider" | "invalid-field";
+    }
+  | WorkstreamPullRequestStatus
+  | WorkstreamPullRequestUnknown;
+
+const GITHUB_HOSTS = new Set(["github.com", "www.github.com"]);
+const GITHUB_URL_RE = /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+\/?$/i;
+const MAX_GITHUB_POLLS = 10;
+const DEFAULT_GITHUB_POLL_INTERVAL_MS = 30_000;
+const DEFAULT_GITHUB_POLL_LIFETIME_MS = 5 * 60_000;
+const NIP34_STATUS_KINDS = [
+  KIND_GIT_STATUS_OPEN,
+  KIND_GIT_STATUS_MERGED,
+  KIND_GIT_STATUS_CLOSED,
+  KIND_GIT_STATUS_DRAFT,
+];
+
+function normalizeRawUrl(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "[invalid reference]";
+}
+
+function unsupportedReference(
+  rawUrl: string,
+  reason: Extract<
+    WorkstreamPullRequestReference,
+    { kind: "unsupported" }
+  >["reason"],
+): WorkstreamPullRequestReference {
+  return {
+    kind: "unsupported",
+    rawUrl,
+    href: rawUrl,
+    identity: `unsupported:${reason}:${rawUrl}`,
+    reason,
+  };
+}
+
+/** Parse a single v1 canvas PR reference without throwing. */
+export function parseWorkstreamPullRequestReference(
+  value: unknown,
+): WorkstreamPullRequestReference {
+  const rawUrl = normalizeRawUrl(value);
+  if (!rawUrl || rawUrl === "[invalid reference]") {
+    return unsupportedReference(rawUrl, "invalid-field");
+  }
+
+  if (rawUrl.startsWith("buzz://")) {
+    const parsed = parseEntityLink(rawUrl);
+    if (!parsed.ok || parsed.value.type !== "pr") {
+      return unsupportedReference(rawUrl, "malformed");
+    }
+
+    const { id, owner, dtag } = parsed.value;
+    return {
+      kind: "buzz",
+      rawUrl,
+      href: buildPullRequestLink({ dtag, id, owner }),
+      identity: `buzz:${owner.toLowerCase()}:${dtag}:${id.toLowerCase()}`,
+      repoAddress: `30617:${owner.toLowerCase()}:${dtag}`,
+      eventId: id.toLowerCase(),
+      repository: dtag,
+    };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return unsupportedReference(rawUrl, "malformed");
+  }
+
+  if (!GITHUB_HOSTS.has(parsed.hostname.toLowerCase())) {
+    return unsupportedReference(rawUrl, "unsupported-provider");
+  }
+  if (
+    parsed.username ||
+    parsed.password ||
+    parsed.port ||
+    parsed.protocol !== "https:"
+  ) {
+    return unsupportedReference(rawUrl, "malformed");
+  }
+
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  if (
+    segments.length !== 4 ||
+    segments[2].toLowerCase() !== "pull" ||
+    !/^\d+$/.test(segments[3])
+  ) {
+    return unsupportedReference(rawUrl, "malformed");
+  }
+
+  const number = Number(segments[3]);
+  if (
+    !Number.isSafeInteger(number) ||
+    number < 1 ||
+    !GITHUB_URL_RE.test(rawUrl)
+  ) {
+    return unsupportedReference(rawUrl, "malformed");
+  }
+
+  const owner = segments[0].toLowerCase();
+  const repository = segments[1].toLowerCase();
+  const href = `https://github.com/${owner}/${repository}/pull/${number}`;
+  return {
+    kind: "github",
+    rawUrl,
+    href,
+    identity: `github:${owner}/${repository}#${number}`,
+    owner,
+    repository,
+    number,
+  };
+}
+
+export function parseWorkstreamPullRequestReferences(
+  values: readonly unknown[],
+): WorkstreamPullRequestReference[] {
+  return values.map(parseWorkstreamPullRequestReference);
+}
+
+type GithubResponse = {
+  state?: unknown;
+  draft?: unknown;
+  merged_at?: unknown;
+  number?: unknown;
+  title?: unknown;
+  requested_reviewers?: unknown;
+};
+
+type GithubReview = {
+  user?: { login?: unknown } | null;
+  state?: unknown;
+  submitted_at?: unknown;
+  updated_at?: unknown;
+};
+
+export type GithubFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+type EventFetcher = (
+  filter: Parameters<typeof relayClient.fetchEvents>[0],
+) => Promise<RelayEvent[]>;
+
+function isGithubReview(value: unknown): value is GithubReview {
+  return typeof value === "object" && value !== null;
+}
+
+function reviewState(
+  reviews: unknown[],
+  requestedReviewers: unknown,
+): WorkstreamReviewState {
+  const latestByReviewer = new Map<string, GithubReview>();
+  for (const review of reviews.filter(isGithubReview)) {
+    const login =
+      typeof review.user?.login === "string" ? review.user.login : null;
+    if (!login) continue;
+    const current = latestByReviewer.get(login.toLowerCase());
+    const currentAt = String(
+      current?.submitted_at ?? current?.updated_at ?? "",
+    );
+    const nextAt = String(review.submitted_at ?? review.updated_at ?? "");
+    if (!current || nextAt >= currentAt) {
+      latestByReviewer.set(login.toLowerCase(), review);
+    }
+  }
+
+  const latestStates = [...latestByReviewer.values()].map((review) =>
+    typeof review.state === "string" ? review.state.toUpperCase() : "",
+  );
+  if (latestStates.includes("CHANGES_REQUESTED")) return "changes-requested";
+  if (latestStates.includes("APPROVED")) return "approved";
+  if (Array.isArray(requestedReviewers) && requestedReviewers.length > 0) {
+    return "review-requested";
+  }
+  return "no-reviews";
+}
+
+function lifecycleFromGithubResponse(
+  response: GithubResponse,
+): WorkstreamPullRequestStatus["lifecycle"] {
+  if (typeof response.merged_at === "string" && response.merged_at) {
+    return "merged";
+  }
+  if (response.draft === true) return "draft";
+  return response.state === "closed" ? "closed" : "open";
+}
+
+async function fetchJson(
+  fetcher: GithubFetch,
+  url: string,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const response = await fetcher(url, {
+    headers: { Accept: "application/vnd.github+json" },
+    signal,
+  });
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(`GitHub metadata request failed (${response.status}).`);
+  }
+  return response.json();
+}
+
+/** Fetch bounded, unauthenticated GitHub PR metadata for one canonical PR. */
+export async function fetchGithubPullRequestStatus(
+  reference: Extract<WorkstreamPullRequestReference, { kind: "github" }>,
+  options: { fetcher?: GithubFetch; signal?: AbortSignal } = {},
+): Promise<WorkstreamPullRequestStatus | WorkstreamPullRequestUnknown> {
+  const fetcher = options.fetcher ?? fetch;
+  const base = `https://api.github.com/repos/${reference.owner}/${reference.repository}/pulls/${reference.number}`;
+  const [rawPullRequest, rawReviews] = await Promise.all([
+    fetchJson(fetcher, base, options.signal),
+    fetchJson(fetcher, `${base}/reviews?per_page=100`, options.signal),
+  ]);
+
+  if (rawPullRequest === null) {
+    return { status: "unknown", href: reference.href, reason: "not-found" };
+  }
+  if (
+    typeof rawPullRequest !== "object" ||
+    rawPullRequest === null ||
+    !Array.isArray(rawReviews)
+  ) {
+    throw new Error("GitHub metadata response was unavailable.");
+  }
+
+  const response = rawPullRequest as GithubResponse;
+  if (
+    typeof response.title !== "string" ||
+    response.number !== reference.number
+  ) {
+    throw new Error("GitHub metadata response was invalid.");
+  }
+
+  return {
+    status: "live",
+    provider: "github",
+    href: reference.href,
+    repository: `${reference.owner}/${reference.repository}`,
+    number: reference.number,
+    title: response.title,
+    lifecycle: lifecycleFromGithubResponse(response),
+    reviewState: reviewState(rawReviews, response.requested_reviewers),
+  };
+}
+
+/** Consume the existing NIP-34 root/status event streams for one Buzz PR. */
+export async function fetchBuzzPullRequestStatus(
+  reference: Extract<WorkstreamPullRequestReference, { kind: "buzz" }>,
+  fetchEvents: EventFetcher = (filter) => relayClient.fetchEvents(filter),
+): Promise<WorkstreamPullRequestStatus | WorkstreamPullRequestUnknown> {
+  const roots = await fetchEvents({
+    kinds: [KIND_GIT_PULL_REQUEST],
+    ids: [reference.eventId],
+    "#a": [reference.repoAddress],
+    limit: 1,
+  });
+  const root = roots.find(
+    (event) => event.id.toLowerCase() === reference.eventId,
+  );
+  if (!root) {
+    return { status: "unknown", href: reference.href, reason: "not-found" };
+  }
+
+  const [updates, comments, statuses] = await Promise.all([
+    fetchEvents({ kinds: [1634], "#a": [reference.repoAddress], limit: 500 }),
+    fetchEvents({ kinds: [1], "#a": [reference.repoAddress], limit: 500 }),
+    fetchEvents({
+      kinds: NIP34_STATUS_KINDS,
+      "#a": [reference.repoAddress],
+      limit: 500,
+    }),
+  ]);
+  const pullRequest = eventToProjectPullRequest(
+    root,
+    updates,
+    comments,
+    statuses,
+  );
+  return {
+    status: "live",
+    provider: "buzz",
+    href: reference.href,
+    repository: reference.repository,
+    number: null,
+    title: pullRequest.title,
+    lifecycle:
+      pullRequest.status.toLowerCase() as WorkstreamPullRequestStatus["lifecycle"],
+    reviewState:
+      pullRequest.changeRequests.length > 0
+        ? "changes-requested"
+        : pullRequest.approvals.length > 0
+          ? "approved"
+          : pullRequest.reviewers.length > 0
+            ? "review-requested"
+            : "no-reviews",
+  };
+}
+
+type PollerListener = (state: WorkstreamPullRequestDisplayState) => void;
+type PollerReference = Exclude<
+  WorkstreamPullRequestReference,
+  { kind: "unsupported" }
+>;
+type PollerEntry = {
+  reference: PollerReference;
+  listeners: Set<PollerListener>;
+  state: WorkstreamPullRequestDisplayState;
+  controller: AbortController | null;
+  timer: ReturnType<typeof setTimeout> | null;
+  startedAt: number;
+  pollCount: number;
+};
+
+export type WorkstreamPollingRegistryOptions = {
+  fetcher?: GithubFetch;
+  fetchEvents?: EventFetcher;
+  intervalMs?: number;
+  maxPolls?: number;
+  maxLifetimeMs?: number;
+  now?: () => number;
+  schedule?: (
+    callback: () => void,
+    delayMs: number,
+  ) => ReturnType<typeof setTimeout>;
+  cancel?: (timer: ReturnType<typeof setTimeout>) => void;
+};
+
+/** One bounded, route-scoped metadata stream per canonical PR identity. */
+export function createWorkstreamPollingRegistry(
+  options: WorkstreamPollingRegistryOptions = {},
+) {
+  const githubFetcher = options.fetcher ?? fetch;
+  const fetchEvents =
+    options.fetchEvents ?? ((filter) => relayClient.fetchEvents(filter));
+  const intervalMs = options.intervalMs ?? DEFAULT_GITHUB_POLL_INTERVAL_MS;
+  const maxPolls = options.maxPolls ?? MAX_GITHUB_POLLS;
+  const maxLifetimeMs =
+    options.maxLifetimeMs ?? DEFAULT_GITHUB_POLL_LIFETIME_MS;
+  const now = options.now ?? (() => Date.now());
+  const schedule =
+    options.schedule ?? ((callback, delay) => setTimeout(callback, delay));
+  const cancel = options.cancel ?? ((timer) => clearTimeout(timer));
+  const entries = new Map<string, PollerEntry>();
+
+  const stop = (entry: PollerEntry) => {
+    if (entry.timer !== null) cancel(entry.timer);
+    entry.timer = null;
+    entry.controller?.abort();
+    entry.controller = null;
+    entries.delete(entry.reference.identity);
+  };
+
+  const notify = (entry: PollerEntry) => {
+    for (const listener of entry.listeners) listener(entry.state);
+  };
+
+  const fetchStatus = (entry: PollerEntry, signal: AbortSignal) =>
+    entry.reference.kind === "github"
+      ? fetchGithubPullRequestStatus(entry.reference, {
+          fetcher: githubFetcher,
+          signal,
+        })
+      : fetchBuzzPullRequestStatus(entry.reference, fetchEvents);
+
+  const poll = async (entry: PollerEntry) => {
+    if (!entries.has(entry.reference.identity) || entry.listeners.size === 0)
+      return;
+    const controller = new AbortController();
+    entry.controller = controller;
+    try {
+      entry.state = await fetchStatus(entry, controller.signal);
+      notify(entry);
+    } catch {
+      if (controller.signal.aborted && entry.listeners.size === 0) return;
+      entry.state = { status: "error", href: entry.reference.href };
+      notify(entry);
+    } finally {
+      entry.controller = null;
+      entry.pollCount += 1;
+      const bounded =
+        entry.pollCount >= maxPolls || now() - entry.startedAt >= maxLifetimeMs;
+      if (entry.listeners.size > 0 && !bounded) {
+        entry.timer = schedule(() => {
+          entry.timer = null;
+          void poll(entry);
+        }, intervalMs);
+      }
+    }
+  };
+
+  const subscribe = (reference: PollerReference, listener: PollerListener) => {
+    let entry = entries.get(reference.identity);
+    if (!entry) {
+      entry = {
+        reference,
+        listeners: new Set(),
+        state: { status: "loading" },
+        controller: null,
+        timer: null,
+        startedAt: now(),
+        pollCount: 0,
+      };
+      entries.set(reference.identity, entry);
+    }
+    entry.listeners.add(listener);
+    if (
+      entry.pollCount === 0 &&
+      entry.controller === null &&
+      entry.timer === null
+    ) {
+      void poll(entry);
+    }
+    listener(entry.state);
+    return () => {
+      if (!entry?.listeners.delete(listener)) return;
+      if (entry.listeners.size === 0) stop(entry);
+    };
+  };
+
+  return {
+    subscribe,
+    entryCount: () => entries.size,
+    reset: () => {
+      for (const entry of [...entries.values()]) stop(entry);
+    },
+  };
+}
+
+const defaultWorkstreamPollingRegistry = createWorkstreamPollingRegistry();
+
+export function useWorkstreamPullRequestStatuses(
+  references: readonly WorkstreamPullRequestReference[],
+): ReadonlyMap<string, WorkstreamPullRequestDisplayState> {
+  const [states, setStates] = React.useState<
+    ReadonlyMap<string, WorkstreamPullRequestDisplayState>
+  >(() => new Map());
+  const referencesByIdentity = React.useMemo(() => {
+    const next = new Map<string, WorkstreamPullRequestReference>();
+    for (const reference of references) next.set(reference.identity, reference);
+    return next;
+  }, [references]);
+
+  React.useEffect(() => {
+    const next = new Map<string, WorkstreamPullRequestDisplayState>();
+    const unsubscribers: Array<() => void> = [];
+    for (const reference of referencesByIdentity.values()) {
+      if (reference.kind === "unsupported") {
+        next.set(reference.identity, {
+          status: "unsupported",
+          href: reference.href,
+          reason: reference.reason,
+        });
+        continue;
+      }
+      const unsubscribe = defaultWorkstreamPollingRegistry.subscribe(
+        reference,
+        (state) => {
+          setStates((current) => {
+            const updated = new Map(current);
+            updated.set(reference.identity, state);
+            return updated;
+          });
+        },
+      );
+      unsubscribers.push(unsubscribe);
+    }
+    setStates(next);
+    return () => {
+      for (const unsubscribe of unsubscribers) unsubscribe();
+    };
+  }, [referencesByIdentity]);
+
+  return states;
+}
+
+export const workstreamPollingLimits = {
+  intervalMs: DEFAULT_GITHUB_POLL_INTERVAL_MS,
+  maxLifetimeMs: DEFAULT_GITHUB_POLL_LIFETIME_MS,
+  maxPolls: MAX_GITHUB_POLLS,
+};

--- a/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.ts
+++ b/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.ts
@@ -86,7 +86,12 @@ const NIP34_STATUS_KINDS = [
 ];
 
 function normalizeRawUrl(value: unknown): string {
-  return typeof value === "string" ? value.trim() : "[invalid reference]";
+  if (typeof value === "string") return value.trim();
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    const url = (value as { url?: unknown }).url;
+    if (typeof url === "string") return url.trim();
+  }
+  return "[invalid reference]";
 }
 
 function unsupportedReference(

--- a/desktop/src/features/workstream-board/ui/WorkstreamCard.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamCard.tsx
@@ -1,12 +1,15 @@
+import * as React from "react";
 import { Hash } from "lucide-react";
 
 import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
 import { useCanvasQuery } from "@/features/channels/hooks";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import { parseWorkstreamPullRequestReferences } from "@/features/workstream-board/lib/workstreamPullRequestStatus";
 import { buildWorkstreamCardViewModel } from "@/features/workstream-board/lib/workstreamCardViewModel";
+import { WorkstreamPullRequests } from "@/features/workstream-board/ui/WorkstreamPullRequests";
+import { WorkstreamWorkingIndicator } from "@/features/workstream-board/ui/WorkstreamWorkingIndicator";
 import type { Channel } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
-import { WorkstreamWorkingIndicator } from "@/features/workstream-board/ui/WorkstreamWorkingIndicator";
 
 type WorkstreamCardProps = {
   activeWorking?: ActiveChannelTurnSummary;
@@ -27,6 +30,13 @@ export function WorkstreamCard({
     isLoading: canvasQuery.isLoading,
     isError: canvasQuery.isError,
   });
+  const references = React.useMemo(
+    () =>
+      viewModel.status === "ready"
+        ? parseWorkstreamPullRequestReferences(viewModel.card.pullRequests)
+        : [],
+    [viewModel],
+  );
 
   return (
     <div
@@ -72,6 +82,9 @@ export function WorkstreamCard({
                     </span>
                   ))}
                 </div>
+              ) : null}
+              {references.length > 0 ? (
+                <WorkstreamPullRequests references={references} />
               ) : null}
             </div>
           </>

--- a/desktop/src/features/workstream-board/ui/WorkstreamPullRequests.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamPullRequests.tsx
@@ -1,0 +1,108 @@
+import { ExternalLink, GitPullRequest } from "lucide-react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+
+import { parseEntityLink } from "@/shared/lib/entityLink";
+import { useOpenEntityLink } from "@/shared/ui/markdown/entityLinks";
+import {
+  type WorkstreamPullRequestDisplayState,
+  type WorkstreamPullRequestReference,
+  useWorkstreamPullRequestStatuses,
+} from "@/features/workstream-board/lib/workstreamPullRequestStatus";
+
+function lifecycleLabel(
+  state: Extract<WorkstreamPullRequestDisplayState, { status: "live" }>,
+) {
+  return state.lifecycle[0].toUpperCase() + state.lifecycle.slice(1);
+}
+
+function reviewLabel(
+  state: Extract<WorkstreamPullRequestDisplayState, { status: "live" }>,
+) {
+  switch (state.reviewState) {
+    case "approved":
+      return "Approved";
+    case "changes-requested":
+      return "Changes requested";
+    case "review-requested":
+      return "Review requested";
+    default:
+      return "No reviews";
+  }
+}
+
+function referenceLabel(reference: WorkstreamPullRequestReference) {
+  if (reference.kind === "github") {
+    return `${reference.owner}/${reference.repository} #${reference.number}`;
+  }
+  if (reference.kind === "buzz") {
+    return `${reference.repository} · ${reference.eventId.slice(0, 8)}`;
+  }
+  return reference.rawUrl;
+}
+
+export function WorkstreamPullRequests({
+  references,
+}: {
+  references: readonly WorkstreamPullRequestReference[];
+}) {
+  const states = useWorkstreamPullRequestStatuses(references);
+  const openEntityLink = useOpenEntityLink();
+
+  return (
+    <div
+      className="pointer-events-auto mt-4 space-y-1.5"
+      data-testid="workstream-pull-requests"
+    >
+      <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Pull requests
+      </p>
+      {references.map((reference) => {
+        const state = states.get(reference.identity);
+        const label = referenceLabel(reference);
+        const parsedBuzzLink =
+          reference.kind === "buzz" ? parseEntityLink(reference.href) : null;
+        const open = () => {
+          if (parsedBuzzLink?.ok) {
+            // Keep Buzz PRs in the existing canonical entity navigation path.
+            openEntityLink(parsedBuzzLink.value);
+            return;
+          }
+          void openUrl(reference.href);
+        };
+
+        return (
+          <button
+            className="flex w-full items-center gap-2 rounded-md border border-border/50 bg-background/60 px-2 py-1.5 text-left text-2xs transition-colors hover:bg-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+            data-testid="workstream-pull-request"
+            key={reference.identity}
+            onClick={open}
+            type="button"
+          >
+            <GitPullRequest className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1 truncate" title={reference.rawUrl}>
+              {state?.status === "live" && state.title
+                ? `${label} · ${state.title}`
+                : label}
+            </span>
+            {state?.status === "loading" ? (
+              <span className="shrink-0 text-muted-foreground">Loading…</span>
+            ) : state?.status === "live" ? (
+              <span className="shrink-0 text-muted-foreground">
+                {lifecycleLabel(state)} · {reviewLabel(state)}
+              </span>
+            ) : state?.status === "error" ? (
+              <span className="shrink-0 text-red-400">Unavailable</span>
+            ) : state?.status === "unknown" ? (
+              <span className="shrink-0 text-muted-foreground">Unknown</span>
+            ) : state?.status === "unsupported" ? (
+              <span className="shrink-0 text-muted-foreground">
+                Unsupported
+              </span>
+            ) : null}
+            <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -13714,6 +13714,29 @@ export function maybeInstallE2eTauriMocks() {
         if (canvasReadError) {
           throw new Error(canvasReadError);
         }
+        if (isRelayMode(activeConfig)) {
+          const channelId = (payload as { channelId?: string }).channelId;
+          if (!channelId) {
+            throw new Error("get_canvas requires channelId");
+          }
+          const events = await relayQuery(activeConfig, [
+            { kinds: [40100], "#h": [channelId], limit: 1 },
+          ]);
+          const event = events[0];
+          return event
+            ? {
+                content: event.content,
+                event_id: event.id,
+                updated_at: event.created_at,
+                author: event.pubkey,
+              }
+            : {
+                content: "",
+                event_id: null,
+                updated_at: null,
+                author: null,
+              };
+        }
         // Return the no-canvas success shape — content null means no canvas set.
         return { content: null, updated_at: null, author: null };
       }

--- a/desktop/tests/e2e/get-canvas-bridge.spec.ts
+++ b/desktop/tests/e2e/get-canvas-bridge.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge, installRelayBridge } from "../helpers/bridge";
+
+async function invokeCanvas(
+  page: import("@playwright/test").Page,
+  channelId: string,
+) {
+  return page.evaluate(async (id) => {
+    const tauriWindow = window as Window & {
+      __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+        command: string,
+        payload?: Record<string, unknown>,
+      ) => Promise<unknown>;
+      __TAURI_INTERNALS__?: {
+        invoke?: (
+          command: string,
+          payload?: Record<string, unknown>,
+        ) => Promise<unknown>;
+      };
+    };
+    const invoke =
+      tauriWindow.__BUZZ_E2E_INVOKE_MOCK_COMMAND__ ??
+      tauriWindow.__TAURI_INTERNALS__?.invoke;
+    if (!invoke) throw new Error("Mock invoke bridge is unavailable.");
+    return invoke("get_canvas", { channelId: id });
+  }, channelId);
+}
+
+test("relay mode forwards get_canvas to the authenticated kind-40100 query", async ({
+  page,
+}) => {
+  await installRelayBridge(page, "tyler");
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(
+    () =>
+      typeof (window as Window & { __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: unknown })
+        .__BUZZ_E2E_INVOKE_MOCK_COMMAND__ === "function",
+  );
+
+  const result = (await invokeCanvas(
+    page,
+    "eb4d4cee-2b29-4d53-addf-e6c4b93b4c0d",
+  )) as { content?: string | null; event_id?: string | null };
+  expect(result.event_id).toBeTruthy();
+  expect(result.content).toContain("B3 linked PR");
+});
+
+test("mock mode keeps the deterministic null canvas response", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(
+    () =>
+      typeof (window as Window & { __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: unknown })
+        .__BUZZ_E2E_INVOKE_MOCK_COMMAND__ === "function",
+  );
+
+  await expect(await invokeCanvas(page, "mock-channel")).toEqual({
+    content: null,
+    updated_at: null,
+    author: null,
+  });
+});
+
+test("mock mode keeps configured canvas errors isolated", async ({ page }) => {
+  await installMockBridge(page, { canvasReadError: "canvas unavailable" });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(
+    () =>
+      typeof (window as Window & { __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: unknown })
+        .__BUZZ_E2E_INVOKE_MOCK_COMMAND__ === "function",
+  );
+
+  await expect(invokeCanvas(page, "mock-channel")).rejects.toThrow(
+    "canvas unavailable",
+  );
+});

--- a/desktop/tests/e2e/workstream-board-b3-pr.capture.spec.ts
+++ b/desktop/tests/e2e/workstream-board-b3-pr.capture.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "@playwright/test";
+
+import { installRelayBridge } from "../helpers/bridge";
+
+test("continuous relay-backed Workstream Board bullet 3 PR-status demo", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(120_000);
+  await installRelayBridge(page, "tyler", { seedPreviewFeatures: true });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("app-sidebar")).toBeVisible();
+  await expect(page.getByTestId("open-workstream-board-view")).toBeVisible();
+  // Hold only the authenticated NIP-34 root query long enough for the
+  // continuous artifact to show the promised loading -> live transition.
+  await page.route("http://localhost:3000/query", async (route) => {
+    const body = route.request().postDataJSON() as Array<{
+      kinds?: number[];
+    }> | null;
+    if (body?.some((filter) => filter.kinds?.includes(1618))) {
+      await new Promise((resolve) => setTimeout(resolve, 1_500));
+    }
+    await route.continue();
+  });
+  await page.getByTestId("open-workstream-board-view").click();
+
+  const board = page.getByTestId("workstream-board-view");
+  await expect(board).toBeVisible();
+  const channelId = "eb4d4cee-2b29-4d53-addf-e6c4b93b4c0d";
+  // Focused bridge regression: relay mode must return the real kind-40100
+  // canvas event. Mock mode intentionally keeps the deterministic null/error
+  // behavior covered by relay-connectivity.spec.ts.
+  const canvas = (await page.evaluate(async (id) => {
+    const tauriWindow = window as Window & {
+      __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+        command: string,
+        payload?: Record<string, unknown>,
+      ) => Promise<unknown>;
+      __TAURI_INTERNALS__?: {
+        invoke?: (
+          command: string,
+          payload?: Record<string, unknown>,
+        ) => Promise<unknown>;
+      };
+    };
+    const invoke =
+      tauriWindow.__BUZZ_E2E_INVOKE_MOCK_COMMAND__ ??
+      tauriWindow.__TAURI_INTERNALS__?.invoke;
+    if (!invoke) throw new Error("Mock invoke bridge is unavailable.");
+    return invoke("get_canvas", { channelId: id });
+  }, channelId)) as { content?: string | null };
+  expect(canvas.content).toContain("B3 linked PR");
+
+  const card = page.getByTestId(`workstream-card-${channelId}`);
+  await expect(card).toBeVisible();
+  await expect(card).toContainText(
+    "Show a real linked PR loading then live status",
+  );
+
+  const pullRequest = card.getByTestId("workstream-pull-request");
+  await expect(pullRequest).toBeVisible();
+  await expect(pullRequest).toContainText(/Loading…|B3 linked PR/);
+  await page.screenshot({
+    path: testInfo.outputPath("b3-loading.png"),
+    fullPage: true,
+  });
+
+  await expect(pullRequest).toContainText("B3 linked PR");
+  await expect(pullRequest).toContainText("Open");
+  await expect(pullRequest).toContainText("No reviews");
+  await page.screenshot({
+    path: testInfo.outputPath("b3-live.png"),
+    fullPage: true,
+  });
+  await page.waitForTimeout(3_000);
+
+  await pullRequest.click();
+  await expect(page).toHaveURL(/\/projects\//);
+  await expect(
+    page.locator("[data-project-detail-panel]:visible").first(),
+  ).toBeVisible({ timeout: 15_000 });
+  await page.screenshot({
+    path: testInfo.outputPath("b3-canonical-open.png"),
+    fullPage: true,
+  });
+  await page.waitForTimeout(3_000);
+});

--- a/desktop/tests/e2e/workstream-board-b3-pr.capture.spec.ts
+++ b/desktop/tests/e2e/workstream-board-b3-pr.capture.spec.ts
@@ -6,21 +6,13 @@ test("continuous relay-backed Workstream Board bullet 3 PR-status demo", async (
   page,
 }, testInfo) => {
   test.setTimeout(120_000);
-  await installRelayBridge(page, "tyler", { seedPreviewFeatures: true });
+  await installRelayBridge(page, "tyler", {
+    seedPreviewFeatures: true,
+    relayPullRequestQueryDelayMs: 2_500,
+  });
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await expect(page.getByTestId("app-sidebar")).toBeVisible();
   await expect(page.getByTestId("open-workstream-board-view")).toBeVisible();
-  // Hold only the authenticated NIP-34 root query long enough for the
-  // continuous artifact to show the promised loading -> live transition.
-  await page.route("http://localhost:3000/query", async (route) => {
-    const body = route.request().postDataJSON() as Array<{
-      kinds?: number[];
-    }> | null;
-    if (body?.some((filter) => filter.kinds?.includes(1618))) {
-      await new Promise((resolve) => setTimeout(resolve, 1_500));
-    }
-    await route.continue();
-  });
   await page.getByTestId("open-workstream-board-view").click();
 
   const board = page.getByTestId("workstream-board-view");
@@ -58,7 +50,8 @@ test("continuous relay-backed Workstream Board bullet 3 PR-status demo", async (
 
   const pullRequest = card.getByTestId("workstream-pull-request");
   await expect(pullRequest).toBeVisible();
-  await expect(pullRequest).toContainText(/Loading…|B3 linked PR/);
+  await expect(pullRequest).toContainText("Loading…");
+  await page.waitForTimeout(1_000);
   await page.screenshot({
     path: testInfo.outputPath("b3-loading.png"),
     fullPage: true,

--- a/desktop/tests/e2e/workstream-board-b3-pr.capture.spec.ts
+++ b/desktop/tests/e2e/workstream-board-b3-pr.capture.spec.ts
@@ -6,9 +6,25 @@ test("continuous relay-backed Workstream Board bullet 3 PR-status demo", async (
   page,
 }, testInfo) => {
   test.setTimeout(120_000);
-  await installRelayBridge(page, "tyler", {
-    seedPreviewFeatures: true,
-    relayPullRequestQueryDelayMs: 2_500,
+  await installRelayBridge(page, "tyler", { seedPreviewFeatures: true });
+  await page.routeWebSocket(/localhost:3000/, (socket) => {
+    const server = socket.connectToServer();
+    server.onMessage((message) => {
+      if (typeof message === "string") {
+        try {
+          const payload = JSON.parse(message) as unknown[];
+          const event = payload[2] as { kind?: unknown } | undefined;
+          if (payload[0] === "EVENT" && event?.kind === 1618) {
+            setTimeout(() => socket.send(message), 2_500);
+            return;
+          }
+        } catch {
+          // Pass non-JSON relay frames through unchanged.
+        }
+      }
+      socket.send(message);
+    });
+    socket.onMessage((message) => server.send(message));
   });
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await expect(page.getByTestId("app-sidebar")).toBeVisible();

--- a/desktop/tests/e2e/workstream-board-b3-pr.capture.spec.ts
+++ b/desktop/tests/e2e/workstream-board-b3-pr.capture.spec.ts
@@ -9,13 +9,34 @@ test("continuous relay-backed Workstream Board bullet 3 PR-status demo", async (
   await installRelayBridge(page, "tyler", { seedPreviewFeatures: true });
   await page.routeWebSocket(/localhost:3000/, (socket) => {
     const server = socket.connectToServer();
+    let delayedPrSubscription: string | null = null;
+    let delayedFrames: string[] = [];
+    let releaseScheduled = false;
+    const release = () => {
+      const frames = delayedFrames;
+      delayedFrames = [];
+      delayedPrSubscription = null;
+      releaseScheduled = false;
+      for (const frame of frames) socket.send(frame);
+    };
     server.onMessage((message) => {
       if (typeof message === "string") {
         try {
           const payload = JSON.parse(message) as unknown[];
+          const type = payload[0];
+          const subId = typeof payload[1] === "string" ? payload[1] : null;
           const event = payload[2] as { kind?: unknown } | undefined;
-          if (payload[0] === "EVENT" && event?.kind === 1618) {
-            setTimeout(() => socket.send(message), 2_500);
+          if (type === "EVENT" && event?.kind === 1618 && subId) {
+            delayedPrSubscription = subId;
+            delayedFrames.push(message);
+            if (!releaseScheduled) {
+              releaseScheduled = true;
+              setTimeout(release, 2_500);
+            }
+            return;
+          }
+          if (type === "EOSE" && subId === delayedPrSubscription) {
+            delayedFrames.push(message);
             return;
           }
         } catch {


### PR DESCRIPTION
🤖

## Summary

Workstream coordinators need a compact way to tell whether a board card's linked pull request is still loading, open, or otherwise actionable without leaving the board. This adds pull-request status to Workstream Board cards while preserving the existing per-card fallbacks for unavailable or malformed data.

This is **PR 3 of a four-PR Workstream Board stack**, stacked on [PR 2](https://github.com/block/buzz/pull/6219). It remains an experiment, **off by default**; enable Workstream Board in Settings → Experiments to use it. The originating discussion is [the Buzz workstream channel](buzz://channel/156498d7-62a1-499d-bcfe-b73227d6a2a4).

### What changes

- Seeds supported pull-request rows as `Loading…` before status resolution so the board exposes the real pending state instead of appearing empty.
- Resolves canonical Buzz pull requests and GitHub pull URLs to the existing `Open · No reviews` status presentation, while preserving cached states and local degradation when a status cannot be read.
- Deduplicates subscriptions by canonical pull-request identity and removes stale identities when the board's reference set changes.
- Keeps the capture-only timing seam and relay bridge out of the product diff; the capture exercises the real loading state and ordered event delivery.

The implementation lives on this PR branch in [`workstreamPullRequestStatus.ts`](https://github.com/block/buzz/blob/workstream-board/03-pr-status/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.ts), its tests, and [`workstream-board-b3-pr.capture.spec.ts`](https://github.com/block/buzz/blob/workstream-board/03-pr-status/desktop/tests/e2e/workstream-board-b3-pr.capture.spec.ts).

### Related issue

None found. This is an experiment-gated product spike.

### Testing

- Exact head `f2aa42e9e10d9b986a9f59c8f8c044a5a9878181`:
  - Focused Workstream PR status tests: **7/7**
  - Relay bridge + continuous capture tests: **4/4**
  - Desktop typecheck: pass
  - Full Desktop test suite: **5,004 passed, 0 failed**
  - E2E build: pass
  - `pnpm check`: only four pre-existing Biome findings, disclosed below
- Three independent Royal reviews cleared the immutable head with zero material findings (content scores: Princess Donut 9.6/10, Carl 9.4/10, Mongo 9.0/10).

**Acceptance gates**

- [x] Supported pull-request rows seed a visible loading state before resolution.
- [x] Canonical Buzz and GitHub pull-request references resolve through one deduplicated status path.
- [x] Cached status, stale-reference removal, and per-card degradation are preserved.
- [x] Continuous relay-backed capture completed before PR creation.
- [x] Three independent Royal reviews passed at the exact PR head with zero material findings.
- [ ] Required CI checks are green.
- [ ] Maintainer review is complete.

> [!NOTE]
> Security may report the known baseline-wide `RUSTSEC-2026-0258` / `h2 0.4.14` advisory. A separate fix lane owns it; it is unrelated to this Desktop-only diff. `pnpm check` also reports four pre-existing Biome findings.

### Demo

The qualifying uninterrupted capture is the canonical WebM (10.52 seconds, SHA-256 `ab15869cf5a09069e1527777adec154f740ecdf455d228e1f57e975eb90938a1`). The WebM remains the artifact of record; the animated GIF below is a presentation derivative. A local MP4 transcode is preserved at `.scratch/b3-f2-final-video.mp4` (SHA-256 `1a4356d766486068aeca7a16580afbea0dcd16247ade7e8b227ca07146943d61`) and is not routed through S3/CloudFront.

![Continuous Workstream Board capture: loading pull-request status, live status, canonical open navigation, and PR detail](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/b3-f2aa42e9/b3-demo.gif)

| Loading status | Live board |
| --- | --- |
| ![Workstream Board card showing pull-request Loading state](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/b3-f2aa42e9/loading.png) | ![Workstream Board card showing live pull-request status](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/b3-f2aa42e9/live.png) |

| Canonical open | PR-detail presentation |
| --- | --- |
| ![Canonical open outcome on the repository surface; the PR-detail frame below shows the final pull-request presentation](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/b3-f2aa42e9/canonical-open.png) | ![PR-detail presentation frame extracted from the final moment of the canonical capture](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/b3-f2aa42e9/pr-detail.png) |

The canonical-open PNG is intentionally scoped to the repository README surface (SHA-256 `772113a880cfdf1434aa6fa773065a42c61769487e5463cdff828eeb3f8dd9f3`); it does not claim to show PR detail. The PR-detail presentation frame is extracted from the final navigation outcome.

The capture uses a capture-only Playwright network timing seam: the real kind-1618 PR `EVENT` and matching `EOSE` are queued together and released in order after 2.5 seconds. The UI receives the real product loading state; no row state is injected. The rendered `Loading…` state is held for 1 second before its screenshot.

### Stack and review gates

- Base branch: `workstream-board/02-live-working` at `2dfbd23581783c54eba52d405593fb00fdabc0d7`
- Head branch: `workstream-board/03-pr-status` at `f2aa42e9e10d9b986a9f59c8f8c044a5a9878181`
- Stack position: PR 3/4
- Originating Buzz channel: [Workstream Board tracer-bullet channel](buzz://channel/156498d7-62a1-499d-bcfe-b73227d6a2a4)
- Royal attestations at the immutable head: Princess Donut 9.6 (`bd7ff66d…`), Carl 9.4 (`aaa4ab26…`), Mongo 9.0 (`b19027a7…`)
- Bridge/parser carry was confirmed untouched by the final fix.

Draft only; no auto-merge.
