### PR TITLE
Surface waits and prioritize Workstream Board cards

### DIFF
--- a/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.test.mjs
+++ b/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.test.mjs
@@ -236,6 +236,51 @@ test("workstream status hook preserves a synchronous live callback", async () =>
   cleanup();
 });
 
+test("workstream status hook keeps subscriptions stable across equivalent rerenders", async () => {
+  const { act, cleanup, renderHook } = await import("@testing-library/react");
+  const { useWorkstreamPullRequestStatuses } = await import(
+    "./workstreamPullRequestStatus.ts"
+  );
+  const reference = parseWorkstreamPullRequestReference(
+    "https://github.com/block/buzz/pull/42",
+  );
+  let subscribes = 0;
+  let unsubscribes = 0;
+  const registry = {
+    subscribe: (_reference, listener) => {
+      subscribes += 1;
+      listener({ status: "loading" });
+      return () => {
+        unsubscribes += 1;
+      };
+    },
+  };
+  const { rerender, unmount } = renderHook(
+    ({ refs }) => useWorkstreamPullRequestStatuses(refs, registry),
+    { initialProps: { refs: [reference] } },
+  );
+
+  await act(async () => {
+    rerender({ refs: [{ ...reference }] });
+    rerender({ refs: [{ ...reference }] });
+  });
+  assert.equal(subscribes, 1);
+  assert.equal(unsubscribes, 0);
+
+  const replacement = parseWorkstreamPullRequestReference(
+    "https://github.com/block/buzz/pull/43",
+  );
+  await act(async () => {
+    rerender({ refs: [replacement] });
+  });
+  assert.equal(subscribes, 2);
+  assert.equal(unsubscribes, 1);
+
+  unmount();
+  assert.equal(unsubscribes, 2);
+  cleanup();
+});
+
 test("workstream status hook removes stale references and preserves unsupported state", async () => {
   const { act, cleanup, renderHook } = await import("@testing-library/react");
   const { useWorkstreamPullRequestStatuses } = await import(

--- a/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.ts
+++ b/desktop/src/features/workstream-board/lib/workstreamPullRequestStatus.ts
@@ -519,11 +519,26 @@ export function useWorkstreamPullRequestStatuses(
   const [states, setStates] = React.useState<
     ReadonlyMap<string, WorkstreamPullRequestDisplayState>
   >(() => new Map());
-  const referencesByIdentity = React.useMemo(() => {
+  // Cards rebuild parsed references on every render. Subscribe by their
+  // semantic identity instead of that transient array/object identity so a
+  // synchronous registry listener cannot cause an effect resubscribe loop.
+  const referenceIdentityKey = references
+    .map((reference) => reference.identity)
+    .sort()
+    .join("\u0000");
+  const referencesByIdentityRef = React.useRef<{
+    identityKey: string;
+    references: ReadonlyMap<string, WorkstreamPullRequestReference>;
+  } | null>(null);
+  if (referencesByIdentityRef.current?.identityKey !== referenceIdentityKey) {
     const next = new Map<string, WorkstreamPullRequestReference>();
     for (const reference of references) next.set(reference.identity, reference);
-    return next;
-  }, [references]);
+    referencesByIdentityRef.current = {
+      identityKey: referenceIdentityKey,
+      references: next,
+    };
+  }
+  const referencesByIdentity = referencesByIdentityRef.current.references;
 
   React.useEffect(() => {
     const initial = new Map<string, WorkstreamPullRequestDisplayState>();

--- a/desktop/src/features/workstream-board/lib/workstreamWaits.test.mjs
+++ b/desktop/src/features/workstream-board/lib/workstreamWaits.test.mjs
@@ -202,3 +202,24 @@ test("derived reviewer waits cover all unapproved open review states and exclude
   ]);
   assert.equal(deriveReviewerWaits([reference], approved).length, 0);
 });
+
+test("manual wording overlays an identical derived PR key while a deleted manual wait leaves the derived wait", () => {
+  const derived = [
+    {
+      key: "github:block/buzz#4",
+      actor: { kind: "team", name: "Reviewers" },
+      reason: "Review requested",
+      source: "derived",
+    },
+  ];
+  const manual = [
+    {
+      key: "github:block/buzz#4",
+      actor: { kind: "team", name: "Release reviewers" },
+      reason: "Please review release notes",
+      source: "manual",
+    },
+  ];
+  assert.deepEqual(mergeWorkstreamWaits(manual, derived), manual);
+  assert.deepEqual(mergeWorkstreamWaits([], derived), derived);
+});

--- a/desktop/src/features/workstream-board/lib/workstreamWaits.test.mjs
+++ b/desktop/src/features/workstream-board/lib/workstreamWaits.test.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  deriveReviewerWaits,
+  mergeWorkstreamWaits,
+  parseManualWorkstreamWaits,
+  sortWorkstreamCards,
+} from "./workstreamWaits.ts";
+
+const LOGAN = "a".repeat(64);
+
+test("manual waits retain simultaneous unique entries and ignore malformed or duplicate keys", () => {
+  assert.deepEqual(
+    parseManualWorkstreamWaits([
+      {
+        key: "log",
+        actor: { kind: "person", pubkey: LOGAN, name: "Logan" },
+        reason: "Decision",
+      },
+      {
+        key: "review",
+        actor: { kind: "team", name: "Reviewers" },
+        reason: "Review",
+      },
+      {
+        key: "review",
+        actor: { kind: "team", name: "Duplicate" },
+        reason: "Ignored",
+      },
+      { key: "bad", actor: { kind: "person", name: "" }, reason: "Invalid" },
+    ]).map((wait) => wait.key),
+    ["log", "review"],
+  );
+});
+
+test("an open unapproved PR derives a wait which manual deletion cannot clear", () => {
+  const reference = {
+    kind: "github",
+    identity: "github:block/buzz#1",
+    rawUrl: "https://github.com/block/buzz/pull/1",
+    href: "https://github.com/block/buzz/pull/1",
+    owner: "block",
+    repository: "buzz",
+    number: 1,
+  };
+  const states = new Map([
+    [
+      reference.identity,
+      {
+        status: "live",
+        provider: "github",
+        href: reference.href,
+        repository: "block/buzz",
+        number: 1,
+        title: "One",
+        lifecycle: "open",
+        reviewState: "review-requested",
+      },
+    ],
+  ]);
+  const derived = deriveReviewerWaits([reference], states);
+  assert.equal(mergeWorkstreamWaits([], derived).length, 1);
+  states.set(reference.identity, {
+    ...states.get(reference.identity),
+    lifecycle: "merged",
+  });
+  assert.equal(deriveReviewerWaits([reference], states).length, 0);
+});
+
+test("sorting authenticates the current owner by pubkey and remains stable across elapsed ticks", () => {
+  const cards = [
+    {
+      channelId: "lookalike",
+      channelName: "alpha",
+      createdAt: "2026-08-18T02:00:00Z",
+      waits: [
+        {
+          key: "name",
+          actor: { kind: "person", name: "Logan" },
+          reason: "Name only",
+          source: "manual",
+        },
+      ],
+    },
+    {
+      channelId: "active",
+      channelName: "beta",
+      createdAt: "2026-08-18T03:00:00Z",
+      waits: [],
+      activeWorking: {
+        channelId: "active",
+        agentCount: 1,
+        agentPubkeys: ["b"],
+        anchorAt: 1,
+      },
+    },
+    {
+      channelId: "owner",
+      channelName: "zeta",
+      createdAt: "2026-08-18T04:00:00Z",
+      waits: [
+        {
+          key: "owner",
+          actor: {
+            kind: "person",
+            name: "Not Logan",
+            pubkey: LOGAN.toUpperCase(),
+          },
+          reason: "Decision",
+          source: "manual",
+        },
+      ],
+    },
+  ];
+  const ordered = sortWorkstreamCards(cards, LOGAN).map(
+    (card) => card.channelId,
+  );
+  assert.deepEqual(ordered, ["owner", "active", "lookalike"]);
+  assert.deepEqual(
+    sortWorkstreamCards(
+      cards.map((card) => ({
+        ...card,
+        activeWorking: card.activeWorking
+          ? { ...card.activeWorking, anchorAt: 999999 }
+          : undefined,
+      })),
+      LOGAN,
+    ).map((card) => card.channelId),
+    ordered,
+  );
+});

--- a/desktop/src/features/workstream-board/lib/workstreamWaits.test.mjs
+++ b/desktop/src/features/workstream-board/lib/workstreamWaits.test.mjs
@@ -130,3 +130,75 @@ test("sorting authenticates the current owner by pubkey and remains stable acros
     ordered,
   );
 });
