### PR TITLE
test(desktop): settle hover before sampling color

### DIFF
--- a/desktop/tests/e2e/message-feedback-snapshots.spec.ts
+++ b/desktop/tests/e2e/message-feedback-snapshots.spec.ts
@@ -101,6 +101,7 @@ test("profile hover uses the channel hover surface", async ({ page }) => {
   const profile = page.getByTestId("sidebar-profile-card");
   const channel = page.getByTestId("channel-random");
   await channel.hover();
+  await waitForAnimations(page);
   const channelHoverColor = await channel.evaluate(
     (element) => getComputedStyle(element).backgroundColor,
   );


### PR DESCRIPTION
## Summary

Wait for the channel hover transition to settle before sampling its computed background color.

The test previously captured an arbitrary mid-transition alpha, then compared that value with the settled profile-card color. Sampling after `waitForAnimations` keeps the runtime oracle deterministic without changing product behavior.

### Related issue

Fixes #6237.

No duplicate pull request found in the final open and historical search.

### Testing

- `pnpm --dir desktop exec biome check tests/e2e/message-feedback-snapshots.spec.ts`
- Focused Playwright test: 50/50 passed with one worker and retries disabled (`--repeat-each=50 --workers=1 --retries=0 --max-failures=1`)
- `CHECK_FILE_SIZES_BASE=upstream/main just ci`
- Screenshots: N/A (test-only change)