### PR TITLE
fix(desktop): morph the drawer panel icon instead of sliding it

### DIFF
--- a/desktop/src/shared/ui/DrawerPanelIcon.tsx
+++ b/desktop/src/shared/ui/DrawerPanelIcon.tsx
@@ -1,3 +1,5 @@
+import { motion, useReducedMotion } from "motion/react";
+
 import { cn } from "@/shared/lib/cn";
 
 export function DrawerPanelIcon({
@@ -7,6 +9,9 @@ export function DrawerPanelIcon({
   className?: string;
   side: "left" | "right";
 }) {
+  const prefersReducedMotion = useReducedMotion();
+  const isOpen = side === "left";
+
   return (
     <svg
       aria-hidden="true"
@@ -26,15 +31,18 @@ export function DrawerPanelIcon({
         x="1"
         y="1"
       />
-      <rect
-        className="transition-transform duration-200 ease-out motion-reduce:transition-none"
+      <motion.rect
+        animate={{
+          rx: isOpen ? 2.5 : 1,
+          width: isOpen ? 5 : 2,
+        }}
         fill="currentColor"
         height="14"
-        rx="3"
-        style={{
-          transform: side === "right" ? "translateX(10px)" : "translateX(0)",
+        initial={false}
+        transition={{
+          duration: prefersReducedMotion ? 0 : 0.2,
+          ease: "linear",
         }}
-        width="6"
         x="4"
         y="4"
       />


### PR DESCRIPTION
## Summary
- Replaces the drawer panel icon's CSS `translateX` slide with a `motion/react` width + corner-radius morph, so the icon reads as the panel opening rather than the glyph drifting sideways.
- Honors `prefers-reduced-motion` via `useReducedMotion` (no animation for users who opt out).

Follow-up polish to the projects workspaces work that just landed in #6003 — the slide animation shipped there was the wrong visual.

## Test plan
- [x] Desktop unit tests and typecheck pass with this file at this content (validated as part of the projects-v6 branch validation)
- [ ] Visual check: open/close the right drawer and confirm the icon morphs in place