+
+test("derived reviewer waits cover all unapproved open review states and exclude approved or terminal states", () => {
+  const reference = {
+    kind: "github",
+    identity: "github:block/buzz#2",
+    rawUrl: "https://github.com/block/buzz/pull/2",
+    href: "https://github.com/block/buzz/pull/2",
+    owner: "block",
+    repository: "buzz",
+    number: 2,
+  };
+  for (const reviewState of [
+    "no-reviews",
+    "review-requested",
+    "changes-requested",
+  ]) {
+    const states = new Map([
+      [
+        reference.identity,
+        {
+          status: "live",
+          provider: "github",
+          href: reference.href,
+          repository: "block/buzz",
+          number: 2,
+          title: "Two",
+          lifecycle: "open",
+          reviewState,
+        },
+      ],
+    ]);
+    assert.equal(
+      deriveReviewerWaits([reference], states).length,
+      1,
+      reviewState,
+    );
+  }
+  for (const lifecycle of ["draft", "merged", "closed"]) {
+    const states = new Map([
+      [
+        reference.identity,
+        {
+          status: "live",
+          provider: "github",
+          href: reference.href,
+          repository: "block/buzz",
+          number: 2,
+          title: "Two",
+          lifecycle,
+          reviewState: "review-requested",
+        },
+      ],
+    ]);
+    assert.equal(deriveReviewerWaits([reference], states).length, 0, lifecycle);
+  }
+  const approved = new Map([
+    [
+      reference.identity,
+      {
+        status: "live",
+        provider: "github",
+        href: reference.href,
+        repository: "block/buzz",
+        number: 2,
+        title: "Two",
+        lifecycle: "open",
+        reviewState: "approved",
+      },
+    ],
+  ]);
+  assert.equal(deriveReviewerWaits([reference], approved).length, 0);
+});

