### PR TITLE
fix(desktop): set window title to "Buzz" for Windows taskbar

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
   "app": {
     "windows": [
       {
-        "title": "",
+        "title": "Buzz",
         "width": 800,
         "height": 600,
         "maximized": true,


### PR DESCRIPTION
## What
    
    The Tauri window title field in tauri.conf.json was an empty string. On Windows, the taskbar draws its label from the window caption, so the Buzz entry rendered as an icon with no name.
    
## How
    
    Set app.windows[0].title to "Buzz" in desktop/src-tauri/tauri.conf.json (line 19).
    
    This is the only change — one line in one file. The hiddenTitle: true field on line 26 only affects the macOS title bar and does not interfere with the Windows taskbar label.

## Before / After
    
    |                 | Before             | After         |
    |-----------------|--------------------|---------------|
    | Windows taskbar | Icon only, no text | Icon + "Buzz" |
    
## Testing
    
    - Verified the JSON is valid after the change
    - hiddenTitle: true is unchanged — macOS behavior is unaffected
    
    Fixes #6295