### PR TITLE
fix(desktop): channel member hover shows the profile name, not the raw pubkey

### DIFF
--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -27,7 +27,10 @@ import {
   useUserSearchFetchMoreOnScroll,
   useUsersBatchQuery,
 } from "@/features/profile/hooks";
-import { formatOwnerLabel } from "@/features/profile/lib/identity";
+import {
+  formatOwnerLabel,
+  resolveUserLabel,
+} from "@/features/profile/lib/identity";
 import { rankUserCandidatesBySearch } from "@/features/profile/lib/userCandidateSearch";
 import { usePresenceQuery } from "@/features/presence/hooks";
 import { VirtualizedList } from "@/shared/ui/VirtualizedList";
@@ -603,6 +606,12 @@ export function MembersSidebar({
   function renderMemberCard(member: ChannelMember, memberIsBot: boolean) {
     const memberProfile =
       memberProfilesQuery.data?.profiles[member.pubkey.toLowerCase()];
+    const memberHoverLabel = resolveUserLabel({
+      pubkey: member.pubkey,
+      currentPubkey,
+      fallbackName: member.displayName,
+      profiles: memberProfilesQuery.data?.profiles,
+    });
     const viewerIsOwner = Boolean(
       memberProfile?.ownerPubkey &&
         currentPubkey &&
@@ -645,6 +654,7 @@ export function MembersSidebar({
           memberAvatarLabel={
             member.displayName ?? truncatePubkey(member.pubkey)
           }
+          memberHoverLabel={memberHoverLabel}
           memberLabel={formatMemberName(member, currentPubkey)}
           moderationState={moderationStateByPubkey.get(
             normalizePubkey(member.pubkey),

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -25,7 +25,6 @@ import {
   MANAGED_AGENT_PAIR_ACTION_LABELS,
   type ManagedAgentPairAction,
 } from "@/features/agents/managedAgentRuntimeStatus";
-import { truncatePubkey } from "@/shared/lib/pubkey";
 import type {
   ChannelMember,
   ManagedAgent,
@@ -59,6 +58,7 @@ type MembersSidebarMemberCardProps = {
   member: ChannelMember;
   memberAvatarLabel: string;
   memberIsBot: boolean;
+  memberHoverLabel: string;
   memberLabel: string;
   moderationState?: MemberModerationState;
   onBan: (member: ChannelMember) => void;
@@ -127,6 +127,7 @@ export function MembersSidebarMemberCard({
   member,
   memberAvatarLabel,
   memberIsBot,
+  memberHoverLabel,
   memberLabel,
   moderationState,
   onBan,
@@ -189,7 +190,7 @@ export function MembersSidebarMemberCard({
             </div>
             <span className="absolute inset-0 flex items-center opacity-0 transition-opacity duration-150 ease-out group-hover/member:opacity-100 group-focus-within/member:opacity-100">
               <span className="truncate font-mono text-sm text-muted-foreground">
-                {truncatePubkey(member.pubkey)}
+                {memberHoverLabel}
               </span>
             </span>
           </div>


### PR DESCRIPTION
Hovering an agent row in the channel members sidebar swapped the readable name for the raw truncated pubkey. The hover label now resolves through the existing users-batch profile lookup.