### PR TITLE
Extract reusable IFC policy and classify worker placement

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -86,7 +86,8 @@ buzz-core    (zero I/O — types, verification, filter matching, kind registry)
          │
          └── buzz-relay       (ties everything together — the server)
 
-buzz-acp            (agent harness — bridges relay @mentions → AI agents via ACP/JSON-RPC)
+buzz-ifc            (zero I/O — execution-domain derivation and IFC rules)
+    └── buzz-acp            (relay/ACP adapter and worker routing)
 buzz-sdk            (typed Nostr event builders — used by buzz-acp and buzz-cli)
 buzz-media          (Blossom/S3 media storage)
 buzz-cli            (agent-first CLI)
@@ -669,9 +670,18 @@ Buzz Relay ──WS──→ buzz-acp ──stdio (ACP/JSON-RPC)──→ Agent 
 - Pool of 1–32 agent subprocesses with claim/return lifecycle.
 - Per-channel queuing: at most one prompt in-flight per channel; subsequent @mentions queue until the agent responds.
 - Crash recovery: agent subprocess crashes are detected and the agent is respawned.
-- Depends on `buzz-core` (kind constants) and `buzz-sdk` (relay/REST utilities).
+- Optional information-flow modes verify signed channel policy, share realm-public work, and route restricted work only to ACP children bound to the same exact domain. The feature is off by default.
+- Depends on `buzz-core` (kind constants), `buzz-sdk` (relay/REST utilities), and `buzz-ifc` (execution-domain policy).
 
 **Does NOT:** persist state.
+
+---
+
+### buzz-ifc — Shared Agent Policy
+
+`buzz-ifc` is a zero-I/O policy crate. Given facts already verified by a trusted Buzz adapter, it derives the invocation's audience, retained-state context, membership epoch, and effective capabilities. It also evaluates reads, calls, publications, and process reuse while retaining a conservative label for each process.
+
+`buzz-acp` links the crate directly. The surrounding adapter remains responsible for signed-event and membership verification, process lifecycle, credential mediation, and OS or VM confinement for confidential domains.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "buzz-core",
+ "buzz-ifc",
  "buzz-persona",
  "buzz-sdk",
  "chrono",
