### PR TITLE
fix(desktop): point huddle voice guidelines at the huddle channel

### DIFF
--- a/desktop/src-tauri/src/huddle/agents.rs
+++ b/desktop/src-tauri/src/huddle/agents.rs
@@ -34,14 +34,21 @@ use super::{pipeline::start_auto_enabled_transcription, HuddlePhase};
 ///
 /// Keep this deliberately short: the invariant that matters is that a directly
 /// addressed user receives an immediate spoken response before any other work.
-pub fn voice_mode_guidelines(parent_channel_id: &str) -> String {
+///
+/// `huddle_channel_id` MUST be the ephemeral huddle channel: it is the only
+/// channel whose messages are transcribed to speech. Naming the parent here
+/// sends every spoken reply to the parent channel instead, where `buzz messages
+/// send` still returns `accepted: true` and the huddle stays silent. Both ids
+/// are rendered so an agent can tell them apart rather than trusting one
+/// opaque uuid.
+pub fn voice_mode_guidelines(huddle_channel_id: &str, parent_channel_id: &str) -> String {
     format!(
         "\
-You are in a live voice huddle attached to channel {parent_channel_id}.
-Only messages sent with `buzz messages send` to this huddle channel are spoken aloud, in the order sent; everything else you produce is silent.
-When a user addresses you, your FIRST tool call must send a brief spoken reply to this channel, before any file read, search, or other tool call. The usual rule against bare acknowledgments does not apply here; the pickup is the feedback that you heard them.
+You are in a live voice huddle in channel {huddle_channel_id}, started from channel {parent_channel_id}.
+Only messages sent with `buzz messages send` to the huddle channel {huddle_channel_id} are spoken aloud, in the order sent; everything else you produce is silent.
+When a user addresses you, your FIRST tool call must send a brief spoken reply to {huddle_channel_id}, before any file read, search, or other tool call. The usual rule against bare acknowledgments does not apply here; the pickup is the feedback that you heard them.
 Then work, sending each useful sentence as its own message the moment it is ready—a few sentences per answer, not a monologue.
-Speak plainly without markdown; post code or long detail to the attached channel instead.
+Speak plainly without markdown; post code or long detail to the parent channel {parent_channel_id} instead.
 If you are not addressed, stay silent."
     )
 }
@@ -301,13 +308,39 @@ mod tests {
 
     #[test]
     fn voice_mode_guidelines_pin_spoken_reply_as_first_tool_call() {
-        let guidelines = voice_mode_guidelines("parent-channel");
+        let guidelines = voice_mode_guidelines("huddle-channel", "parent-channel");
         assert_eq!(guidelines.lines().count(), 6);
         assert!(guidelines.contains("Only messages sent with `buzz messages send`"));
         assert!(guidelines.contains("your FIRST tool call must send a brief spoken reply"));
         assert!(guidelines.contains("before any file read, search, or other tool call"));
         assert!(guidelines.contains("rule against bare acknowledgments does not apply here"));
+        assert!(guidelines.contains("huddle-channel"));
         assert!(guidelines.contains("parent-channel"));
+    }
+
+    /// Regression: the spoken-output rules must name the ephemeral huddle
+    /// channel. Pointing them at the parent silently routes every spoken reply
+    /// to a text channel while `buzz messages send` still reports success.
+    #[test]
+    fn voice_mode_guidelines_route_spoken_output_to_the_huddle_channel() {
+        let guidelines = voice_mode_guidelines("huddle-channel", "parent-channel");
+
+        let spoken_rules: Vec<&str> = guidelines
+            .lines()
+            .filter(|line| {
+                line.contains("are spoken aloud")
+                    || line.contains("your FIRST tool call must send a brief spoken reply")
+            })
+            .collect();
+        assert_eq!(spoken_rules.len(), 2, "expected both spoken-output rules");
+
+        for rule in spoken_rules {
+            assert!(
+                rule.contains("huddle-channel"),
+                "not routed to huddle: {rule}"
+            );
+            assert!(!rule.contains("parent-channel"), "routed to parent: {rule}");
+        }
     }
 
     #[test]

--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -257,7 +257,7 @@ pub async fn start_huddle(
         //    Agents auto-subscribe on membership notification (kind:9000) and may
         //    complete EOSE before guidelines are stored if we post them after.
         //    Best-effort: don't fail the huddle if this fails.
-        let guidelines = agents::voice_mode_guidelines(&parent_channel_id);
+        let guidelines = agents::voice_mode_guidelines(&ephemeral_channel_id, &parent_channel_id);
         if let Ok(guidelines_builder) =
             events::build_huddle_guidelines(&ephemeral_channel_id, &guidelines)
         {


### PR DESCRIPTION
Fixes #6298.

## What's wrong

`start_huddle` passes the **parent** channel id to `voice_mode_guidelines`, but the text that function renders tells the agent that id **is** the huddle channel and that only messages sent there are spoken aloud:

```
You are in a live voice huddle attached to channel {parent_channel_id}.
Only messages sent with `buzz messages send` to this huddle channel are spoken aloud...
```

So every spoken reply goes to the parent text channel. The huddle stays silent, and spoken-intended text leaks into the persistent channel where it reads as odd out-of-band chatter later.

Nothing surfaces the mistake. `buzz messages send` returns `accepted: true` for the misrouted message, so the only verification available to the agent is one that cannot fail. Re-reading the instructions actively reinforces the error, because they assert the named id is the huddle.

I hit this as the agent: two huddles in a row, both silent, until the human said out loud that I was replying in the wrong chat.

## The fix

`ephemeral_channel_id` was already in scope at the call site — it's used two lines below to address the guidelines event itself. Pass it.

The template now takes both ids and names the relationship, so an agent can distinguish them instead of trusting one opaque uuid:

```
You are in a live voice huddle in channel {huddle_channel_id}, started from channel {parent_channel_id}.
Only messages sent with `buzz messages send` to the huddle channel {huddle_channel_id} are spoken aloud...
Speak plainly without markdown; post code or long detail to the parent channel {parent_channel_id} instead.
```

That last line is the one place the parent is genuinely the right target, so it now says so explicitly rather than relying on "the attached channel".

Line count and every pinned phrase are unchanged, so the existing behavioural assertions still hold.

## About the test

The existing test asserted `guidelines.contains("parent-channel")` — it was written against the buggy behaviour, so it passed and would have kept passing forever. Updated to cover both ids, plus a new test that asserts the **negative** that actually catches this class of regression: the spoken-output rules must name the huddle channel and must **not** name the parent.

Verified by effect, not by presence — with the bug reintroduced, the new test fails and the old one still passes:

```
test voice_mode_guidelines_pin_spoken_reply_as_first_tool_call ... ok      <- old test, bug present
test voice_mode_guidelines_route_spoken_output_to_the_huddle_channel ... FAILED

panicked at src/huddle/agents.rs:338:
not routed to huddle: Only messages sent with `buzz messages send` to the huddle
channel parent-channel are spoken aloud, ...
```

## Verification

Run on `aarch64-apple-darwin` with the Hermit-pinned toolchain (Rust 1.95.0):

- `cargo test --lib` (desktop/src-tauri) — **2571 passed, 0 failed**, 17 ignored
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check` — clean
- `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings` — clean

Not exercised: a live huddle end-to-end. The change is a single argument plus template text, so the unit tests cover the routing decision, but a real huddle run would be the stronger check if a maintainer can do one.

## Related

Suggestion 3 from #6298 — have the harness reject or warn on a send to a non-huddle channel while a huddle is active — is deliberately **not** in this PR. It's the deeper fix (right now the success signal can never go red), but it's a behavioural change to the send path and deserves its own discussion.

Searched open PRs and issues for duplicates: none found.
