### PR TITLE
fix(desktop): stop the claude-spawn test reading a poisoned resolve cache

### DIFF
--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -53,6 +53,56 @@ pub(crate) fn lock_path_mutex() -> std::sync::MutexGuard<'static, ()> {
     PATH_MUTEX.lock().unwrap_or_else(|e| e.into_inner())
 }
 
+/// Swap `PATH` for the duration of a test, holding [`lock_path_mutex`] and
+/// keeping the `resolve_command` cache consistent with it.
+///
+/// Taking the mutex is not sufficient on its own. `resolve_command` caches
+/// results keyed on the **command name alone** — not on `PATH` — for the life
+/// of the process, so a test that changes `PATH` without clearing that cache
+/// leaks in both directions: a resolution made under the real `PATH` is
+/// returned for a lookup that should hit the test's temp directory, and the
+/// test's own temp-directory resolution outlives its `TempDir` and is handed to
+/// every later test.
+///
+/// That is not hypothetical. `claude_spawn_uses_the_probed_cli_executable`
+/// asserted that its fake CLI was picked up, but read a real `claude` cached by
+/// an earlier test instead — and only on machines where Claude Code is actually
+/// installed, so it failed for developers and never once in CI.
+///
+/// Restoration happens in `Drop`, so a panicking assertion no longer leaves the
+/// process with a temp-directory `PATH`.
+#[cfg(test)]
+pub(crate) struct PathOverride {
+    _guard: std::sync::MutexGuard<'static, ()>,
+    original: Option<std::ffi::OsString>,
+}
+
+#[cfg(test)]
+impl PathOverride {
+    /// Replace `PATH` entirely with `path`.
+    pub(crate) fn set(path: impl AsRef<std::ffi::OsStr>) -> Self {
+        let guard = lock_path_mutex();
+        let original = std::env::var_os("PATH");
+        std::env::set_var("PATH", path);
+        discovery::clear_resolve_cache();
+        Self {
+            _guard: guard,
+            original,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for PathOverride {
+    fn drop(&mut self) {
+        match self.original.take() {
+            Some(path) => std::env::set_var("PATH", path),
+            None => std::env::remove_var("PATH"),
+        }
+        discovery::clear_resolve_cache();
+    }
+}
+
 pub use backend::*;
 pub(crate) use definition_validation::{
     validate_agent_definition_text, validate_managed_agent_definition_text,

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -584,7 +584,6 @@ fn name_matches_interpreter_rejects_node_prefix() {
 
 #[test]
 fn claude_spawn_uses_the_probed_cli_executable() {
-    let _guard = crate::managed_agents::lock_path_mutex();
     let temp = tempfile::tempdir().expect("temp dir");
     let cli = temp
         .path()
@@ -596,17 +595,23 @@ fn claude_spawn_uses_the_probed_cli_executable() {
         std::fs::set_permissions(&cli, std::fs::Permissions::from_mode(0o755))
             .expect("make fake cli executable");
     }
-    let original_path = std::env::var_os("PATH");
-    std::env::set_var("PATH", temp.path());
+
+    // Holding the PATH mutex is not enough on its own: `resolve_command`
+    // caches by command name for the life of the process, ignoring PATH. Any
+    // earlier test that resolved a real `claude` therefore satisfied this
+    // lookup from cache and the assertion below compared it against the temp
+    // fake and failed — deterministically under `--test-threads=1`, and
+    // seemingly at random otherwise, because parallel scheduling decides
+    // whether a poisoning test ran first. CI never saw it: there is no Claude
+    // Code on those runners, so nothing was ever cached to leak.
+    //
+    // `PathOverride` clears the cache on entry and on drop, so this test both
+    // starts clean and cannot poison the tests that follow it.
+    let _path = crate::managed_agents::PathOverride::set(temp.path());
 
     let mut command = std::process::Command::new("buzz-acp");
     super::configure_runtime_cli(&mut command, super::known_acp_runtime("claude-agent-acp"));
 
-    if let Some(path) = original_path {
-        std::env::set_var("PATH", path);
-    } else {
-        std::env::remove_var("PATH");
-    }
     assert!(command
         .get_envs()
         .any(|(key, value)| { key == "CLAUDE_CODE_EXECUTABLE" && value == Some(cli.as_os_str()) }));
@@ -628,8 +633,10 @@ fn codex_spawn_does_not_set_a_claude_executable() {
 ///
 /// These tests exercise `is_batch_shim` directly — a pure path predicate with
 /// no global PATH or resolve_command cache involvement — so they run on every
-/// host and cannot be poisoned by the `claude_spawn_uses_the_probed_cli_executable`
-/// test that runs before them.
+/// host. (`claude_spawn_uses_the_probed_cli_executable` above used to leak its
+/// temp-directory resolution into the shared cache; it now scopes that through
+/// `PathOverride`, but keeping these tests cache-free is still the right shape
+/// for a pure predicate.)
 #[test]
 fn batch_shim_cmd_extension_is_rejected() {
     assert!(


### PR DESCRIPTION
fix(desktop): stop the claude-spawn test reading a poisoned resolve cache

`claude_spawn_uses_the_probed_cli_executable` has been failing on developer
machines for a long time and passing in CI, which reads like a timing flake.
It is not. It is deterministic, and the determinism is easy to miss because
what decides it is test *order*.

`resolve_command` caches results in a process-wide map keyed on the **command
name alone** — `HashMap<String, Option<PathBuf>>` — with no PATH in the key and
no expiry. The test plants a fake `claude` in a temp directory, points PATH at
it, and asserts `configure_runtime_cli` picked that file up. It took the PATH
mutex but never touched the cache, so if any earlier test had already resolved
a real `claude`, the lookup was served from cache and the assertion compared a
real install against the temp fake and failed.

That explains the whole shape of it:

- **Passes in isolation.** Cache is empty, so the fake resolves.
- **Fails under `--test-threads=1`.** Deterministic order puts a poisoning test
  first — 2443 passed / 1 failed, every run.
- **Looks random in a normal run.** Parallel scheduling decides whether that
  test lands first.
- **Never fails in CI.** No Claude Code on the runners, and only successful
  resolutions are cached, so there is nothing to leak.

The leak also ran the other way: the test cached its temp-directory path and
left it there after `TempDir` was dropped, handing a dangling path to every
later test. The neighbouring `is_batch_shim` tests already carry a comment
about being written to avoid exactly that poisoning — the workaround was in the
tree, the cause was not.

## The fix

`PathOverride` (test-only, beside `lock_path_mutex`) takes the mutex, swaps
PATH, and clears the resolve cache on both entry and exit. Restoration moved
into `Drop`, so a panicking assertion no longer leaves the process with a
temp-directory PATH — the old code restored by hand before the assert, which
worked here but is not a property the next test author gets for free.

The rest of the PATH-mutating tests were audited and are fine: they either call
`resolve_command_uncached` deliberately, or use command names unique to the
test, or resolve nothing. This was the only one on the cached path, so the
change is one test plus the shared guard.

## Verification

x86_64-pc-windows-msvc, `cargo test --manifest-path desktop/src-tauri/Cargo.toml
--lib -- --test-threads=1` — deterministic order, so this is a before/after, not
a sample:

- before: **2443 passed, 1 failed**
- after: **2444 passed, 0 failed**

`claude` resolves on this machine (`AppData\Roaming\npm\claude.ps1`), which is
the precondition CI lacks and developers have.
