### PR TITLE
fix(desktop-tooltips): migrate tooltips from primary to secondary

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       testMatch: [
         "**/smoke.spec.ts",
         "**/sidebar-offcanvas-rail.spec.ts",
+        "**/tooltip-semantics.spec.ts",
         "**/search-scope-screenshots.spec.ts",
         "**/onboarding-docked-cta-screenshots.spec.ts",
         "**/identity-key-help.spec.ts",

--- a/desktop/src/features/agents/ui/RestartDiffBadge.tsx
+++ b/desktop/src/features/agents/ui/RestartDiffBadge.tsx
@@ -88,8 +88,8 @@ function ChangeDescription({ change }: { change: RestartChange }) {
 const TOOLTIP_CAP = 6;
 
 /**
- * `tooltip` — renders inside the dark `bg-primary` tooltip; uses
- *   `text-primary-foreground` variants for contrast there.
+ * `tooltip` — renders inside the semantic secondary tooltip surface; uses
+ *   `text-secondary-foreground` variants for contrast there.
  * `inline`  — renders inside the amber Runtime banner or other light
  *   surfaces; inherits foreground from the container instead.
  */
@@ -107,10 +107,10 @@ function DiffList({
     cap !== undefined && entries.length > cap ? entries.length - cap : 0;
 
   const valueClass =
-    variant === "tooltip" ? "text-primary-foreground/80" : "text-foreground";
+    variant === "tooltip" ? "text-secondary-foreground/80" : "text-foreground";
   const overflowClass =
     variant === "tooltip"
-      ? "text-primary-foreground/60"
+      ? "text-secondary-foreground/60"
       : "text-muted-foreground";
 
   return (
@@ -180,7 +180,7 @@ export function RestartDiffBadge({
       <TooltipContent className="max-w-72 text-xs" side="bottom">
         <p className="mb-1.5 font-semibold">Config changed since last start:</p>
         <DiffList cap={TOOLTIP_CAP} entries={restartDiff} />
-        <p className="mt-1.5 text-primary-foreground/70">
+        <p className="mt-1.5 text-secondary-foreground/70">
           {autoRestartEnabled ? AUTO_RESTART_ON_BLURB : AUTO_RESTART_OFF_BLURB}
         </p>
       </TooltipContent>

--- a/desktop/src/features/channels/ui/AddChannelBotTeamsSection.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotTeamsSection.tsx
@@ -154,12 +154,14 @@ export function AddChannelBotTeamsSection({
                         return (
                           <div
                             className="flex items-center gap-1 rounded-full bg-secondary-foreground/10 px-1.5 py-0.5"
+                            data-testid="team-tooltip-persona-chip"
                             key={persona.id}
                           >
                             <ProfileAvatar
                               avatarUrl={persona.avatarUrl}
                               className="h-4 w-4 text-3xs bg-secondary-foreground/20 text-secondary-foreground"
                               label={persona.displayName}
+                              testId="team-tooltip-persona-avatar"
                             />
                             <span className="text-2xs text-secondary-foreground">
                               {persona.displayName}

--- a/desktop/src/features/channels/ui/AddChannelBotTeamsSection.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotTeamsSection.tsx
@@ -143,7 +143,7 @@ export function AddChannelBotTeamsSection({
                   <div className="space-y-1.5">
                     <p className="font-medium">{team.name}</p>
                     {team.description ? (
-                      <p className="text-2xs text-primary-foreground/80">
+                      <p className="text-2xs text-secondary-foreground/80">
                         {team.description}
                       </p>
                     ) : null}
@@ -153,15 +153,15 @@ export function AddChannelBotTeamsSection({
                           inChannelPersonaIds?.has(persona.id) ?? false;
                         return (
                           <div
-                            className="flex items-center gap-1 rounded-full bg-primary-foreground/10 px-1.5 py-0.5"
+                            className="flex items-center gap-1 rounded-full bg-secondary-foreground/10 px-1.5 py-0.5"
                             key={persona.id}
                           >
                             <ProfileAvatar
                               avatarUrl={persona.avatarUrl}
-                              className="h-4 w-4 text-3xs bg-primary-foreground/20 text-primary-foreground"
+                              className="h-4 w-4 text-3xs bg-secondary-foreground/20 text-secondary-foreground"
                               label={persona.displayName}
                             />
-                            <span className="text-2xs text-primary-foreground">
+                            <span className="text-2xs text-secondary-foreground">
                               {persona.displayName}
                             </span>
                             {personaInChannel ? (

--- a/desktop/src/features/projects/ui/ProjectAuthorIdentity.tsx
+++ b/desktop/src/features/projects/ui/ProjectAuthorIdentity.tsx
@@ -60,7 +60,7 @@ export function ProjectAuthorIdentity({
             />
             <span className="min-w-0">
               <span className="block truncate font-medium">{label}</span>
-              <span className="block text-primary-foreground/70">
+              <span className="block text-secondary-foreground/70">
                 {roleLabel}
               </span>
             </span>

--- a/desktop/src/features/projects/ui/ProjectCards.tsx
+++ b/desktop/src/features/projects/ui/ProjectCards.tsx
@@ -330,7 +330,7 @@ function RepositoryUnavailableIndicator({
       </TooltipTrigger>
       <TooltipContent className="max-w-64">
         <p className="font-medium">{label}</p>
-        <p className="text-muted-foreground">{description}</p>
+        <p className="text-secondary-foreground">{description}</p>
       </TooltipContent>
     </Tooltip>
   );

--- a/desktop/src/shared/styles/globals/tooltipSemantics.test.mjs
+++ b/desktop/src/shared/styles/globals/tooltipSemantics.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const utilitiesCss = readFileSync(
+  new URL("./utilities.css", import.meta.url),
+  "utf8",
+);
+const huddleTooltipRule = utilitiesCss.match(
+  /\.buzz-huddle-tooltip\s*\{([\s\S]*?)\n\s*\}/,
+)?.[1];
+
+test("huddle tooltips consume their dedicated semantic tokens", () => {
+  assert.ok(huddleTooltipRule, "missing .buzz-huddle-tooltip rule");
+  assert.match(
+    huddleTooltipRule,
+    /background:\s*hsl\(\s*var\(--huddle-tooltip-surface,/,
+  );
+  assert.match(
+    huddleTooltipRule,
+    /color:\s*hsl\(\s*var\(\s*--huddle-tooltip-foreground,/,
+  );
+  assert.doesNotMatch(
+    huddleTooltipRule,
+    /--(?:primary|secondary)(?:-foreground)?/,
+  );
+});

--- a/desktop/src/shared/styles/globals/utilities.css
+++ b/desktop/src/shared/styles/globals/utilities.css
@@ -38,16 +38,9 @@
   }
 
   .buzz-huddle-tooltip {
-    --primary: var(
-      --huddle-tooltip-surface,
-      var(--huddle-control-surface, 0 0% 20%)
+    background: hsl(
+      var(--huddle-tooltip-surface, var(--huddle-control-surface, 0 0% 20%))
     );
-    --primary-foreground: var(
-      --huddle-tooltip-foreground,
-      var(--huddle-control-foreground, 0 0% 98%)
-    );
-
-    background: hsl(var(--primary));
     border: 1px solid
       hsl(
         var(
@@ -57,7 +50,12 @@
         0.72
       );
     box-shadow: 0 10px 22px rgb(0 0 0 / 35%);
-    color: hsl(var(--primary-foreground));
+    color: hsl(
+      var(
+        --huddle-tooltip-foreground,
+        var(--huddle-control-foreground, 0 0% 98%)
+      )
+    );
   }
 
   .buzz-huddle-drawer .buzz-huddle-control-button,

--- a/desktop/src/shared/ui/tooltip.tsx
+++ b/desktop/src/shared/ui/tooltip.tsx
@@ -34,7 +34,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)",
+        "z-50 overflow-hidden rounded-md bg-secondary px-3 py-1.5 text-xs text-secondary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)",
         className,
       )}
       {...props}

--- a/desktop/tests/e2e/tooltip-semantics.spec.ts
+++ b/desktop/tests/e2e/tooltip-semantics.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+import { waitForAnimations } from "../helpers/animations";
+
+const THEMES = ["buzz", "catppuccin-mocha"] as const;
+
+async function seedTheme(page: Page, theme: (typeof THEMES)[number]) {
+  await page.addInitScript((value) => {
+    window.localStorage.setItem("buzz-theme", value);
+  }, theme);
+}
+
+async function expectSecondarySurface(tooltip: Locator) {
+  const colors = await tooltip.evaluate((element) => {
+    const sample = document.createElement("div");
+    sample.style.cssText =
+      "position:fixed;visibility:hidden;background:hsl(var(--secondary));color:hsl(var(--secondary-foreground))";
+    document.body.append(sample);
+    const tooltipStyle = getComputedStyle(element);
+    const sampleStyle = getComputedStyle(sample);
+    const result = {
+      background: tooltipStyle.backgroundColor,
+      color: tooltipStyle.color,
+      expectedBackground: sampleStyle.backgroundColor,
+      expectedColor: sampleStyle.color,
+    };
+    sample.remove();
+    return result;
+  });
+
+  expect(colors.background).toBe(colors.expectedBackground);
+  expect(colors.color).toBe(colors.expectedColor);
+}
+
+for (const theme of THEMES) {
+  test(`simple and rich tooltips use the secondary surface — ${theme}`, async ({
+    page,
+  }) => {
+    await seedTheme(page, theme);
+    await installMockBridge(page, {
+      personas: [
+        {
+          id: "tooltip-reviewer",
+          displayName: "Tooltip Reviewer",
+          systemPrompt: "Review tooltip contrast.",
+        },
+      ],
+      teams: [
+        {
+          id: "tooltip-team",
+          name: "Contrast Crew",
+          description: "Checks semantic surface contrast",
+          personaIds: ["tooltip-reviewer"],
+        },
+      ],
+    });
+    await page.goto("/");
+
+    await page.getByTestId("channel-random").click();
+    await page.getByTestId("channel-members-trigger").hover();
+    const simpleTooltip = page.getByRole("tooltip");
+    await expect(simpleTooltip).toHaveText("Channel members");
+    await expectSecondarySurface(simpleTooltip);
+
+    await page.mouse.move(0, 0);
+    await page.getByTestId("channel-intro-action-create-agent").click();
+    const dialog = page.getByTestId("add-channel-bot-dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Contrast Crew" }).hover();
+
+    const richTooltip = page.getByRole("tooltip");
+    await expect(richTooltip).toContainText("Checks semantic surface contrast");
+    await expect(richTooltip).toContainText("Tooltip Reviewer");
+    await expectSecondarySurface(richTooltip);
+    await expect(
+      richTooltip.getByText("Checks semantic surface contrast"),
+    ).toHaveClass(/text-secondary-foreground\/80/);
+    await expect(richTooltip.getByText("Tooltip Reviewer")).toHaveClass(
+      /text-secondary-foreground/,
+    );
+
+    await waitForAnimations(page);
+    await dialog.screenshot({
+      path: `test-results/tooltip-semantics/${theme}-team-tooltip.png`,
+    });
+  });
+}

--- a/desktop/tests/e2e/tooltip-semantics.spec.ts
+++ b/desktop/tests/e2e/tooltip-semantics.spec.ts
@@ -79,6 +79,12 @@ for (const theme of THEMES) {
     await expect(richTooltip.getByText("Tooltip Reviewer")).toHaveClass(
       /text-secondary-foreground/,
     );
+    await expect(
+      richTooltip.getByTestId("team-tooltip-persona-chip"),
+    ).toHaveClass(/bg-secondary-foreground\/10/);
+    await expect(
+      richTooltip.getByTestId("team-tooltip-persona-avatar"),
+    ).toHaveClass(/bg-secondary-foreground\/20.*text-secondary-foreground/);
 
     await waitForAnimations(page);
     await dialog.screenshot({


### PR DESCRIPTION
**Category:** fix

**User Impact:** Tooltips now use the secondary color surface instead of the primary accent while remaining readable across light and dark themes.

**Problem:** The shared tooltip and several rich-tooltip descendants used primary surface and foreground tokens. Migrating only the shared background would leave nested descriptions, metadata, and chips coupled to the old primary surface and create contrast regressions.

**Solution:** Migrate the shared tooltip from the primary color pair to the secondary pair, migrate every confirmed rich descendant to matching secondary-foreground tokens, and remove the huddle tooltip’s misleading primary-token aliases while preserving its dedicated palette. Add light- and dark-theme browser coverage for both a simple tooltip and the rich add-channel team tooltip, plus a source contract test for the huddle token path.

<details>
<summary>File changes</summary>

**desktop/src/shared/ui/tooltip.tsx**
Changes the shared tooltip background and foreground from the primary pair to the semantic secondary pair.

**desktop/src/features/agents/ui/RestartDiffBadge.tsx**
Updates restart-diff values, overflow text, supporting copy, and documentation to match the secondary tooltip surface.

**desktop/src/features/channels/ui/AddChannelBotTeamsSection.tsx**
Updates team descriptions, persona chips, avatars, and names so the rich team tooltip retains contrast on the secondary surface.

**desktop/src/features/projects/ui/ProjectAuthorIdentity.tsx**
Updates the secondary author-role label to use the tooltip's matching semantic foreground.

**desktop/src/features/projects/ui/ProjectCards.tsx**
Aligns repository-unavailable tooltip descriptions with the secondary tooltip foreground.

**desktop/src/shared/styles/globals/utilities.css**
Makes huddle tooltips consume their dedicated surface and foreground tokens directly, preserving their custom palette without primary semantic aliases.

**desktop/src/shared/styles/globals/tooltipSemantics.test.mjs**
Pins direct huddle-token consumption and rejects primary or secondary alias indirection in the huddle tooltip rule.

**desktop/tests/e2e/tooltip-semantics.spec.ts**
Verifies computed tooltip surface colors and every migrated rich descendant token in Buzz light and Catppuccin Mocha dark themes, including team persona chips and avatars.

**desktop/playwright.config.ts**
Registers the tooltip semantics coverage in the desktop smoke suite.

</details>

## Reproduction Steps

1. Run `cd desktop && pnpm build:e2e`.
2. Run `pnpm exec playwright test tests/e2e/tooltip-semantics.spec.ts --project=smoke`.
3. In the app, hover the channel-members control and confirm the simple tooltip uses the neutral secondary surface.
4. Open **Add agents**, hover a team, and confirm its description and persona chips remain readable.
5. Repeat in the Buzz light and Catppuccin Mocha dark themes.

## Screenshots/Demos

| Buzz light | Catppuccin Mocha dark |
|---|---|
| ![Rich team tooltip on the secondary surface in Buzz light](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6290/buzz-team-tooltip.png) | ![Rich team tooltip on the secondary surface in Catppuccin Mocha dark](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6290/catppuccin-mocha-team-tooltip.png) |