@@ -1117,6 +1118,18 @@ dependencies = [
  "tracing-subscriber",
  "windows-sys 0.61.2",
  "zeroize",
+]
+
+[[package]]
+name = "buzz-ifc"
+version = "0.1.0"
+dependencies = [
+ "hex",
+ "nostr 0.44.7",
+ "serde",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/buzz-search",
     "crates/buzz-audit",
     "crates/buzz-acp",
+    "crates/buzz-ifc",
     "crates/buzz-agent",
     "crates/sprig",
     "crates/buzz-test-client",
@@ -134,6 +135,7 @@ schemars = { version = "1", default-features = false }
 
 # Internal crates
 buzz-core = { path = "crates/buzz-core" }
+buzz-ifc = { path = "crates/buzz-ifc" }
 buzz-conformance = { path = "crates/buzz-conformance" }
 buzz-db = { path = "crates/buzz-db" }
 buzz-deletion = { path = "crates/buzz-deletion" }

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ A Rust workspace of focused crates. Single source of truth: the relay. See [ARCH
 
 **Services** — `buzz-db` (Postgres) · `buzz-auth` (NIP-42/98 Schnorr auth, rate limiting) · `buzz-pubsub` (Redis, presence, typing) · `buzz-search` (Postgres FTS) · `buzz-audit` (hash-chain log). Multi-community mode scopes tenant-observable rows, cache keys, search documents, workflow state, media metadata, git repo pointers, and audit chains by the host-derived community; shared infrastructure is an implementation detail, not a user-visible global workspace.
 
-**Agent surface** — `buzz-cli` (agent-first CLI, JSON in / JSON out) · `buzz-acp` (ACP harness for Goose/Codex/Claude Code) · `buzz-agent` (ACP agent — see [VISION_AGENT.md](VISION_AGENT.md)) · `buzz-dev-mcp` (shell + file-edit tools) · `buzz-workflow` (YAML automation) · `buzz-persona` (agent persona packs)
+**Agent surface** — `buzz-cli` (agent-first CLI, JSON in / JSON out) · `buzz-acp` (ACP harness for Goose/Codex/Claude Code) · `buzz-agent` (ACP agent — see [VISION_AGENT.md](VISION_AGENT.md)) · `buzz-dev-mcp` (shell + file-edit tools) · `buzz-ifc` (shared audience-scoped agent policy) · `buzz-workflow` (YAML automation) · `buzz-persona` (agent persona packs)
 
 **Git & pairing** — `git-sign-nostr` / `git-credential-nostr` (nostr-signed git) · `buzz-pair-relay` / `buzz-pairing-cli` (relay pairing)
 

--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [dependencies]
 # Internal
 buzz-core = { workspace = true }
+buzz-ifc = { workspace = true }
 buzz-sdk = { workspace = true }
 buzz-persona = { path = "../buzz-persona" }
 

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -127,21 +127,33 @@ policy, derives `D = (Audience, Context, Epoch, Capabilities)`, evaluates read,
 call, publish, and process-reuse rules, and keeps a conservative process-level
 state label. Decisions are emitted under the `buzz_acp::ifc` tracing target.
 
-`--information-flow isolate` evaluates the same policy before pool selection and
-uses the complete execution domain as the ACP worker routing key. A fresh child is
-bound on first use. If its audience, context, membership epoch, or capabilities no
-longer match, Buzz starts a replacement child and clears all ACP sessions and
-harness-side session state before delivering the turn. Owner-private core memory
-is not fetched for public or shared-conversation domains. Heartbeats use their own
-owner-private domain.
+`--information-flow route` evaluates the same policy before pool selection and
+uses the complete execution domain as the ACP worker routing key. Public channels
+select the `shared_public` compartment profile and may reuse the same pool of
+public-bound children. Restricted channels, DMs, and owner-private work select
+`domain_confined`; their children and retained state may be reused only within
+the exact same domain. Crossing between either profile, or between two
+confidential domains, replaces the child and clears its ACP sessions and
+harness-side session state before delivering the turn.
+
+Owner-private core memory is fetched only for the owner-private domain. Public
+workers otherwise keep the existing ACP runtime and tools. Heartbeats use their
+own owner-private domain.
 
 The default is `off`. In that mode no IFC auditor is constructed, no extra channel
 policy queries run, and prompt/session behavior is unchanged.
 
-Audit mode remains entirely observational. Isolate mode enforces ACP process and
-core-memory separation, but it does not yet mediate tool credentials, bind replies
-to a broker-controlled destination, isolate the shared workspace, or provide OS
-confinement. Its logs report those remaining gaps explicitly.
+Audit mode remains entirely observational. Route mode enforces ACP child and
+core-memory separation, but `domain_confined` is a placement requirement rather
+than a claim that `buzz-acp` has created an OS sandbox. The surrounding runtime
+must still keep confidential workers away from public workers and the broker,
+mediate sensitive credentials and output paths, and provide separate writable
+state. Its logs report those remaining gaps explicitly.
+
+The deterministic label, domain, capability, reuse, and confinement rules live
+in the runtime-independent `buzz-ifc` crate. `buzz-acp` supplies the trusted
+Buzz-specific half: signed-event admission, relay-signed membership resolution,
+and ACP worker replacement.
 
 ### Parallel Agents & Heartbeat
 

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -106,7 +106,7 @@ pub enum AcpError {
     #[error("Protocol error: {0}")]
     Protocol(String),
 
-    #[error("Information-flow isolation failed: {0}")]
+    #[error("Information-flow policy failed: {0}")]
     InformationFlow(String),
 
     #[error("Agent reported error (code {code}): {message}")]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -142,8 +142,8 @@ pub enum PermissionMode {
 ///
 /// `Off` preserves the existing harness path without membership queries or policy
 /// bookkeeping. `Audit` evaluates and logs the design-paper rules without changing
-/// runtime behavior. `Isolate` additionally binds each ACP child process and all of
-/// its retained state to one execution domain.
+/// runtime behavior. `Route` additionally binds each ACP child process and its
+/// retained ACP state to one execution domain. It does not claim OS confinement.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
 pub enum InformationFlowMode {
     /// Do not construct or invoke the experimental policy evaluator.
@@ -151,8 +151,9 @@ pub enum InformationFlowMode {
     Off,
     /// Evaluate and log policy without changing the existing turn.
     Audit,
-    /// Replace an ACP child before it crosses an execution-domain boundary.
-    Isolate,
+    /// Route ACP children by domain and replace them before domain changes.
+    #[value(alias = "isolate")]
+    Route,
 }
 
 impl std::fmt::Display for InformationFlowMode {
@@ -160,7 +161,7 @@ impl std::fmt::Display for InformationFlowMode {
         match self {
             Self::Off => f.write_str("off"),
             Self::Audit => f.write_str("audit"),
-            Self::Isolate => f.write_str("isolate"),
+            Self::Route => f.write_str("route"),
         }
     }
 }
@@ -172,8 +173,8 @@ impl InformationFlowMode {
     }
 
     /// Whether execution-domain boundaries change ACP process reuse.
-    pub(crate) fn isolates_processes(self) -> bool {
-        self == Self::Isolate
+    pub(crate) fn routes_workers(self) -> bool {
+        self == Self::Route
     }
 }
 
@@ -483,8 +484,8 @@ pub struct CliArgs {
     pub permission_mode: PermissionMode,
 
     /// Apply the audience-scoped information-flow policy. `audit` only logs;
-    /// `isolate` also confines ACP process reuse and retained state by domain.
-    /// `off` is the default and leaves existing harness behavior unchanged.
+    /// `route` also separates ACP process reuse and retained state by domain.
+    /// This does not provide OS confinement. `off` is the default.
     #[arg(
         long,
         env = "BUZZ_ACP_INFORMATION_FLOW",
@@ -2275,16 +2276,25 @@ channels = "ALL"
         ]);
         assert_eq!(audit.information_flow, InformationFlowMode::Audit);
 
-        let isolate = CliArgs::parse_from([
+        let route = CliArgs::parse_from([
+            "buzz-acp",
+            "--private-key",
+            &key,
+            "--information-flow",
+            "route",
+        ]);
+        assert_eq!(route.information_flow, InformationFlowMode::Route);
+        assert!(route.information_flow.enabled());
+        assert!(route.information_flow.routes_workers());
+
+        let isolate_alias = CliArgs::parse_from([
             "buzz-acp",
             "--private-key",
             &key,
             "--information-flow",
             "isolate",
         ]);
-        assert_eq!(isolate.information_flow, InformationFlowMode::Isolate);
-        assert!(isolate.information_flow.enabled());
-        assert!(isolate.information_flow.isolates_processes());
+        assert_eq!(isolate_alias.information_flow, InformationFlowMode::Route);
     }
 
     #[test]

--- a/crates/buzz-acp/src/ifc.rs
+++ b/crates/buzz-acp/src/ifc.rs
@@ -3,7 +3,7 @@
 //! This module is deliberately isolated from ACP transport and prompt formatting. In
 //! `off` mode it is not constructed at all. In `audit` mode it observes the data that
 //! the existing harness admits and emits structured decisions without changing runtime
-//! behavior. In `isolate` mode the harness also uses its domain key to route or replace
+//! behavior. In `route` mode the harness also uses its domain key to route or replace
 //! ACP children before state crosses an audience, context, epoch, or capability boundary.
 //!
 //! Comments prefixed with "Paper" refer to the matching section in the
@@ -11,8 +11,12 @@
 
 use std::collections::BTreeSet;
 use std::fmt;
-use std::marker::PhantomData;
 
+use buzz_ifc::{
+    derive_execution_domain, CapabilityPolicy, CapabilitySet, CompartmentProfile, ConversationKind,
+    DerivationError, DomainFacts, DomainKey, ExecutionDomain, MembershipEpoch, Principal,
+    ProcessState, RealmId, ResourceLabel, RuleEvaluator,
+};
 use nostr::{Alphabet, Event, Filter, Kind, PublicKey, SingleLetterTag};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -21,560 +25,47 @@ use crate::config::InformationFlowMode;
 use crate::queue::FlushBatch;
 use crate::relay::RestClient;
 
-/// A Buzz principal represented by a validated, normalized Nostr public key.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-struct Principal(String);
+pub(crate) type ProcessAuditState = ProcessState;
 
-impl Principal {
-    fn from_hex(value: &str) -> Result<Self, ResolutionError> {
-        PublicKey::from_hex(value)
-            .map(|key| Self(key.to_hex().to_ascii_lowercase()))
-            .map_err(|_| ResolutionError::InvalidPrincipal)
-    }
-
-    fn from_key(value: PublicKey) -> Self {
-        Self(value.to_hex().to_ascii_lowercase())
-    }
-}
-
-/// A confidentiality universe. Public in one Buzz community is not public in
-/// another, so every reader-set lattice is scoped to a relay/community realm.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-struct RealmId([u8; 32]);
-
-impl RealmId {
-    fn from_relay_url(relay_url: &str) -> Self {
-        Self(Sha256::digest(relay_url.as_bytes()).into())
-    }
-
-    fn fingerprint(&self) -> String {
-        hex::encode(&self.0[..6])
-    }
-}
-
-/// The authorized readers of a value.
+/// The complete policy assignment retained beside an ACP child.
 ///
-/// Paper: "Labels and ordering." `Everyone` is the bottom/public element. An
-/// explicit set becomes more restrictive as principals are removed.
+/// The opaque key prevents cross-domain reuse. The profile tells the runtime
+/// whether this is the shared public worker class or a confidential domain that
+/// requires an externally enforced compartment.
 #[derive(Clone, Debug, Eq, PartialEq)]
-enum ReaderSet {
-    Everyone,
-    Only(BTreeSet<Principal>),
+pub(crate) struct DomainBinding {
+    key: DomainKey,
+    profile: CompartmentProfile,
 }
 
-impl ReaderSet {
-    /// The paper's square ordering, `source ⊑ destination`, is reverse set
-    /// inclusion: every reader at the destination must be able to read source.
-    fn can_flow_to(&self, destination: &Self) -> bool {
-        match (self, destination) {
-            (Self::Everyone, _) => true,
-            (Self::Only(_), Self::Everyone) => false,
-            (Self::Only(source), Self::Only(destination)) => destination.is_subset(source),
-        }
-    }
-
-    /// Paper: "Combining information." Join is reader-set intersection, which
-    /// gives a result influenced by both inputs the stricter combined label.
-    fn join(&self, other: &Self) -> Self {
-        match (self, other) {
-            (Self::Everyone, value) | (value, Self::Everyone) => value.clone(),
-            (Self::Only(left), Self::Only(right)) => {
-                Self::Only(left.intersection(right).cloned().collect())
-            }
-        }
-    }
-
-    /// The lattice meet is reader-set union.
-    #[cfg(test)]
-    fn meet(&self, other: &Self) -> Self {
-        match (self, other) {
-            (Self::Everyone, _) | (_, Self::Everyone) => Self::Everyone,
-            (Self::Only(left), Self::Only(right)) => {
-                Self::Only(left.union(right).cloned().collect())
-            }
-        }
-    }
-
-    fn explicit_count(&self) -> Option<usize> {
-        match self {
-            Self::Everyone => None,
-            Self::Only(readers) => Some(readers.len()),
-        }
-    }
-
-    fn stable_hash(&self, hasher: &mut Sha256) {
-        match self {
-            Self::Everyone => hasher.update(b"everyone"),
-            Self::Only(readers) => {
-                hasher.update(b"only");
-                for reader in readers {
-                    hash_field(hasher, reader.0.as_bytes());
-                }
-            }
-        }
-    }
-}
-
-/// A reader-set label within one Buzz community.
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct ConfidentialityLabel {
-    realm: RealmId,
-    readers: ReaderSet,
-}
-
-impl ConfidentialityLabel {
-    fn public(realm: RealmId) -> Self {
+impl DomainBinding {
+    fn from_domain(domain: &ExecutionDomain) -> Self {
         Self {
-            realm,
-            readers: ReaderSet::Everyone,
+            key: domain.key(),
+            profile: domain.compartment_profile(),
         }
     }
 
-    fn restricted(realm: RealmId, readers: BTreeSet<Principal>) -> Self {
-        Self {
-            realm,
-            readers: ReaderSet::Only(readers),
-        }
-    }
-
-    fn can_flow_to(&self, destination: &Self) -> bool {
-        self.realm == destination.realm && self.readers.can_flow_to(&destination.readers)
-    }
-
-    fn join(&self, other: &Self) -> Result<Self, LatticeError> {
-        if self.realm != other.realm {
-            return Err(LatticeError::CrossRealm);
-        }
-        Ok(Self {
-            realm: self.realm.clone(),
-            readers: self.readers.join(&other.readers),
-        })
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum LatticeError {
-    CrossRealm,
-}
-
-/// Which retained context a worker belongs to. Audience and context remain
-/// separate: two private conversations can have identical readers without
-/// implicitly sharing memory.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-enum DomainContext {
-    RealmPublic(RealmId),
-    Conversation { realm: RealmId, channel_id: Uuid },
-    OwnerPrivate { realm: RealmId, owner: Principal },
-}
-
-impl DomainContext {
-    fn realm(&self) -> &RealmId {
-        match self {
-            Self::RealmPublic(realm)
-            | Self::Conversation { realm, .. }
-            | Self::OwnerPrivate { realm, .. } => realm,
-        }
-    }
-
-    fn resource_context(&self) -> ResourceContext {
-        match self {
-            Self::RealmPublic(realm) => ResourceContext::RealmPublic(realm.clone()),
-            Self::Conversation { realm, channel_id } => ResourceContext::Conversation {
-                realm: realm.clone(),
-                channel_id: *channel_id,
-            },
-            Self::OwnerPrivate { realm, owner } => ResourceContext::OwnerPrivate {
-                realm: realm.clone(),
-                owner: owner.clone(),
-            },
-        }
-    }
-
-    /// Context policy used by the paper's `ContextPolicy(D, x)` predicate.
-    /// Owner-private work may aggregate conversations the owner can read; the
-    /// confidentiality check independently proves that the owner is a reader.
-    fn permits(&self, resource: &ResourceContext) -> bool {
-        match resource {
-            ResourceContext::TrustedConfiguration => true,
-            ResourceContext::RealmPublic(resource_realm) => self.realm() == resource_realm,
-            ResourceContext::Conversation {
-                realm: resource_realm,
-                channel_id: resource_channel,
-            } => match self {
-                Self::Conversation { realm, channel_id } => {
-                    realm == resource_realm && channel_id == resource_channel
-                }
-                Self::OwnerPrivate { realm, .. } => realm == resource_realm,
-                Self::RealmPublic(_) => false,
-            },
-            ResourceContext::OwnerPrivate {
-                realm: resource_realm,
-                owner: resource_owner,
-            } => matches!(
-                self,
-                Self::OwnerPrivate { realm, owner }
-                    if realm == resource_realm && owner == resource_owner
-            ),
-        }
-    }
-
-    fn stable_hash(&self, hasher: &mut Sha256) {
-        match self {
-            Self::RealmPublic(realm) => {
-                hasher.update(b"realm-public");
-                hasher.update(realm.0);
-            }
-            Self::Conversation { realm, channel_id } => {
-                hasher.update(b"conversation");
-                hasher.update(realm.0);
-                hasher.update(channel_id.as_bytes());
-            }
-            Self::OwnerPrivate { realm, owner } => {
-                hasher.update(b"owner-private");
-                hasher.update(realm.0);
-                hash_field(hasher, owner.0.as_bytes());
-            }
-        }
-    }
-
-    fn kind(&self) -> &'static str {
-        match self {
-            Self::RealmPublic(_) => "public",
-            Self::Conversation { .. } => "conversation",
-            Self::OwnerPrivate { .. } => "owner_private",
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-enum ResourceContext {
-    TrustedConfiguration,
-    RealmPublic(RealmId),
-    Conversation { realm: RealmId, channel_id: Uuid },
-    OwnerPrivate { realm: RealmId, owner: Principal },
-}
-
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-struct Capability(String);
-
-impl Capability {
-    fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-}
-
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-struct CapabilitySet(BTreeSet<Capability>);
-
-impl CapabilitySet {
-    fn from_names<const N: usize>(names: [&str; N]) -> Self {
-        Self(names.into_iter().map(Capability::new).collect())
-    }
-
-    /// Paper: `C(turn) = C(bot) ∩ C(requester) ∩ C(domain)`.
-    fn effective(bot: &Self, requester: &Self, domain: &Self) -> Self {
-        let bot_and_requester: BTreeSet<_> = bot.0.intersection(&requester.0).cloned().collect();
-        Self(bot_and_requester.intersection(&domain.0).cloned().collect())
-    }
-
-    fn contains(&self, operation: &str) -> bool {
-        self.0.contains(&Capability::new(operation))
-    }
-
-    fn stable_hash(&self, hasher: &mut Sha256) {
-        for capability in &self.0 {
-            hash_field(hasher, capability.0.as_bytes());
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct MembershipEpoch(String);
-
-/// Opaque routing key for one complete execution domain.
-///
-/// The pool may compare and log this value, but only this module constructs it.
-/// That keeps worker routing coupled to the complete paper definition rather
-/// than a caller-selected subset such as channel ID or audience alone.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub(crate) struct DomainKey(String);
-
-impl DomainKey {
     pub(crate) fn fingerprint(&self) -> String {
-        short_fingerprint(&self.0)
+        self.key.fingerprint()
     }
 
-    #[cfg(test)]
-    pub(crate) fn for_test(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
-/// Paper: `D = (Audience, Context, Epoch, Capabilities)`.
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct ExecutionDomain {
-    audience: ConfidentialityLabel,
-    context: DomainContext,
-    epoch: MembershipEpoch,
-    capabilities: CapabilitySet,
-}
-
-impl ExecutionDomain {
-    fn id(&self) -> String {
-        let mut hasher = Sha256::new();
-        hasher.update(b"buzz-ifc-domain-v1");
-        hasher.update(self.audience.realm.0);
-        self.audience.readers.stable_hash(&mut hasher);
-        self.context.stable_hash(&mut hasher);
-        hash_field(&mut hasher, self.epoch.0.as_bytes());
-        self.capabilities.stable_hash(&mut hasher);
-        hex::encode(hasher.finalize())
-    }
-
-    fn key(&self) -> DomainKey {
-        DomainKey(self.id())
-    }
-
-    fn resource_label(&self) -> ResourceLabel {
-        ResourceLabel {
-            confidentiality: self.audience.clone(),
-            context: self.context.resource_context(),
-        }
+    pub(crate) fn profile(&self) -> CompartmentProfile {
+        self.profile
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct ResourceLabel {
-    confidentiality: ConfidentialityLabel,
-    context: ResourceContext,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct RuleDecision {
-    allowed: bool,
-    reason: &'static str,
-}
-
-impl RuleDecision {
-    fn allow(reason: &'static str) -> Self {
-        Self {
-            allowed: true,
-            reason,
-        }
+#[cfg(test)]
+pub(crate) fn domain_binding_for_test(value: &str, profile: CompartmentProfile) -> DomainBinding {
+    let domain = ExecutionDomain::public(
+        RealmId::from_relay_url("wss://ifc.test"),
+        MembershipEpoch::new(value),
+        CapabilitySet::default(),
+    );
+    DomainBinding {
+        key: domain.key(),
+        profile,
     }
-
-    fn deny(reason: &'static str) -> Self {
-        Self {
-            allowed: false,
-            reason,
-        }
-    }
-
-    fn result(&self) -> &'static str {
-        if self.allowed {
-            "allow"
-        } else {
-            "deny"
-        }
-    }
-}
-
-struct RuleEvaluator;
-
-impl RuleEvaluator {
-    /// Paper: `read(D, x) ⇔ A(D) ⊆ R(x) ∧ ContextPolicy(D, x)`.
-    fn read(domain: &ExecutionDomain, resource: &ResourceLabel) -> RuleDecision {
-        if !resource.confidentiality.can_flow_to(&domain.audience) {
-            return RuleDecision::deny("destination audience includes an unauthorized reader");
-        }
-        if !domain.context.permits(&resource.context) {
-            return RuleDecision::deny("resource belongs to a different context");
-        }
-        RuleDecision::allow("audience and context both permit the read")
-    }
-
-    /// Paper: `call(D, op) ⇔ op ∈ C(D)`.
-    fn call(domain: &ExecutionDomain, operation: &str) -> RuleDecision {
-        if domain.capabilities.contains(operation) {
-            RuleDecision::allow("operation is in the effective capability set")
-        } else {
-            RuleDecision::deny("operation is absent from the effective capability set")
-        }
-    }
-
-    /// Paper: `reuse(D, e)` requires the complete domain, including epoch, to
-    /// match. A separate ACP session in the same process is not sufficient.
-    fn reuse(existing: &ExecutionDomain, requested: &ExecutionDomain) -> RuleDecision {
-        if existing == requested {
-            RuleDecision::allow("complete execution domain matches")
-        } else {
-            RuleDecision::deny("agent process has already entered a different domain")
-        }
-    }
-
-    /// Paper: "Confinement invariant." Output may flow only to an audience no
-    /// broader than the accumulated label, unless an exact verified grant applies.
-    fn publish(
-        state: &ConfinementState,
-        source_domain: &ExecutionDomain,
-        destination: &ConfidentialityLabel,
-        destination_context: &DomainContext,
-        content_digest: &[u8; 32],
-        grant: Option<&DeclassificationGrant<VerifiedGrant>>,
-    ) -> RuleDecision {
-        if grant.is_some_and(|grant| {
-            grant.matches(
-                &source_domain.id(),
-                destination,
-                destination_context,
-                content_digest,
-            )
-        }) {
-            return RuleDecision::allow("exact owner-authorized declassification grant matches");
-        }
-        if state.unknown_input || state.cross_realm {
-            return RuleDecision::deny("process state contains unresolved input provenance");
-        }
-        if !source_domain.audience.can_flow_to(destination) {
-            return RuleDecision::deny("destination is broader than the execution domain");
-        }
-        if state
-            .label
-            .as_ref()
-            .is_some_and(|label| label.can_flow_to(destination))
-        {
-            return RuleDecision::allow("destination is no broader than accumulated state");
-        }
-        RuleDecision::deny("output would widen the accumulated reader set")
-    }
-}
-
-/// Conservative label for everything an agent process may remember. This is
-/// process-level rather than ACP-session-level because model sessions, tools,
-/// files, and caches can influence one another inside a worker.
-#[derive(Clone, Debug, Default)]
-struct ConfinementState {
-    label: Option<ConfidentialityLabel>,
-    contexts: BTreeSet<ResourceContext>,
-    unknown_input: bool,
-    cross_realm: bool,
-}
-
-impl ConfinementState {
-    fn observe(&mut self, resource: &ResourceLabel) {
-        self.contexts.insert(resource.context.clone());
-        self.label = match self.label.take() {
-            None => Some(resource.confidentiality.clone()),
-            Some(existing) => match existing.join(&resource.confidentiality) {
-                Ok(combined) => Some(combined),
-                Err(LatticeError::CrossRealm) => {
-                    self.cross_realm = true;
-                    Some(existing)
-                }
-            },
-        };
-    }
-
-    fn mark_unknown(&mut self) {
-        self.unknown_input = true;
-    }
-}
-
-/// Audit state tied to one actual ACP agent process. It intentionally survives
-/// channel-session invalidation: replacing a session does not make the process
-/// forget information it has already seen.
-#[derive(Clone, Debug, Default)]
-pub(crate) struct ProcessAuditState {
-    entered_domains: Vec<ExecutionDomain>,
-    confinement: ConfinementState,
-}
-
-impl ProcessAuditState {
-    fn enter(&mut self, requested: &ExecutionDomain) -> RuleDecision {
-        let decision = match self.entered_domains.as_slice() {
-            [] => RuleDecision::allow("fresh process has no prior execution domain"),
-            [existing] => RuleEvaluator::reuse(existing, requested),
-            _ => RuleDecision::deny("agent process has entered multiple execution domains"),
-        };
-        if !self
-            .entered_domains
-            .iter()
-            .any(|domain| domain == requested)
-        {
-            self.entered_domains.push(requested.clone());
-        }
-        decision
-    }
-}
-
-/// Typestate marker: the owner's signature has not yet been checked.
-#[allow(dead_code)]
-struct PendingGrant;
-
-/// Typestate marker: an external verifier has authenticated the owner signature.
-struct VerifiedGrant;
-
-/// A content-specific declassification grant. The evaluator only accepts the
-/// `VerifiedGrant` state, so an unchecked grant cannot accidentally reach the
-/// publish rule.
-struct DeclassificationGrant<State> {
-    approver: Principal,
-    source_domain_id: String,
-    destination: ConfidentialityLabel,
-    destination_context: DomainContext,
-    content_digest: [u8; 32],
-    _state: PhantomData<State>,
-}
-
-#[allow(dead_code)]
-trait GrantSignatureVerifier {
-    fn verifies(&self, grant: &DeclassificationGrant<PendingGrant>) -> bool;
-}
-
-#[allow(dead_code)]
-impl DeclassificationGrant<PendingGrant> {
-    fn verify<V: GrantSignatureVerifier>(
-        self,
-        expected_owner: &Principal,
-        verifier: &V,
-    ) -> Result<DeclassificationGrant<VerifiedGrant>, GrantError> {
-        if &self.approver != expected_owner {
-            return Err(GrantError::WrongApprover);
-        }
-        if !verifier.verifies(&self) {
-            return Err(GrantError::InvalidSignature);
-        }
-        Ok(DeclassificationGrant {
-            approver: self.approver,
-            source_domain_id: self.source_domain_id,
-            destination: self.destination,
-            destination_context: self.destination_context,
-            content_digest: self.content_digest,
-            _state: PhantomData,
-        })
-    }
-}
-
-impl DeclassificationGrant<VerifiedGrant> {
-    fn matches(
-        &self,
-        source_domain_id: &str,
-        destination: &ConfidentialityLabel,
-        destination_context: &DomainContext,
-        content_digest: &[u8; 32],
-    ) -> bool {
-        self.source_domain_id == source_domain_id
-            && &self.destination == destination
-            && &self.destination_context == destination_context
-            && &self.content_digest == content_digest
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[allow(dead_code)]
-enum GrantError {
-    WrongApprover,
-    InvalidSignature,
 }
 
 /// Trigger events after ID/signature and channel-binding checks. Domain
@@ -596,6 +87,7 @@ enum ResolutionError {
     MissingMembership,
     InvalidAuthoritativeEvent,
     InvalidPrincipal,
+    InvalidDomain,
     EmptyRestrictedAudience,
     AgentNotMember,
     RequesterNotMember,
@@ -618,6 +110,7 @@ impl fmt::Display for ResolutionError {
                 "channel policy event failed identity, signature, or channel checks"
             }
             Self::InvalidPrincipal => "channel policy contains an invalid principal",
+            Self::InvalidDomain => "resolved execution-domain fields are inconsistent",
             Self::EmptyRestrictedAudience => "restricted channel has no human audience",
             Self::AgentNotMember => "executing agent is absent from channel membership",
             Self::RequesterNotMember => "trigger requester is absent from channel membership",
@@ -628,7 +121,7 @@ impl fmt::Display for ResolutionError {
     }
 }
 
-/// Stateless policy front-end retained by `PromptContext` in audit or isolate mode.
+/// Stateless policy front-end retained by `PromptContext` in audit or route mode.
 pub(crate) struct Auditor {
     realm: RealmId,
     rest_client: RestClient,
@@ -651,8 +144,8 @@ impl Auditor {
             realm: RealmId::from_relay_url(relay_url),
             rest_client,
             relay_self: relay_self.and_then(|value| PublicKey::from_hex(value).ok()),
-            agent: Principal::from_key(agent),
-            owner: owner.map(Principal::from_key),
+            agent: Principal::from_public_key(&agent),
+            owner: owner.map(|key| Principal::from_public_key(&key)),
             mode,
         }
     }
@@ -675,7 +168,7 @@ impl Auditor {
                     rule: "event_admission",
                     decision: "allow",
                     reason: "all trigger IDs, signatures, and channel bindings verified",
-                    enforced: self.mode.isolates_processes(),
+                    enforced: self.mode.routes_workers(),
                 });
                 verified
             }
@@ -688,7 +181,7 @@ impl Auditor {
                     rule: "event_admission",
                     decision: "deny",
                     reason: &error.to_string(),
-                    enforced: self.mode.isolates_processes(),
+                    enforced: self.mode.routes_workers(),
                 });
                 return ActiveTurn::unresolved(
                     turn_id,
@@ -711,7 +204,7 @@ impl Auditor {
                     rule: "domain_resolution",
                     decision: "deny",
                     reason: &error.to_string(),
-                    enforced: self.mode.isolates_processes(),
+                    enforced: self.mode.routes_workers(),
                 });
                 return ActiveTurn::unresolved(
                     turn_id,
@@ -731,15 +224,16 @@ impl Auditor {
             agent_index,
             domain_id = %domain_id,
             realm = %self.realm.fingerprint(),
-            context = domain.context.kind(),
-            audience = if matches!(domain.audience.readers, ReaderSet::Everyone) {
+            context = domain.context().kind(),
+            compartment = domain.compartment_profile().as_str(),
+            audience = if domain.audience().is_public() {
                 "public"
             } else {
                 "restricted"
             },
-            reader_count = domain.audience.readers.explicit_count(),
+            reader_count = domain.audience().reader_count(),
             requester_count = verified.requesters.len(),
-            epoch = %short_fingerprint(&domain.epoch.0),
+            epoch = %domain.epoch_fingerprint(),
             "ifc execution domain resolved"
         );
 
@@ -769,7 +263,7 @@ impl Auditor {
                 rule: "domain_resolution",
                 decision: "deny",
                 reason: &ResolutionError::NoOwner.to_string(),
-                enforced: self.mode.isolates_processes(),
+                enforced: self.mode.routes_workers(),
             });
             return ActiveTurn::unresolved(
                 turn_id,
@@ -779,16 +273,12 @@ impl Auditor {
                 TurnOrigin::Heartbeat,
             );
         };
-        let context = DomainContext::OwnerPrivate {
-            realm: self.realm.clone(),
-            owner: owner.clone(),
-        };
-        let domain = ExecutionDomain {
-            audience: ConfidentialityLabel::restricted(self.realm.clone(), BTreeSet::from([owner])),
-            context,
-            epoch: MembershipEpoch("owner-heartbeat-v1".to_string()),
-            capabilities: bot_capabilities(),
-        };
+        let domain = ExecutionDomain::owner_private(
+            self.realm.clone(),
+            owner,
+            MembershipEpoch::new("owner-heartbeat-v1"),
+            bot_capabilities(),
+        );
         tracing::info!(
             target: "buzz_acp::ifc",
             ifc_mode = %self.mode,
@@ -796,10 +286,11 @@ impl Auditor {
             agent_index,
             domain_id = %domain.id(),
             realm = %self.realm.fingerprint(),
-            context = domain.context.kind(),
+            context = domain.context().kind(),
+            compartment = domain.compartment_profile().as_str(),
             audience = "restricted",
             reader_count = 1,
-            epoch = %short_fingerprint(&domain.epoch.0),
+            epoch = %domain.epoch_fingerprint(),
             "ifc execution domain resolved"
         );
         ActiveTurn {
@@ -850,66 +341,54 @@ impl Auditor {
         )
         .await?
         .ok_or(ResolutionError::MissingMetadata)?;
-        let channel_type = channel_type(&metadata);
-        if channel_type == "stream" {
-            let context = DomainContext::RealmPublic(self.realm.clone());
-            return Ok(ExecutionDomain {
-                audience: ConfidentialityLabel::public(self.realm.clone()),
-                capabilities: effective_turn_capabilities(&context, trigger, self.owner.as_ref()),
-                context,
+        let (kind, epoch, members) = match channel_type(&metadata) {
+            "stream" => (
+                ConversationKind::Public,
                 // All public channels in this community intentionally share one
                 // execution domain and public memory.
-                epoch: MembershipEpoch(format!("community:{}", relay_self.to_hex())),
-            });
-        }
-
-        let membership = select_authoritative_event(
-            &events,
-            buzz_core::kind::KIND_NIP29_GROUP_MEMBERS,
-            trigger.channel_id,
-            relay_self,
-        )
-        .await?
-        .ok_or(ResolutionError::MissingMembership)?;
-        let mut readers = member_principals(&membership)?;
-        if !readers.contains(&self.agent) {
-            return Err(ResolutionError::AgentNotMember);
-        }
-        let relay_principal = Principal::from_key(relay_self);
-        if verified_requester_outside_membership(trigger, &readers, &relay_principal) {
-            return Err(ResolutionError::RequesterNotMember);
-        }
-        // The executing bot is a processor, not an additional human recipient.
-        // Other bots remain in the audience because they may relay what they see.
-        readers.remove(&self.agent);
-        if readers.is_empty() {
-            return Err(ResolutionError::EmptyRestrictedAudience);
-        }
-
-        let context = match (&self.owner, channel_type) {
-            (Some(owner), "dm")
-                if readers.len() == 1 && readers.first().is_some_and(|reader| reader == owner) =>
-            {
-                DomainContext::OwnerPrivate {
-                    realm: self.realm.clone(),
-                    owner: owner.clone(),
-                }
+                MembershipEpoch::new(format!("community:{}", relay_self.to_hex())),
+                BTreeSet::new(),
+            ),
+            restricted_kind => {
+                let membership = select_authoritative_event(
+                    &events,
+                    buzz_core::kind::KIND_NIP29_GROUP_MEMBERS,
+                    trigger.channel_id,
+                    relay_self,
+                )
+                .await?
+                .ok_or(ResolutionError::MissingMembership)?;
+                let members = member_principals(&membership)?;
+                let kind = if restricted_kind == "dm" {
+                    ConversationKind::DirectMessage
+                } else {
+                    ConversationKind::Restricted
+                };
+                (
+                    kind,
+                    // The relay-signed replaceable membership event is the epoch,
+                    // not merely a hash of the current roster. Remove-then-readd
+                    // rotates state even if the final readers are identical.
+                    MembershipEpoch::new(format!("membership:{}", membership.id.to_hex())),
+                    members,
+                )
             }
-            _ => DomainContext::Conversation {
+        };
+        derive_execution_domain(
+            DomainFacts {
                 realm: self.realm.clone(),
                 channel_id: trigger.channel_id,
+                kind,
+                epoch,
+                members,
+                executing_agent: self.agent.clone(),
+                requesters: trigger.requesters.clone(),
+                system_principal: Some(Principal::from_public_key(&relay_self)),
+                owner: self.owner.clone(),
             },
-        };
-
-        Ok(ExecutionDomain {
-            audience: ConfidentialityLabel::restricted(self.realm.clone(), readers),
-            capabilities: effective_turn_capabilities(&context, trigger, self.owner.as_ref()),
-            context,
-            // The relay-signed replaceable membership event is the epoch, not
-            // merely a hash of the current roster. Remove-then-readd therefore
-            // rotates state even if the final reader set happens to be identical.
-            epoch: MembershipEpoch(format!("membership:{}", membership.id.to_hex())),
-        })
+            &capability_policy(),
+        )
+        .map_err(map_derivation_error)
     }
 }
 
@@ -947,8 +426,8 @@ impl ActiveTurn {
         }
     }
 
-    pub(crate) fn domain_key(&self) -> Option<DomainKey> {
-        self.domain.as_ref().map(ExecutionDomain::key)
+    pub(crate) fn domain_binding(&self) -> Option<DomainBinding> {
+        self.domain.as_ref().map(DomainBinding::from_domain)
     }
 
     pub(crate) fn assign_agent(&mut self, agent_index: usize) {
@@ -960,7 +439,7 @@ impl ActiveTurn {
     /// process is either proven reusable or replaced for this domain.
     pub(crate) fn enter_process(&self, process: &mut ProcessAuditState) {
         let Some(domain) = self.domain.as_ref() else {
-            process.confinement.mark_unknown();
+            process.mark_unknown();
             return;
         };
         let domain_id = domain.id();
@@ -972,8 +451,8 @@ impl ActiveTurn {
             domain_id: Some(&domain_id),
             rule: "reuse",
             decision: reuse.result(),
-            reason: reuse.reason,
-            enforced: self.mode.isolates_processes(),
+            reason: reuse.reason(),
+            enforced: self.mode.routes_workers(),
         });
         match self.origin {
             TurnOrigin::Channel => {
@@ -989,27 +468,16 @@ impl ActiveTurn {
     }
 
     /// Whether owner-private material may enter this turn's domain. This is
-    /// checked before the broker fetches core memory in isolate mode.
+    /// checked before the harness fetches core memory in route mode.
     pub(crate) fn permits_owner_private_input(&self) -> bool {
         let (Some(domain), Some(owner)) = (self.domain.as_ref(), self.owner.as_ref()) else {
             return false;
         };
-        let mut readers = BTreeSet::new();
-        readers.insert(owner.clone());
         RuleEvaluator::read(
             domain,
-            &ResourceLabel {
-                confidentiality: ConfidentialityLabel::restricted(
-                    domain.audience.realm.clone(),
-                    readers,
-                ),
-                context: ResourceContext::OwnerPrivate {
-                    realm: domain.audience.realm.clone(),
-                    owner: owner.clone(),
-                },
-            },
+            &ResourceLabel::owner_private(domain.audience().realm().clone(), owner.clone()),
         )
-        .allowed
+        .allowed()
     }
 
     pub(crate) fn log_blocked_owner_private_input(&self, source: &'static str) {
@@ -1036,7 +504,7 @@ impl ActiveTurn {
         source: &'static str,
     ) {
         let Some(domain) = self.domain.as_ref() else {
-            process.confinement.mark_unknown();
+            process.mark_unknown();
             log_rule(RuleLog {
                 mode: self.mode,
                 turn_id: &self.turn_id,
@@ -1045,7 +513,7 @@ impl ActiveTurn {
                 rule: "read",
                 decision: "deny",
                 reason: "execution domain is unresolved",
-                enforced: self.mode.isolates_processes(),
+                enforced: self.mode.routes_workers(),
             });
             return;
         };
@@ -1059,7 +527,7 @@ impl ActiveTurn {
         source: &'static str,
     ) {
         let (Some(domain), Some(owner)) = (self.domain.as_ref(), self.owner.as_ref()) else {
-            process.confinement.mark_unknown();
+            process.mark_unknown();
             let domain_id = self.domain.as_ref().map(ExecutionDomain::id);
             log_rule(RuleLog {
                 mode: self.mode,
@@ -1069,25 +537,14 @@ impl ActiveTurn {
                 rule: "read",
                 decision: "deny",
                 reason: "owner-private input lacks a resolved owner or domain",
-                enforced: self.mode.isolates_processes(),
+                enforced: self.mode.routes_workers(),
             });
             return;
         };
-        let mut readers = BTreeSet::new();
-        readers.insert(owner.clone());
         self.observe_resource(
             process,
             source,
-            ResourceLabel {
-                confidentiality: ConfidentialityLabel::restricted(
-                    domain.audience.realm.clone(),
-                    readers,
-                ),
-                context: ResourceContext::OwnerPrivate {
-                    realm: domain.audience.realm.clone(),
-                    owner: owner.clone(),
-                },
-            },
+            ResourceLabel::owner_private(domain.audience().realm().clone(), owner.clone()),
         );
     }
 
@@ -1099,16 +556,13 @@ impl ActiveTurn {
         source: &'static str,
     ) {
         let Some(domain) = self.domain.as_ref() else {
-            process.confinement.mark_unknown();
+            process.mark_unknown();
             return;
         };
         self.observe_resource(
             process,
             source,
-            ResourceLabel {
-                confidentiality: ConfidentialityLabel::public(domain.audience.realm.clone()),
-                context: ResourceContext::TrustedConfiguration,
-            },
+            ResourceLabel::trusted_configuration(domain.audience().realm().clone()),
         );
     }
 
@@ -1120,7 +574,7 @@ impl ActiveTurn {
         process: &mut ProcessAuditState,
         source: &'static str,
     ) {
-        process.confinement.mark_unknown();
+        process.mark_unknown();
         tracing::info!(
             target: "buzz_acp::ifc",
             ifc_mode = %self.mode,
@@ -1143,15 +597,15 @@ impl ActiveTurn {
         resource: ResourceLabel,
     ) {
         let Some(domain) = self.domain.as_ref() else {
-            process.confinement.mark_unknown();
+            process.mark_unknown();
             return;
         };
         let decision = RuleEvaluator::read(domain, &resource);
         // Audit mode records denied inputs because the model still sees them.
-        // Isolate mode records only admitted inputs; denied owner-private input
+        // Route mode records only admitted inputs; denied owner-private input
         // is stopped before the broker fetches it.
-        if decision.allowed || !self.mode.isolates_processes() {
-            process.confinement.observe(&resource);
+        if decision.allowed() || !self.mode.routes_workers() {
+            process.observe(&resource);
         }
         let domain_id = domain.id();
         tracing::info!(
@@ -1163,8 +617,8 @@ impl ActiveTurn {
             rule = "read",
             source,
             decision = decision.result(),
-            reason = decision.reason,
-            enforced = self.mode.isolates_processes(),
+            reason = decision.reason(),
+            enforced = self.mode.routes_workers(),
             "ifc rule evaluated"
         );
     }
@@ -1194,7 +648,7 @@ impl ActiveTurn {
                 attempted = false,
                 stage = "capability_assignment",
                 decision = decision.result(),
-                reason = decision.reason,
+                reason = decision.reason(),
                 enforced = false,
                 "ifc rule evaluated"
             );
@@ -1219,14 +673,7 @@ impl ActiveTurn {
             return;
         };
         let digest: [u8; 32] = Sha256::digest(b"audit-only-unbound-output").into();
-        let decision = RuleEvaluator::publish(
-            &process.confinement,
-            domain,
-            &domain.audience,
-            &domain.context,
-            &digest,
-            None,
-        );
+        let decision = process.publish(domain, domain.audience(), domain.context(), &digest, None);
         tracing::info!(
             target: "buzz_acp::ifc",
             ifc_mode = %self.mode,
@@ -1235,7 +682,7 @@ impl ActiveTurn {
             domain_id = %domain.id(),
             rule = "publish",
             decision = decision.result(),
-            reason = decision.reason,
+            reason = decision.reason(),
             output_bound = false,
             enforced = false,
             "ifc rule evaluated"
@@ -1243,10 +690,23 @@ impl ActiveTurn {
     }
 
     fn log_unmediated_coverage(&self) {
-        let gaps = if self.mode.isolates_processes() {
-            "ambient_workspace, credential_bearing_mcp, direct_buzz_publication, static_capability_inventory, operating_system_isolation"
-        } else {
-            "shared_agent_process, ambient_workspace, credential_bearing_mcp, direct_buzz_publication, static_capability_inventory, operating_system_isolation"
+        let (compartment, gaps) = match self
+            .domain
+            .as_ref()
+            .map(ExecutionDomain::compartment_profile)
+        {
+            Some(CompartmentProfile::SharedPublic) => (
+                CompartmentProfile::SharedPublic.as_str(),
+                "broker_process_protection, private_compartment_protection, ambient_private_sources, direct_buzz_publication, static_capability_inventory",
+            ),
+            Some(CompartmentProfile::DomainConfined) => (
+                CompartmentProfile::DomainConfined.as_str(),
+                "dedicated_writable_state, credential_bearing_mcp, controlled_output_paths, direct_buzz_publication, operating_system_isolation",
+            ),
+            None => (
+                "unresolved",
+                "shared_agent_process, ambient_workspace, credential_bearing_mcp, direct_buzz_publication, operating_system_isolation",
+            ),
         };
         tracing::warn!(
             target: "buzz_acp::ifc",
@@ -1254,6 +714,7 @@ impl ActiveTurn {
             turn_id = %self.turn_id,
             agent_index = self.agent_index,
             domain_id = self.domain.as_ref().map(ExecutionDomain::id),
+            compartment,
             rule = "confinement_coverage",
             decision = "not_proven",
             enforced = false,
@@ -1281,7 +742,7 @@ async fn verify_trigger_batch(batch: &FlushBatch) -> Result<VerifiedTrigger, Res
             if !has_channel_tag(&event, "h", &channel_id.to_string()) {
                 return Err(ResolutionError::TriggerChannelMismatch);
             }
-            requesters.insert(Principal::from_key(event.pubkey));
+            requesters.insert(Principal::from_public_key(&event.pubkey));
         }
         Ok(VerifiedTrigger {
             channel_id,
@@ -1364,54 +825,15 @@ fn member_principals(event: &Event) -> Result<BTreeSet<Principal>, ResolutionErr
                 .then(|| fields.get(1).map(String::as_str))
                 .flatten()
         })
-        .map(Principal::from_hex)
+        .map(|value| Principal::from_hex(value).map_err(|_| ResolutionError::InvalidPrincipal))
         .collect()
 }
 
-fn verified_requester_outside_membership(
-    trigger: &VerifiedTrigger,
-    members: &BTreeSet<Principal>,
-    relay: &Principal,
-) -> bool {
-    // Relay-signed workflow events are admitted by Buzz's existing attributed-
-    // author gate. They remain trusted system events here; requester-specific
-    // capability delegation still needs the attributed human identity.
-    trigger
-        .requesters
-        .iter()
-        .any(|requester| requester != relay && !members.contains(requester))
-}
-
-fn effective_turn_capabilities(
-    context: &DomainContext,
-    trigger: &VerifiedTrigger,
-    owner: Option<&Principal>,
-) -> CapabilitySet {
+fn capability_policy() -> CapabilityPolicy {
     let conversation =
         CapabilitySet::from_names(["buzz.read.current", "buzz.publish.current", "memory.domain"]);
     let bot = bot_capabilities();
-    let requester_is_owner = owner.is_some_and(|owner| {
-        !trigger.requesters.is_empty()
-            && trigger
-                .requesters
-                .iter()
-                .all(|requester| requester == owner)
-    });
-    let requester = if requester_is_owner {
-        bot.clone()
-    } else {
-        conversation.clone()
-    };
-    let domain = if matches!(context, DomainContext::OwnerPrivate { .. }) {
-        bot.clone()
-    } else {
-        conversation
-    };
-
-    // Paper: "Integrity and capabilities." Personal tools require both an
-    // owner-authored request and the owner-private execution domain. Either
-    // condition alone is insufficient.
-    CapabilitySet::effective(&bot, &requester, &domain)
+    CapabilityPolicy::new(bot, conversation)
 }
 
 fn bot_capabilities() -> CapabilitySet {
@@ -1425,14 +847,15 @@ fn bot_capabilities() -> CapabilitySet {
     ])
 }
 
-fn hash_field(hasher: &mut Sha256, value: &[u8]) {
-    hasher.update(value.len().to_be_bytes());
-    hasher.update(value);
-}
-
-fn short_fingerprint(value: &str) -> String {
-    let digest = Sha256::digest(value.as_bytes());
-    hex::encode(&digest[..6])
+fn map_derivation_error(error: DerivationError) -> ResolutionError {
+    match error {
+        DerivationError::AgentNotMember => ResolutionError::AgentNotMember,
+        DerivationError::RequesterNotMember => ResolutionError::RequesterNotMember,
+        DerivationError::EmptyRestrictedAudience => ResolutionError::EmptyRestrictedAudience,
+        DerivationError::EmptyRequesters | DerivationError::InvalidDomain => {
+            ResolutionError::InvalidDomain
+        }
+    }
 }
 
 struct RuleLog<'a> {
@@ -1475,212 +898,17 @@ fn log_rule(entry: RuleLog<'_>) {
 mod tests {
     use super::*;
     use crate::queue::BatchEvent;
+    use buzz_ifc::DomainContext;
     use nostr::{EventBuilder, Keys, Tag};
     use std::time::Instant;
 
     fn principal(name: &str) -> Principal {
-        Principal(name.to_string())
-    }
-
-    fn set(names: &[&str]) -> BTreeSet<Principal> {
-        names.iter().map(|name| principal(name)).collect()
+        let digest = Sha256::digest(name.as_bytes());
+        Principal::from_hex(&hex::encode(digest)).expect("valid deterministic test principal")
     }
 
     fn realm() -> RealmId {
         RealmId::from_relay_url("wss://buzz.example")
-    }
-
-    fn label(readers: &[&str]) -> ConfidentialityLabel {
-        ConfidentialityLabel::restricted(realm(), set(readers))
-    }
-
-    fn public_label() -> ConfidentialityLabel {
-        ConfidentialityLabel::public(realm())
-    }
-
-    fn domain(
-        readers: &[&str],
-        channel_id: Uuid,
-        epoch: &str,
-        capabilities: CapabilitySet,
-    ) -> ExecutionDomain {
-        ExecutionDomain {
-            audience: label(readers),
-            context: DomainContext::Conversation {
-                realm: realm(),
-                channel_id,
-            },
-            epoch: MembershipEpoch(epoch.to_string()),
-            capabilities,
-        }
-    }
-
-    #[test]
-    fn reader_order_is_reverse_set_inclusion() {
-        let public = ReaderSet::Everyone;
-        let alice_bob = ReaderSet::Only(set(&["alice", "bob"]));
-        let alice = ReaderSet::Only(set(&["alice"]));
-
-        assert!(public.can_flow_to(&alice_bob));
-        assert!(alice_bob.can_flow_to(&alice));
-        assert!(!alice.can_flow_to(&alice_bob));
-        assert!(!alice.can_flow_to(&public));
-    }
-
-    #[test]
-    fn reader_sets_obey_lattice_laws() {
-        let values = [
-            ReaderSet::Everyone,
-            ReaderSet::Only(set(&[])),
-            ReaderSet::Only(set(&["alice"])),
-            ReaderSet::Only(set(&["bob"])),
-            ReaderSet::Only(set(&["alice", "bob"])),
-        ];
-
-        for a in &values {
-            assert_eq!(a.join(a), *a);
-            assert_eq!(a.meet(a), *a);
-            for b in &values {
-                assert_eq!(a.join(b), b.join(a));
-                assert_eq!(a.meet(b), b.meet(a));
-                assert_eq!(a.join(&a.meet(b)), *a);
-                assert_eq!(a.meet(&a.join(b)), *a);
-                for c in &values {
-                    assert_eq!(a.join(&b.join(c)), a.join(b).join(c));
-                    assert_eq!(a.meet(&b.meet(c)), a.meet(b).meet(c));
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn combining_inputs_intersects_authorized_readers() {
-        let left = label(&["alice", "bob"]);
-        let right = label(&["alice", "carol"]);
-        assert_eq!(left.join(&right).expect("same realm"), label(&["alice"]));
-    }
-
-    #[test]
-    fn labels_never_flow_across_communities() {
-        let first = ConfidentialityLabel::public(RealmId::from_relay_url("wss://one"));
-        let second = ConfidentialityLabel::public(RealmId::from_relay_url("wss://two"));
-        assert!(!first.can_flow_to(&second));
-        assert_eq!(first.join(&second), Err(LatticeError::CrossRealm));
-    }
-
-    #[test]
-    fn read_requires_both_audience_and_context() {
-        let channel = Uuid::new_v4();
-        let other_channel = Uuid::new_v4();
-        let turn = domain(&["alice", "bob"], channel, "v1", CapabilitySet::default());
-        let wrong_audience = ResourceLabel {
-            confidentiality: label(&["alice"]),
-            context: ResourceContext::Conversation {
-                realm: realm(),
-                channel_id: channel,
-            },
-        };
-        let wrong_context = ResourceLabel {
-            confidentiality: label(&["alice", "bob"]),
-            context: ResourceContext::Conversation {
-                realm: realm(),
-                channel_id: other_channel,
-            },
-        };
-
-        assert!(!RuleEvaluator::read(&turn, &wrong_audience).allowed);
-        assert!(!RuleEvaluator::read(&turn, &wrong_context).allowed);
-        assert!(RuleEvaluator::read(&turn, &turn.resource_label()).allowed);
-    }
-
-    #[test]
-    fn owner_private_context_can_aggregate_only_data_owner_may_read() {
-        let owner = principal("alice");
-        let owner_domain = ExecutionDomain {
-            audience: label(&["alice"]),
-            context: DomainContext::OwnerPrivate {
-                realm: realm(),
-                owner,
-            },
-            epoch: MembershipEpoch("owner-v1".into()),
-            capabilities: CapabilitySet::default(),
-        };
-        let readable_channel = ResourceLabel {
-            confidentiality: label(&["alice", "bob"]),
-            context: ResourceContext::Conversation {
-                realm: realm(),
-                channel_id: Uuid::new_v4(),
-            },
-        };
-        let unreadable_channel = ResourceLabel {
-            confidentiality: label(&["bob", "carol"]),
-            context: ResourceContext::Conversation {
-                realm: realm(),
-                channel_id: Uuid::new_v4(),
-            },
-        };
-
-        assert!(RuleEvaluator::read(&owner_domain, &readable_channel).allowed);
-        assert!(!RuleEvaluator::read(&owner_domain, &unreadable_channel).allowed);
-    }
-
-    #[test]
-    fn effective_capabilities_are_the_three_way_intersection() {
-        let bot = CapabilitySet::from_names(["buzz.read.current", "email.read", "drive.read"]);
-        let requester = CapabilitySet::from_names(["buzz.read.current", "email.read"]);
-        let domain = CapabilitySet::from_names(["buzz.read.current", "drive.read"]);
-        assert_eq!(
-            CapabilitySet::effective(&bot, &requester, &domain),
-            CapabilitySet::from_names(["buzz.read.current"])
-        );
-    }
-
-    #[test]
-    fn personal_capabilities_require_owner_request_and_owner_context() {
-        let owner = principal("alice");
-        let owner_trigger = VerifiedTrigger {
-            channel_id: Uuid::new_v4(),
-            requesters: BTreeSet::from([owner.clone()]),
-        };
-        let other_trigger = VerifiedTrigger {
-            channel_id: Uuid::new_v4(),
-            requesters: BTreeSet::from([principal("bob")]),
-        };
-        let owner_context = DomainContext::OwnerPrivate {
-            realm: realm(),
-            owner: owner.clone(),
-        };
-        let public_context = DomainContext::RealmPublic(realm());
-
-        assert!(
-            effective_turn_capabilities(&owner_context, &owner_trigger, Some(&owner))
-                .contains("email.read")
-        );
-        assert!(
-            !effective_turn_capabilities(&public_context, &owner_trigger, Some(&owner))
-                .contains("email.read")
-        );
-        assert!(
-            !effective_turn_capabilities(&owner_context, &other_trigger, Some(&owner))
-                .contains("email.read")
-        );
-    }
-
-    #[test]
-    fn reuse_requires_context_epoch_and_capabilities_to_match() {
-        let channel = Uuid::new_v4();
-        let capabilities = CapabilitySet::from_names(["buzz.read.current"]);
-        let first = domain(&["alice", "bob"], channel, "v1", capabilities.clone());
-        let same = first.clone();
-        let new_epoch = domain(&["alice", "bob"], channel, "v2", capabilities.clone());
-        let new_context = domain(&["alice", "bob"], Uuid::new_v4(), "v1", capabilities);
-
-        assert!(RuleEvaluator::reuse(&first, &same).allowed);
-        assert!(!RuleEvaluator::reuse(&first, &new_epoch).allowed);
-        assert!(!RuleEvaluator::reuse(&first, &new_context).allowed);
-        assert_eq!(first.key(), same.key());
-        assert_ne!(first.key(), new_epoch.key());
-        assert_ne!(first.key(), new_context.key());
     }
 
     #[test]
@@ -1689,164 +917,31 @@ mod tests {
         let owner_turn = ActiveTurn {
             turn_id: "owner".into(),
             agent_index: Some(0),
-            domain: Some(ExecutionDomain {
-                audience: label(&["alice"]),
-                context: DomainContext::OwnerPrivate {
-                    realm: realm(),
-                    owner: owner.clone(),
-                },
-                epoch: MembershipEpoch("owner-v1".into()),
-                capabilities: bot_capabilities(),
-            }),
+            domain: Some(ExecutionDomain::owner_private(
+                realm(),
+                owner.clone(),
+                MembershipEpoch::new("owner-v1"),
+                bot_capabilities(),
+            )),
             owner: Some(owner.clone()),
-            mode: InformationFlowMode::Isolate,
+            mode: InformationFlowMode::Route,
             origin: TurnOrigin::Channel,
         };
         let public_turn = ActiveTurn {
             turn_id: "public".into(),
             agent_index: Some(1),
-            domain: Some(ExecutionDomain {
-                audience: public_label(),
-                context: DomainContext::RealmPublic(realm()),
-                epoch: MembershipEpoch("public-v1".into()),
-                capabilities: CapabilitySet::default(),
-            }),
+            domain: Some(ExecutionDomain::public(
+                realm(),
+                MembershipEpoch::new("public-v1"),
+                CapabilitySet::default(),
+            )),
             owner: Some(owner),
-            mode: InformationFlowMode::Isolate,
+            mode: InformationFlowMode::Route,
             origin: TurnOrigin::Channel,
         };
 
         assert!(owner_turn.permits_owner_private_input());
         assert!(!public_turn.permits_owner_private_input());
-    }
-
-    #[test]
-    fn process_reuse_stays_denied_after_crossing_a_domain_boundary() {
-        let capabilities = CapabilitySet::from_names(["buzz.read.current"]);
-        let first = domain(
-            &["alice", "bob"],
-            Uuid::new_v4(),
-            "v1",
-            capabilities.clone(),
-        );
-        let second = domain(&["alice", "carol"], Uuid::new_v4(), "v1", capabilities);
-        let mut process = ProcessAuditState::default();
-
-        assert!(process.enter(&first).allowed);
-        assert!(!process.enter(&second).allowed);
-        assert!(
-            !process.enter(&first).allowed,
-            "returning to the first domain does not erase the second domain's influence"
-        );
-    }
-
-    #[test]
-    fn denied_input_still_taints_a_log_only_process() {
-        let channel = Uuid::new_v4();
-        let turn = domain(&["alice", "bob"], channel, "v1", CapabilitySet::default());
-        let private = ResourceLabel {
-            confidentiality: label(&["alice"]),
-            context: ResourceContext::OwnerPrivate {
-                realm: realm(),
-                owner: principal("alice"),
-            },
-        };
-        assert!(!RuleEvaluator::read(&turn, &private).allowed);
-
-        let mut state = ConfinementState::default();
-        state.observe(&turn.resource_label());
-        state.observe(&private);
-        let digest = [7; 32];
-        assert!(
-            !RuleEvaluator::publish(&state, &turn, &turn.audience, &turn.context, &digest, None,)
-                .allowed,
-            "audit mode must not claim safety after allowing a denied read through"
-        );
-    }
-
-    struct AlwaysValid;
-
-    impl GrantSignatureVerifier for AlwaysValid {
-        fn verifies(&self, _grant: &DeclassificationGrant<PendingGrant>) -> bool {
-            true
-        }
-    }
-
-    #[test]
-    fn declassification_is_owner_verified_and_exact() {
-        let channel = Uuid::new_v4();
-        let turn = domain(&["alice"], channel, "v1", CapabilitySet::default());
-        let destination = public_label();
-        let content = [9; 32];
-        let pending = DeclassificationGrant::<PendingGrant> {
-            approver: principal("alice"),
-            source_domain_id: turn.id(),
-            destination: destination.clone(),
-            destination_context: DomainContext::RealmPublic(realm()),
-            content_digest: content,
-            _state: PhantomData,
-        };
-        let verified = pending
-            .verify(&principal("alice"), &AlwaysValid)
-            .expect("owner signature");
-        let mut state = ConfinementState::default();
-        state.observe(&turn.resource_label());
-
-        assert!(
-            RuleEvaluator::publish(
-                &state,
-                &turn,
-                &destination,
-                &DomainContext::RealmPublic(realm()),
-                &content,
-                Some(&verified),
-            )
-            .allowed
-        );
-        assert!(
-            !RuleEvaluator::publish(
-                &state,
-                &turn,
-                &destination,
-                &DomainContext::RealmPublic(realm()),
-                &[8; 32],
-                Some(&verified),
-            )
-            .allowed
-        );
-        assert!(
-            !RuleEvaluator::publish(
-                &state,
-                &turn,
-                &destination,
-                &DomainContext::Conversation {
-                    realm: realm(),
-                    channel_id: Uuid::new_v4(),
-                },
-                &content,
-                Some(&verified),
-            )
-            .allowed,
-            "a grant for one destination context cannot authorize another"
-        );
-    }
-
-    #[test]
-    fn public_domain_ids_match_across_public_channels() {
-        let capabilities = CapabilitySet::from_names(["buzz.read.current"]);
-        let first = ExecutionDomain {
-            audience: public_label(),
-            context: DomainContext::RealmPublic(realm()),
-            epoch: MembershipEpoch("community".into()),
-            capabilities: capabilities.clone(),
-        };
-        let second = ExecutionDomain {
-            audience: public_label(),
-            context: DomainContext::RealmPublic(realm()),
-            epoch: MembershipEpoch("community".into()),
-            capabilities,
-        };
-        assert_eq!(first.id(), second.id());
     }
 
     #[tokio::test]
@@ -1944,7 +1039,7 @@ mod tests {
         .expect("signed membership");
         assert_eq!(
             member_principals(&valid).expect("valid members"),
-            BTreeSet::from([Principal::from_key(member.public_key())])
+            BTreeSet::from([Principal::from_public_key(&member.public_key())])
         );
 
         let invalid = EventBuilder::new(
@@ -1960,40 +1055,6 @@ mod tests {
         assert!(matches!(
             member_principals(&invalid),
             Err(ResolutionError::InvalidPrincipal)
-        ));
-    }
-
-    #[test]
-    fn restricted_event_admission_rejects_nonmember_requesters() {
-        let alice = principal("alice");
-        let bob = principal("bob");
-        let relay = principal("relay");
-        let members = BTreeSet::from([alice.clone()]);
-
-        let member = VerifiedTrigger {
-            channel_id: Uuid::new_v4(),
-            requesters: BTreeSet::from([alice]),
-        };
-        assert!(!verified_requester_outside_membership(
-            &member, &members, &relay
-        ));
-
-        let nonmember = VerifiedTrigger {
-            channel_id: Uuid::new_v4(),
-            requesters: BTreeSet::from([bob]),
-        };
-        assert!(verified_requester_outside_membership(
-            &nonmember, &members, &relay
-        ));
-
-        let relay_workflow = VerifiedTrigger {
-            channel_id: Uuid::new_v4(),
-            requesters: BTreeSet::from([relay.clone()]),
-        };
-        assert!(!verified_requester_outside_membership(
-            &relay_workflow,
-            &members,
-            &relay,
         ));
     }
 
@@ -2082,10 +1143,13 @@ mod tests {
         turn.enter_process(&mut process);
         let domain = turn.domain.as_ref().expect("resolved domain");
 
-        assert!(matches!(domain.context, DomainContext::OwnerPrivate { .. }));
-        assert_eq!(domain.audience.readers.explicit_count(), Some(1));
-        assert!(domain.capabilities.contains("email.read"));
-        assert_eq!(process.entered_domains.len(), 1);
+        assert!(matches!(
+            domain.context(),
+            DomainContext::OwnerPrivate { .. }
+        ));
+        assert_eq!(domain.audience().reader_count(), Some(1));
+        assert!(domain.capabilities().contains("email.read"));
+        assert_eq!(process.entered_domain_count(), 1);
         server.await.expect("policy server");
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2186,7 +2186,7 @@ async fn tokio_main() -> Result<()> {
         } else {
             tracing::warn!(
                 target: "buzz_acp::ifc",
-                "information-flow isolation enabled; ACP process reuse and owner-core reads are enforced, but tool and publication paths remain unmediated"
+                "information-flow routing enabled; public work shares the public worker class, confidential domains use dedicated ACP children, and OS confinement remains external"
             );
         }
         ifc::Auditor::new(
@@ -2198,7 +2198,7 @@ async fn tokio_main() -> Result<()> {
             config.information_flow,
         )
     });
-    let ifc_process_spec = config.information_flow.isolates_processes().then(|| {
+    let ifc_process_spec = config.information_flow.routes_workers().then(|| {
         pool::AgentProcessSpec::new(
             config.agent_command.clone(),
             config.agent_args.clone(),
@@ -3866,7 +3866,7 @@ async fn dispatch_pending(
             .map(|event| queue::parse_thread_tags(&event.event))
             .unwrap_or_default();
         let turn_id = Uuid::new_v4().to_string();
-        let mut prepared_ifc_turn = if ctx.information_flow.isolates_processes() {
+        let mut prepared_ifc_turn = if ctx.information_flow.routes_workers() {
             match ctx.ifc_auditor.as_ref() {
                 Some(auditor) => Some(auditor.resolve_turn(&batch, &turn_id, None).await),
                 None => None,
@@ -3876,7 +3876,7 @@ async fn dispatch_pending(
         };
         let domain = prepared_ifc_turn
             .as_ref()
-            .and_then(crate::ifc::ActiveTurn::domain_key);
+            .and_then(crate::ifc::ActiveTurn::domain_binding);
         let affinity_hit = pool.has_affinity_for(channel_id, domain.as_ref());
         let agent = match pool.try_claim(Some(channel_id), domain.as_ref()) {
             Some(a) => a,
@@ -4546,7 +4546,7 @@ fn dispatch_heartbeat(
         return;
     }
     let turn_id = Uuid::new_v4().to_string();
-    let mut prepared_ifc_turn = if ctx.information_flow.isolates_processes() {
+    let mut prepared_ifc_turn = if ctx.information_flow.routes_workers() {
         ctx.ifc_auditor
             .as_ref()
             .map(|auditor| auditor.resolve_heartbeat(&turn_id, None))
@@ -4555,7 +4555,7 @@ fn dispatch_heartbeat(
     };
     let domain = prepared_ifc_turn
         .as_ref()
-        .and_then(crate::ifc::ActiveTurn::domain_key);
+        .and_then(crate::ifc::ActiveTurn::domain_binding);
     let agent = match pool.try_claim(None, domain.as_ref()) {
         Some(a) => a,
         None => return,

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -132,10 +132,10 @@ pub struct SessionState {
     /// Process-level IFC audit state. This is intentionally not cleared when an
     /// ACP session is invalidated: a live process does not forget prior input.
     pub ifc_audit: crate::ifc::ProcessAuditState,
-    /// Complete execution domain to which this ACP child is bound in isolate
-    /// mode. It survives session invalidation and changes only when the child
-    /// process itself is replaced.
-    pub ifc_domain: Option<crate::ifc::DomainKey>,
+    /// Complete execution-domain assignment retained by this ACP child in
+    /// route mode. It survives session invalidation and changes only when the
+    /// child process itself is replaced.
+    pub ifc_domain: Option<crate::ifc::DomainBinding>,
 }
 
 impl SessionState {
@@ -561,7 +561,7 @@ impl ChannelInfoResolver {
 }
 
 /// Everything needed to replace an ACP child when a slot crosses an execution
-/// domain. Constructed only in isolate mode so off/audit keep the existing
+/// domain. Constructed only in route mode so off/audit keep the existing
 /// process lifecycle and configuration footprint.
 #[derive(Clone)]
 pub(crate) struct AgentProcessSpec {
@@ -627,12 +627,12 @@ pub struct PromptContext {
     pub max_turns_per_session: u32,
     /// Permission mode to apply after session creation. `Default` = skip.
     pub permission_mode: PermissionMode,
-    /// Present for information-flow audit or isolation. `None` is the default
+    /// Present for information-flow audit or routing. `None` is the default
     /// fast path and performs no membership queries or IFC bookkeeping.
     pub ifc_auditor: Option<crate::ifc::Auditor>,
     /// Information-flow behavior selected at startup.
     pub information_flow: InformationFlowMode,
-    /// Spawn configuration used only when isolate mode must replace an ACP
+    /// Spawn configuration used only when route mode must replace an ACP
     /// child before binding it to another domain.
     pub ifc_process_spec: Option<AgentProcessSpec>,
     /// Agent identity — used to derive the NIP-AE conversation key at
@@ -684,7 +684,7 @@ impl AgentPool {
     pub fn try_claim(
         &mut self,
         channel_id: Option<Uuid>,
-        domain: Option<&crate::ifc::DomainKey>,
+        domain: Option<&crate::ifc::DomainBinding>,
     ) -> Option<OwnedAgent> {
         // Pass 1: prefer agent with existing session for this channel.
         if let Some(cid) = channel_id {
@@ -704,8 +704,8 @@ impl AgentPool {
         }
 
         // Pass 2: prefer a process already bound to the resolved domain. This
-        // lets all public channels share their public worker while keeping
-        // restricted conversations on their own workers.
+        // lets all public channels reuse public-bound workers while keeping
+        // restricted conversations on workers bound to their exact domain.
         if let Some(domain) = domain {
             if let Some(index) = self.agents.iter().position(|slot| {
                 slot.as_ref()
@@ -725,7 +725,7 @@ impl AgentPool {
             return self.agents[index].take();
         }
 
-        // Pass 4: first idle agent. Isolate mode replaces it before use if its
+        // Pass 4: first idle agent. Route mode replaces it before use if its
         // binding differs; off/audit mode preserve the historical behavior.
         let idx = self.agents.iter().position(|slot| slot.is_some());
         idx.and_then(|i| self.agents[i].take())
@@ -757,7 +757,7 @@ impl AgentPool {
     pub fn has_affinity_for(
         &self,
         channel_id: Uuid,
-        domain: Option<&crate::ifc::DomainKey>,
+        domain: Option<&crate::ifc::DomainBinding>,
     ) -> bool {
         self.agents.iter().flatten().any(|agent| {
             let domain_matches =
@@ -1559,8 +1559,8 @@ enum DomainBindingAction {
 }
 
 fn domain_binding_action(
-    current: Option<&crate::ifc::DomainKey>,
-    requested: &crate::ifc::DomainKey,
+    current: Option<&crate::ifc::DomainBinding>,
+    requested: &crate::ifc::DomainBinding,
 ) -> DomainBindingAction {
     match current {
         None => DomainBindingAction::BindFresh,
@@ -1572,11 +1572,13 @@ fn domain_binding_action(
 /// Bind an ACP child to one complete execution domain before any turn input is
 /// delivered. Crossing a domain boundary replaces the child, which clears its
 /// model context, ACP sessions, process group, and harness-side session state.
-/// Files and credentials outside that process group still require the separate
-/// OS-confinement work described by the design.
+/// Realm-public work shares the public profile. Restricted and owner-private
+/// work receives the domain-confined profile and never reuses another domain's
+/// child. Files, credentials, and output paths outside the child process still
+/// require the runtime confinement described by the design.
 async fn bind_agent_to_domain(
     agent: &mut OwnedAgent,
-    requested: crate::ifc::DomainKey,
+    requested: crate::ifc::DomainBinding,
     spec: Option<&AgentProcessSpec>,
     turn_id: &str,
 ) -> Result<(), AcpError> {
@@ -1584,10 +1586,11 @@ async fn bind_agent_to_domain(
         DomainBindingAction::BindFresh => {
             tracing::info!(
                 target: "buzz_acp::ifc",
-                ifc_mode = "isolate",
+                ifc_mode = "route",
                 turn_id,
                 agent_index = agent.index,
                 domain = %requested.fingerprint(),
+                compartment = requested.profile().as_str(),
                 rule = "process_binding",
                 decision = "allow",
                 action = "bind_fresh",
@@ -1600,10 +1603,11 @@ async fn bind_agent_to_domain(
         DomainBindingAction::Reuse => {
             tracing::info!(
                 target: "buzz_acp::ifc",
-                ifc_mode = "isolate",
+                ifc_mode = "route",
                 turn_id,
                 agent_index = agent.index,
                 domain = %requested.fingerprint(),
+                compartment = requested.profile().as_str(),
                 rule = "process_binding",
                 decision = "allow",
                 action = "reuse",
@@ -1617,15 +1621,16 @@ async fn bind_agent_to_domain(
                 .state
                 .ifc_domain
                 .as_ref()
-                .map(crate::ifc::DomainKey::fingerprint)
+                .map(crate::ifc::DomainBinding::fingerprint)
                 .unwrap_or_else(|| "unbound".to_string());
             tracing::warn!(
                 target: "buzz_acp::ifc",
-                ifc_mode = "isolate",
+                ifc_mode = "route",
                 turn_id,
                 agent_index = agent.index,
                 previous_domain = %previous,
                 requested_domain = %requested.fingerprint(),
+                compartment = requested.profile().as_str(),
                 rule = "process_binding",
                 decision = "deny",
                 action = "replace_process",
@@ -1634,7 +1639,7 @@ async fn bind_agent_to_domain(
             );
             let spec = spec.ok_or_else(|| {
                 AcpError::InformationFlow(
-                    "isolate mode has no ACP process replacement configuration".to_string(),
+                    "route mode has no ACP process replacement configuration".to_string(),
                 )
             })?;
             const REPLACEMENT_TIMEOUT: Duration = Duration::from_secs(60);
@@ -1675,10 +1680,11 @@ async fn bind_agent_to_domain(
 
             tracing::info!(
                 target: "buzz_acp::ifc",
-                ifc_mode = "isolate",
+                ifc_mode = "route",
                 turn_id,
                 agent_index = agent.index,
                 domain = %requested.fingerprint(),
+                compartment = requested.profile().as_str(),
                 rule = "process_binding",
                 decision = "allow",
                 action = "replacement_bound",
@@ -1733,7 +1739,7 @@ pub(crate) async fn run_prompt_task(
     };
 
     // Resolve the complete execution domain before the ACP child receives any
-    // prompt, memory, session, or tool state. Isolate-mode channel dispatch
+    // prompt, memory, session, or tool state. Route-mode channel dispatch
     // normally prepares this before pool selection so the domain is the routing
     // key; audit mode resolves here to preserve the old non-blocking dispatcher.
     let ifc_turn = match prepared_ifc_turn {
@@ -1749,7 +1755,7 @@ pub(crate) async fn run_prompt_task(
         },
     };
 
-    if ctx.information_flow.isolates_processes() {
+    if ctx.information_flow.routes_workers() {
         let Some(turn) = ifc_turn.as_ref() else {
             send_prompt_result(
                 &result_tx,
@@ -1763,7 +1769,7 @@ pub(crate) async fn run_prompt_task(
             );
             return;
         };
-        let Some(domain) = turn.domain_key() else {
+        let Some(domain) = turn.domain_binding() else {
             send_prompt_result(
                 &result_tx,
                 &turn_id,
@@ -1901,7 +1907,7 @@ pub(crate) async fn run_prompt_task(
     // `SessionState::invalidate_channel`).
     //
     // Operator opt-out: `--no-memory` / `BUZZ_ACP_NO_MEMORY` skips the fetch.
-    let owner_memory_allowed = !ctx.information_flow.isolates_processes()
+    let owner_memory_allowed = !ctx.information_flow.routes_workers()
         || ifc_turn
             .as_ref()
             .is_some_and(crate::ifc::ActiveTurn::permits_owner_private_input);
@@ -1943,7 +1949,7 @@ pub(crate) async fn run_prompt_task(
             }
         }
     } else if ctx.memory_enabled
-        && ctx.information_flow.isolates_processes()
+        && ctx.information_flow.routes_workers()
         && matches!(&source, PromptSource::Channel(_))
         && ctx.agent_owner_pubkey.is_some()
     {
@@ -4778,8 +4784,14 @@ mod tests {
 
     #[test]
     fn domain_binding_requires_replacement_only_across_domains() {
-        let first = crate::ifc::DomainKey::for_test("first");
-        let second = crate::ifc::DomainKey::for_test("second");
+        let first = crate::ifc::domain_binding_for_test(
+            "first",
+            buzz_ifc::CompartmentProfile::SharedPublic,
+        );
+        let second = crate::ifc::domain_binding_for_test(
+            "second",
+            buzz_ifc::CompartmentProfile::DomainConfined,
+        );
 
         assert_eq!(
             domain_binding_action(None, &first),
@@ -4791,6 +4803,15 @@ mod tests {
         );
         assert_eq!(
             domain_binding_action(Some(&first), &second),
+            DomainBindingAction::Replace
+        );
+
+        let confidential_first = crate::ifc::domain_binding_for_test(
+            "first",
+            buzz_ifc::CompartmentProfile::DomainConfined,
+        );
+        assert_eq!(
+            domain_binding_action(Some(&first), &confidential_first),
             DomainBindingAction::Replace
         );
     }
@@ -4805,8 +4826,14 @@ mod tests {
         )
         .await
         .expect("spawn old ACP child");
-        let old_domain = crate::ifc::DomainKey::for_test("old-domain");
-        let new_domain = crate::ifc::DomainKey::for_test("new-domain");
+        let old_domain = crate::ifc::domain_binding_for_test(
+            "old-domain",
+            buzz_ifc::CompartmentProfile::SharedPublic,
+        );
+        let new_domain = crate::ifc::domain_binding_for_test(
+            "new-domain",
+            buzz_ifc::CompartmentProfile::DomainConfined,
+        );
         let channel = Uuid::new_v4();
         let mut state = SessionState {
             ifc_domain: Some(old_domain),
@@ -4875,8 +4902,14 @@ while IFS= read -r line; do :; done"#;
             .await
             .expect("spawn inert ACP child")
         };
-        let first_domain = crate::ifc::DomainKey::for_test("first-domain");
-        let requested_domain = crate::ifc::DomainKey::for_test("requested-domain");
+        let first_domain = crate::ifc::domain_binding_for_test(
+            "first-domain",
+            buzz_ifc::CompartmentProfile::SharedPublic,
+        );
+        let requested_domain = crate::ifc::domain_binding_for_test(
+            "requested-domain",
+            buzz_ifc::CompartmentProfile::DomainConfined,
+        );
         let make_agent = |index, acp, domain| OwnedAgent {
             index,
             acp,

--- a/crates/buzz-ifc/Cargo.toml
+++ b/crates/buzz-ifc/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "buzz-ifc"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Audience-scoped information-flow policy for Buzz agents"
+
+[dependencies]
+hex = { workspace = true }
+nostr = { workspace = true }
+serde = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }

--- a/crates/buzz-ifc/src/declassification.rs
+++ b/crates/buzz-ifc/src/declassification.rs
@@ -1,0 +1,94 @@
+use std::marker::PhantomData;
+
+use crate::domain::DomainContext;
+use crate::label::{ConfidentialityLabel, Principal};
+
+/// Typestate marker for a grant whose owner signature has not been checked.
+pub struct PendingGrant;
+
+/// Typestate marker for a grant authenticated by an external verifier.
+pub struct VerifiedGrant;
+
+/// Paper: "Declassification." A content- and destination-specific grant.
+pub struct DeclassificationGrant<State> {
+    approver: Principal,
+    source_domain_id: String,
+    destination: ConfidentialityLabel,
+    destination_context: DomainContext,
+    content_digest: [u8; 32],
+    _state: PhantomData<State>,
+}
+
+/// Verifies the owner signature over a pending grant's canonical payload.
+pub trait GrantSignatureVerifier {
+    /// Return true only when the grant bears an authentic owner signature.
+    fn verifies(&self, grant: &DeclassificationGrant<PendingGrant>) -> bool;
+}
+
+impl DeclassificationGrant<PendingGrant> {
+    /// Construct an unverified grant from signed-event fields.
+    pub fn pending(
+        approver: Principal,
+        source_domain_id: String,
+        destination: ConfidentialityLabel,
+        destination_context: DomainContext,
+        content_digest: [u8; 32],
+    ) -> Self {
+        Self {
+            approver,
+            source_domain_id,
+            destination,
+            destination_context,
+            content_digest,
+            _state: PhantomData,
+        }
+    }
+
+    /// Authenticate the owner and move the grant into the verified typestate.
+    pub fn verify<V: GrantSignatureVerifier>(
+        self,
+        expected_owner: &Principal,
+        verifier: &V,
+    ) -> Result<DeclassificationGrant<VerifiedGrant>, GrantError> {
+        if &self.approver != expected_owner {
+            return Err(GrantError::WrongApprover);
+        }
+        if !verifier.verifies(&self) {
+            return Err(GrantError::InvalidSignature);
+        }
+        Ok(DeclassificationGrant {
+            approver: self.approver,
+            source_domain_id: self.source_domain_id,
+            destination: self.destination,
+            destination_context: self.destination_context,
+            content_digest: self.content_digest,
+            _state: PhantomData,
+        })
+    }
+}
+
+impl DeclassificationGrant<VerifiedGrant> {
+    pub(crate) fn matches(
+        &self,
+        source_domain_id: &str,
+        destination: &ConfidentialityLabel,
+        destination_context: &DomainContext,
+        content_digest: &[u8; 32],
+    ) -> bool {
+        self.source_domain_id == source_domain_id
+            && &self.destination == destination
+            && &self.destination_context == destination_context
+            && &self.content_digest == content_digest
+    }
+}
+
+/// A declassification grant failed owner authentication.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum GrantError {
+    /// The signer is not the expected bot owner.
+    #[error("declassification grant was signed by the wrong principal")]
+    WrongApprover,
+    /// The supplied signature did not authenticate the grant.
+    #[error("declassification grant signature is invalid")]
+    InvalidSignature,
+}

--- a/crates/buzz-ifc/src/domain.rs
+++ b/crates/buzz-ifc/src/domain.rs
@@ -1,0 +1,567 @@
+use std::collections::BTreeSet;
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::hash::{hash_field, short_fingerprint};
+use crate::label::{ConfidentialityLabel, LabelError, Principal, ReaderSet, RealmId};
+
+/// Which retained context a worker belongs to.
+///
+/// Paper: "Execution domains." Context remains separate from audience: two
+/// conversations may have identical participants without implicitly sharing
+/// memory.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum DomainContext {
+    /// Shared state for public conversations in one realm.
+    RealmPublic(RealmId),
+    /// State retained for one specific restricted conversation.
+    Conversation {
+        /// The Buzz community containing the conversation.
+        realm: RealmId,
+        /// The channel, DM, or group-DM identifier.
+        channel_id: Uuid,
+    },
+    /// State visible only to the bot owner.
+    OwnerPrivate {
+        /// The Buzz community containing the owner relationship.
+        realm: RealmId,
+        /// The bot owner.
+        owner: Principal,
+    },
+}
+
+/// Runtime placement required by an execution domain.
+///
+/// The IFC rules do not implement an OS sandbox. They tell the harness whether
+/// a worker may use the shared public runtime or must be placed in a compartment
+/// dedicated to one complete execution domain.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompartmentProfile {
+    /// Realm-public conversations may share a worker, public memory, and public
+    /// tools. The worker must still be unable to reach broker secrets or private
+    /// compartments.
+    SharedPublic,
+    /// A restricted conversation or owner-private task requires a worker whose
+    /// writable state and output paths are confined to the exact domain.
+    DomainConfined,
+}
+
+impl CompartmentProfile {
+    /// Return the stable wire and log representation.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SharedPublic => "shared_public",
+            Self::DomainConfined => "domain_confined",
+        }
+    }
+}
+
+impl DomainContext {
+    /// Return the realm containing this context.
+    pub fn realm(&self) -> &RealmId {
+        match self {
+            Self::RealmPublic(realm)
+            | Self::Conversation { realm, .. }
+            | Self::OwnerPrivate { realm, .. } => realm,
+        }
+    }
+
+    /// Return a stable context category for logs and protocol responses.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::RealmPublic(_) => "public",
+            Self::Conversation { .. } => "conversation",
+            Self::OwnerPrivate { .. } => "owner_private",
+        }
+    }
+
+    /// Whether this is the private aggregation context for `owner`.
+    pub fn is_owner_private_for(&self, owner: &Principal) -> bool {
+        matches!(self, Self::OwnerPrivate { owner: candidate, .. } if candidate == owner)
+    }
+
+    fn resource_context(&self) -> ResourceContext {
+        match self {
+            Self::RealmPublic(realm) => ResourceContext::RealmPublic(realm.clone()),
+            Self::Conversation { realm, channel_id } => ResourceContext::Conversation {
+                realm: realm.clone(),
+                channel_id: *channel_id,
+            },
+            Self::OwnerPrivate { realm, owner } => ResourceContext::OwnerPrivate {
+                realm: realm.clone(),
+                owner: owner.clone(),
+            },
+        }
+    }
+
+    pub(crate) fn permits(&self, resource: &ResourceContext) -> bool {
+        match resource {
+            ResourceContext::TrustedConfiguration => true,
+            ResourceContext::RealmPublic(resource_realm) => self.realm() == resource_realm,
+            ResourceContext::Conversation {
+                realm: resource_realm,
+                channel_id: resource_channel,
+            } => match self {
+                Self::Conversation { realm, channel_id } => {
+                    realm == resource_realm && channel_id == resource_channel
+                }
+                Self::OwnerPrivate { realm, .. } => realm == resource_realm,
+                Self::RealmPublic(_) => false,
+            },
+            ResourceContext::OwnerPrivate {
+                realm: resource_realm,
+                owner: resource_owner,
+            } => matches!(
+                self,
+                Self::OwnerPrivate { realm, owner }
+                    if realm == resource_realm && owner == resource_owner
+            ),
+        }
+    }
+
+    fn stable_hash(&self, hasher: &mut Sha256) {
+        match self {
+            Self::RealmPublic(realm) => {
+                hasher.update(b"realm-public");
+                realm.stable_hash(hasher);
+            }
+            Self::Conversation { realm, channel_id } => {
+                hasher.update(b"conversation");
+                realm.stable_hash(hasher);
+                hasher.update(channel_id.as_bytes());
+            }
+            Self::OwnerPrivate { realm, owner } => {
+                hasher.update(b"owner-private");
+                realm.stable_hash(hasher);
+                hash_field(hasher, owner.0.as_bytes());
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum ResourceContext {
+    TrustedConfiguration,
+    RealmPublic(RealmId),
+    Conversation { realm: RealmId, channel_id: Uuid },
+    OwnerPrivate { realm: RealmId, owner: Principal },
+}
+
+/// An operation that a worker may request.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct Capability(String);
+
+/// The complete set of operations admitted for one execution domain.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CapabilitySet(BTreeSet<Capability>);
+
+impl CapabilitySet {
+    /// Build a set from stable operation names.
+    pub fn from_names<I, S>(names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self(
+            names
+                .into_iter()
+                .map(|name| Capability(name.into()))
+                .collect(),
+        )
+    }
+
+    /// Paper: "Broker behavior — Enforcement rules." Compute
+    /// `C(bot) ∩ C(requester) ∩ C(domain)`.
+    pub fn effective(bot: &Self, requester: &Self, domain: &Self) -> Self {
+        let bot_and_requester: BTreeSet<_> = bot.0.intersection(&requester.0).cloned().collect();
+        Self(bot_and_requester.intersection(&domain.0).cloned().collect())
+    }
+
+    /// Whether this set admits an operation.
+    pub fn contains(&self, operation: &str) -> bool {
+        self.0.contains(&Capability(operation.to_string()))
+    }
+
+    fn stable_hash(&self, hasher: &mut Sha256) {
+        for capability in &self.0 {
+            hash_field(hasher, capability.0.as_bytes());
+        }
+    }
+}
+
+/// Capability ceilings used while deriving an invocation's effective set.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CapabilityPolicy {
+    bot: CapabilitySet,
+    conversation: CapabilitySet,
+}
+
+impl CapabilityPolicy {
+    /// Construct policy from the bot's full ceiling and the ceiling permitted
+    /// in shared Buzz conversations.
+    pub fn new(bot: CapabilitySet, conversation: CapabilitySet) -> Self {
+        Self { bot, conversation }
+    }
+}
+
+/// The membership or policy version under which state was created.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MembershipEpoch(String);
+
+impl MembershipEpoch {
+    /// Construct an epoch from a stable, verifier-controlled identifier.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Return a short identifier suitable for logs.
+    pub fn fingerprint(&self) -> String {
+        short_fingerprint(&self.0)
+    }
+}
+
+/// Buzz conversation classification after signed metadata verification.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConversationKind {
+    /// Realm-wide public channel. All public channels intentionally share one
+    /// execution domain.
+    Public,
+    /// Invite-only channel or group DM with conversation-specific state.
+    Restricted,
+    /// A DM. A two-party owner/bot DM becomes owner-private; group DMs remain
+    /// conversation-specific.
+    DirectMessage,
+}
+
+/// Verified Buzz facts from which the shared policy derives an execution
+/// domain.
+///
+/// A trusted adapter constructs this only after checking trigger signatures,
+/// channel binding, and the relay signature on metadata and membership.
+pub struct DomainFacts {
+    /// Community realm selected by the trusted Buzz connection.
+    pub realm: RealmId,
+    /// Channel, DM, or group-DM identifier that triggered the invocation.
+    pub channel_id: Uuid,
+    /// Verified conversation classification.
+    pub kind: ConversationKind,
+    /// Relay-controlled membership or community policy version.
+    pub epoch: MembershipEpoch,
+    /// Complete verified roster. Public derivation does not consume this set.
+    pub members: BTreeSet<Principal>,
+    /// Agent process receiving the invocation.
+    pub executing_agent: Principal,
+    /// Authors whose events are included in this invocation.
+    pub requesters: BTreeSet<Principal>,
+    /// Optional relay principal allowed to author trusted workflow events.
+    pub system_principal: Option<Principal>,
+    /// Optional human owner of the executing agent.
+    pub owner: Option<Principal>,
+}
+
+/// Domain derivation failed despite the adapter's claim that its facts were
+/// already verified.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum DerivationError {
+    /// Every invocation must contain at least one authenticated requester.
+    #[error("invocation has no authenticated requester")]
+    EmptyRequesters,
+    /// Restricted conversations must include the executing agent in their
+    /// verified roster.
+    #[error("executing agent is absent from channel membership")]
+    AgentNotMember,
+    /// A non-system requester is absent from restricted membership.
+    #[error("requester is absent from channel membership")]
+    RequesterNotMember,
+    /// Removing the executing processor left no authorized recipient.
+    #[error("restricted conversation has no recipient audience")]
+    EmptyRestrictedAudience,
+    /// The derived audience and context violated a domain invariant.
+    #[error("derived execution domain is inconsistent")]
+    InvalidDomain,
+}
+
+/// Paper: "Execution domains." Derive
+/// `D = (Audience, Context, Epoch, Capabilities)` from verified Buzz facts.
+/// This is the mapping shared by local ACP and remote agent harnesses.
+pub fn derive_execution_domain(
+    facts: DomainFacts,
+    policy: &CapabilityPolicy,
+) -> Result<ExecutionDomain, DerivationError> {
+    if facts.requesters.is_empty() {
+        return Err(DerivationError::EmptyRequesters);
+    }
+
+    if facts.kind == ConversationKind::Public {
+        let context = DomainContext::RealmPublic(facts.realm.clone());
+        let capabilities = effective_capabilities(&context, &facts, policy);
+        return Ok(ExecutionDomain::public(
+            facts.realm,
+            facts.epoch,
+            capabilities,
+        ));
+    }
+
+    if !facts.members.contains(&facts.executing_agent) {
+        return Err(DerivationError::AgentNotMember);
+    }
+    if facts.requesters.iter().any(|requester| {
+        facts.system_principal.as_ref() != Some(requester) && !facts.members.contains(requester)
+    }) {
+        return Err(DerivationError::RequesterNotMember);
+    }
+
+    let mut readers = facts.members.clone();
+    readers.remove(&facts.executing_agent);
+    if readers.is_empty() {
+        return Err(DerivationError::EmptyRestrictedAudience);
+    }
+
+    let context = match (&facts.owner, facts.kind) {
+        (Some(owner), ConversationKind::DirectMessage)
+            if readers.len() == 1 && readers.contains(owner) =>
+        {
+            DomainContext::OwnerPrivate {
+                realm: facts.realm.clone(),
+                owner: owner.clone(),
+            }
+        }
+        _ => DomainContext::Conversation {
+            realm: facts.realm.clone(),
+            channel_id: facts.channel_id,
+        },
+    };
+    let capabilities = effective_capabilities(&context, &facts, policy);
+    let audience = ConfidentialityLabel::restricted(facts.realm, readers)
+        .map_err(|_| DerivationError::EmptyRestrictedAudience)?;
+    ExecutionDomain::new(audience, context, facts.epoch, capabilities)
+        .map_err(|_| DerivationError::InvalidDomain)
+}
+
+fn effective_capabilities(
+    context: &DomainContext,
+    facts: &DomainFacts,
+    policy: &CapabilityPolicy,
+) -> CapabilitySet {
+    let requester_is_owner = facts
+        .owner
+        .as_ref()
+        .is_some_and(|owner| facts.requesters.iter().all(|requester| requester == owner));
+    let requester = if requester_is_owner {
+        &policy.bot
+    } else {
+        &policy.conversation
+    };
+    let domain = if matches!(context, DomainContext::OwnerPrivate { .. }) {
+        &policy.bot
+    } else {
+        &policy.conversation
+    };
+    CapabilitySet::effective(&policy.bot, requester, domain)
+}
+
+/// Opaque routing key for one complete execution domain.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct DomainKey(String);
+
+impl DomainKey {
+    /// Return a short identifier suitable for logs.
+    pub fn fingerprint(&self) -> String {
+        short_fingerprint(&self.0)
+    }
+
+    /// Return the full stable identifier used as a worker-pool routing key.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// `D = (Audience, Context, Epoch, Capabilities)`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExecutionDomain {
+    pub(crate) audience: ConfidentialityLabel,
+    pub(crate) context: DomainContext,
+    epoch: MembershipEpoch,
+    pub(crate) capabilities: CapabilitySet,
+}
+
+impl ExecutionDomain {
+    /// Construct a domain after the trusted adapter has resolved its inputs.
+    pub fn new(
+        audience: ConfidentialityLabel,
+        context: DomainContext,
+        epoch: MembershipEpoch,
+        capabilities: CapabilitySet,
+    ) -> Result<Self, DomainError> {
+        if audience.realm() != context.realm() {
+            return Err(DomainError::ContextRealmMismatch);
+        }
+        match (&audience.readers, &context) {
+            (ReaderSet::Everyone, DomainContext::RealmPublic(_)) => {}
+            (ReaderSet::Only(readers), DomainContext::Conversation { .. })
+                if !readers.is_empty() => {}
+            (ReaderSet::Only(readers), DomainContext::OwnerPrivate { owner, .. })
+                if readers.len() == 1 && readers.contains(owner) => {}
+            _ => return Err(DomainError::AudienceContextMismatch),
+        }
+        Ok(Self {
+            audience,
+            context,
+            epoch,
+            capabilities,
+        })
+    }
+
+    /// Construct the realm-wide public domain.
+    pub fn public(realm: RealmId, epoch: MembershipEpoch, capabilities: CapabilitySet) -> Self {
+        Self {
+            audience: ConfidentialityLabel::public(realm.clone()),
+            context: DomainContext::RealmPublic(realm),
+            epoch,
+            capabilities,
+        }
+    }
+
+    /// Construct the exact owner-private domain.
+    pub fn owner_private(
+        realm: RealmId,
+        owner: Principal,
+        epoch: MembershipEpoch,
+        capabilities: CapabilitySet,
+    ) -> Self {
+        let readers = BTreeSet::from([owner.clone()]);
+        Self {
+            audience: ConfidentialityLabel {
+                realm: realm.clone(),
+                readers: ReaderSet::Only(readers),
+            },
+            context: DomainContext::OwnerPrivate { realm, owner },
+            epoch,
+            capabilities,
+        }
+    }
+
+    /// Return the authorized audience.
+    pub fn audience(&self) -> &ConfidentialityLabel {
+        &self.audience
+    }
+
+    /// Return the retained-state context.
+    pub fn context(&self) -> &DomainContext {
+        &self.context
+    }
+
+    /// Return the runtime placement required to preserve this domain.
+    pub fn compartment_profile(&self) -> CompartmentProfile {
+        if self.audience.is_public() {
+            CompartmentProfile::SharedPublic
+        } else {
+            CompartmentProfile::DomainConfined
+        }
+    }
+
+    /// Return the effective capability set.
+    pub fn capabilities(&self) -> &CapabilitySet {
+        &self.capabilities
+    }
+
+    /// Return a short fingerprint of the membership or policy epoch.
+    pub fn epoch_fingerprint(&self) -> String {
+        self.epoch.fingerprint()
+    }
+
+    /// Return the canonical identifier for the complete domain tuple.
+    pub fn id(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(b"buzz-ifc-domain-v1");
+        self.audience.realm.stable_hash(&mut hasher);
+        self.audience.readers.stable_hash(&mut hasher);
+        self.context.stable_hash(&mut hasher);
+        hash_field(&mut hasher, self.epoch.0.as_bytes());
+        self.capabilities.stable_hash(&mut hasher);
+        hex::encode(hasher.finalize())
+    }
+
+    /// Return the opaque worker-pool routing key.
+    pub fn key(&self) -> DomainKey {
+        DomainKey(self.id())
+    }
+
+    /// Label information whose provenance is this domain itself.
+    pub fn resource_label(&self) -> ResourceLabel {
+        ResourceLabel {
+            confidentiality: self.audience.clone(),
+            context: self.context.resource_context(),
+        }
+    }
+}
+
+/// An execution domain contains inconsistent realms.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum DomainError {
+    /// The audience and retained context belong to different Buzz realms.
+    #[error("execution-domain audience and context belong to different realms")]
+    ContextRealmMismatch,
+    /// Public, conversation, and owner-private contexts require their
+    /// corresponding audience shape.
+    #[error("execution-domain audience does not match its context")]
+    AudienceContextMismatch,
+}
+
+/// The confidentiality and context assigned to one input resource.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResourceLabel {
+    pub(crate) confidentiality: ConfidentialityLabel,
+    pub(crate) context: ResourceContext,
+}
+
+impl ResourceLabel {
+    /// Label immutable configuration that is public in the supplied realm.
+    pub fn trusted_configuration(realm: RealmId) -> Self {
+        Self {
+            confidentiality: ConfidentialityLabel::public(realm),
+            context: ResourceContext::TrustedConfiguration,
+        }
+    }
+
+    /// Label information already scoped to an execution domain.
+    pub fn domain(domain: &ExecutionDomain) -> Self {
+        domain.resource_label()
+    }
+
+    /// Label information public to every member of one realm.
+    pub fn realm_public(realm: RealmId) -> Self {
+        Self {
+            confidentiality: ConfidentialityLabel::public(realm.clone()),
+            context: ResourceContext::RealmPublic(realm),
+        }
+    }
+
+    /// Label information belonging to one restricted conversation.
+    pub fn conversation(
+        realm: RealmId,
+        channel_id: Uuid,
+        readers: BTreeSet<Principal>,
+    ) -> Result<Self, LabelError> {
+        Ok(Self {
+            confidentiality: ConfidentialityLabel::restricted(realm.clone(), readers)?,
+            context: ResourceContext::Conversation { realm, channel_id },
+        })
+    }
+
+    /// Label owner-private information such as personal memory.
+    pub fn owner_private(realm: RealmId, owner: Principal) -> Self {
+        let readers = BTreeSet::from([owner.clone()]);
+        Self {
+            confidentiality: ConfidentialityLabel {
+                realm: realm.clone(),
+                readers: ReaderSet::Only(readers),
+            },
+            context: ResourceContext::OwnerPrivate { realm, owner },
+        }
+    }
+}

--- a/crates/buzz-ifc/src/hash.rs
+++ b/crates/buzz-ifc/src/hash.rs
@@ -1,0 +1,12 @@
+use sha2::{Digest, Sha256};
+
+pub(crate) fn hash_field(hasher: &mut Sha256, value: &[u8]) {
+    let length = u64::try_from(value.len()).unwrap_or(u64::MAX);
+    hasher.update(length.to_be_bytes());
+    hasher.update(value);
+}
+
+pub(crate) fn short_fingerprint(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    hex::encode(&digest[..6])
+}

--- a/crates/buzz-ifc/src/label.rs
+++ b/crates/buzz-ifc/src/label.rs
@@ -1,0 +1,196 @@
+use std::collections::BTreeSet;
+
+use nostr::PublicKey;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::hash::hash_field;
+
+/// A Buzz principal represented by a validated, normalized Nostr public key.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct Principal(pub(crate) String);
+
+impl Principal {
+    /// Parse and normalize a hexadecimal Nostr public key.
+    pub fn from_hex(value: &str) -> Result<Self, PrincipalError> {
+        PublicKey::from_hex(value)
+            .map(|key| Self::from_public_key(&key))
+            .map_err(|_| PrincipalError::InvalidPublicKey)
+    }
+
+    /// Convert an already validated Nostr public key.
+    pub fn from_public_key(value: &PublicKey) -> Self {
+        Self(value.to_hex().to_ascii_lowercase())
+    }
+
+    /// Return the normalized hexadecimal public key.
+    pub fn as_hex(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A principal could not be constructed from the supplied key.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum PrincipalError {
+    /// The value is not a valid Nostr public key.
+    #[error("invalid Nostr public key")]
+    InvalidPublicKey,
+}
+
+/// A confidentiality universe derived from one canonical Buzz relay URL.
+///
+/// Public data in one community is not public in another, so labels from
+/// different realms never flow to one another.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct RealmId(pub(crate) [u8; 32]);
+
+impl RealmId {
+    /// Derive a realm identifier from the relay URL selected by Buzz.
+    pub fn from_relay_url(relay_url: &str) -> Self {
+        Self(Sha256::digest(relay_url.as_bytes()).into())
+    }
+
+    /// Return a short identifier suitable for structured logs.
+    pub fn fingerprint(&self) -> String {
+        hex::encode(&self.0[..6])
+    }
+
+    pub(crate) fn stable_hash(&self, hasher: &mut Sha256) {
+        hasher.update(self.0);
+    }
+}
+
+/// The authorized readers of a value.
+///
+/// Paper: "Appendix: Security labels as a lattice — Labels and ordering."
+/// `Everyone` is the public lattice element. An explicit set becomes more
+/// restrictive as principals are removed.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ReaderSet {
+    Everyone,
+    Only(BTreeSet<Principal>),
+}
+
+impl ReaderSet {
+    /// The IFC ordering is reverse set inclusion: every reader at the
+    /// destination must already be authorized to read the source.
+    fn can_flow_to(&self, destination: &Self) -> bool {
+        match (self, destination) {
+            (Self::Everyone, _) => true,
+            (Self::Only(_), Self::Everyone) => false,
+            (Self::Only(source), Self::Only(destination)) => destination.is_subset(source),
+        }
+    }
+
+    /// Paper: "Combining information." Inputs are joined by intersecting their
+    /// authorized reader sets.
+    pub(crate) fn join(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Everyone, value) | (value, Self::Everyone) => value.clone(),
+            (Self::Only(left), Self::Only(right)) => {
+                Self::Only(left.intersection(right).cloned().collect())
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn meet(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Everyone, _) | (_, Self::Everyone) => Self::Everyone,
+            (Self::Only(left), Self::Only(right)) => {
+                Self::Only(left.union(right).cloned().collect())
+            }
+        }
+    }
+
+    fn explicit_count(&self) -> Option<usize> {
+        match self {
+            Self::Everyone => None,
+            Self::Only(readers) => Some(readers.len()),
+        }
+    }
+
+    pub(crate) fn stable_hash(&self, hasher: &mut Sha256) {
+        match self {
+            Self::Everyone => hasher.update(b"everyone"),
+            Self::Only(readers) => {
+                hasher.update(b"only");
+                for reader in readers {
+                    hash_field(hasher, reader.0.as_bytes());
+                }
+            }
+        }
+    }
+}
+
+/// A reader-set label within one Buzz community.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConfidentialityLabel {
+    pub(crate) realm: RealmId,
+    pub(crate) readers: ReaderSet,
+}
+
+impl ConfidentialityLabel {
+    /// Label data that every member of the realm may read.
+    pub fn public(realm: RealmId) -> Self {
+        Self {
+            realm,
+            readers: ReaderSet::Everyone,
+        }
+    }
+
+    /// Label data with an explicit non-empty authorized reader set.
+    pub fn restricted(realm: RealmId, readers: BTreeSet<Principal>) -> Result<Self, LabelError> {
+        if readers.is_empty() {
+            return Err(LabelError::EmptyReaderSet);
+        }
+        Ok(Self {
+            realm,
+            readers: ReaderSet::Only(readers),
+        })
+    }
+
+    /// Return the realm in which this label is meaningful.
+    pub fn realm(&self) -> &RealmId {
+        &self.realm
+    }
+
+    /// Whether the label permits every member of the realm to read the value.
+    pub fn is_public(&self) -> bool {
+        matches!(self.readers, ReaderSet::Everyone)
+    }
+
+    /// Return the explicit number of readers, or `None` for public data.
+    pub fn reader_count(&self) -> Option<usize> {
+        self.readers.explicit_count()
+    }
+
+    /// Whether information with this label may flow to `destination`.
+    pub fn can_flow_to(&self, destination: &Self) -> bool {
+        self.realm == destination.realm && self.readers.can_flow_to(&destination.readers)
+    }
+
+    /// Combine the influence of two inputs.
+    pub fn join(&self, other: &Self) -> Result<Self, LabelError> {
+        if self.realm != other.realm {
+            return Err(LabelError::CrossRealm);
+        }
+        Ok(Self {
+            realm: self.realm.clone(),
+            readers: self.readers.join(&other.readers),
+        })
+    }
+}
+
+/// A confidentiality label violates the reader-set lattice invariants.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum LabelError {
+    /// Restricted information must name at least one authorized reader.
+    #[error("restricted label has no authorized readers")]
+    EmptyReaderSet,
+    /// Labels from different Buzz communities cannot be combined.
+    #[error("labels belong to different Buzz realms")]
+    CrossRealm,
+}

--- a/crates/buzz-ifc/src/lib.rs
+++ b/crates/buzz-ifc/src/lib.rs
@@ -1,0 +1,448 @@
+//! Deterministic information-flow policy for Buzz agent execution.
+//!
+//! This crate contains no relay, ACP, process, or storage code. A trusted Buzz
+//! adapter verifies events and membership, supplies [`DomainFacts`], and uses
+//! these rules to derive an [`ExecutionDomain`] and decide whether a worker may
+//! be reused, read a resource, call an operation, or publish a result. Keeping
+//! the policy pure lets local ACP and remote harnesses apply the same rules
+//! without sharing an agent implementation.
+//!
+//! Comments prefixed with `Paper:` identify the matching section of
+//! "Practical information-flow for Buzz agents."
+
+mod declassification;
+mod domain;
+mod hash;
+mod label;
+mod policy;
+
+pub use declassification::{
+    DeclassificationGrant, GrantError, GrantSignatureVerifier, PendingGrant, VerifiedGrant,
+};
+pub use domain::{
+    derive_execution_domain, CapabilityPolicy, CapabilitySet, CompartmentProfile, ConversationKind,
+    DerivationError, DomainContext, DomainError, DomainFacts, DomainKey, ExecutionDomain,
+    MembershipEpoch, ResourceLabel,
+};
+pub use label::{ConfidentialityLabel, LabelError, Principal, PrincipalError, RealmId};
+pub use policy::{ProcessState, RuleDecision, RuleEvaluator};
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::label::ReaderSet;
+
+    fn principal(value: u8) -> Principal {
+        let hex = format!("{value:02x}").repeat(32);
+        Principal::from_hex(&hex).expect("test principal")
+    }
+
+    fn readers(values: &[u8]) -> BTreeSet<Principal> {
+        values.iter().copied().map(principal).collect()
+    }
+
+    fn realm() -> RealmId {
+        RealmId::from_relay_url("wss://buzz.example")
+    }
+
+    fn label(values: &[u8]) -> ConfidentialityLabel {
+        ConfidentialityLabel::restricted(realm(), readers(values)).expect("non-empty readers")
+    }
+
+    fn conversation(values: &[u8], channel_id: Uuid, epoch: &str) -> ExecutionDomain {
+        ExecutionDomain::new(
+            label(values),
+            DomainContext::Conversation {
+                realm: realm(),
+                channel_id,
+            },
+            MembershipEpoch::new(epoch),
+            CapabilitySet::from_names(["buzz.read.current"]),
+        )
+        .expect("same realm")
+    }
+
+    #[test]
+    fn reader_sets_obey_lattice_laws() {
+        let values = [
+            ReaderSet::Everyone,
+            ReaderSet::Only(readers(&[1])),
+            ReaderSet::Only(readers(&[2])),
+            ReaderSet::Only(readers(&[1, 2])),
+        ];
+
+        for a in &values {
+            assert_eq!(a.join(a), *a);
+            assert_eq!(a.meet(a), *a);
+            for b in &values {
+                assert_eq!(a.join(b), b.join(a));
+                assert_eq!(a.meet(b), b.meet(a));
+                assert_eq!(a.join(&a.meet(b)), *a);
+                assert_eq!(a.meet(&a.join(b)), *a);
+                for c in &values {
+                    assert_eq!(a.join(&b.join(c)), a.join(b).join(c));
+                    assert_eq!(a.meet(&b.meet(c)), a.meet(b).meet(c));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn combining_inputs_intersects_authorized_readers() {
+        let left = label(&[1, 2]);
+        let right = label(&[1, 3]);
+        let combined = left.join(&right).expect("same realm");
+
+        assert!(combined.can_flow_to(&label(&[1])));
+        assert!(!combined.can_flow_to(&label(&[1, 2])));
+    }
+
+    #[test]
+    fn labels_never_flow_across_realms() {
+        let first = ConfidentialityLabel::public(RealmId::from_relay_url("wss://one"));
+        let second = ConfidentialityLabel::public(RealmId::from_relay_url("wss://two"));
+
+        assert!(!first.can_flow_to(&second));
+        assert_eq!(first.join(&second), Err(LabelError::CrossRealm));
+    }
+
+    #[test]
+    fn read_requires_both_audience_and_context() {
+        let channel = Uuid::from_u128(1);
+        let domain = conversation(&[1, 2], channel, "v1");
+        let wrong_audience = ResourceLabel::conversation(realm(), channel, readers(&[1]))
+            .expect("non-empty readers");
+        let wrong_context =
+            ResourceLabel::conversation(realm(), Uuid::from_u128(2), readers(&[1, 2]))
+                .expect("non-empty readers");
+
+        assert!(!RuleEvaluator::read(&domain, &wrong_audience).allowed());
+        assert!(!RuleEvaluator::read(&domain, &wrong_context).allowed());
+        assert!(RuleEvaluator::read(&domain, &domain.resource_label()).allowed());
+    }
+
+    #[test]
+    fn owner_private_context_aggregates_only_owner_readable_conversations() {
+        let owner = principal(1);
+        let domain = ExecutionDomain::owner_private(
+            realm(),
+            owner,
+            MembershipEpoch::new("owner-v1"),
+            CapabilitySet::default(),
+        );
+        let readable = ResourceLabel::conversation(realm(), Uuid::from_u128(1), readers(&[1, 2]))
+            .expect("non-empty readers");
+        let unreadable = ResourceLabel::conversation(realm(), Uuid::from_u128(2), readers(&[2, 3]))
+            .expect("non-empty readers");
+
+        assert!(RuleEvaluator::read(&domain, &readable).allowed());
+        assert!(!RuleEvaluator::read(&domain, &unreadable).allowed());
+    }
+
+    #[test]
+    fn effective_capabilities_are_the_three_way_intersection() {
+        let bot = CapabilitySet::from_names(["buzz.read.current", "email.read", "drive.read"]);
+        let requester = CapabilitySet::from_names(["buzz.read.current", "email.read"]);
+        let domain = CapabilitySet::from_names(["buzz.read.current", "drive.read"]);
+
+        assert_eq!(
+            CapabilitySet::effective(&bot, &requester, &domain),
+            CapabilitySet::from_names(["buzz.read.current"])
+        );
+    }
+
+    #[test]
+    fn domain_derivation_grants_personal_tools_only_in_owner_private_work() {
+        let owner = principal(1);
+        let agent = principal(9);
+        let policy = CapabilityPolicy::new(
+            CapabilitySet::from_names(["buzz.read.current", "email.read"]),
+            CapabilitySet::from_names(["buzz.read.current"]),
+        );
+        let owner_dm = derive_execution_domain(
+            DomainFacts {
+                realm: realm(),
+                channel_id: Uuid::from_u128(1),
+                kind: ConversationKind::DirectMessage,
+                epoch: MembershipEpoch::new("membership:v1"),
+                members: BTreeSet::from([agent.clone(), owner.clone()]),
+                executing_agent: agent.clone(),
+                requesters: BTreeSet::from([owner.clone()]),
+                system_principal: None,
+                owner: Some(owner.clone()),
+            },
+            &policy,
+        )
+        .expect("owner DM domain");
+        assert!(owner_dm.context().is_owner_private_for(&owner));
+        assert!(owner_dm.capabilities().contains("email.read"));
+
+        let public = derive_execution_domain(
+            DomainFacts {
+                realm: realm(),
+                channel_id: Uuid::from_u128(2),
+                kind: ConversationKind::Public,
+                epoch: MembershipEpoch::new("community:v1"),
+                members: BTreeSet::new(),
+                executing_agent: agent,
+                requesters: BTreeSet::from([owner.clone()]),
+                system_principal: None,
+                owner: Some(owner),
+            },
+            &policy,
+        )
+        .expect("public domain");
+        assert!(!public.capabilities().contains("email.read"));
+    }
+
+    #[test]
+    fn restricted_domain_derivation_checks_agent_and_requester_membership() {
+        let owner = principal(1);
+        let agent = principal(9);
+        let outsider = principal(8);
+        let policy = CapabilityPolicy::new(
+            CapabilitySet::from_names(["buzz.read.current"]),
+            CapabilitySet::from_names(["buzz.read.current"]),
+        );
+        let facts = |members, requesters| DomainFacts {
+            realm: realm(),
+            channel_id: Uuid::from_u128(1),
+            kind: ConversationKind::Restricted,
+            epoch: MembershipEpoch::new("membership:v1"),
+            members,
+            executing_agent: agent.clone(),
+            requesters,
+            system_principal: None,
+            owner: Some(owner.clone()),
+        };
+
+        assert_eq!(
+            derive_execution_domain(
+                facts(
+                    BTreeSet::from([owner.clone()]),
+                    BTreeSet::from([owner.clone()]),
+                ),
+                &policy,
+            ),
+            Err(DerivationError::AgentNotMember)
+        );
+        assert_eq!(
+            derive_execution_domain(
+                facts(
+                    BTreeSet::from([owner.clone(), agent.clone()]),
+                    BTreeSet::from([outsider]),
+                ),
+                &policy,
+            ),
+            Err(DerivationError::RequesterNotMember)
+        );
+    }
+
+    #[test]
+    fn process_reuse_requires_the_complete_domain() {
+        let first = conversation(&[1, 2], Uuid::from_u128(1), "v1");
+        let same = first.clone();
+        let changed_epoch = conversation(&[1, 2], Uuid::from_u128(1), "v2");
+        let mut state = ProcessState::default();
+
+        assert!(state.enter(&first).allowed());
+        assert!(state.enter(&same).allowed());
+        assert!(!state.enter(&changed_epoch).allowed());
+        assert!(!state.enter(&first).allowed());
+        state.observe(&first.resource_label());
+        assert!(!state
+            .publish(&first, first.audience(), first.context(), &[1; 32], None)
+            .allowed());
+    }
+
+    #[test]
+    fn domain_id_has_a_canonical_golden_value() {
+        let domain = conversation(&[1, 2], Uuid::from_u128(1), "membership:event-1");
+        assert_eq!(
+            domain.id(),
+            "fbad5ec7aed0f274f9c517fed619cb41262c2295fb62451477a3df7caf1f3ef1"
+        );
+    }
+
+    #[test]
+    fn domain_shape_rejects_a_public_audience_for_a_private_context() {
+        let result = ExecutionDomain::new(
+            ConfidentialityLabel::public(realm()),
+            DomainContext::Conversation {
+                realm: realm(),
+                channel_id: Uuid::from_u128(1),
+            },
+            MembershipEpoch::new("v1"),
+            CapabilitySet::default(),
+        );
+
+        assert_eq!(result, Err(DomainError::AudienceContextMismatch));
+    }
+
+    #[test]
+    fn public_domain_ids_do_not_depend_on_the_triggering_channel() {
+        let first = ExecutionDomain::public(
+            realm(),
+            MembershipEpoch::new("community"),
+            CapabilitySet::from_names(["buzz.read.current"]),
+        );
+        let second = ExecutionDomain::public(
+            realm(),
+            MembershipEpoch::new("community"),
+            CapabilitySet::from_names(["buzz.read.current"]),
+        );
+
+        assert_eq!(first.id(), second.id());
+    }
+
+    #[test]
+    fn compartment_profile_is_asymmetric() {
+        let public = ExecutionDomain::public(
+            realm(),
+            MembershipEpoch::new("community"),
+            CapabilitySet::default(),
+        );
+        let restricted = conversation(&[1, 2], Uuid::from_u128(1), "membership:v1");
+        let owner_private = ExecutionDomain::owner_private(
+            realm(),
+            principal(1),
+            MembershipEpoch::new("owner:v1"),
+            CapabilitySet::default(),
+        );
+
+        assert_eq!(
+            public.compartment_profile(),
+            CompartmentProfile::SharedPublic
+        );
+        assert_eq!(
+            restricted.compartment_profile(),
+            CompartmentProfile::DomainConfined
+        );
+        assert_eq!(
+            owner_private.compartment_profile(),
+            CompartmentProfile::DomainConfined
+        );
+    }
+
+    #[test]
+    fn denied_input_still_taints_an_audit_only_process() {
+        let domain = conversation(&[1, 2], Uuid::from_u128(1), "v1");
+        let private = ResourceLabel::owner_private(realm(), principal(1));
+        assert!(!RuleEvaluator::read(&domain, &private).allowed());
+
+        let mut state = ProcessState::default();
+        state.enter(&domain);
+        state.observe(&domain.resource_label());
+        state.observe(&private);
+
+        assert!(!state
+            .publish(&domain, domain.audience(), domain.context(), &[7; 32], None,)
+            .allowed());
+    }
+
+    #[test]
+    fn ordinary_publication_stays_in_the_source_context() {
+        let domain = conversation(&[1, 2], Uuid::from_u128(1), "v1");
+        let other_context = DomainContext::Conversation {
+            realm: realm(),
+            channel_id: Uuid::from_u128(2),
+        };
+        let mut state = ProcessState::default();
+        state.enter(&domain);
+        state.observe(&domain.resource_label());
+
+        assert!(!state
+            .publish(&domain, domain.audience(), &other_context, &[7; 32], None)
+            .allowed());
+    }
+
+    #[test]
+    fn equal_reader_sets_do_not_hide_cross_context_input() {
+        let domain = conversation(&[1, 2], Uuid::from_u128(1), "v1");
+        let other = ResourceLabel::conversation(realm(), Uuid::from_u128(2), readers(&[1, 2]))
+            .expect("non-empty readers");
+        let mut state = ProcessState::default();
+        state.enter(&domain);
+        state.observe(&domain.resource_label());
+        state.observe(&other);
+
+        assert!(!state
+            .publish(&domain, domain.audience(), domain.context(), &[7; 32], None)
+            .allowed());
+    }
+
+    struct AlwaysValid;
+
+    impl GrantSignatureVerifier for AlwaysValid {
+        fn verifies(&self, _grant: &DeclassificationGrant<PendingGrant>) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn declassification_is_owner_verified_and_exact() {
+        let owner = principal(1);
+        let domain = conversation(&[1], Uuid::from_u128(1), "v1");
+        let destination = ConfidentialityLabel::public(realm());
+        let destination_context = DomainContext::RealmPublic(realm());
+        let content = [9; 32];
+        let grant = DeclassificationGrant::pending(
+            owner.clone(),
+            domain.id(),
+            destination.clone(),
+            destination_context.clone(),
+            content,
+        )
+        .verify(&owner, &AlwaysValid)
+        .expect("owner-authenticated grant");
+        let mut state = ProcessState::default();
+        state.enter(&domain);
+        state.observe(&domain.resource_label());
+
+        assert!(state
+            .publish(
+                &domain,
+                &destination,
+                &destination_context,
+                &content,
+                Some(&grant),
+            )
+            .allowed());
+        assert!(!state
+            .publish(
+                &domain,
+                &destination,
+                &destination_context,
+                &[8; 32],
+                Some(&grant),
+            )
+            .allowed());
+        state.mark_unknown();
+        assert!(!state
+            .publish(
+                &domain,
+                &destination,
+                &destination_context,
+                &content,
+                Some(&grant),
+            )
+            .allowed());
+    }
+
+    #[test]
+    fn unknown_input_prevents_publication() {
+        let domain = conversation(&[1, 2], Uuid::from_u128(1), "v1");
+        let mut state = ProcessState::default();
+        state.enter(&domain);
+        state.observe(&domain.resource_label());
+        state.mark_unknown();
+
+        assert!(!state
+            .publish(&domain, domain.audience(), domain.context(), &[7; 32], None,)
+            .allowed());
+    }
+}

--- a/crates/buzz-ifc/src/policy.rs
+++ b/crates/buzz-ifc/src/policy.rs
@@ -1,0 +1,210 @@
+use std::collections::BTreeSet;
+
+use serde::Serialize;
+
+use crate::declassification::{DeclassificationGrant, VerifiedGrant};
+use crate::domain::{DomainContext, ExecutionDomain, ResourceContext, ResourceLabel};
+use crate::label::{ConfidentialityLabel, LabelError};
+
+/// The result of evaluating one IFC rule.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RuleDecision {
+    allowed: bool,
+    reason: &'static str,
+}
+
+impl RuleDecision {
+    fn allow(reason: &'static str) -> Self {
+        Self {
+            allowed: true,
+            reason,
+        }
+    }
+
+    fn deny(reason: &'static str) -> Self {
+        Self {
+            allowed: false,
+            reason,
+        }
+    }
+
+    /// Whether the operation is admitted by policy.
+    pub fn allowed(&self) -> bool {
+        self.allowed
+    }
+
+    /// Stable explanation intended for logs and operator diagnostics.
+    pub fn reason(&self) -> &'static str {
+        self.reason
+    }
+
+    /// Return `allow` or `deny` for structured logs.
+    pub fn result(&self) -> &'static str {
+        if self.allowed {
+            "allow"
+        } else {
+            "deny"
+        }
+    }
+}
+
+/// Pure IFC rule evaluation.
+pub struct RuleEvaluator;
+
+impl RuleEvaluator {
+    /// Evaluate `read(D, x) ⇔ A(D) ⊆ R(x) ∧ ContextPolicy(D, x)`.
+    pub fn read(domain: &ExecutionDomain, resource: &ResourceLabel) -> RuleDecision {
+        if !resource.confidentiality.can_flow_to(&domain.audience) {
+            return RuleDecision::deny("destination audience includes an unauthorized reader");
+        }
+        if !domain.context.permits(&resource.context) {
+            return RuleDecision::deny("resource belongs to a different context");
+        }
+        RuleDecision::allow("audience and context both permit the read")
+    }
+
+    /// Evaluate `call(D, op) ⇔ op ∈ C(D)`.
+    pub fn call(domain: &ExecutionDomain, operation: &str) -> RuleDecision {
+        if domain.capabilities.contains(operation) {
+            RuleDecision::allow("operation is in the effective capability set")
+        } else {
+            RuleDecision::deny("operation is absent from the effective capability set")
+        }
+    }
+
+    /// Require every component of the execution domain to match for reuse.
+    pub fn reuse(existing: &ExecutionDomain, requested: &ExecutionDomain) -> RuleDecision {
+        if existing == requested {
+            RuleDecision::allow("complete execution domain matches")
+        } else {
+            RuleDecision::deny("agent process has already entered a different domain")
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct ConfinementState {
+    label: Option<ConfidentialityLabel>,
+    contexts: BTreeSet<ResourceContext>,
+    unknown_input: bool,
+    cross_realm: bool,
+}
+
+impl ConfinementState {
+    fn observe(&mut self, resource: &ResourceLabel) {
+        self.contexts.insert(resource.context.clone());
+        self.label = match self.label.take() {
+            None => Some(resource.confidentiality.clone()),
+            Some(existing) => match existing.join(&resource.confidentiality) {
+                Ok(combined) => Some(combined),
+                Err(LabelError::CrossRealm) => {
+                    self.cross_realm = true;
+                    Some(existing)
+                }
+                Err(LabelError::EmptyReaderSet) => Some(existing),
+            },
+        };
+    }
+}
+
+/// Conservative policy state for one actual agent process.
+///
+/// Paper: "Confinement invariant." The accumulated label and observed contexts
+/// cover every input that actually entered the process.
+///
+/// This state intentionally survives model-session invalidation. A new session
+/// does not make the surrounding process forget information it has observed.
+#[derive(Clone, Debug, Default)]
+pub struct ProcessState {
+    entered_domains: Vec<ExecutionDomain>,
+    confinement: ConfinementState,
+}
+
+impl ProcessState {
+    /// Record entry into a domain and decide whether this process is reusable.
+    pub fn enter(&mut self, requested: &ExecutionDomain) -> RuleDecision {
+        let decision = match self.entered_domains.as_slice() {
+            [] => RuleDecision::allow("fresh process has no prior execution domain"),
+            [existing] => RuleEvaluator::reuse(existing, requested),
+            _ => RuleDecision::deny("agent process has entered multiple execution domains"),
+        };
+        if !self
+            .entered_domains
+            .iter()
+            .any(|domain| domain == requested)
+        {
+            self.entered_domains.push(requested.clone());
+        }
+        decision
+    }
+
+    /// Record an input that actually entered the process.
+    pub fn observe(&mut self, resource: &ResourceLabel) {
+        self.confinement.observe(resource);
+    }
+
+    /// Record input whose provenance could not be established.
+    pub fn mark_unknown(&mut self) {
+        self.confinement.unknown_input = true;
+    }
+
+    /// Return how many distinct domains have entered this process.
+    pub fn entered_domain_count(&self) -> usize {
+        self.entered_domains.len()
+    }
+
+    /// Paper: "Confinement invariant" and "Declassification." Evaluate
+    /// publication under the process's accumulated label.
+    pub fn publish(
+        &self,
+        source_domain: &ExecutionDomain,
+        destination: &ConfidentialityLabel,
+        destination_context: &DomainContext,
+        content_digest: &[u8; 32],
+        grant: Option<&DeclassificationGrant<VerifiedGrant>>,
+    ) -> RuleDecision {
+        if self.entered_domains.len() != 1 || self.entered_domains.first() != Some(source_domain) {
+            return RuleDecision::deny(
+                "process state is not confined to the claimed source domain",
+            );
+        }
+        if self.confinement.unknown_input || self.confinement.cross_realm {
+            return RuleDecision::deny("process state contains unresolved input provenance");
+        }
+        if self
+            .confinement
+            .contexts
+            .iter()
+            .any(|context| !source_domain.context.permits(context))
+        {
+            return RuleDecision::deny("process state contains input from another context");
+        }
+        if grant.is_some_and(|grant| {
+            grant.matches(
+                &source_domain.id(),
+                destination,
+                destination_context,
+                content_digest,
+            )
+        }) {
+            return RuleDecision::allow("exact owner-authorized declassification grant matches");
+        }
+        if &source_domain.context != destination_context {
+            return RuleDecision::deny(
+                "publishing to a different context requires declassification",
+            );
+        }
+        if !source_domain.audience.can_flow_to(destination) {
+            return RuleDecision::deny("destination is broader than the execution domain");
+        }
+        if self
+            .confinement
+            .label
+            .as_ref()
+            .is_some_and(|label| label.can_flow_to(destination))
+        {
+            return RuleDecision::allow("destination is no broader than accumulated state");
+        }
+        RuleDecision::deny("output would widen the accumulated reader set")
+    }
+}


### PR DESCRIPTION
Extracts the deterministic label, domain, capability, publication, declassification, and process-reuse rules from `buzz-acp` into the zero-I/O `buzz-ifc` crate. The ACP harness remains responsible for verifying Buzz events and membership and for acting on the resulting policy decisions.

This layer also makes worker placement explicit. Public channels in one community use `shared_public` and may reuse the same public-bound pool. Restricted channels, DMs, group DMs, and owner-private work use `domain_confined` and require an exact domain match. The experimental enforcement mode is named `route`; `isolate` remains accepted as a compatibility alias.

The behavior remains off by default. `domain_confined` is a placement requirement for a future launcher or sandbox, not a claim that this PR provides OS confinement.

Testing:

- `cargo test -p buzz-ifc -p buzz-acp` (828 tests)
- `cargo clippy -p buzz-ifc -p buzz-acp --all-targets -- -D warnings`

Stack:

1. #6273: audit-only IFC evaluation
2. #6274: exact-domain ACP worker routing
3. **#6275: reusable policy and worker placement**
4. #6176: external harness broker
