### PR TITLE
fix(desktop): show non-ASCII paths and their diffs in Projects

### DIFF
--- a/desktop/src-tauri/src/commands/project_git.rs
+++ b/desktop/src-tauri/src/commands/project_git.rs
@@ -986,3 +986,63 @@ pub async fn pull_project_local_repository(
     .await
     .map_err(|error| format!("repo pull task failed: {error}"))?
 }
+
+#[cfg(test)]
+mod tests {
+    use super::snapshot_from_worktree;
+    use crate::commands::project_git_exec::{build_test_git_auth_config, run_git};
+
+    /// `ls-files -z` prints raw paths while `log --name-only` quotes them, so
+    /// without `core.quotepath=false` the file-browser lookup misses every
+    /// non-ASCII path and the "last commit" column comes back empty.
+    #[test]
+    fn worktree_snapshot_resolves_the_latest_commit_of_a_non_ascii_path() {
+        const NON_ASCII_PATH: &str = "Beppo-Aufträge/B1 — Ergebnis.md";
+
+        let auth = build_test_git_auth_config().expect("build test git config");
+        let root = tempfile::tempdir().expect("create test directory");
+        let repo = root.path().join("repo");
+        run_git(
+            &["init", "--", repo.to_str().expect("repo path")],
+            None,
+            &auth,
+        )
+        .expect("init repo");
+
+        let file = repo.join(NON_ASCII_PATH);
+        std::fs::create_dir_all(file.parent().expect("parent")).expect("create directory");
+        std::fs::write(&file, "hallo\n").expect("write fixture");
+        run_git(&["add", "-A"], Some(&repo), &auth).expect("stage fixture");
+        run_git(
+            &[
+                "-c",
+                "user.name=Buzz Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "-m",
+                "init",
+            ],
+            Some(&repo),
+            &auth,
+        )
+        .expect("commit fixture");
+
+        let snapshot = snapshot_from_worktree(&repo, &auth, None, None);
+        let file = snapshot
+            .files
+            .iter()
+            .find(|file| file.path == NON_ASCII_PATH)
+            .unwrap_or_else(|| {
+                panic!(
+                    "expected {NON_ASCII_PATH} in {:?}",
+                    snapshot.files.iter().map(|f| &f.path).collect::<Vec<_>>()
+                )
+            });
+        let latest_commit = file
+            .latest_commit
+            .as_ref()
+            .expect("non-ASCII path must resolve its latest commit");
+        assert_eq!(latest_commit.subject, "init");
+    }
+}

--- a/desktop/src-tauri/src/commands/project_git_diff.rs
+++ b/desktop/src-tauri/src/commands/project_git_diff.rs
@@ -148,18 +148,56 @@ fn parse_count(value: &str) -> usize {
     value.parse::<usize>().unwrap_or_default()
 }
 
