### PR TITLE
fix(acp,relay): publish the agent directory entry clients already read

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -90,6 +90,76 @@ async fn publish_presence(
     Ok(())
 }
 
+/// Publish this agent's kind:10100 entry in the relay agent directory.
+///
+/// The directory is how a client that does NOT manage this agent locally
+/// learns the agent can be invoked. Desktop resolves mention candidates
+/// through `getMentionableAgentPubkeys`, whose only source for a
+/// non-locally-managed agent is this event (`respond_to`,
+/// `respond_to_allowlist`, `channel_ids`); mobile mirrors the same rule in
+/// `agentIsSharedWithUser`. Both have consumed it since before this commit —
+/// nothing on any surface published it, so the whole path sat dead and an
+/// agent was mentionable only from the one machine holding it in
+/// `managed-agents.json`. Mobile's `role == "bot"` member fallback masked it
+/// there; desktop has no such fallback, so mentions silently went out with no
+/// `p` tag and the agent was never woken.
+///
+/// `display_name` is deliberately omitted: both clients prefer the kind:0
+/// profile for the rendered name, and the harness has no configured name of
+/// its own to contribute.
+///
+/// Kind 10100 is replaceable, so each publish supersedes this pubkey's
+/// previous entry.
+async fn publish_agent_directory_entry(
+    publisher: &relay::RelayEventPublisher,
+    keys: &nostr::Keys,
+    respond_to: &config::RespondTo,
+    respond_to_allowlist: &HashSet<String>,
+    channel_ids: &HashSet<Uuid>,
+) -> Result<(), relay::RelayError> {
+    use buzz_core::kind::KIND_AGENT_PROFILE;
+    use nostr::{EventBuilder, Kind};
+
+    let content = agent_directory_content(respond_to, respond_to_allowlist, channel_ids);
+
+    let event = EventBuilder::new(Kind::Custom(KIND_AGENT_PROFILE as u16), content)
+        .tags([])
+        .sign_with_keys(keys)
+        .map_err(|e| relay::RelayError::Http(format!("agent directory sign error: {e}")))?;
+    publisher.publish_event(event).await?;
+    Ok(())
+}
+
+/// Build the kind:10100 content body. Field names are the wire contract shared
+/// with desktop (`nostr_convert::agents_from_events`) and mobile
+/// (`AgentDirectoryEntry.fromEvent`) — renaming one silently drops the agent
+/// from that client's mention autocomplete rather than failing loudly.
+///
+/// Sets are serialized sorted: the event is replaceable and re-signed on every
+/// start, so a stable byte order keeps an unchanged agent from looking like a
+/// new entry on each restart.
+///
+/// `channel_add_policy` is deliberately NOT emitted. The relay treats it as the
+/// authoritative policy for the author, so including a guess here would
+/// overwrite whatever the operator set via `buzz channels set-add-policy`.
+fn agent_directory_content(
+    respond_to: &config::RespondTo,
+    respond_to_allowlist: &HashSet<String>,
+    channel_ids: &HashSet<Uuid>,
+) -> String {
+    let mut allowlist: Vec<String> = respond_to_allowlist.iter().cloned().collect();
+    allowlist.sort();
+    let mut channels: Vec<String> = channel_ids.iter().map(Uuid::to_string).collect();
+    channels.sort();
+
+    serde_json::json!({
+        "respond_to": respond_to.to_string(),
+        "respond_to_allowlist": allowlist,
+        "channel_ids": channels,
+    })
+    .to_string()
+}
+
 fn emit_runtime_lifecycle(
     observer: Option<&observer::ObserverHandle>,
     start_nonce: &str,
@@ -2171,6 +2241,36 @@ async fn tokio_main() -> Result<()> {
         match publish_presence(&presence_publisher, &presence_keys, "online").await {
             Ok(_) => tracing::info!("presence set to online"),
             Err(e) => tracing::warn!("failed to set initial presence: {e}"),
+        }
+    }
+
+    // Published from the same readiness boundary as presence, and for the same
+    // reason: the channel set is only truthful once subscriptions resolved.
+    // Desktop scopes eligibility per channel (`relayAgentCanRespondInChannel`),
+    // so an entry listing channels the agent never subscribed to would offer a
+    // mention that can never be answered.
+    //
+    // `Nobody` is skipped rather than advertised. It is a heartbeat-only mode
+    // with nothing to invoke, and the desktop's `RespondTo` has no `nobody`
+    // variant — publishing it would fail deserialization of the whole
+    // `Vec<RelayAgentInfo>` and blank the directory for *every* agent, not
+    // just this one.
+    if config.respond_to != config::RespondTo::Nobody {
+        match publish_agent_directory_entry(
+            &presence_publisher,
+            &presence_keys,
+            &config.respond_to,
+            &config.respond_to_allowlist,
+            &subscribed_channel_ids,
+        )
+        .await
+        {
+            Ok(_) => tracing::info!(
+                respond_to = %config.respond_to,
+                channels = subscribed_channel_ids.len(),
+                "published agent directory entry (kind:10100)"
+            ),
+            Err(e) => tracing::warn!("failed to publish agent directory entry: {e}"),
         }
     }
 
@@ -7278,6 +7378,55 @@ mod build_mcp_servers_tests {
                 .iter()
                 .any(|e| e.name == "BUZZ_ACP_DISPLAY_NAME"),
             "empty display name should not be forwarded"
+        );
+    }
+
+    #[test]
+    fn agent_directory_content_carries_the_fields_clients_gate_on() {
+        let channel = Uuid::parse_str("53d663bd-383d-4719-a3ff-ddc44d8d1917").unwrap();
+        let content = agent_directory_content(
+            &config::RespondTo::Anyone,
+            &HashSet::new(),
+            &HashSet::from([channel]),
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+        // These three keys ARE the cross-device mention contract: desktop's
+        // `relayAgentCanRespondInChannel` and mobile's `agentIsSharedWithUser`
+        // read exactly these to decide the agent is invocable.
+        assert_eq!(parsed["respond_to"], "anyone");
+        assert_eq!(parsed["respond_to_allowlist"], serde_json::json!([]));
+        assert_eq!(
+            parsed["channel_ids"],
+            serde_json::json!(["53d663bd-383d-4719-a3ff-ddc44d8d1917"])
+        );
+        // Emitting a policy here would clobber the operator's stored value.
+        assert!(parsed.get("channel_add_policy").is_none());
+    }
+
+    #[test]
+    fn agent_directory_content_is_stable_across_restarts() {
+        let a = Uuid::parse_str("53d663bd-383d-4719-a3ff-ddc44d8d1917").unwrap();
+        let b = Uuid::parse_str("6ab8a700-fad7-41ac-966c-889e1965b652").unwrap();
+        let allowlist = HashSet::from(["b".repeat(64), "a".repeat(64)]);
+
+        // Same logical entry, different HashSet iteration order.
+        let first = agent_directory_content(
+            &config::RespondTo::Allowlist,
+            &allowlist,
+            &HashSet::from([a, b]),
+        );
+        let second = agent_directory_content(
+            &config::RespondTo::Allowlist,
+            &allowlist,
+            &HashSet::from([b, a]),
+        );
+        assert_eq!(first, second);
+
+        let parsed: serde_json::Value = serde_json::from_str(&first).unwrap();
+        assert_eq!(
+            parsed["respond_to_allowlist"],
+            serde_json::json!(["a".repeat(64), "b".repeat(64)])
         );
     }
 

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -1167,6 +1167,18 @@ pub async fn emit_group_discovery_events(
     Ok(())
 }
 
+/// Extract the policy a kind:10100 event asks us to store, if any.
+///
+/// `channel_add_policy` is ONE optional field of the agent profile, not the
+/// whole event: agents also publish kind:10100 purely to advertise themselves
+/// in the mention directory (`respond_to` / `channel_ids`) and carry no policy
+/// at all. Requiring it logged an `error!` on every agent startup claiming a
+/// side effect had failed, when nothing was ever asked for. Absent field means
+/// leave the stored policy untouched — not "reset it", and not an error.
+fn agent_profile_channel_add_policy(content: &serde_json::Value) -> Option<&str> {
+    content.get("channel_add_policy").and_then(|v| v.as_str())
+}
+
 async fn handle_agent_profile(
     tenant: &TenantContext,
     event: &Event,
@@ -1175,10 +1187,9 @@ async fn handle_agent_profile(
     let content: serde_json::Value = serde_json::from_str(&event.content)
         .map_err(|e| anyhow::anyhow!("kind:10100 content parse error: {e}"))?;
 
-    let policy = content
-        .get("channel_add_policy")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| anyhow::anyhow!("kind:10100 missing channel_add_policy field"))?;
+    let Some(policy) = agent_profile_channel_add_policy(&content) else {
+        return Ok(());
+    };
 
     let pubkey_bytes = event.pubkey.to_bytes().to_vec();
     if state
@@ -3583,5 +3594,33 @@ mod tests {
         }];
 
         assert!(actor_is_channel_owner_or_admin(&members, &actor));
+    }
+    #[test]
+    fn agent_profile_without_a_policy_asks_for_no_policy_change() {
+        // The mention-directory shape buzz-acp publishes on every start.
+        let content = serde_json::json!({
+            "respond_to": "anyone",
+            "respond_to_allowlist": [],
+            "channel_ids": ["53d663bd-383d-4719-a3ff-ddc44d8d1917"],
+        });
+
+        assert_eq!(agent_profile_channel_add_policy(&content), None);
+    }
+
+    #[test]
+    fn agent_profile_with_a_policy_still_yields_it() {
+        let content = serde_json::json!({ "channel_add_policy": "owner_only" });
+
+        assert_eq!(
+            agent_profile_channel_add_policy(&content),
+            Some("owner_only")
+        );
+    }
+
+    #[test]
+    fn agent_profile_ignores_a_non_string_policy() {
+        let content = serde_json::json!({ "channel_add_policy": 1 });
+
+        assert_eq!(agent_profile_channel_add_policy(&content), None);
     }
 }


