### PR TITLE
fix: make the workspace unit suite and Tauri clippy pass on Windows

### DIFF
--- a/crates/buzz-agent/src/hints.rs
+++ b/crates/buzz-agent/src/hints.rs
@@ -409,11 +409,18 @@ mod tests {
             "first wins (.agents/)"
         );
         // Path should point to the .agents/ version (first wins).
-        assert!(skills[0]
-            .path
-            .to_str()
-            .unwrap()
-            .contains(".agents/skills/shared"));
+        //
+        // Compared with `ends_with`, which matches whole path components, not
+        // as a substring: the separator is `\` on Windows, so a literal
+        // ".agents/skills/shared" never matched there and this test failed on
+        // every Windows host regardless of the behaviour it was checking.
+        assert!(
+            skills[0]
+                .path
+                .ends_with(Path::new(".agents/skills/shared/SKILL.md")),
+            "expected the .agents/ copy to win, got {:?}",
+            skills[0].path
+        );
     }
 
     #[test]

--- a/crates/buzz-backend-kubernetes/src/client.rs
+++ b/crates/buzz-backend-kubernetes/src/client.rs
@@ -132,11 +132,13 @@ mod tests {
     /// race every other test in the binary.
     #[test]
     fn plugin_directories_are_prepended_in_order() {
-        let joined = prepended_path(
-            Some(Path::new("/tmp/fake-home")),
-            std::ffi::OsStr::new("/inherited/bin:/usr/bin"),
-        )
-        .unwrap();
+        // Built with `join_paths` rather than a literal "a:b": the PATH
+        // separator is `;` on Windows, so a hard-coded colon made
+        // `split_paths` see one entry and this test failed on every Windows
+        // host without saying anything about the ordering it checks.
+        let inherited =
+            std::env::join_paths([Path::new("/inherited/bin"), Path::new("/usr/bin")]).unwrap();
+        let joined = prepended_path(Some(Path::new("/tmp/fake-home")), &inherited).unwrap();
         let dirs: Vec<PathBuf> = std::env::split_paths(&joined).collect();
         assert_eq!(
             dirs,
@@ -174,9 +176,15 @@ mod tests {
         );
     }
 
+    /// An absolute path is answered from the filesystem, not from PATH.
+    ///
+    /// The positive case uses this test binary rather than `/bin/sh`, which
+    /// does not exist on Windows and made the assertion fail there for a
+    /// reason unrelated to what it checks.
     #[test]
     fn resolves_absolute_paths_directly() {
-        assert!(resolves_on_path("/bin/sh"));
+        let exe = std::env::current_exe().expect("current exe");
+        assert!(resolves_on_path(&exe.to_string_lossy()));
         assert!(!resolves_on_path("/nonexistent/plugin-binary"));
     }
 }

--- a/desktop/src-tauri/crates/buzz-terminal/src/lifecycle.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/lifecycle.rs
@@ -44,9 +44,16 @@
 //! session is the documented way to survive one's terminal, and honouring it
 //! is correct behaviour, not a gap.
 
+// Everything below except `Duration` is used only by the `#[cfg(unix)]`
+// shutdown path, so on Windows these are dead and `-D warnings` rejects the
+// crate. Gate the imports rather than the lint.
+#[cfg(unix)]
 use std::io;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(unix)]
+use std::time::Instant;
 
+#[cfg(unix)]
 use portable_pty::Child;
 
 /// How long the group gets to honour `SIGTERM` before `SIGKILL`.
@@ -62,6 +69,7 @@ pub const TERM_GRACE: Duration = Duration::from_millis(250);
 /// Polling rather than blocking in `wait()`: a blocking wait cannot be given a
 /// deadline without a second thread, and the whole point of the grace period
 /// is that it expires.
+#[cfg(unix)]
 const POLL_INTERVAL: Duration = Duration::from_millis(5);
 
 /// How a session ended.

--- a/desktop/src-tauri/crates/buzz-terminal/src/shell.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/shell.rs
@@ -21,6 +21,9 @@
 //! on many systems. A directory or a non-executable file falls through to the
 //! next candidate instead of becoming an unspawnable child.
 
+// Only the `#[cfg(unix)]` executable probes take a `Path`; on Windows this
+// import is dead and `-D warnings` rejects the crate.
+#[cfg(unix)]
 use std::path::Path;
 
 /// Last-resort shell. POSIX guarantees `/bin/sh`; if this is not executable


### PR DESCRIPTION
fix: make the workspace unit suite and Tauri clippy pass on Windows

`just test-unit` fails three tests on Windows at `main`, and
`just desktop-tauri-clippy` fails outright. None of it is a real defect — every
failure is a Unix assumption baked into a test or an import — but the effect is
that a Windows contributor cannot get a green local gate, and so cannot tell
their own breakage from the background noise.

CI never caught any of it: these crates are exercised on Linux runners, and
nothing runs `cargo test --workspace`.

## `just test-unit` — 3 failures

**`buzz-backend-kubernetes::client::plugin_directories_are_prepended_in_order`**
built its input PATH as the literal `"/inherited/bin:/usr/bin"`. The separator
is `;` on Windows, so `split_paths` saw one entry and the ordering assertion
compared the wrong list. Now built with `join_paths`, which emits the host's
separator — the test asserts the same ordering, portably.

**`buzz-backend-kubernetes::client::resolves_absolute_paths_directly`** asserted
`resolves_on_path("/bin/sh")`. There is no `/bin/sh` on Windows, so the
assertion failed for a reason unrelated to the behaviour under test. It now
uses `current_exe()` — an absolute path that exists wherever the test runs —
and keeps the negative case unchanged.

**`buzz-agent::hints::discover_skills_dedup_by_name`** asserted the winning
skill path via `.contains(".agents/skills/shared")`. Paths use `\` on Windows,
so that substring never matched however correct the result was. Replaced with
`Path::ends_with`, which compares whole components and treats both separators
as separators.

## `just desktop-tauri-clippy` — 5 errors

`buzz-terminal` fails `-D warnings` on Windows with four unused imports and one
unused constant: `io`, `Instant`, `portable_pty::Child`, `std::path::Path`, and
`POLL_INTERVAL` are each used only from `#[cfg(unix)]` code, so on Windows they
are genuinely dead. Gated the imports and the constant to match their use
sites, rather than silencing the lint — the lint is right.

## Verification

x86_64-pc-windows-msvc, on a branch off `main`:

- `just test-unit`: **All tests passed!** (was 3 failures — `buzz-backend-kubernetes`
  155 passed/2 failed, `buzz-agent` 450 passed/1 failed).
- `cargo test -p buzz-backend-kubernetes`: 157 passed, 0 failed.
- `cargo test -p buzz-agent --lib hints::`: 23 passed, 0 failed.
- `cargo clippy -p buzz-terminal --manifest-path desktop/src-tauri/Cargo.toml
  --all-targets -- -D warnings`: clean (was 5 errors).
- `cargo test -p buzz-terminal --manifest-path desktop/src-tauri/Cargo.toml`:
  25 passed across 4 binaries, 0 failed.
- `cargo fmt --all --check` and the Tauri workspace equivalent: clean.

Non-Windows behaviour is unchanged: the `cfg(unix)` imports still import on
Unix, and the two rewritten assertions check the same properties.