+/// Parses `git diff --numstat -z` output.
+///
+/// NUL-separated records sidestep git's path quoting entirely — not just the
+/// octal escaping of non-ASCII bytes that `core.quotepath=false` disables, but
+/// also the quoting git still applies to paths containing `"`, a backslash or
+/// a newline. The path handed back is therefore the literal one on disk and is
+/// safe to reuse as a pathspec.
+///
+/// Record shapes:
+/// - normal: `additions \t deletions \t path NUL`
+/// - rename or copy: `additions \t deletions \t NUL old NUL new NUL` — the
+///   empty third field signals that two more NUL-terminated fields follow.
+///   The new path is reported, because that is what the patch and the UI
+///   refer to.
+///
+/// Binary files carry `-` counts; [`parse_count`] maps those to 0 and the
+/// record is kept, so a binary change still shows up as a file.
 fn parse_numstat(output: &str) -> Vec<(String, usize, usize)> {
-    output
-        .lines()
-        .filter_map(|line| {
-            let mut parts = line.split('\t');
-            let additions = parse_count(parts.next()?);
-            let deletions = parse_count(parts.next()?);
-            let path = parts.next()?.to_string();
-            Some((path, additions, deletions))
-        })
-        .take(250)
-        .collect()
+    let mut records = output.split('\0');
+    let mut files = Vec::new();
+    while let Some(record) = records.next() {
+        if record.is_empty() {
+            continue;
+        }
+        let mut fields = record.splitn(3, '\t');
+        let (Some(additions), Some(deletions), Some(path)) =
+            (fields.next(), fields.next(), fields.next())
+        else {
+            continue;
+        };
+        let path = if path.is_empty() {
+            // Rename or copy: skip the old path, take the new one.
+            records.next();
+            match records.next() {
+                Some(new_path) if !new_path.is_empty() => new_path,
+                _ => continue,
+            }
+        } else {
+            path
+        };
+        files.push((
+            path.to_string(),
+            parse_count(additions),
+            parse_count(deletions),
+        ));
+        if files.len() == 250 {
+            break;
+        }
+    }
+    files
 }
 
 fn empty_tree_ref(repo_dir: &std::path::Path, auth: &GitAuthConfig) -> Result<String, String> {
@@ -360,10 +398,13 @@ fn diff_from_repo(
         })
         .transpose()?
         .filter(|body| !body.is_empty());
