### PR TITLE
feat(tooling): add file-size-check-ci, which uses the base CI actually uses

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -103,6 +103,34 @@ file-size-check:
     node web/scripts/check-file-sizes.mjs
     node mobile/scripts/check-file-sizes.mjs
 
+# Run the ratchet the way CI runs it: against origin/main, not the merge base.
+#
+# `resolveBaseRef` picks merge-base(origin/main, HEAD) locally but `HEAD^1`
+# under GITHUB_ACTIONS — on a PR that is the *main tip*, with the merge commit
+# as the candidate. Those two bases disagree, and the disagreement is not
+# theoretical: a governed file that main shrank, or one that main and a branch
+# each grew a little, can produce a violation that exists only in the merge.
+# PR #5888 hit exactly that — main at 941 lines, branch tip at 994, both under
+# the 1000-line limit, merge result 1008 — so `just file-size-check` passed and
+# CI would have failed.
+#
+# Merge origin/main into your branch first for an exact answer; the note below
+# fires when you have not, because the working tree is then not the merge
+# result CI measures.
+file-size-check-ci:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    git fetch --quiet origin main
+    if ! git merge-base --is-ancestor origin/main HEAD; then
+        echo "note: origin/main is not merged into HEAD, so the working tree is not the"
+        echo "      merge result CI measures. Merge main in for an exact check; this run"
+        echo "      still catches everything except a violation the merge itself creates."
+    fi
+    export CHECK_FILE_SIZES_BASE=origin/main
+    node desktop/scripts/check-file-sizes.mjs
+    node web/scripts/check-file-sizes.mjs
+    node mobile/scripts/check-file-sizes.mjs
+
 # Format all Rust code
 fmt:
     cargo fmt --all


### PR DESCRIPTION
feat(tooling): add file-size-check-ci, which uses the base CI actually uses

`check-file-sizes-core` resolves its base two different ways.
`resolveBaseRef` returns `merge-base(origin/main, HEAD)` locally, but `HEAD^1`
when `GITHUB_ACTIONS` is set — and on a `pull_request` the checkout is the
merge commit, so `HEAD^1` is the *main tip* with the merge result as the
candidate. `just file-size-check` therefore answers a different question than
CI does, and can pass on a branch CI will reject.

The gap is not theoretical. PR #5888 hit it: `observerRelayStore.ts` was 927
lines at the merge base, main grew it to 941, the branch grew it to 994 — both
comfortably under the 1000-line limit — and the merge result was 1008. The
local gate compared 994 against a 927-line base and passed; CI would have
compared 1008 against a 941-line base and failed. Neither side is over budget
alone, so no amount of local checking on either branch finds it, and the
failure lands on whichever PR merges second.

`just file-size-check-ci` runs the same three project gates with
`CHECK_FILE_SIZES_BASE=origin/main`, which the core already honours. It also
warns when `origin/main` is not an ancestor of `HEAD`, because the working tree
is then not the merge result CI measures — merging main in first is what makes
the check exact, and the note says so rather than implying a clean run proves
more than it does.

`file-size-check` is left exactly as it is: it is the cheap pre-push check and
it is wired into `just check`. This is the deliberate second opinion you run
before pushing a long-lived branch.

## Verification

x86_64-pc-windows-msvc:

- `just file-size-check-ci` on a branch level with main: exit 0.
- Appending two lines to `agentSessionTranscript.ts` (already over budget at
  1174) makes it fail as intended:
  `Desktop file size ratchet failed (base origin/main): 1174 -> 1176 (+2)
  lines (allowed 1174)` — note the base is reported as `origin/main`, not a
  merge base. Reverted; the recipe returns to exit 0.
