### PR TITLE
chore: serialize mobile pre-push checks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -81,9 +81,8 @@ pre-push:
       # serially so parallel pre-push hooks do not contend for Cargo's lock.
       glob: ["desktop/src-tauri/**", "crates/**", "migrations/**", "schema/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "deny.toml", "scripts/run-tests.sh", "Justfile"]
       run: just desktop-tauri-clippy && just desktop-tauri-test
-    mobile-check:
+    mobile-checks:
+      # Run analysis and tests serially so parallel pre-push hooks do not
+      # contend for shared Flutter state (.dart_tool, shader bundle).
       glob: ["mobile/**"]
-      run: just mobile-check
-    mobile-test:
-      glob: ["mobile/**"]
-      run: just mobile-test
+      run: just mobile-check && just mobile-test


### PR DESCRIPTION
Serialize the mobile pre-push analysis and test commands into one lane, mirroring the existing `desktop-tauri-checks` pattern.

The shared Flutter state under `mobile/` (`.dart_tool`, shader bundle, and `pubspec.lock`) must not be driven by parallel hook processes. The existing `mobile/**` path filter is unchanged; `mobile-check` now runs before `mobile-test` in the same lane.

- Replace the parallel `mobile-check` and `mobile-test` commands with `mobile-checks`.
- Keep the commands serial with `just mobile-check && just mobile-test`.