-    let numstat = run_git(&["diff", "--numstat", range], Some(repo_dir), auth)?;
+    let numstat = run_git(&["diff", "--numstat", "-z", range], Some(repo_dir), auth)?;
     let files = parse_numstat(&numstat)
         .into_iter()
         .map(|(path, additions, deletions)| {
+            // `:(literal)` keeps glob metacharacters (`*`, `?`, `[`) in a file
+            // name from being read as a pattern.
+            let pathspec = format!(":(literal){path}");
             let patch = run_git(
                 &[
                     "diff",
@@ -375,12 +416,23 @@ fn diff_from_repo(
                     "--dst-prefix=b/",
                     range,
                     "--",
-                    &path,
+                    &pathspec,
                 ],
                 Some(repo_dir),
                 auth,
             )
-            .unwrap_or_default();
+            .unwrap_or_else(|error| {
+                tracing::warn!("project diff: git diff failed for {path}: {error}");
+                String::new()
+            });
+            if patch.is_empty() && (additions > 0 || deletions > 0) {
+                // git exits 0 with empty stdout when a pathspec matches
+                // nothing, so a mismatch between the numstat path and the
+                // pathspec would otherwise be silent.
+                tracing::warn!(
+                    "project diff: empty patch for {path} despite +{additions} -{deletions}"
+                );
+            }
             let (patch, truncated) = truncate_patch(patch);
             ProjectRepoDiffFileInfo {
                 path,
@@ -502,4 +554,159 @@ pub async fn get_project_local_repo_diff(
     })
     .await
     .map_err(|error| format!("local repo diff task failed: {error}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{diff_from_repo, parse_numstat};
+    use crate::commands::project_git_exec::{build_test_git_auth_config, run_git, GitAuthConfig};
+
+    /// A path that exercises both octal escaping (`ä` → `\303\244`) and a
+    /// multi-byte punctuation character (`—` → `\342\200\224`), plus a space.
+    const NON_ASCII_PATH: &str = "Beppo-Aufträge/B1 — Ergebnis.md";
+
+    #[test]
+    fn parse_numstat_reads_nul_terminated_records() {
+        assert_eq!(
+            parse_numstat("1\t0\tsrc/main.rs\0"),
+            vec![("src/main.rs".to_string(), 1, 0)]
+        );
+    }
+
+    #[test]
+    fn parse_numstat_keeps_non_ascii_paths_verbatim() {
+        let output = format!("158\t0\t{NON_ASCII_PATH}\0");
+        assert_eq!(
+            parse_numstat(&output),
+            vec![(NON_ASCII_PATH.to_string(), 158, 0)]
+        );
+    }
+
+    #[test]
+    fn parse_numstat_reports_the_new_path_of_a_rename() {
+        assert_eq!(
+            parse_numstat("0\t0\t\0alt.md\0neu.md\0"),
+            vec![("neu.md".to_string(), 0, 0)]
+        );
+    }
+
+    #[test]
+    fn parse_numstat_reads_a_mixed_record_sequence() {
+        let output = format!(
+            "3\t1\ta.rs\0\
+             -\t-\tbin.dat\0\
+             7\t2\t\0old.md\0new.md\0\
+             9\t0\t{NON_ASCII_PATH}\0"
+        );
+        assert_eq!(
+            parse_numstat(&output),
+            vec![
+                ("a.rs".to_string(), 3, 1),
+                // Binary counts are `-`; the record must survive as a 0/0 file
+                // rather than being swallowed.
+                ("bin.dat".to_string(), 0, 0),
+                ("new.md".to_string(), 7, 2),
+                (NON_ASCII_PATH.to_string(), 9, 0),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_numstat_caps_the_file_list() {
+        let output = (0..300)
+            .map(|index| format!("1\t0\tfile{index}.txt\0"))
+            .collect::<String>();
+        assert_eq!(parse_numstat(&output).len(), 250);
+    }
+
+    fn commit(repo: &std::path::Path, auth: &GitAuthConfig, message: &str) {
+        run_git(&["add", "-A"], Some(repo), auth).expect("stage fixture");
+        run_git(
+            &[
+                "-c",
+                "user.name=Buzz Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "-m",
+                message,
+            ],
+            Some(repo),
+            auth,
+        )
+        .expect("commit fixture");
+    }
+
+    #[test]
+    fn diff_reports_unescaped_non_ascii_paths_with_a_populated_patch() {
+        let auth = build_test_git_auth_config().expect("build test git config");
+        let root = tempfile::tempdir().expect("create test directory");
+        let repo = root.path().join("repo");
+        run_git(
+            &["init", "--", repo.to_str().expect("repo path")],
+            None,
+            &auth,
+        )
+        .expect("init repo");
+
+        let file = repo.join(NON_ASCII_PATH);
+        std::fs::create_dir_all(file.parent().expect("parent")).expect("create directory");
+        std::fs::write(&file, "hallo\n").expect("write fixture");
+        commit(&repo, &auth, "init");
+        std::fs::write(&file, "hallo\nzeile2\n").expect("update fixture");
+        commit(&repo, &auth, "second");
+
+        let diff = diff_from_repo(&repo, &auth, "HEAD~1..HEAD", None).expect("diff repo");
+        let [file] = diff.files.as_slice() else {
+            panic!(
+                "expected exactly one changed file, got {}",
+                diff.files.len()
+            );
+        };
+        assert_eq!(file.path, NON_ASCII_PATH);
+        assert_eq!((file.additions, file.deletions), (1, 0));
+        assert!(
+            file.patch.contains("+zeile2"),
+            "patch should carry the changed line, got {:?}",
+            file.patch
+        );
+        // The patch header repeats the path; without `core.quotepath=false`
+        // it arrives octal-escaped and the UI renders it that way.
+        assert!(
+            file.patch.contains(&format!("--- a/{NON_ASCII_PATH}")),
+            "patch header should carry the unescaped path, got {:?}",
+            file.patch
+        );
+    }
+
+    #[test]
+    fn diff_reports_the_new_path_and_patch_of_a_rename() {
+        let auth = build_test_git_auth_config().expect("build test git config");
+        let root = tempfile::tempdir().expect("create test directory");
+        let repo = root.path().join("repo");
+        run_git(
+            &["init", "--", repo.to_str().expect("repo path")],
+            None,
+            &auth,
+        )
+        .expect("init repo");
+
+        std::fs::write(repo.join("alt.md"), "a\nb\nc\n").expect("write fixture");
+        commit(&repo, &auth, "init");
+        run_git(&["mv", "alt.md", "neu.md"], Some(&repo), &auth).expect("rename fixture");
+        commit(&repo, &auth, "rename");
+
+        let diff = diff_from_repo(&repo, &auth, "HEAD~1..HEAD", None).expect("diff repo");
+        let [file] = diff.files.as_slice() else {
+            panic!(
+                "expected exactly one changed file, got {}",
+                diff.files.len()
+            );
+        };
+        assert_eq!(file.path, "neu.md");
+        assert!(
+            !file.patch.is_empty(),
+            "a rename must still render a patch for the new path"
+        );
+    }
 }

--- a/desktop/src-tauri/src/commands/project_git_exec.rs
+++ b/desktop/src-tauri/src/commands/project_git_exec.rs
@@ -154,6 +154,13 @@ fn configure_git_auth(command: &mut Command, auth: &GitAuthConfig, needs_credent
         ("credential.helper", String::new()),
         ("core.hooksPath", "/dev/null".to_string()),
         ("core.fsmonitor", "false".to_string()),
+        // Git escapes every byte >= 0x80 in a path octally and wraps the path
+        // in quotes unless `core.quotepath` is off. Because the system and
+        // global configs are disabled above, a user cannot turn that off in
+        // their own `.gitconfig` — so non-ASCII paths would reach the UI as
+        // `"Auftr\303\244ge/..."`, and any path parsed out of one git call
+        // and fed back into the next as a pathspec would match nothing.
+        ("core.quotepath", "false".to_string()),
         ("protocol.allow", "never".to_string()),
         ("protocol.http.allow", "always".to_string()),
         ("protocol.https.allow", "always".to_string()),
@@ -393,10 +400,63 @@ fn validate_clone_url_against_relay(clone_url: &str, relay_base: &str) -> Result
 #[cfg(test)]
 mod tests {
     use super::{
-        clean_branch, clean_target_ref, credential_helper_config_value, git_needs_credentials,
-        git_subcommand, validate_clone_url, validate_clone_url_against_relay,
-        validate_local_clone_url,
+        build_test_git_auth_config, clean_branch, clean_target_ref, configure_git_auth,
+        credential_helper_config_value, git_needs_credentials, git_subcommand, validate_clone_url,
+        validate_clone_url_against_relay, validate_local_clone_url,
     };
+    use std::collections::HashMap;
+    use std::process::Command;
+
+    /// Reassembles the `GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n` pairs that
+    /// `configure_git_auth` injected into a command.
+    fn injected_git_config(command: &Command) -> HashMap<String, String> {
+        let env: HashMap<String, String> = command
+            .get_envs()
+            .filter_map(|(key, value)| {
+                Some((
+                    key.to_str()?.to_string(),
+                    value?.to_str().unwrap_or_default().to_string(),
+                ))
+            })
+            .collect();
+        let count: usize = env
+            .get("GIT_CONFIG_COUNT")
+            .expect("GIT_CONFIG_COUNT")
+            .parse()
+            .expect("numeric GIT_CONFIG_COUNT");
+        (0..count)
+            .map(|index| {
+                let key = env
+                    .get(&format!("GIT_CONFIG_KEY_{index}"))
+                    .unwrap_or_else(|| panic!("GIT_CONFIG_KEY_{index}"))
+                    .clone();
+                let value = env
+                    .get(&format!("GIT_CONFIG_VALUE_{index}"))
+                    .unwrap_or_else(|| panic!("GIT_CONFIG_VALUE_{index}"))
+                    .clone();
+                (key, value)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn injected_config_disables_path_quoting() {
+        // The system and global configs are disabled, so this is the only
+        // place `core.quotepath` can be turned off — without it git escapes
+        // non-ASCII bytes in every path it prints.
+        let auth = build_test_git_auth_config().expect("build test git config");
+        for needs_credentials in [false, true] {
+            let mut command = Command::new("git");
+            configure_git_auth(&mut command, &auth, needs_credentials);
+            assert_eq!(
+                injected_git_config(&command)
+                    .get("core.quotepath")
+                    .map(String::as_str),
+                Some("false"),
+                "core.quotepath must be injected (needs_credentials = {needs_credentials})"
+            );
+        }
+    }
 
     #[test]
     fn credential_helper_config_value_uses_forward_slashes() {


### PR DESCRIPTION
## Summary

In the Projects PR view, files with non-ASCII names rendered as `"Beppo-Auftr\303\244ge/B1 \342\200\224 Ergebnis.md"` and — worse — their diff body was empty despite a correct `+158 −0` counter.

`project_git_exec.rs` runs git with `GIT_CONFIG_NOSYSTEM=1` and `GIT_CONFIG_GLOBAL=/dev/null` plus a fixed list of injected keys. `core.quotepath` was not in that list, so git's default octal-escaping applied and a user could not turn it off from their own `.gitconfig` either. The escaped path was then handed straight back to `git diff` as a pathspec, which matches nothing and exits 0 with empty stdout — silent, and swallowed on top by `unwrap_or_default()`.

While fixing that I found a second, independent bug in the same function: `parse_numstat` takes the third tab field, which for a detected rename is `alt.md => neu.md`. That is not a valid pathspec either, so **a renamed file rendered an empty patch even with pure ASCII names**.

Three changes:

- **Inject `core.quotepath=false`** alongside the other hardening keys. This also repairs the file browser, where the `latest_commit_by_path` keys from `log --name-only` (quoted) never matched the `ls-files -z` paths (raw), so non-ASCII files showed no "last commit" info.
- **Read `git diff --numstat -z`** and parse NUL-terminated records. This also sidesteps the quoting git still applies to paths containing `"`, a backslash or a newline, and it handles the rename record shape (`adds \t dels \t NUL old NUL new NUL`), so renamed files render their patch.
- **Pass the path as a `:(literal)` pathspec** so glob metacharacters (`*`, `?`, `[`) in a file name are not read as a pattern, and `warn!` instead of silently dropping an empty patch for a file numstat reported as changed.

No frontend change: `desktop/src/features/projects/` contains no path unescaping to adjust.

### Related issue

Fixes #6309. Searched issues and PRs for `quotepath`, `non-ASCII`, `umlaut`, `diacritic`, `octal`, `numstat` — no duplicates. Related but distinct code paths: #5070 (message renderer corrupts non-ASCII to `?`) and #5989 (Windows `MAX_PATH` in the repo browser); neither is addressed here.

### Testing

`cargo test --workspace` in `desktop/src-tauri`: 2579 passed, 0 failed. `cargo clippy --all-targets` and `cargo fmt --check` clean.

New coverage, none of which existed before (there were no tests for non-ASCII paths under `commands/` at all):

- unit tests for the NUL-record numstat parser: plain records, non-ASCII paths kept verbatim, the rename double-record, a mixed sequence including a binary file, and the 250-file cap
- end-to-end diff tests over a real repo for a non-ASCII path and for a rename, asserting both the file path and a populated patch
- a file-browser regression test that a non-ASCII path resolves its latest commit
- a test asserting `core.quotepath` is actually injected

Both fixes were checked as load-bearing by reverting each one separately — each revert fails tests. Worth noting for review: `-z` alone is not sufficient. It carries the numstat path correctly, but the patch header (`diff --git`, `---`, `+++`) is *also* octal-escaped without `core.quotepath=false`, and that is what the UI renders. The integration test asserts the header for that reason.

Verified manually in a local release build of the desktop app against a real repository: the file name renders as `Beppo-Aufträge/B1 — Ergebnis.md` and the diff body is populated.

**Not verified on Windows.** `GIT_CONFIG_GLOBAL=/dev/null` is mapped to `NUL` by Git for Windows, and I have no Windows machine to confirm the injected config behaves identically there.
