### PR TITLE
test(desktop): stop the focus-resume test racing a fixed 10ms sleep

### DIFF
--- a/desktop/src/shared/lib/useDocumentVisible.test.mjs
+++ b/desktop/src/shared/lib/useDocumentVisible.test.mjs
@@ -288,12 +288,19 @@ describe("visibility-gated hooks", () => {
     await act(async () => window.dispatchEvent(new window.Event("focus")));
     assert.deepEqual(observed, [1_000, false]);
     // Wait for the resume to actually land rather than for a fixed duration.
-    // `scheduleAfterForegroundReady` is a three-hop chain —
-    // setTimeout(0) → requestAnimationFrame → setTimeout(0) — and jsdom fires
-    // rAF on a ~16ms cadence, so a single 10ms sleep could never reliably
-    // cover it: the test passed only when the event loop happened to be idle
-    // and failed under parallel load. Polling keeps the assertion exactly as
-    // strict while removing the race.
+    //
+    // `scheduleAfterForegroundReady` defers through `setTimeout(0)` and then,
+    // because this jsdom is built without `pretendToBeVisual` and so exposes no
+    // `requestAnimationFrame`, through the fallback `setTimeout(0)` rather than
+    // a frame (`foregroundReady.ts`). Two timer turns, then React has to
+    // re-render and flush the effect that records `observed`.
+    //
+    // None of that is bounded by 10ms once the event loop is contended: Node
+    // starves the timer phase under load, so the second callback and the effect
+    // can both land after a fixed sleep has already resolved. Measured on this
+    // file with six busy loops saturating the CPU, the old form failed 4 runs
+    // in 12. Polling keeps the assertion exactly as strict while removing the
+    // race.
     await act(async () => {
       const deadline = Date.now() + 2_000;
       while (observed.length < 3 && Date.now() < deadline) {

--- a/desktop/src/shared/lib/useDocumentVisible.test.mjs
+++ b/desktop/src/shared/lib/useDocumentVisible.test.mjs
@@ -287,9 +287,19 @@ describe("visibility-gated hooks", () => {
     focused = true;
     await act(async () => window.dispatchEvent(new window.Event("focus")));
     assert.deepEqual(observed, [1_000, false]);
-    await act(
-      async () => new Promise((resolve) => window.setTimeout(resolve, 10)),
-    );
+    // Wait for the resume to actually land rather than for a fixed duration.
+    // `scheduleAfterForegroundReady` is a three-hop chain —
+    // setTimeout(0) → requestAnimationFrame → setTimeout(0) — and jsdom fires
+    // rAF on a ~16ms cadence, so a single 10ms sleep could never reliably
+    // cover it: the test passed only when the event loop happened to be idle
+    // and failed under parallel load. Polling keeps the assertion exactly as
+    // strict while removing the race.
+    await act(async () => {
+      const deadline = Date.now() + 2_000;
+      while (observed.length < 3 && Date.now() < deadline) {
+        await new Promise((resolve) => window.setTimeout(resolve, 5));
+      }
+    });
     assert.deepEqual(observed, [1_000, false, 1_000]);
 
     await act(async () => root.unmount());


### PR DESCRIPTION
`focused polling pauses on blur and resumes after activation yields` waited a
single `setTimeout(…, 10)` for the resume to land, then asserted the observed
sequence. It passed on an idle machine and failed whenever the event loop was
contended — which is what a full `pnpm test` run does.

## Why 10ms was never enough

`scheduleAfterForegroundReady` defers through `setTimeout(0)` and then, because
this test's jsdom is built without `pretendToBeVisual` and so exposes no
`requestAnimationFrame`, through its fallback `setTimeout(0)` rather than a
frame (`foregroundReady.ts`). That is two timer turns, after which React still
has to re-render and flush the effect that appends to `observed`.

None of that is bounded by a fixed 10ms once the loop is contended: Node starves
the timer phase under load, so the second callback and the effect can both land
after the sleep has already resolved.

> An earlier revision of this description blamed jsdom's ~16ms
> `requestAnimationFrame` cadence. That was wrong — rAF is `undefined` in a
> plain jsdom — and [@jemiahw caught
> it](https://github.com/block/buzz/pull/6278#discussion_r3814874754). The fix and the
> measurement below are unchanged; only the explanation was.

## The fix

Poll until the resume is observed (2s ceiling) instead of guessing a duration.
The assertion is untouched and just as strict: the same
`assert.deepEqual(observed, [1_000, false, 1_000])` still runs, so a resume that
never fires still fails, with the same diff.

## Measurement

x86_64-pc-windows-msvc, running the file 12x with six busy loops saturating the
CPU:

- before: 8 passed, 4 failed
- after: 12 passed, 0 failed

Full desktop suite with the fix: `pnpm test` 5037 passed, 0 failed (it had been
reporting 5036/1 on this test); `pnpm check` exit 0.