--- a/desktop/src/features/workstream-board/lib/workstreamWaits.ts
+++ b/desktop/src/features/workstream-board/lib/workstreamWaits.ts
@@ -1,0 +1,167 @@
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
+import type { WorkstreamCardV1 } from "@/features/workstream-board/lib/workstreamCardParser";
+import type {
+  WorkstreamPullRequestDisplayState,
+  WorkstreamPullRequestReference,
+} from "@/features/workstream-board/lib/workstreamPullRequestStatus";
+
+export type WorkstreamWaitActor = {
+  kind: "person" | "agent" | "team";
+  name: string;
+  pubkey?: string;
+};
+
+export type WorkstreamWait = {
+  key: string;
+  actor: WorkstreamWaitActor;
+  reason: string;
+  since?: string;
+  source: "manual" | "derived";
+};
+
+export type WorkstreamCardSortInput = {
+  channelId: string;
+  channelName: string;
+  createdAt: string | null | undefined;
+  waits: readonly WorkstreamWait[];
+  activeWorking?: ActiveChannelTurnSummary;
+};
+
+export function isWorkstreamWait(
+  value: unknown,
+): value is Omit<WorkstreamWait, "source"> {
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    return false;
+  const wait = value as Record<string, unknown>;
+  if (
+    typeof wait.key !== "string" ||
+    !wait.key.trim() ||
+    typeof wait.reason !== "string" ||
+    !wait.reason.trim()
+  )
+    return false;
+  if (
+    typeof wait.actor !== "object" ||
+    wait.actor === null ||
+    Array.isArray(wait.actor)
+  )
+    return false;
+  const actor = wait.actor as Record<string, unknown>;
+  if (
+    actor.kind !== "person" &&
+    actor.kind !== "agent" &&
+    actor.kind !== "team"
+  )
+    return false;
+  if (typeof actor.name !== "string" || !actor.name.trim()) return false;
+  return (
+    actor.pubkey === undefined ||
+    (typeof actor.pubkey === "string" && !!actor.pubkey.trim())
+  );
+}
+
+export function parseManualWorkstreamWaits(
+  values: readonly unknown[],
+): WorkstreamWait[] {
+  const waits: WorkstreamWait[] = [];
+  const keys = new Set<string>();
+  for (const value of values) {
+    if (!isWorkstreamWait(value) || keys.has(value.key)) continue;
+    keys.add(value.key);
+    waits.push({ ...value, actor: { ...value.actor }, source: "manual" });
+  }
+  return waits;
+}
+
+function needsReviewerWait(
+  state: WorkstreamPullRequestDisplayState | undefined,
+): state is Extract<WorkstreamPullRequestDisplayState, { status: "live" }> {
+  return (
+    state?.status === "live" &&
+    state.lifecycle === "open" &&
+    state.reviewState !== "approved"
+  );
+}
+
+export function deriveReviewerWaits(
+  references: readonly WorkstreamPullRequestReference[],
+  states: ReadonlyMap<string, WorkstreamPullRequestDisplayState>,
+): WorkstreamWait[] {
+  return references.flatMap((reference) => {
+    const state = states.get(reference.identity);
+    if (!needsReviewerWait(state)) return [];
+    return [
+      {
+        key: reference.identity,
+        actor: { kind: "team", name: "Reviewers" },
+        reason: `Review requested for ${state.repository}${state.number ? ` #${state.number}` : ""}`,
+        source: "derived" as const,
+      },
+    ];
+  });
+}
+
+/** Manual wording wins for an intentionally matching derived PR key. */
+export function mergeWorkstreamWaits(
+  manual: readonly WorkstreamWait[],
+  derived: readonly WorkstreamWait[],
+): WorkstreamWait[] {
+  const merged = new Map<string, WorkstreamWait>();
+  for (const wait of derived) merged.set(wait.key, wait);
+  for (const wait of manual) merged.set(wait.key, wait);
+  return [...merged.values()];
+}
+
+function isCurrentOwnerWait(
+  wait: WorkstreamWait,
+  currentOwnerPubkey?: string | null,
+): boolean {
+  return (
+    !!currentOwnerPubkey &&
+    !!wait.actor.pubkey &&
+    normalizePubkey(wait.actor.pubkey) === normalizePubkey(currentOwnerPubkey)
+  );
+}
+
+function createdAtMillis(value: string | null | undefined): number {
+  const parsed = value ? Date.parse(value) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : Number.MAX_SAFE_INTEGER;
+}
+
+/** Stable board priority: current owner wait, active work, creation time, then name and ID. */
+export function sortWorkstreamCards<T extends WorkstreamCardSortInput>(
+  cards: readonly T[],
+  currentOwnerPubkey?: string | null,
+): T[] {
+  return [...cards].sort((left, right) => {
+    const leftOwner = left.waits.some((wait) =>
+      isCurrentOwnerWait(wait, currentOwnerPubkey),
+    );
+    const rightOwner = right.waits.some((wait) =>
+      isCurrentOwnerWait(wait, currentOwnerPubkey),
+    );
+    if (leftOwner !== rightOwner) return leftOwner ? -1 : 1;
+    const leftActive = Boolean(left.activeWorking);
+    const rightActive = Boolean(right.activeWorking);
+    if (leftActive !== rightActive) return leftActive ? -1 : 1;
+    const creationDelta =
+      createdAtMillis(left.createdAt) - createdAtMillis(right.createdAt);
+    if (creationDelta !== 0) return creationDelta;
+    const nameDelta = left.channelName.localeCompare(right.channelName);
+    return nameDelta !== 0
+      ? nameDelta
+      : left.channelId.localeCompare(right.channelId);
+  });
+}
+
+export function waitsForCard(
+  card: WorkstreamCardV1,
+  references: readonly WorkstreamPullRequestReference[],
+  states: ReadonlyMap<string, WorkstreamPullRequestDisplayState>,
+): WorkstreamWait[] {
+  return mergeWorkstreamWaits(
+    parseManualWorkstreamWaits(card.waitingOn),
+    deriveReviewerWaits(references, states),
+  );
+}