### PR DESCRIPTION
# fix(acp,relay): publish the agent directory entry clients already read

## Summary

Nothing in the tree ever published `kind:10100`. Both clients consume it as the **agent directory**, and it is the only source that makes an agent mentionable to someone who does not manage it locally:

- desktop → `getMentionableAgentPubkeys` → `relayAgentCanRespondInChannel`
- mobile → `agentIsSharedWithUser`

The only writer anywhere was `buzz channels set-add-policy`, which writes a policy and no directory fields.

**Consequence: `respond_to: anyone` never actually reached anyone.** An agent was mentionable only from the one machine holding it in `managed-agents.json`. On every other device it appeared in the member list, produced no autocomplete entry, and any message went out with no `p` tag — which is indistinguishable, from the user's side, from an agent that simply ignores you.

Mobile masked the hole behind its `role == "bot"` member fallback — whose own comment admits agents *"may not have published a kind:10100 profile event yet"* — which is why the phone worked and the desktop did not.

## Changes

**`crates/buzz-acp/src/lib.rs`** — publish the directory entry at the same readiness boundary as presence, once channel subscriptions have resolved.

Desktop scopes eligibility *per channel*, so an entry naming channels the agent never subscribed to would advertise a mention that can never be answered. Publishing after subscriptions resolve keeps the advertised set truthful.

