### PR TITLE
fix(buzz-relay): retry S3 conformance probe on startup transport errors

### DIFF
--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -521,11 +521,44 @@ async fn main() -> anyhow::Result<()> {
             race_rounds,
             "running git object-store conformance probe (A3 gate)"
         );
-        let report = state
-            .git_store
-            .run_conformance_probe(cfg)
-            .await
-            .map_err(|e| anyhow::anyhow!("git conformance probe failed: {e}"))?;
+        // The S3/MinIO backend can still be coming up when the relay starts
+        // (e.g. both launched together by systemd/compose with no ordering
+        // dependency) — the probe's first request then fails with a
+        // transport error, not a conformance verdict. Retry only that
+        // transport-error case with backoff; a real `ProbeFailure` (the
+        // backend answered but violated A3) is a deployment problem no
+        // retry fixes, so it still fails fast on the first attempt.
+        let startup_retries: u32 = std::env::var("BUZZ_GIT_PROBE_STARTUP_RETRIES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(5);
+        let mut backoff_ms: u64 = std::env::var("BUZZ_GIT_PROBE_STARTUP_BACKOFF_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(500);
+        let mut attempt = 0u32;
+        let report = loop {
+            match state.git_store.run_conformance_probe(cfg.clone()).await {
+                Ok(report) => break report,
+                Err(e @ buzz_relay::api::git::store::StoreError::Backend(_))
+                    if attempt < startup_retries =>
+                {
+                    attempt += 1;
+                    tracing::warn!(
+                        attempt,
+                        max_attempts = startup_retries,
+                        backoff_ms,
+                        error = %e,
+                        "git object-store conformance probe hit a transport error, retrying (backend may still be starting)"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                    backoff_ms = (backoff_ms * 2).min(8_000);
+                }
+                Err(e) => {
+                    return Err(anyhow::anyhow!("git conformance probe failed: {e}"));
+                }
+            }
+        };
         tracing::info!(
             race_width = report.race_width,
             race_rounds = report.race_rounds,

--- a/deploy/charts/buzz/README.md
+++ b/deploy/charts/buzz/README.md
@@ -100,6 +100,14 @@ disables that probe through `relay.extraEnv`, `/_readiness` does not test object
 storage; configuration is still parsed strictly, but reachability and addressing
 errors surface on the first storage operation.
 
+If the S3/MinIO backend is still starting when the relay probes it, the probe
+transparently retries on transport errors (connection refused, DNS not
+resolved yet, etc.) with exponential backoff — up to `BUZZ_GIT_PROBE_STARTUP_RETRIES`
+attempts (default 5), starting at `BUZZ_GIT_PROBE_STARTUP_BACKOFF_MS` (default
+500ms, doubling each attempt, capped at 8s). This only covers "backend isn't
+reachable yet"; a backend that responds but fails the A3 conformance checks
+still fails startup immediately — retrying a semantic failure wouldn't help.
+
 ## Relay Pod extensions
 
 The chart exposes narrow extension points for init containers, volumes, relay


### PR DESCRIPTION
## Summary
- The relay's A3 git-conformance probe runs once at startup and treats any error as fatal — including plain transport failures (connection refused, DNS not resolved) when the S3/MinIO backend just hasn't finished starting yet.
- Observed in practice: relay and its object store started together with no explicit ordering (systemd/compose), the probe hit the backend before it was listening, and the relay crash-looped for ~20s until the backend came up on its own — during which `buzz-acp` clients saw connection-refused.
- Now retries only the transport-error case (`StoreError::Backend`) with exponential backoff — bounded by `BUZZ_GIT_PROBE_STARTUP_RETRIES` (default 5), starting at `BUZZ_GIT_PROBE_STARTUP_BACKOFF_MS` (default 500ms, capped at 8s). A real `ProbeFailure` (backend responded but violated A3) still fails immediately — retrying a semantic conformance failure can't fix it.
- Documented the new behavior/env vars in `deploy/charts/buzz/README.md` next to the existing conformance-probe/readiness notes.

## Test plan
- [x] `cargo build -p buzz-relay`
- [x] `cargo fmt -p buzz-relay -- --check`
- [x] `cargo clippy -p buzz-relay --no-deps`
- [x] `cargo test -p buzz-relay --bin buzz-relay` (11 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)