--- a/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
@@ -6,18 +6,37 @@ import { useChannelsQuery } from "@/features/channels/hooks";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { filterWorkstreamChannels } from "@/features/workstream-board/lib/discoverWorkstreamChannels";
 import { getActiveWorkstreamTurns } from "@/features/workstream-board/lib/activeWorkstreamTurns";
+import {
+  sortWorkstreamCards,
+  type WorkstreamWait,
+} from "@/features/workstream-board/lib/workstreamWaits";
 import { WorkstreamCard } from "@/features/workstream-board/ui/WorkstreamCard";
+import { useIdentityQuery } from "@/shared/api/hooks";
 import { Button } from "@/shared/ui/button";
 import { PageHeader } from "@/shared/ui/PageHeader";
 
 const WORKSTREAM_CARD_GRID_CLASS =
   "grid grid-cols-1 gap-3 [@container(min-width:38rem)]:grid-cols-2 [@container(min-width:54rem)]:grid-cols-3";
+type CardMetadata = {
+  waits: readonly WorkstreamWait[];
+  createdAt: string | null | undefined;
+};
+
+function sameMetadata(
+  left: CardMetadata | undefined,
+  right: CardMetadata,
+): boolean {
+  return (
+    left?.createdAt === right.createdAt &&
+    JSON.stringify(left?.waits) === JSON.stringify(right.waits)
+  );
+}
 
 export function WorkstreamBoardScreen() {
   const { goChannel } = useAppNavigation();
+  const identityQuery = useIdentityQuery();
   const channelsQuery = useChannelsQuery();
-  const channels = channelsQuery.data ?? [];
-  const workstreamChannels = filterWorkstreamChannels(channels);
+  const workstreamChannels = filterWorkstreamChannels(channelsQuery.data ?? []);
   const activeTurnsByChannel = useActiveAgentTurnsByChannel();
   const activeWorkstreamTurns = React.useMemo(
     () => getActiveWorkstreamTurns(workstreamChannels, activeTurnsByChannel),
@@ -32,7 +51,45 @@ export function WorkstreamBoardScreen() {
     [activeWorkstreamTurns],
   );
   const activeProfilesQuery = useUsersBatchQuery(activeAgentPubkeys);
-  const activeProfiles = activeProfilesQuery.data?.profiles;
+  const [metadataByChannel, setMetadataByChannel] = React.useState<
+    ReadonlyMap<string, CardMetadata>
+  >(() => new Map());
+  const onWaitsChange = React.useCallback(
+    (
+      channelId: string,
+      waits: readonly WorkstreamWait[],
+      createdAt: string | null | undefined,
+    ) => {
+      const next = { waits, createdAt };
+      setMetadataByChannel((current) => {
+        if (sameMetadata(current.get(channelId), next)) return current;
+        const updated = new Map(current);
+        updated.set(channelId, next);
+        return updated;
+      });
+    },
+    [],
+  );
+  const sortedChannels = React.useMemo(
+    () =>
+      sortWorkstreamCards(
+        workstreamChannels.map((channel) => ({
+          channelId: channel.id,
+          channelName: channel.name,
+          createdAt: metadataByChannel.get(channel.id)?.createdAt,
+          waits: metadataByChannel.get(channel.id)?.waits ?? [],
+          activeWorking: activeTurnsByChannelId.get(channel.id),
+          channel,
+        })),
+        identityQuery.data?.pubkey,
+      ).map((entry) => entry.channel),
+    [
+      activeTurnsByChannelId,
+      identityQuery.data?.pubkey,
+      metadataByChannel,
+      workstreamChannels,
+    ],
+  );
 
   return (
     <div
@@ -48,7 +105,6 @@ export function WorkstreamBoardScreen() {
             description="Live canvases for active workstream channels."
             title="Workstream Board"
           />
-
           {channelsQuery.isLoading ? (
             <p className="text-sm text-muted-foreground">
               Loading workstreams…
@@ -64,20 +120,23 @@ export function WorkstreamBoardScreen() {
                 Retry
               </Button>
             </div>
-          ) : workstreamChannels.length === 0 ? (
+          ) : sortedChannels.length === 0 ? (
             <p className="text-sm text-muted-foreground">
               No workstream channels found. Channels named "loganj-ws-…" will
               appear here.
             </p>
           ) : (
             <div className={WORKSTREAM_CARD_GRID_CLASS}>
-              {workstreamChannels.map((channel) => (
+              {sortedChannels.map((channel) => (
                 <WorkstreamCard
                   activeWorking={activeTurnsByChannelId.get(channel.id)}
                   channel={channel}
                   key={channel.id}
-                  profiles={activeProfiles}
                   onSelect={(channelId) => void goChannel(channelId)}
+                  onWaitsChange={(waits, createdAt) =>
+                    onWaitsChange(channel.id, waits, createdAt)
+                  }
+                  profiles={activeProfilesQuery.data?.profiles}
                 />
               ))}
             </div>

--- a/desktop/src/features/workstream-board/ui/WorkstreamCard.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamCard.tsx
@@ -2,11 +2,22 @@ import * as React from "react";
 import { Hash } from "lucide-react";
 
 import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
-import { useCanvasQuery } from "@/features/channels/hooks";
+import {
+  useCanvasQuery,
+  useChannelDetailsQuery,
+} from "@/features/channels/hooks";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
-import { parseWorkstreamPullRequestReferences } from "@/features/workstream-board/lib/workstreamPullRequestStatus";
+import {
+  parseWorkstreamPullRequestReferences,
+  useWorkstreamPullRequestStatuses,
+} from "@/features/workstream-board/lib/workstreamPullRequestStatus";
+import {
+  waitsForCard,
+  type WorkstreamWait,
+} from "@/features/workstream-board/lib/workstreamWaits";
 import { buildWorkstreamCardViewModel } from "@/features/workstream-board/lib/workstreamCardViewModel";
 import { WorkstreamPullRequests } from "@/features/workstream-board/ui/WorkstreamPullRequests";
+import { WorkstreamWaits } from "@/features/workstream-board/ui/WorkstreamWaits";
 import { WorkstreamWorkingIndicator } from "@/features/workstream-board/ui/WorkstreamWorkingIndicator";
 import type { Channel } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
@@ -15,6 +26,10 @@ type WorkstreamCardProps = {
   activeWorking?: ActiveChannelTurnSummary;
   channel: Channel;
   profiles?: UserProfileLookup;
+  onWaitsChange?: (
+    waits: readonly WorkstreamWait[],
+    createdAt: string | null | undefined,
+  ) => void;
   onSelect: (channelId: string) => void;
 };
 
@@ -22,9 +37,11 @@ export function WorkstreamCard({
   activeWorking,
   channel,
   onSelect,
+  onWaitsChange,
   profiles,
 }: WorkstreamCardProps) {
   const canvasQuery = useCanvasQuery(channel.id);
+  const detailsQuery = useChannelDetailsQuery(channel.id);
   const viewModel = buildWorkstreamCardViewModel({
     canvasContent: canvasQuery.data?.content,
     isLoading: canvasQuery.isLoading,
@@ -37,6 +54,17 @@ export function WorkstreamCard({
         : [],
     [viewModel],
   );
+  const pullRequestStates = useWorkstreamPullRequestStatuses(references);
+  const waits = React.useMemo(
+    () =>
+      viewModel.status === "ready"
+        ? waitsForCard(viewModel.card, references, pullRequestStates)
+        : [],
+    [pullRequestStates, references, viewModel],
+  );
+  React.useEffect(() => {
+    onWaitsChange?.(waits, detailsQuery.data?.createdAt);
+  }, [detailsQuery.data?.createdAt, onWaitsChange, waits]);
 
   return (
     <div
@@ -52,13 +80,11 @@ export function WorkstreamCard({
       >
         <span className="sr-only">Open #{channel.name}</span>
       </button>
-
       <div className="pointer-events-none relative z-10 flex h-full min-h-40 flex-col">
         <div className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground">
           <Hash className="h-3.5 w-3.5 shrink-0" />
           <span className="truncate">{channel.name}</span>
         </div>
-
         {viewModel.status === "ready" ? (
           <>
             <p className="mt-3 line-clamp-3 text-sm leading-relaxed text-foreground">
@@ -84,8 +110,12 @@ export function WorkstreamCard({
                 </div>
               ) : null}
               {references.length > 0 ? (
-                <WorkstreamPullRequests references={references} />
+                <WorkstreamPullRequests
+                  references={references}
+                  states={pullRequestStates}
+                />
               ) : null}
+              <WorkstreamWaits waits={waits} />
             </div>
           </>
         ) : viewModel.status === "loading" ? (

--- a/desktop/src/features/workstream-board/ui/WorkstreamPullRequests.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamPullRequests.tsx
@@ -42,10 +42,13 @@ function referenceLabel(reference: WorkstreamPullRequestReference) {
 
 export function WorkstreamPullRequests({
   references,
+  states: providedStates,
 }: {
   references: readonly WorkstreamPullRequestReference[];
+  states?: ReadonlyMap<string, WorkstreamPullRequestDisplayState>;
 }) {
-  const states = useWorkstreamPullRequestStatuses(references);
+  const queriedStates = useWorkstreamPullRequestStatuses(references);
+  const states = providedStates ?? queriedStates;
   const openEntityLink = useOpenEntityLink();
 
   return (

--- a/desktop/src/features/workstream-board/ui/WorkstreamPullRequests.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamPullRequests.tsx
@@ -3,10 +3,9 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 
 import { parseEntityLink } from "@/shared/lib/entityLink";
 import { useOpenEntityLink } from "@/shared/ui/markdown/entityLinks";
-import {
-  type WorkstreamPullRequestDisplayState,
-  type WorkstreamPullRequestReference,
-  useWorkstreamPullRequestStatuses,
+import type {
+  WorkstreamPullRequestDisplayState,
+  WorkstreamPullRequestReference,
 } from "@/features/workstream-board/lib/workstreamPullRequestStatus";
 
 function lifecycleLabel(
@@ -42,13 +41,11 @@ function referenceLabel(reference: WorkstreamPullRequestReference) {
 
 export function WorkstreamPullRequests({
   references,
-  states: providedStates,
+  states,
 }: {
   references: readonly WorkstreamPullRequestReference[];
-  states?: ReadonlyMap<string, WorkstreamPullRequestDisplayState>;
+  states: ReadonlyMap<string, WorkstreamPullRequestDisplayState>;
 }) {
-  const queriedStates = useWorkstreamPullRequestStatuses(references);
-  const states = providedStates ?? queriedStates;
   const openEntityLink = useOpenEntityLink();
 
   return (

--- a/desktop/src/features/workstream-board/ui/WorkstreamWaits.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamWaits.tsx
@@ -1,0 +1,32 @@
+import type { WorkstreamWait } from "@/features/workstream-board/lib/workstreamWaits";
+export function WorkstreamWaits({
+  waits,
+}: {
+  waits: readonly WorkstreamWait[];
+}) {
+  if (waits.length === 0) return null;
+  return (
+    <section
+      aria-label="Waiting on"
+      className="pointer-events-auto mt-4 space-y-1.5"
+      data-testid="workstream-waits"
+    >
+      <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Waiting on
+      </p>
+      <ul className="space-y-1">
+        {waits.map((wait) => (
+          <li
+            className="rounded-md border border-amber-500/25 bg-amber-500/10 px-2 py-1.5 text-2xs text-foreground"
+            data-testid={`workstream-wait-${wait.key}`}
+            key={wait.key}
+          >
+            <span className="font-medium">{wait.actor.name}</span>
+            {" · "}
+            {wait.reason}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
🤖
## Summary

Workstream coordinators need to see what each card is waiting on and which work deserves attention first without opening every linked pull request. This final slice adds manual and review-derived waits, deterministic owner-first ordering, and compact card polish to the experiment-gated Workstream Board.

This is **PR 4/4** in the Workstream Board stack, based on the presence-retry regression prerequisite. The board remains off by default under Settings → Experiments. This PR is draft, and auto-merge is off.

### What changes

- Shows manual waits from the channel canvas together with waits derived from linked pull-request review state.
- Lets a manual wait override matching derived wording without hiding unrelated waits; removing that manual override restores the derived wait until its underlying condition resolves.
- Prioritizes cards owned by the authenticated user, then active work, with stable creation/name fallbacks. A display-name lookalike does not receive owner priority.
- Keeps pull-request subscriptions shared and stable as cards remount, and improves compact wait/status presentation and accessibility labels.

**Scope boundary:** external canvas revisions refresh after ordinary route remount/refetch, NOT via live external subscription or in-place refresh.

### Related issue

None found. This is an experiment-gated product slice.

### Testing

- Exact-head Blox integration validation at `2892e4aa74fe6f1761550108fdda10e5164c0185`: Workstream Board **52/52**, presence reconciler **12/12**, Desktop **5,143/5,143**, typecheck passed, and check completed with zero errors.
- Patch-equivalent pre-rebase matrix at `6e918ee1b806febe20e44cff7ce8dc05204e5b59`: Desktop **5,011/5,011**, focused tests **8/8**, keyboard/accessibility **16/16**, typecheck, check, production build, E2E build, and diff check passed.
- Independent implementation review: **9.7/10**, no material findings. Independent full-media reviews by Princess Donut, Carl, and Mongo: **PASS**.

The validated implementation was first rebased from `6e918ee1b806febe20e44cff7ce8dc05204e5b59` to `a39a72b918d5f290a01bf87e88a8cf604d5c851f`; the B4 patch was byte-identical across that SHA migration, and the new head was separately integration-validated. The stack was then rebased onto current `main`, moving this PR from `a39a72b918d5f290a01bf87e88a8cf604d5c851f` to `2892e4aa74fe6f1761550108fdda10e5164c0185`. The B4 commits remain patch-identical across the second migration; the foundation reconciliation is limited to the upstream repository-aware sidebar structure and its rewritten drag-test helper. The current exact head was separately integration-validated after that rebase.

### Demo

[▶ Watch the full uninterrupted 369.920-second relay-backed demo](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/b4-wait-lifecycle-01.webm) — SHA-256 `e6406b4e6b9c1db129d899035667bc87609dd0da032c8b9e3abd6b65312148df`.

| Derived reviewer wait | Manual same-key override after remount |
| --- | --- |
| ![Derived pull-request reviewer wait](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/01-derived-pr-reviewer-wait-exists.png) | ![Manual wait replacing matching derived wording](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/02-manual-wait-added.png) |

| Manual card detail | Removing override restores derived wait |
| --- | --- |
| ![Manual wait card detail](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/02b-manual-wait-added-card.png) | ![Derived reviewer wait restored after manual removal](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/03-manual-wait-removed-derived-wait-remains.png) |

| Approval clears derived wait | Live card added |
| --- | --- |
| ![Approved pull request with derived wait cleared](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/04-approval-cleared-derived-wait.png) | ![Fifth live board card added](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/05-live-board-card-added.png) |

| Live card removed | Stable after sustained remounts |
| --- | --- |
| ![Live board card removed and stable four-card order restored](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/06-live-board-card-removed.png) | ![Stable board after sustained remount round six](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/08-sustained-round-6-board-remounted.png) |

Additional full-board frames: [manual publication before remount](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/02a-manual-wait-added-pre-remount-board.png), [manual removal before remount](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/03a-manual-wait-removed-pre-remount-board.png), [sustained round one](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/07-sustained-round-1-board-remounted.png), and [healthy terminal UI](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/99-first-concrete-failure-state.png).

The capture proves owner-first/lookalike-safe ordering, manual override/removal, approval clearing, live card add/remove, and six sustained rounds over **334.424 seconds** with bounded memory. All **32/32** mechanical gates and **9/9** complete relay-pipeline readiness gates passed.

Evidence archives:

- [Source capture archive](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/b4-wait-lifecycle-20260818T225201Z.tar.gz) — SHA-256 `2d62de4ed70256604eb79dea385c7ce963074f0a763750234bbcab38b91afdda`; 696-entry manifest SHA-256 `4b9308947d24bbbc2d38d28fab9740bfd9263cd8e11d64affdc1f0a106f6b946`.
- [Additive immutable-transcript correction](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6277/b4-correction-attestation-20260818T225201Z.tar.gz) — SHA-256 `87ac6ac4db0bc95b03bc0803175ea981417f2dac934691d692177280926fcec9`; 13-entry manifest SHA-256 `a316dcbaa13ec6d5edb7c34a5b347c1e366f36bc446dba16fc343e0dfc57beda`.

The source capture preserved one terminal validator failure caused by treating an explicit no-event rate-limit closure as an event-order violation. The separate correction leaves the source immutable and classifies its 65 relevant requests as 32 ordered event-bearing, 32 successful-empty, and one terminal-closed request, with zero actual ordering violations; its self-tests passed **35/35**.

### Stack

- Base: `workstream-board/03a-presence-timer-retry`
- Head: `workstream-board/04-waits-sort-polish` at `2892e4aa74fe6f1761550108fdda10e5164c0185`
- Position: **PR 4/4**
- Discussion: [Workstream Board thread](buzz://message?channel=156498d7-62a1-499d-bcfe-b73227d6a2a4&id=61eb23a5b39b6fda8332164dd99a701fc75db5eefa98eca4f2d6217a214c5fa9)

Draft only; no auto-merge.

