### PR TITLE
test(desktop): let relay state poll retry

### DIFF
--- a/desktop/tests/e2e/relay-reconnect.spec.ts
+++ b/desktop/tests/e2e/relay-reconnect.spec.ts
@@ -180,15 +180,7 @@ test("failed initial relay dial retries automatically", async ({ page }) => {
   await expect
     .poll(
       () =>
-        page.evaluate(() => {
-          const getState = (
-            window as Window & {
-              __BUZZ_E2E_GET_RELAY_CONNECTION_STATE__?: () => string;
-            }
-          ).__BUZZ_E2E_GET_RELAY_CONNECTION_STATE__;
-          if (!getState) throw new Error("Relay state seam is not installed.");
-          return getState();
-        }),
+        page.evaluate(() => window.__BUZZ_E2E_GET_RELAY_CONNECTION_STATE__?.()),
       { timeout: 10_000 },
     )
     .toBe("connected");


### PR DESCRIPTION
## Summary

- let `expect.poll` retry while the E2E relay-state hook is still being installed
- keep the final assertion unchanged: the relay must still reach `connected`

The old callback threw when the hook was absent, which stopped the poll instead of letting it retry. This uses the same optional call pattern as the other relay-state polls in the file.

This PR addresses the order-dependent poll in #6242. The separate fixed-port environment note remains out of scope.

### Related issue

Fixes #6242.

### Testing

- Before the change, a temporary no-op predecessor and 10 repeats produced 1 failure and 19 passes with `Relay state seam is not installed.`
- With the change, the same 20-test run passed 20 of 20.
- `pnpm -C desktop exec playwright test tests/e2e/relay-reconnect.spec.ts --project=smoke --workers=1`: 14 passed
- `pnpm -C desktop exec biome check tests/e2e/relay-reconnect.spec.ts`
- `pnpm -C desktop typecheck`
- `just ci`
