### PR TITLE
Fix presence retry timers after failed opens

### DIFF
--- a/desktop/src/features/presence/lib/presenceSubscriptionReconciler.test.mjs
+++ b/desktop/src/features/presence/lib/presenceSubscriptionReconciler.test.mjs
@@ -148,6 +148,66 @@ test("failed replacement preserves the previous subscription and retries", async
   reconciler.dispose();
 });
 
+test("default browser timers retry safely after an open failure and cancel pending work", async () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const timers = [];
+  const cleared = [];
+  const opened = [];
+  let shouldFail = true;
+  const setTimerWithGlobalReceiver = function (callback, delayMs) {
+    assert.equal(this, globalThis);
+    const timer = { callback, delayMs };
+    timers.push(timer);
+    return timer;
+  };
+  const clearTimerWithGlobalReceiver = function (timer) {
+    assert.equal(this, globalThis);
+    cleared.push(timer);
+  };
+
+  const reconciler = new PresenceSubscriptionReconciler({
+    open: async (authors) => {
+      opened.push(authors);
+      if (shouldFail) throw new Error("rate-limited: retry later");
+      return async () => {};
+    },
+    retryDelay: () => 25,
+  });
+
+  try {
+    globalThis.setTimeout = setTimerWithGlobalReceiver;
+    reconciler.setAuthors([A]);
+    await Promise.resolve();
+    await Promise.resolve();
+    globalThis.setTimeout = originalSetTimeout;
+
+    assert.equal(timers.length, 1);
+    assert.equal(timers[0].delayMs, 25);
+
+    shouldFail = false;
+    timers[0].callback();
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.deepEqual(opened, [[A], [A]]);
+
+    shouldFail = true;
+    globalThis.setTimeout = setTimerWithGlobalReceiver;
+    reconciler.setAuthors([B]);
+    await Promise.resolve();
+    await Promise.resolve();
+    globalThis.setTimeout = originalSetTimeout;
+
+    globalThis.clearTimeout = clearTimerWithGlobalReceiver;
+    reconciler.dispose();
+    globalThis.clearTimeout = originalClearTimeout;
+    assert.deepEqual(cleared, [timers[1]]);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
 test("rapid A to B to C keeps A until C is confirmed", async () => {
   const openingB = deferred();
   const actions = [];


### PR DESCRIPTION
🤖
## Summary

The production presence-retry defect is already fixed on `main` by [#6213](https://github.com/block/buzz/pull/6213). After rebasing onto that fix, this PR contains **regression coverage only**; it does not change production behavior.

The retained test protects the stronger recovery lifecycle that exposed the defect: a failed subscription open schedules one bounded retry, a later attempt succeeds, a subsequent replacement can fail open, and disposal cancels the pending retry.

### Related issue

Production fix: [#6213](https://github.com/block/buzz/pull/6213)

### Testing

- Adds one failed-open/retry/recovery/disposal regression test to the presence subscription reconciler suite.
- Verifies the default timer callbacks use the browser global as their receiver.
- Fresh Blox stack-tip verification at `2892e4aa74fe6f1761550108fdda10e5164c0185`, which includes the current regression prerequisite head `307496e2e961e5193afebf28bc910cf6b3c8f9bd`: presence reconciler **12/12**, Workstream Board **52/52**, Desktop **5,143/5,143**, typecheck passed, and check completed with zero errors.

### Stack

This is the regression-only prerequisite between [Workstream Board PR 3/4](https://github.com/block/buzz/pull/6244) and the final waits/sorting/polish PR. Draft only; auto-merge is off.

Discussion: [Workstream Board thread](buzz://message?channel=156498d7-62a1-499d-bcfe-b73227d6a2a4&id=61eb23a5b39b6fda8332164dd99a701fc75db5eefa98eca4f2d6217a214c5fa9)

