### PR TITLE
ci: bound desktop apt dependency installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
               - 'scripts/normative-corpus.json'
               - 'desktop/**'
               - '!desktop/src-tauri/**'
+              - 'scripts/install-desktop-system-deps-ci.sh'
               - 'pnpm-lock.yaml'
             desktop-rust:
               - 'desktop/src-tauri/**'
@@ -152,30 +153,23 @@ jobs:
           workspaces: desktop/src-tauri
           save-if: ${{ github.event_name != 'pull_request' }}
       - name: Install Tauri dependencies (Linux)
-        env:
-          DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get update \
-            -o Acquire::Retries=3 \
-            -o Acquire::http::Timeout=30 \
-            -o Acquire::https::Timeout=30
-          sudo apt-get install -y --no-install-recommends \
-            -o Acquire::Retries=3 \
-            -o Acquire::http::Timeout=30 \
-            -o Acquire::https::Timeout=30 \
-            -o DPkg::Lock::Timeout=120 \
-            build-essential \
-            curl \
-            file \
-            libasound2-dev \
-            libayatana-appindicator3-dev \
-            libgtk-3-dev \
-            librsvg2-dev \
-            libssl-dev \
-            libwebkit2gtk-4.1-dev \
-            libxdo-dev \
-            patchelf \
-            wget
+          scripts/install-desktop-system-deps-ci.sh bash -c '
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends \
+              build-essential \
+              curl \
+              file \
+              libasound2-dev \
+              libayatana-appindicator3-dev \
+              libgtk-3-dev \
+              librsvg2-dev \
+              libssl-dev \
+              libwebkit2gtk-4.1-dev \
+              libxdo-dev \
+              patchelf \
+              wget
+          '
       - name: Get pnpm store directory
         id: pnpm-cache
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
@@ -264,7 +258,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: cd desktop && pnpm exec playwright install chromium
       - name: Install Playwright system dependencies
-        run: cd desktop && pnpm exec playwright install-deps chromium
+        run: scripts/install-desktop-system-deps-ci.sh pnpm -C desktop exec playwright install-deps chromium
       - name: Save Playwright browser cache
         if: steps.playwright-cache.outputs.cache-hit != 'true' && github.event_name == 'push' && matrix.shard == 1
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
@@ -447,7 +441,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: cd desktop && pnpm exec playwright install chromium
       - name: Install Playwright system dependencies
-        run: cd desktop && pnpm exec playwright install-deps chromium
+        run: scripts/install-desktop-system-deps-ci.sh pnpm -C desktop exec playwright install-deps chromium
       - name: Save Playwright browser cache
         if: steps.playwright-cache.outputs.cache-hit != 'true' && github.event_name == 'push' && matrix.shard == 1
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,7 +1,8 @@
 # Glob patterns below mirror the `changes` job's dorny/paths-filter groups in
 # .github/workflows/ci.yml — keep the two in sync. Deliberate deviations:
 # - The `.github/workflows/ci.yml` path CI adds to its `rust`/`mobile` filters
-#   is omitted; a CI-workflow-only edit doesn't need a local test run.
+#   and the desktop CI system-dependency helper are omitted; CI-only edits
+#   don't need a local application test run.
 # - `desktop-check`/`desktop-typecheck`/`desktop-test` don't trigger on `rust`
 #   changes, though CI's Desktop Core job does. Those commands are pure TS
 #   (biome + tsc + node:test) with no Rust dependency, so the extra trigger

--- a/scripts/install-desktop-system-deps-ci.sh
+++ b/scripts/install-desktop-system-deps-ci.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Bound apt-backed CI dependency installation. The command gets two attempts;
+# each receives 85 seconds to exit after TERM and is killed at 90 seconds.
+set -euo pipefail
+
+readonly apt_config=/etc/apt/apt.conf.d/99buzz-ci-bounds
+readonly max_attempts=2
+readonly retry_delay_seconds=5
+
+cleanup() {
+  sudo rm -f "$apt_config"
+}
+trap cleanup EXIT
+
+sudo tee "$apt_config" >/dev/null <<'APT_CONFIG'
+Acquire::Retries "0";
+Acquire::http::Timeout "15";
+Acquire::https::Timeout "15";
+DPkg::Lock::Timeout "15";
+APT_CONFIG
+
+export DEBIAN_FRONTEND=noninteractive
+for attempt in $(seq 1 "$max_attempts"); do
+  echo "System dependency install attempt ${attempt}/${max_attempts}"
+  set +e
+  timeout --signal=TERM --kill-after=5s 85s "$@"
+  status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  fi
+
+  if [ "$status" -ne 124 ]; then
+    echo "System dependency installation failed (status ${status}); not retrying a non-timeout failure" >&2
+    exit "$status"
+  fi
+
+  if [ "$attempt" -eq "$max_attempts" ]; then
+    echo "System dependency installation timed out after ${max_attempts} bounded attempts" >&2
+    exit "$status"
+  fi
+
+  echo "System dependency install attempt ${attempt} timed out; retrying in ${retry_delay_seconds}s" >&2
+  sleep "$retry_delay_seconds"
+done

--- a/scripts/install-desktop-system-deps-ci.sh
+++ b/scripts/install-desktop-system-deps-ci.sh
@@ -3,9 +3,11 @@
 # each receives 85 seconds to exit after TERM and is killed at 90 seconds.
 set -euo pipefail
 
-readonly apt_config=/etc/apt/apt.conf.d/99buzz-ci-bounds
+readonly apt_config=${BUZZ_APT_CONFIG:-/etc/apt/apt.conf.d/99buzz-ci-bounds}
 readonly max_attempts=2