`respond_to: nobody` is deliberately skipped. It is heartbeat-only, and the desktop's `RespondTo` has no such variant — publishing it would fail deserialization of the whole `Vec<RelayAgentInfo>` and blank the directory **for every agent at once** rather than degrading just this one.

**`crates/buzz-relay/src/handlers/side_effects.rs`** — make `channel_add_policy` optional on `kind:10100`.

The relay previously required that field on every `kind:10100` and raised a side-effect error without it. A directory entry legitimately carries no policy, and emitting a guessed one would clobber whatever the operator set. Absence now means "change nothing" instead of erroring on every agent startup.

## Verification

Verified against a live relay: a patched harness published its entry, the relay stored it without a side-effect error, and it came back over a `REQ` carrying the three fields both clients gate on.

### Field corroboration from a production deployment (2026-08-19)

Independently of the patch, the failure mode was observed on a live Buzz-hosted community:

- Querying `kind:10100` on that relay returned **one** entry, despite several agents being present and configured with `respond_to: anyone`.
- Dead agent identities nonetheless kept showing up in the desktop `@mention` picker — they were reaching it through `kind:39002` channel membership with `role: bot`, i.e. the member-list path, not the directory.
- Removing those roster entries was what actually cleared the picker; archiving the identities (NIP-IA `kind:9035`) did not, because the directory was never the source for them.

This matches the diagnosis above: without a publisher for `kind:10100`, the directory is effectively empty and clients fall back to whatever member-list heuristics they have, producing exactly the "agent is listed but silently unmentionable" behaviour.

## Notes for reviewers

- Rebased onto `origin/main` (clean, no conflicts).
- `Signed-off-by` present (DCO).
- Touches two crates but the change is one mechanism: publish the entry, and stop the relay from rejecting an entry that carries no policy.
