### PR TITLE
fix(desktop): preserve Goose native authentication

### DIFF
--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -92,14 +92,21 @@ pub async fn get_agent_models(
         provider: saved_provider,
         provider_env_var,
         env: merged_env,
-        command: _,
+        command: agent_runtime_command,
     } = discovery;
 
-    let merged_env = discovery_env_with_baked_floor(merged_env);
+    let mut merged_env = discovery_env_with_baked_floor(merged_env);
+    let native_goose_provider =
+        apply_goose_native_discovery_config(&agent_runtime_command, &mut merged_env);
     // Resolve against the baked/process env when the record saved no provider,
     // so a build-provided provider still gets live discovery.
-    let effective_provider =
-        effective_discovery_provider(saved_provider.as_deref(), provider_env_var, &merged_env);
+    let effective_provider = effective_discovery_provider(
+        native_goose_provider
+            .as_deref()
+            .or(saved_provider.as_deref()),
+        provider_env_var,
+        &merged_env,
+    );
     if let Some(models) = discover_openrouter_models(
         &state.http_client,
         &effective_provider,
@@ -142,7 +149,11 @@ pub async fn get_agent_models(
     )
     .await?
     {
-        return Ok(models);
+        return Ok(filter_databricks_models_for_family(
+            models,
+            saved_provider.as_deref(),
+            effective_provider.as_deref(),
+        ));
     }
 
     run_agent_models_command(
@@ -230,11 +241,14 @@ pub async fn discover_agent_models(
         &input.definition_env,
         &input.env_vars,
     );
-    let merged_env = discovery_env_with_baked_floor(merged_env);
+    let mut merged_env = discovery_env_with_baked_floor(merged_env);
+    let native_goose_provider = apply_goose_native_discovery_config(agent_command, &mut merged_env);
     // Recover a build-provided provider when the form has none, so the create
     // dialog discovers live models instead of falling through to the subprocess.
     let effective_provider = effective_discovery_provider(
-        input.provider.as_deref(),
+        native_goose_provider
+            .as_deref()
+            .or(input.provider.as_deref()),
         runtime_meta.and_then(|meta| meta.provider_env_var),
         &merged_env,
     );
@@ -318,10 +332,75 @@ pub async fn discover_agent_models(
     )
     .await?
     {
-        return Ok(models);
+        return Ok(filter_databricks_models_for_family(
+            models,
+            input.provider.as_deref(),
+            effective_provider.as_deref(),
+        ));
     }
 
     run_agent_models_command(resolved_acp, resolved_agent, agent_args, None, merged_env).await
+}
+
+/// Apply the non-secret pieces of Goose's native transport configuration to a
+/// discovery environment. The provider is authoritative: Buzz's structured
+/// provider may be an Anthropic/OpenAI model-family filter while Goose reaches
+/// those models through Databricks. User/process env still wins for the host.
+fn apply_goose_native_discovery_config(
+    agent_command: &str,
+    env: &mut BTreeMap<String, String>,
+) -> Option<String> {
+    if known_acp_runtime(agent_command).is_none_or(|runtime| runtime.id != "goose") {
+        return None;
+    }
+    let config = crate::managed_agents::config_bridge::read_goose_file_config()?;
+    if let Some(host) = config.extra.get("DATABRICKS_HOST") {
+        env.entry("DATABRICKS_HOST".to_string())
+            .or_insert_with(|| host.clone());
+    }
+    let provider = config.provider?.trim().to_string();
+    if provider.is_empty() {
+        return None;
+    }
+    env.insert("GOOSE_PROVIDER".to_string(), provider.clone());
+    Some(provider)
+}
+
+/// When Goose uses Databricks as its transport, the provider selected in Buzz
+/// scopes the model family rather than changing authentication. Databricks v2's
+/// capability manifest is the authority for whether an endpoint uses the
+/// Anthropic or OpenAI wire family.
+fn filter_databricks_models_for_family(
+    mut response: AgentModelsResponse,
+    requested_family: Option<&str>,
+    execution_provider: Option<&str>,
+) -> AgentModelsResponse {
+    use buzz_agent_pkg::model_capabilities::{resolve, DatabricksV2Route};
+
+    let execution_provider = execution_provider.unwrap_or_default().trim();
+    let requested_family = requested_family.unwrap_or_default().trim();
+    let requested_route = match requested_family.to_ascii_lowercase().as_str() {
+        "anthropic" => DatabricksV2Route::AnthropicMessages,
+        "openai" | "openai-compat" => DatabricksV2Route::OpenaiResponses,
+        _ => return response,
+    };
+    if !execution_provider.eq_ignore_ascii_case("databricks_v2")
+        && !execution_provider.eq_ignore_ascii_case("databricks-v2")
+    {
+        return response;
+    }
+
+    let matches_family = |model: &str| {
+        resolve(execution_provider, model).databricks_v2_wire_route == requested_route
+    };
+    response.models.retain(|model| matches_family(&model.id));
+    response.agent_default_model = response
+        .agent_default_model
+        .filter(|model| matches_family(model));
+    response.selected_model = response
+        .selected_model
+        .filter(|model| matches_family(model));
+    response
 }
 
 #[derive(Debug, Deserialize)]
@@ -787,3 +866,7 @@ pub(super) fn normalize_agent_models(
 #[cfg(test)]
 #[path = "agent_models_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "agent_models_databricks_family_tests.rs"]
+mod databricks_family_tests;

--- a/desktop/src-tauri/src/commands/agent_models_databricks_family_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_models_databricks_family_tests.rs
@@ -1,0 +1,80 @@
+use super::*;
+
+fn databricks_family_fixture() -> AgentModelsResponse {
+    AgentModelsResponse {
+        agent_name: "goose".to_string(),
+        agent_version: "test".to_string(),
+        models: [
+            "databricks-claude-opus-4-7",
+            "databricks-gpt-5-6-sol",
+            "databricks-llama-4-maverick",
+        ]
+        .into_iter()
+        .map(|id| AgentModelInfo {
+            id: id.to_string(),
+            name: None,
+            description: None,
+        })
+        .collect(),
+        agent_default_model: Some("databricks-claude-opus-4-7".to_string()),
+        selected_model: Some("databricks-gpt-5-6-sol".to_string()),
+        supports_switching: true,
+    }
+}
+
+#[test]
+fn databricks_transport_filters_models_to_anthropic_family() {
+    let filtered = filter_databricks_models_for_family(
+        databricks_family_fixture(),
+        Some("anthropic"),
+        Some("databricks_v2"),
+    );
+
+    assert_eq!(
+        filtered
+            .models
+            .iter()
+            .map(|model| model.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["databricks-claude-opus-4-7"]
+    );
+    assert_eq!(
+        filtered.agent_default_model.as_deref(),
+        Some("databricks-claude-opus-4-7")
+    );
+    assert_eq!(filtered.selected_model, None);
+}
+
+#[test]
+fn databricks_transport_filters_models_to_openai_family() {
+    let filtered = filter_databricks_models_for_family(
+        databricks_family_fixture(),
+        Some("openai"),
+        Some("databricks-v2"),
+    );
+
+    assert_eq!(
+        filtered
+            .models
+            .iter()
+            .map(|model| model.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["databricks-gpt-5-6-sol"]
+    );
+    assert_eq!(filtered.agent_default_model, None);
+    assert_eq!(
+        filtered.selected_model.as_deref(),
+        Some("databricks-gpt-5-6-sol")
+    );
+}
+
+#[test]
+fn direct_provider_discovery_is_not_family_filtered() {
+    let response = filter_databricks_models_for_family(
+        databricks_family_fixture(),
+        Some("anthropic"),
+        Some("anthropic"),
+    );
+
+    assert_eq!(response.models.len(), 3);
+}

--- a/desktop/src-tauri/src/managed_agents/goose_transport.rs
+++ b/desktop/src-tauri/src/managed_agents/goose_transport.rs
@@ -1,0 +1,15 @@
+use std::process::Command;
+
+use super::discovery::KnownAcpRuntime;
+
+pub(super) fn apply_native_provider(command: &mut Command, runtime: Option<&KnownAcpRuntime>) {
+    if runtime.is_none_or(|runtime| runtime.id != "goose") {
+        return;
+    }
+    if let Some(native_provider) = super::config_bridge::read_goose_file_config()
+        .and_then(|config| config.provider)
+        .filter(|provider| !provider.trim().is_empty())
+    {
+        command.env("GOOSE_PROVIDER", native_provider);
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod effective_config;
 mod env_vars;
 pub(crate) mod git_bash;
 pub(crate) mod global_config;
+mod goose_transport;
 mod managed_node_paths;
 mod nest;
 pub(crate) mod parallelism;

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -563,13 +563,12 @@ fn goose_requirements(
         .filter(|v| !v.is_empty())
         .map(String::as_str);
 
-    // Effective provider for credential checking: prefer env layer, then file.
-    let effective_provider = provider.or_else(|| {
-        file_cfg
-            .as_ref()
-            .and_then(|c| c.provider.as_deref())
-            .filter(|v| !v.is_empty())
-    });
+    // Goose's native provider owns auth; Buzz may only select a model family.
+    let effective_provider = file_cfg
+        .as_ref()
+        .and_then(|c| c.provider.as_deref())
+        .filter(|v| !v.is_empty())
+        .or(provider);
 
     if provider.is_none() {
         // Silenced if the file config provides a provider.

--- a/desktop/src-tauri/src/managed_agents/readiness_goose_file_config_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness_goose_file_config_tests.rs
@@ -112,27 +112,28 @@ fn goose_file_config_silences_provider_and_model_but_not_anthropic_key() {
 }
 
 #[test]
-fn goose_env_provider_wins_over_file_provider_for_cred_check() {
-    // Env has GOOSE_PROVIDER=anthropic (different from file's databricks_v2).
-    // The env provider must win for credential checking.
+fn goose_file_provider_owns_transport_auth_when_buzz_selects_a_model_family() {
+    // Buzz selects the Anthropic model family while Goose's native config uses
+    // Databricks v2 as its transport/auth provider.
     let env = env_with(&[
         ("GOOSE_PROVIDER", "anthropic"),
         ("GOOSE_MODEL", "claude-opus-4-5"),
     ]);
     let cfg = databricks_file_config(); // has provider=databricks_v2
     let result = goose_requirements(&env, Some(&cfg));
-    // anthropic requires ANTHROPIC_API_KEY, not DATABRICKS_HOST.
+    // The native Databricks provider remains authoritative, and the file also
+    // satisfies DATABRICKS_HOST. No direct Anthropic key is required.
     assert!(
-        result.contains(&Requirement::EnvKey {
+        !result.contains(&Requirement::EnvKey {
             key: "ANTHROPIC_API_KEY".to_string()
         }),
-        "env provider=anthropic must require ANTHROPIC_API_KEY"
+        "a model-family selection must not require direct Anthropic auth"
     );
     assert!(
         !result.contains(&Requirement::EnvKey {
             key: "DATABRICKS_HOST".to_string()
         }),
-        "env provider=anthropic must NOT require DATABRICKS_HOST"
+        "the native file config must satisfy DATABRICKS_HOST"
     );
 }
 

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -804,11 +804,11 @@ pub fn spawn_agent_child(
         );
     }
 
-    // User env (descriptor.env): fully-layered floor→runtime→definition→global→persona→agent,
-    // reserved-key filtered. Written last so user-explicit values win over Buzz-set env.
+    // Layered user env is reserved-key filtered and normally wins over Buzz-set env.
     for (key, value) in &descriptor.env {
         command.env(key, value);
     }
+    super::goose_transport::apply_native_provider(&mut command, runtime_meta);
 
     // B5: carry persisted effort; harness resolves thought_level configId at first session.
     // Written AFTER descriptor.env so the canonical persisted value wins over any

--- a/desktop/src/features/agents/ui/AgentConfigFields.tsx
+++ b/desktop/src/features/agents/ui/AgentConfigFields.tsx
@@ -344,6 +344,7 @@ export function AgentConfigFields({
     apiKeyFileSatisfied,
     apiKeyInherited,
     apiKeyValue,
+    credentialProvider: credentialAuthProvider,
     credentialsValid,
   } = getGlobalAgentCredentialState({
     bakedEnvKeys,
@@ -782,7 +783,7 @@ export function AgentConfigFields({
             }
             isInherited={apiKeyInherited}
             isRequired={!apiKeyInherited && apiKeyValue.length === 0}
-            label={getProviderApiKeyLabel(effectiveProvider) ?? "API Key"}
+            label={getProviderApiKeyLabel(credentialAuthProvider) ?? "API Key"}
             onValueChange={(value) =>
               onConfigChange({
                 ...config,

--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -36,6 +36,7 @@ import {
   BLOCK_BUILD_HIDDEN_PROVIDER_IDS,
   buildPersonaRuntimeDropdownOptions,
   CUSTOM_PROVIDER_DROPDOWN_VALUE,
+  credentialProviderForRuntime,
   computeLocalModeGate,
   formatRuntimeOptionLabel,
   getDefaultPersonaRuntime,
@@ -456,19 +457,22 @@ export function AgentDefinitionDialog({
   // satisfied keys so no further filtering is needed.
   const { requiredEnvKeys } = localModeGate;
   const localModeSatisfied = localModeGate.satisfied;
-  // Effective provider: agent value → global fallback → file fallback.
-  // Mirrors the chain inside computeLocalModeGate so model-option scoping and
-  // model requiredness are consistent with the readiness gate.
+  // Match the readiness gate's agent → global → file provider precedence.
   const fileProvider = runtimeFileConfig?.provider?.trim() ?? "";
   const effectiveProvider =
     trimmedProvider || inheritedProviderDefault.value || fileProvider;
+  const credentialProvider = credentialProviderForRuntime(
+    runtime,
+    effectiveProvider,
+    runtimeFileConfig,
+  );
   const apiKeyFieldState = useProviderApiKeyFieldState({
     bakedEnvKeys,
     effectiveEnvVars: envVars,
     envVars,
     fileSatisfiedEnvKeys: localModeGate.fileSatisfiedEnvKeys,
     globalEnvVars: globalConfig.env_vars,
-    provider: effectiveProvider,
+    provider: credentialProvider,
     requiredEnvKeys,
   });
   const {
@@ -502,14 +506,12 @@ export function AgentDefinitionDialog({
     // Crash-loop guard, create AND edit: an empty allowlist would crash
     // every instance minted from this definition at startup.
     personaBehaviorDraftValid(behaviorDraft) &&
-    // D1: localModeSatisfied covers both missingNormalizedFields AND
-    // missingEnvKeys — credential env keys now block submit, not just display.
+    // Credentials and normalized fields both block submission.
     localModeSatisfied &&
     customAiPairSatisfied &&
     !isAvatarUploadPending;
 
-  // Merge global env as the base layer so credential keys satisfied via global
-  // config are available to model discovery — same rationale as in AgentInstanceEditDialog.
+  // Global credentials are available to model discovery.
   const envVarsForDiscovery = React.useMemo(
     () => ({ ...globalConfig.env_vars, ...envVars }),
     [globalConfig.env_vars, envVars],
@@ -523,9 +525,7 @@ export function AgentDefinitionDialog({
     isCustomProviderEditing,
     modelFieldVisible,
     open,
-    // Gate provider by runtime: runtimes that don't support LLM provider
-    // selection (codex, claude) must not inherit the global provider — doing
-    // so causes them to discover models from the wrong provider.
+    // Provider-locked runtimes must not inherit the global provider.
     provider: runtimeSupportsLlmProviderSelection(runtime)
       ? effectiveProvider
       : "",
@@ -885,7 +885,7 @@ export function AgentDefinitionDialog({
               isInherited={apiKeyIsInherited}
               inheritedLabel={apiKeyInheritedLabel}
               isRequired={apiKeyIsRequired}
-              label={getProviderApiKeyLabel(effectiveProvider) ?? "API key"}
+              label={getProviderApiKeyLabel(credentialProvider) ?? "API key"}
               onValueChange={(next) => {
                 setEnvVars((prev) => ({
                   ...prev,

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -380,30 +380,29 @@ export function AgentInstanceEditDialog({
     inheritedEnvVars: inheritedEnvVarsForAdvanced,
   } = useAgentDialogDefaults({ inheritedEnvVars, open });
 
-  // Runtime/provider-required credential state for the PROSPECTIVE post-submit runtime.
-  // globalProvider/globalEnvVars: fallback for empty per-agent provider; keys satisfied globally don't block Save.
-  const { requiredEnvKeys, fileSatisfiedEnvKeys, requiredEnvKeyMissing } =
-    useRequiredCredentialState({
-      open,
-      prospectiveRuntimeId,
-      provider: inheritedSubmission.provider ?? "",
-      globalProvider: inheritedProviderDefault.value,
-      envVars: inheritedSubmission.envVars,
-      globalEnvVars: globalConfig.env_vars,
-      personaEnvVars: inheritHarness ? inheritedEnvVars : undefined,
-    });
+  // Credential state for the prospective post-submit runtime.
+  const {
+    credentialProvider,
+    requiredEnvKeys,
+    fileSatisfiedEnvKeys,
+    requiredEnvKeyMissing,
+  } = useRequiredCredentialState({
+    open,
+    prospectiveRuntimeId,
+    provider: inheritedSubmission.provider ?? "",
+    globalProvider: inheritedProviderDefault.value,
+    envVars: inheritedSubmission.envVars,
+    globalEnvVars: globalConfig.env_vars,
+    personaEnvVars: inheritHarness ? inheritedEnvVars : undefined,
+  });
 
   const { data: bakedEnvKeys } = useBakedBuildEnvKeysQuery({ enabled: open });
   const { data: agentAccessOwnerOnly } = useAgentAccessOwnerOnlyQuery({
     enabled: open,
   });
 
-  // Merge global env as the base layer so credential keys satisfied via global
-  // config (e.g. ANTHROPIC_API_KEY) are available to model discovery. Use
-  // `inheritedSubmission.envVars` (the same snapshot the credential gate
-  // validates) rather than raw `envVars`, so an inherit-transition that layers
-  // in persona env vars is reflected in discovery. Agent-local env takes
-  // precedence, matching the agent → global → file spawn-path precedence.
+  // Use the same layered credential snapshot for discovery and validation;
+  // agent-local env takes precedence over global and inherited values.
   const envVarsForDiscovery = React.useMemo(
     () => ({ ...globalConfig.env_vars, ...inheritedSubmission.envVars }),
     [globalConfig.env_vars, inheritedSubmission.envVars],
@@ -430,7 +429,7 @@ export function AgentInstanceEditDialog({
   // complete required-key list; advancedRequiredEnvKeys drives EnvVarsEditor
   // display only. The effective snapshot covers persona inheritance during an
   // instance inherit transition.
-  const providerApiKeyEnvVar = getProviderApiKeyEnvVar(effectiveProvider);
+  const providerApiKeyEnvVar = getProviderApiKeyEnvVar(credentialProvider);
   const personaSatisfied =
     providerApiKeyEnvVar != null &&
     !(providerApiKeyEnvVar in envVars) &&
@@ -442,7 +441,7 @@ export function AgentInstanceEditDialog({
     fileSatisfiedEnvKeys,
     globalEnvVars: globalConfig.env_vars,
     personaSatisfied,
-    provider: effectiveProvider,
+    provider: credentialProvider,
     requiredEnvKeys,
   });
   const {
@@ -1063,7 +1062,7 @@ export function AgentInstanceEditDialog({
                 isInherited={apiKeyIsInherited}
                 inheritedLabel={apiKeyInheritedLabel}
                 isRequired={apiKeyIsRequired}
-                label={getProviderApiKeyLabel(effectiveProvider) ?? "API Key"}
+                label={getProviderApiKeyLabel(credentialProvider) ?? "API Key"}
                 onValueChange={(next) => {
                   setEnvVars((prev) => ({
                     ...prev,

--- a/desktop/src/features/agents/ui/agentConfigOptions.test.mjs
+++ b/desktop/src/features/agents/ui/agentConfigOptions.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  computeLocalModeGate,
+  credentialProviderForRuntime,
   getDefaultPersonaRuntime,
   getPersonaModelOptions,
   getPersonaProviderOptions,
@@ -23,6 +25,35 @@ function makeRuntime(id, availability = "available") {
     availability,
   };
 }
+
+test("Goose native provider is the credential authority", () => {
+  const fileConfig = {
+    provider: "databricks_v2",
+    model: "goose-claude-4-6-opus",
+    satisfiedEnvKeys: ["DATABRICKS_HOST"],
+  };
+
+  assert.equal(
+    credentialProviderForRuntime("goose", "anthropic", fileConfig),
+    "databricks_v2",
+  );
+  assert.equal(
+    credentialProviderForRuntime("buzz-agent", "anthropic", fileConfig),
+    "anthropic",
+  );
+
+  const gate = computeLocalModeGate({
+    envVars: {},
+    isProviderMode: false,
+    model: "goose-claude-4-6-opus",
+    provider: "anthropic",
+    runtimeId: "goose",
+    runtimeFileConfig: fileConfig,
+  });
+  assert.equal(gate.satisfied, true);
+  assert.deepEqual(gate.missingEnvKeys, []);
+  assert.deepEqual(gate.fileSatisfiedEnvKeys, ["DATABRICKS_HOST"]);
+});
 
 // ── getPersonaProviderOptions — hideProviderIds ───────────────────────────────
 

--- a/desktop/src/features/agents/ui/agentConfigOptions.tsx
+++ b/desktop/src/features/agents/ui/agentConfigOptions.tsx
@@ -193,6 +193,27 @@ export function requiredCredentialEnvKeys(
   return config?.requiredEnvKeys ?? [];
 }
 
+/**
+ * Resolve the provider whose authentication the harness will actually use.
+ *
+ * Goose owns its transport/auth provider in its native config. When that file
+ * names a provider, Buzz's provider picker scopes the model family only; it
+ * must not replace Goose's working Databricks/OAuth transport with a direct
+ * Anthropic or OpenAI connection. Other runtimes retain their existing
+ * selected-provider semantics.
+ */
+export function credentialProviderForRuntime(
+  runtimeId: string,
+  selectedProvider: string,
+  runtimeFileConfig: RuntimeFileConfigSubset | null | undefined,
+): string {
+  const fileProvider = runtimeFileConfig?.provider?.trim() ?? "";
+  if (runtimeId.trim() === "goose" && fileProvider.length > 0) {
+    return fileProvider;
+  }
+  return selectedProvider.trim();
+}
+
 export function isMissingRequiredDropdownField(
   field: { isRequired: boolean } | null | undefined,
   value: string,
@@ -750,7 +771,13 @@ export function computeLocalModeGate({
   // required beyond the normalized field gate above).
   // Use the effective provider (env → global → file) so credential
   // requirements are computed correctly for all config sources.
-  const providerForKeys = needsProviderSelection ? effectiveProvider : "";
+  const providerForKeys = needsProviderSelection
+    ? credentialProviderForRuntime(
+        runtimeId,
+        effectiveProvider,
+        runtimeFileConfig,
+      )
+    : "";
   const requiredKeys = requiredCredentialEnvKeys(runtimeId, providerForKeys);
 
   // Keys satisfied by the baked build env (Block-internal builds only).

--- a/desktop/src/features/agents/ui/globalAgentCredentialState.test.mjs
+++ b/desktop/src/features/agents/ui/globalAgentCredentialState.test.mjs
@@ -22,6 +22,25 @@ test("global defaults accept an advanced credential set in runtime config", () =
   assert.deepEqual(state.advancedFileSatisfiedEnvKeys, ["DATABRICKS_HOST"]);
 });
 
+test("Goose model-family selection keeps Databricks native authentication", () => {
+  const state = getGlobalAgentCredentialState({
+    bakedEnvKeys: [],
+    envVars: {},
+    provider: "anthropic",
+    runtimeFileConfig: {
+      provider: "databricks_v2",
+      model: "goose-claude-4-6-opus",
+      satisfiedEnvKeys: ["DATABRICKS_HOST"],
+    },
+    runtimeId: "goose",
+  });
+
+  assert.equal(state.credentialProvider, "databricks_v2");
+  assert.equal(state.apiKeyEnvVar, null);
+  assert.equal(state.credentialsValid, true);
+  assert.deepEqual(state.advancedFileSatisfiedEnvKeys, ["DATABRICKS_HOST"]);
+});
+
 test("an explicit empty global value shadows the runtime config", () => {
   const state = getGlobalAgentCredentialState({
     bakedEnvKeys: [],

--- a/desktop/src/features/agents/ui/globalAgentCredentialState.ts
+++ b/desktop/src/features/agents/ui/globalAgentCredentialState.ts
@@ -1,5 +1,6 @@
 import type { RuntimeFileConfigSubset } from "@/shared/api/tauri";
 import {
+  credentialProviderForRuntime,
   getBakedSatisfiedEnvKeys,
   getProviderApiKeyEnvVar,
   requiredCredentialEnvKeys,
@@ -18,8 +19,16 @@ export function getGlobalAgentCredentialState({
   runtimeFileConfig: RuntimeFileConfigSubset | null | undefined;
   runtimeId: string;
 }) {
-  const requiredEnvKeys = requiredCredentialEnvKeys(runtimeId, provider);
-  const apiKeyEnvVar = getProviderApiKeyEnvVar(provider);
+  const credentialProvider = credentialProviderForRuntime(
+    runtimeId,
+    provider,
+    runtimeFileConfig,
+  );
+  const requiredEnvKeys = requiredCredentialEnvKeys(
+    runtimeId,
+    credentialProvider,
+  );
+  const apiKeyEnvVar = getProviderApiKeyEnvVar(credentialProvider);
   const bakedSatisfiedEnvKeys = getBakedSatisfiedEnvKeys(
     requiredEnvKeys,
     envVars,
@@ -65,6 +74,7 @@ export function getGlobalAgentCredentialState({
     apiKeyFileSatisfied,
     apiKeyInherited,
     apiKeyValue,
+    credentialProvider,
     credentialsValid: !advancedCredentialMissing && !apiKeyMissing,
   };
 }

--- a/desktop/src/features/agents/ui/useRequiredCredentialState.ts
+++ b/desktop/src/features/agents/ui/useRequiredCredentialState.ts
@@ -6,6 +6,7 @@ import {
 } from "@/features/agents/hooks";
 
 import {
+  credentialProviderForRuntime,
   getBakedSatisfiedEnvKeys,
   isGloballySatisfiedCredentialKey,
   requiredCredentialEnvKeys,
@@ -15,6 +16,8 @@ import { hasMissingRequiredEnvKey } from "./personaRuntimeModel";
 
 /** Derived required-credential state for the Edit Agent dialog's Advanced section. */
 export interface RequiredCredentialState {
+  /** Provider whose native transport/authentication requirements apply. */
+  credentialProvider: string;
   /** Required env keys still unset and not satisfied by the runtime file config. */
   requiredEnvKeys: string[];
   /** Required keys already satisfied by the runtime file config (shown as info rows). */
@@ -71,12 +74,6 @@ export function useRequiredCredentialState(params: {
     personaEnvVars = {},
   } = params;
 
-  const providerForRequiredKeys = runtimeSupportsLlmProviderSelection(
-    prospectiveRuntimeId,
-  )
-    ? provider.trim() || globalProvider.trim()
-    : "";
-
   const { data: runtimeFileConfig } = useRuntimeFileConfigQuery(
     prospectiveRuntimeId,
     { enabled: open },
@@ -84,11 +81,21 @@ export function useRequiredCredentialState(params: {
 
   const { data: bakedEnvKeys } = useBakedBuildEnvKeysQuery({ enabled: open });
 
+  const selectedProvider = runtimeSupportsLlmProviderSelection(
+    prospectiveRuntimeId,
+  )
+    ? provider.trim() || globalProvider.trim()
+    : "";
+  const credentialProvider = credentialProviderForRuntime(
+    prospectiveRuntimeId,
+    selectedProvider,
+    runtimeFileConfig,
+  );
+
   // All required keys for this runtime + provider combination.
   const allRequiredKeys = React.useMemo(
-    () =>
-      requiredCredentialEnvKeys(prospectiveRuntimeId, providerForRequiredKeys),
-    [prospectiveRuntimeId, providerForRequiredKeys],
+    () => requiredCredentialEnvKeys(prospectiveRuntimeId, credentialProvider),
+    [prospectiveRuntimeId, credentialProvider],
   );
 
   // Keys covered by the baked build env — silenced, produce no info row.
@@ -132,6 +139,7 @@ export function useRequiredCredentialState(params: {
   );
 
   return {
+    credentialProvider,
     requiredEnvKeys,
     fileSatisfiedEnvKeys,
     requiredEnvKeyMissing,


### PR DESCRIPTION
## Why
Buzz treated its OpenAI/Anthropic model-family selection as Goose's execution provider, which replaced a working Databricks OAuth configuration and prompted for an unrelated direct API key.

## What
- Keep Goose's native provider authoritative for credential readiness and spawned runtime transport
- Use the Buzz provider selection to filter Databricks v2 model discovery to the OpenAI or Anthropic wire family
- Cover global, create/edit, readiness, and model-filtering behavior with regression tests

## Risk Assessment
Medium — this changes provider precedence for Goose when native configuration exists; direct-provider behavior is unchanged when Goose has no configured provider.

Generated with Codex