-readonly retry_delay_seconds=5
+readonly attempt_timeout_seconds=${BUZZ_DEPENDENCY_TIMEOUT_SECONDS:-85}
+readonly kill_grace_seconds=${BUZZ_DEPENDENCY_KILL_GRACE_SECONDS:-5}
+readonly retry_delay_seconds=${BUZZ_DEPENDENCY_RETRY_DELAY_SECONDS:-5}
 
 cleanup() {
   sudo rm -f "$apt_config"
@@ -22,15 +24,30 @@ APT_CONFIG
 export DEBIAN_FRONTEND=noninteractive
 for attempt in $(seq 1 "$max_attempts"); do
   echo "System dependency install attempt ${attempt}/${max_attempts}"
+  started_at=$SECONDS
   set +e
-  timeout --signal=TERM --kill-after=5s 85s "$@"
+  timeout \
+    --signal=TERM \
+    --kill-after="${kill_grace_seconds}s" \
+    "${attempt_timeout_seconds}s" \
+    "$@"
   status=$?
   set -e
+  elapsed_seconds=$((SECONDS - started_at))
   if [ "$status" -eq 0 ]; then
     exit 0
   fi
 
-  if [ "$status" -ne 124 ]; then
+  timed_out=false
+  if [ "$status" -eq 124 ]; then
+    timed_out=true
+  elif [ "$status" -eq 137 ] && [ "$elapsed_seconds" -ge "$attempt_timeout_seconds" ]; then
+    # GNU timeout returns 137 when its post-TERM grace expires. Elapsed time
+    # distinguishes that case from a command that exits 137 immediately.
+    timed_out=true
+  fi
+
+  if [ "$timed_out" != true ]; then
     echo "System dependency installation failed (status ${status}); not retrying a non-timeout failure" >&2
     exit "$status"
   fi

--- a/scripts/test-install-desktop-system-deps-ci.sh
+++ b/scripts/test-install-desktop-system-deps-ci.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Linux regression coverage for the outer timeout/retry contract.
+set -euo pipefail
+
+if [ "$(uname -s)" != Linux ]; then
+  echo "This harness requires Linux and GNU timeout" >&2
+  exit 1
+fi
+
+tmp=$(mktemp -d)
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+cat > "$tmp/sudo" <<'SUDO'
+#!/usr/bin/env bash
+exec "$@"
+SUDO
+cat > "$tmp/attempt" <<'ATTEMPT'
+#!/usr/bin/env bash
+mode=$1
+count_file=$2
+count=0
+[ ! -f "$count_file" ] || count=$(cat "$count_file")
+echo $((count + 1)) > "$count_file"
+case "$mode" in
+  success) exit 0 ;;
+  quick-137) exit 137 ;;
+  cooperative-timeout) sleep 10 ;;
+  forced-kill-timeout)
+    trap '' TERM
+    while :; do sleep 1; done
+    ;;
+  *) exit 99 ;;
+esac
+ATTEMPT
+chmod +x "$tmp/sudo" "$tmp/attempt"
+
+run_case() {
+  local mode=$1
+  local expected_status=$2
+  local expected_attempts=$3
+  local count_file="$tmp/${mode}.count"
+
+  set +e
+  PATH="$tmp:$PATH" \
+    BUZZ_APT_CONFIG="$tmp/${mode}.apt.conf" \
+    BUZZ_DEPENDENCY_TIMEOUT_SECONDS=1 \
+    BUZZ_DEPENDENCY_KILL_GRACE_SECONDS=1 \
+    BUZZ_DEPENDENCY_RETRY_DELAY_SECONDS=0 \
+    scripts/install-desktop-system-deps-ci.sh "$tmp/attempt" "$mode" "$count_file"
+  local status=$?
+  set -e
+
+  if [ "$status" -ne "$expected_status" ]; then
+    echo "$mode: expected status $expected_status, got $status" >&2
+    exit 1
+  fi
+  if [ "$(cat "$count_file")" -ne "$expected_attempts" ]; then
+    echo "$mode: expected $expected_attempts attempt(s), got $(cat "$count_file")" >&2
+    exit 1
+  fi
+  if [ -e "$tmp/${mode}.apt.conf" ]; then
+    echo "$mode: apt config was not cleaned up" >&2
+    exit 1
+  fi
+  echo "$mode: PASS (status $status, attempts $expected_attempts)"
+}
+
+run_case success 0 1
+run_case quick-137 137 1
+run_case cooperative-timeout 124 2
+run_case forced-kill-timeout 137 2


### PR DESCRIPTION
## Summary

- bound Linux desktop system-dependency installation with an outer GNU `timeout`
- disable apt's internal retries and cap HTTP, HTTPS, and dpkg lock waits
- retry only genuine outer timeouts, while propagating deterministic failures immediately
- apply the same fail-closed policy to Tauri dependencies and both Playwright dependency-install sites

The worst-case system-dependency phase is 185 seconds: two 85-second TERM windows, up to two 5-second kill-grace windows, and one 5-second retry delay.

## Validation

At tip `426f376fb5b0f448a24f914f7276865a691f4789`:

- Linux harness: success exits 0 after one attempt
- Linux harness: quick status 137 propagates after one attempt
- Linux harness: cooperative timeout 124 retries and exits after two attempts
- Linux harness: TERM-ignoring forced-kill 137 retries and exits after two attempts
- `bash -n` passes for the helper and harness
- workflow YAML parses
- `git diff --check` passes
- commit and push hooks pass

CI exercises all three production workflow call sites on GitHub's Ubuntu runner.
