### PR TITLE
feat(remote-agents): add persistent Kubernetes recovery

### DIFF
--- a/VISION_REMOTE_AGENTS.md
+++ b/VISION_REMOTE_AGENTS.md
@@ -56,6 +56,8 @@ Remote agents solve it from the inside. Because the desktop retains no substrate
 
 **The body's state is mortal.** Files, checkouts, half-finished working trees — gone with the body unless the substrate persists them. The agent survives; its scratch space doesn't. Durable knowledge belongs on the relay, and agents are built to put it there.
 
+**Persistent workspace storage outlives compute — and its bill.** A Kubernetes workspace PVC deliberately survives clean exit, crash, pod deletion, and redeploy so the next body can resume the same checkout. The provider never garbage-collects it. Storage keeps accruing until the cluster operator explicitly deletes the claim or its namespace; choosing persistence also means choosing that cleanup duty.
+
 **Presence can lag the truth, but not for long.** If the substrate kills a body without ceremony, the presence dot can outlive the agent — by seconds if the connection drops cleanly, by at most about three minutes if it doesn't. Presence is a lease the agent renews, not a flag it sets: a dead agent stops renewing and the relay forgets it. A bounded wrong dot, never an indefinite one.
 
 **A running agent finishes on the configuration it started with.** New keys, new models, new settings take effect on the next body. And an instance that never got far enough to run — a body that failed to start — is the substrate operator's residue to clear, with the substrate's own tools. Editing an agent mid-sentence was never on the menu.

--- a/crates/buzz-backend-kubernetes/src/cluster.rs
+++ b/crates/buzz-backend-kubernetes/src/cluster.rs
@@ -567,6 +567,15 @@ mod tests {
     fn workspace_claim_verification_rejects_foreign_or_different_claims() {
         let desired = workspace_claim();
 
+        let mut legacy = desired.clone();
+        legacy.metadata.labels.as_mut().unwrap().insert(
+            crate::naming::LABEL_BINDING_VERSION.into(),
+            crate::naming::LEGACY_BINDING_VERSION.into(),
+        );
+        assert!(verify_workspace_claim(&legacy, &desired)
+            .unwrap_err()
+            .contains("not owned by this Buzz agent"));
+
         let mut foreign = desired.clone();
         foreign
             .metadata

--- a/crates/buzz-backend-kubernetes/src/cluster.rs
+++ b/crates/buzz-backend-kubernetes/src/cluster.rs
@@ -18,7 +18,7 @@
 use crate::classify::Fence;
 use crate::reconcile::{CreateOutcome, DeleteOutcome, Substrate};
 use chrono::{DateTime, Utc};
-use k8s_openapi::api::core::v1::{Namespace, Pod, Secret};
+use k8s_openapi::api::core::v1::{Namespace, PersistentVolumeClaim, Pod, Secret};
 use kube::api::{Api, DeleteParams, GetParams, ListParams, PostParams, Preconditions};
 use kube::core::ErrorResponse;
 use kube::{Client, Resource};
@@ -73,6 +73,10 @@ impl Cluster {
     }
 
     fn secrets(&self) -> Api<Secret> {
+        Api::namespaced(self.client.clone(), &self.namespace)
+    }
+
+    fn workspace_claims(&self) -> Api<PersistentVolumeClaim> {
         Api::namespaced(self.client.clone(), &self.namespace)
     }
 
@@ -170,6 +174,40 @@ impl Substrate for Cluster {
         }
     }
 
+    async fn ensure_workspace_claim(
+        &self,
+        claim: Option<&PersistentVolumeClaim>,
+    ) -> Result<(), String> {
+        let Some(desired) = claim else {
+            return Ok(());
+        };
+        let name = desired.metadata.name.as_deref().ok_or_else(|| {
+            "persistent workspace claim is missing its deterministic name".to_string()
+        })?;
+        let api = self.workspace_claims();
+
+        match api.get_opt(name).await {
+            Ok(Some(existing)) => verify_workspace_claim(&existing, desired),
+            Ok(None) => match api.create(&PostParams::default(), desired).await {
+                Ok(created) => verify_workspace_claim(&created, desired),
+                Err(error) if reason_is(&error, REASON_ALREADY_EXISTS) => {
+                    let existing = api.get(name).await.map_err(|read_error| {
+                        format!(
+                            "workspace claim {name} won a create race but could not be read: {read_error}"
+                        )
+                    })?;
+                    verify_workspace_claim(&existing, desired)
+                }
+                Err(error) => Err(format!(
+                    "could not create persistent workspace claim {name}: {error}"
+                )),
+            },
+            Err(error) => Err(format!(
+                "could not check persistent workspace claim {name}: {error}"
+            )),
+        }
+    }
+
     async fn list_pods(&self, selector: &str) -> Result<(Vec<Pod>, Option<DateTime<Utc>>), String> {
         self.list_with_date::<Pod>(selector).await
     }
@@ -255,6 +293,81 @@ impl Substrate for Cluster {
     fn elapsed(&self) -> Duration {
         self.started.elapsed()
     }
+}
+
+fn verify_workspace_claim(
+    existing: &PersistentVolumeClaim,
+    desired: &PersistentVolumeClaim,
+) -> Result<(), String> {
+    let name = desired.metadata.name.as_deref().unwrap_or("<unnamed>");
+    let desired_labels = desired
+        .metadata
+        .labels
+        .as_ref()
+        .ok_or_else(|| format!("persistent workspace claim {name} has no ownership labels"))?;
+    let existing_labels = existing.metadata.labels.as_ref();
+    if desired_labels
+        .iter()
+        .any(|(key, value)| existing_labels.and_then(|labels| labels.get(key)) != Some(value))
+    {
+        return Err(format!(
+            "persistent workspace claim {name} already exists but is not owned by this Buzz agent"
+        ));
+    }
+
+    let desired_annotations =
+        desired.metadata.annotations.as_ref().ok_or_else(|| {
+            format!("persistent workspace claim {name} has no identity annotation")
+        })?;
+    let existing_annotations = existing.metadata.annotations.as_ref();
+    if desired_annotations.iter().any(|(key, value)| {
+        existing_annotations.and_then(|annotations| annotations.get(key)) != Some(value)
+    }) {
+        return Err(format!(
+            "persistent workspace claim {name} belongs to a different agent identity"
+        ));
+    }
+
+    let desired_spec = desired.spec.as_ref().ok_or_else(|| {
+        format!("persistent workspace claim {name} is missing its requested shape")
+    })?;
+    let existing_spec = existing
+        .spec
+        .as_ref()
+        .ok_or_else(|| format!("persistent workspace claim {name} exists without a spec"))?;
+    let existing_storage = existing_spec
+        .resources
+        .as_ref()
+        .and_then(|resources| resources.requests.as_ref())
+        .and_then(|requests| requests.get("storage"));
+    let desired_storage = desired_spec
+        .resources
+        .as_ref()
+        .and_then(|resources| resources.requests.as_ref())
+        .and_then(|requests| requests.get("storage"));
+    if existing_storage != desired_storage {
+        return Err(format!(
+            "persistent workspace claim {name} already exists with a different storage request; resize or replace it with cluster tools before retrying"
+        ));
+    }
+    if let Some(desired_class) = desired_spec.storage_class_name.as_ref() {
+        if existing_spec.storage_class_name.as_ref() != Some(desired_class) {
+            return Err(format!(
+                "persistent workspace claim {name} already exists with a different storage class"
+            ));
+        }
+    }
+    if !existing_spec
+        .access_modes
+        .as_ref()
+        .is_some_and(|modes| modes.iter().any(|mode| mode == "ReadWriteOnce"))
+    {
+        return Err(format!(
+            "persistent workspace claim {name} does not allow ReadWriteOnce access"
+        ));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -423,5 +536,65 @@ mod tests {
         assert_eq!(REASON_CONFLICT, "Conflict");
         assert_eq!(REASON_NOT_FOUND, "NotFound");
         assert_eq!(REASON_FORBIDDEN, "Forbidden");
+    }
+
+    fn workspace_claim() -> PersistentVolumeClaim {
+        use nostr::nips::nip19::ToBech32;
+        let keys = nostr::Keys::generate();
+        let identity =
+            crate::naming::AgentIdentity::from_nsec(&keys.secret_key().to_bech32().unwrap())
+                .unwrap();
+        let cfg = crate::config::parse(&serde_json::json!({
+            "namespace": "buzz-agents-test",
+            "image": format!(
+                "ghcr.io/block/buzz-sprig@sha256:{}",
+                "a".repeat(64)
+            ),
+            "workspace_storage": "20Gi",
+            "workspace_storage_class": "fast-ssd"
+        }))
+        .unwrap();
+        crate::pod::build_workspace_claim(&identity, &cfg).unwrap()
+    }
+
+    #[test]
+    fn workspace_claim_verification_accepts_the_same_identity_and_shape() {
+        let desired = workspace_claim();
+        assert_eq!(verify_workspace_claim(&desired, &desired), Ok(()));
+    }
+
+    #[test]
+    fn workspace_claim_verification_rejects_foreign_or_different_claims() {
+        let desired = workspace_claim();
+
+        let mut foreign = desired.clone();
+        foreign
+            .metadata
+            .annotations
+            .as_mut()
+            .unwrap()
+            .insert(crate::naming::ANNOTATION_PUBKEY_FULL.into(), "0".repeat(64));
+        assert!(verify_workspace_claim(&foreign, &desired)
+            .unwrap_err()
+            .contains("different agent identity"));
+
+        let mut resized = desired.clone();
+        resized
+            .spec
+            .as_mut()
+            .unwrap()
+            .resources
+            .as_mut()
+            .unwrap()
+            .requests
+            .as_mut()
+            .unwrap()
+            .insert(
+                "storage".into(),
+                k8s_openapi::apimachinery::pkg::api::resource::Quantity("30Gi".into()),
+            );
+        assert!(verify_workspace_claim(&resized, &desired)
+            .unwrap_err()
+            .contains("different storage request"));
     }
 }

--- a/crates/buzz-backend-kubernetes/src/config.rs
+++ b/crates/buzz-backend-kubernetes/src/config.rs
@@ -1,7 +1,7 @@
 //! `provider_config` parsing and the `info` config schema
 //! (spec §`provider_config` v1 fields, `docs/remote-agents.md:1384-1389`).
 //!
-//! Nine fields, all optional except `image` (required at parse time; the
+//! Eleven fields, all optional except `image` (required at parse time; the
 //! schema offers the published sprig image as a prefill default — §Image).
 //! No credential field exists, by I2: cluster auth comes from ambient
 //! kubeconfig resolution and nothing else (`:196-198`).
@@ -71,6 +71,12 @@ pub struct ProviderConfig {
     /// `None` when `inactivity_seconds` was 0 — refused in v1, see [`parse`].
     pub inactivity_seconds: Option<u64>,
     pub service_account: Option<String>,
+    /// Requested capacity for an identity-owned persistent workspace claim.
+    /// `None` preserves the v1 `emptyDir` behavior.
+    pub workspace_storage: Option<String>,
+    /// Optional StorageClass for the persistent workspace claim. Rejected
+    /// unless [`workspace_storage`](Self::workspace_storage) is also set.
+    pub workspace_storage_class: Option<String>,
 }
 
 /// Read an optional non-empty string field. Rejects non-string scalars rather
@@ -165,6 +171,14 @@ pub fn parse(cfg: &serde_json::Value) -> Result<ProviderConfig, String> {
         Some(n) => Some(n),
     };
 
+    let workspace_storage = optional_string(cfg, "workspace_storage")?;
+    let workspace_storage_class = optional_string(cfg, "workspace_storage_class")?;
+    if workspace_storage.is_none() && workspace_storage_class.is_some() {
+        return Err(
+            "provider_config.workspace_storage_class requires workspace_storage".to_string(),
+        );
+    }
+
     Ok(ProviderConfig {
         context: optional_string(cfg, "context")?,
         namespace,
@@ -172,6 +186,8 @@ pub fn parse(cfg: &serde_json::Value) -> Result<ProviderConfig, String> {
         resources,
         inactivity_seconds,
         service_account: optional_string(cfg, "service_account")?,
+        workspace_storage,
+        workspace_storage_class,
     })
 }
 
@@ -236,6 +252,16 @@ pub fn config_schema() -> serde_json::Value {
                 "type": "string",
                 "title": "Service account",
                 "description": "Scheduling/RBAC identity only. No API token is mounted."
+            },
+            "workspace_storage": {
+                "type": "string",
+                "title": "Persistent workspace size",
+                "description": "Optional Kubernetes storage request such as 20Gi. When set, Buzz creates one identity-owned claim that survives pod replacement. Leave empty for an ephemeral workspace."
+            },
+            "workspace_storage_class": {
+                "type": "string",
+                "title": "Workspace storage class",
+                "description": "Optional StorageClass for the persistent workspace claim. Leave empty to use the cluster default."
             }
         },
         "required": ["namespace", "image"]
@@ -265,6 +291,8 @@ mod tests {
         assert_eq!(c.inactivity_seconds, Some(DEFAULT_INACTIVITY_SECONDS));
         assert_eq!(c.context, None);
         assert_eq!(c.service_account, None);
+        assert_eq!(c.workspace_storage, None);
+        assert_eq!(c.workspace_storage_class, None);
     }
 
     #[test]
@@ -386,6 +414,25 @@ mod tests {
     }
 
     #[test]
+    fn persistent_workspace_fields_are_parsed_together() {
+        let mut cfg = minimal();
+        cfg["workspace_storage"] = "20Gi".into();
+        cfg["workspace_storage_class"] = "fast-ssd".into();
+        let parsed = parse(&cfg).unwrap();
+        assert_eq!(parsed.workspace_storage.as_deref(), Some("20Gi"));
+        assert_eq!(parsed.workspace_storage_class.as_deref(), Some("fast-ssd"));
+    }
+
+    #[test]
+    fn workspace_storage_class_requires_a_storage_request() {
+        let mut cfg = minimal();
+        cfg["workspace_storage_class"] = "fast-ssd".into();
+        let error = parse(&cfg).unwrap_err();
+        assert!(error.contains("workspace_storage_class"), "got: {error}");
+        assert!(error.contains("workspace_storage"), "got: {error}");
+    }
+
+    #[test]
     fn generated_namespaces_are_fresh_and_valid() {
         let a = generated_namespace();
         let b = generated_namespace();
@@ -423,10 +470,10 @@ mod tests {
         );
     }
 
-    /// Nine fields exactly (§`provider_config` v1 fields). The cap is 20; the
+    /// Eleven fields exactly (§`provider_config` fields). The cap is 20; the
     /// count is pinned so a field added without a spec change is caught here.
     #[test]
-    fn schema_declares_exactly_the_nine_v1_fields() {
+    fn schema_declares_exactly_the_eleven_fields() {
         let schema = config_schema();
         let props = schema["properties"].as_object().unwrap();
         let mut keys: Vec<&str> = props.keys().map(String::as_str).collect();
@@ -442,7 +489,9 @@ mod tests {
                 "memory_limit",
                 "memory_request",
                 "namespace",
-                "service_account"
+                "service_account",
+                "workspace_storage",
+                "workspace_storage_class"
             ]
         );
         assert_eq!(

--- a/crates/buzz-backend-kubernetes/src/intent.rs
+++ b/crates/buzz-backend-kubernetes/src/intent.rs
@@ -81,12 +81,16 @@ pub struct IntentTemplate {
     /// Fixed placeholder for the per-attempt Secret in `envFrom`.
     pub env_from_secret: &'static str,
     pub workspace_mount_path: String,
+    /// `None` means the v1 ephemeral `emptyDir`; `Some` selects the
+    /// identity-owned persistent claim and records its requested capacity.
+    pub workspace_storage: Option<String>,
+    pub workspace_storage_class: Option<String>,
     pub run_as_user: i64,
     pub run_as_group: i64,
 }
 
 /// Current template schema version.
-pub const TEMPLATE_VERSION: u32 = 1;
+pub const TEMPLATE_VERSION: u32 = 2;
 
 impl IntentTemplate {
     /// Compute the fingerprint. `serde_json` on a struct with declared field
@@ -110,6 +114,8 @@ impl IntentTemplate {
         image: &ImageRef,
         resources: &crate::config::Resources,
         service_account: Option<&str>,
+        workspace_storage: Option<&str>,
+        workspace_storage_class: Option<&str>,
         env_keys: impl IntoIterator<Item = String>,
     ) -> Self {
         let mut env_keys: Vec<String> = env_keys.into_iter().collect();
@@ -128,6 +134,8 @@ impl IntentTemplate {
             env_keys,
             env_from_secret: SECRET_PLACEHOLDER,
             workspace_mount_path: crate::config::WORKSPACE_PATH.to_string(),
+            workspace_storage: workspace_storage.map(str::to_string),
+            workspace_storage_class: workspace_storage_class.map(str::to_string),
             run_as_user: crate::config::RUN_AS_UID,
             run_as_group: crate::config::RUN_AS_GID,
         }
@@ -152,6 +160,8 @@ mod tests {
             "buzz-agents",
             &image('a'),
             &Resources::default(),
+            None,
+            None,
             None,
             ["BUZZ_RELAY_URL".to_string(), "GOOSE_MODE".to_string()],
         )
@@ -178,12 +188,16 @@ mod tests {
             &image('a'),
             &Resources::default(),
             None,
+            None,
+            None,
             ["A".to_string(), "B".to_string(), "C".to_string()],
         );
         let b = IntentTemplate::new(
             "ns",
             &image('a'),
             &Resources::default(),
+            None,
+            None,
             None,
             ["C".to_string(), "A".to_string(), "B".to_string()],
         );
@@ -250,6 +264,16 @@ mod tests {
             (
                 "workspace_mount_path",
                 Box::new(|t: &mut IntentTemplate| t.workspace_mount_path = "/w".into()),
+            ),
+            (
+                "workspace_storage",
+                Box::new(|t: &mut IntentTemplate| t.workspace_storage = Some("20Gi".into())),
+            ),
+            (
+                "workspace_storage_class",
+                Box::new(|t: &mut IntentTemplate| {
+                    t.workspace_storage_class = Some("fast-ssd".into())
+                }),
             ),
             (
                 "run_as_user",

--- a/crates/buzz-backend-kubernetes/src/naming.rs
+++ b/crates/buzz-backend-kubernetes/src/naming.rs
@@ -15,9 +15,18 @@ pub const LABEL_MANAGED_BY: &str = "app.kubernetes.io/managed-by";
 /// Label key carrying [`BINDING_VERSION`] — the marker's schema half.
 pub const LABEL_BINDING_VERSION: &str = "buzz.block.xyz/binding-version";
 
-/// Schema version of the object layout this provider writes. Bumped when the
-/// pod/Secret shape changes in a way a older provider would mis-handle.
-pub const BINDING_VERSION: &str = "1";
+/// Legacy pod/Secret binding that the v2 reader still understands during an
+/// upgrade. It is never written by this provider.
+pub const LEGACY_BINDING_VERSION: &str = "1";
+
+/// Schema version of the object layout this provider writes. Bumped because a
+/// v1 provider would replace a terminal persistent generation with `emptyDir`.
+pub const BINDING_VERSION: &str = "2";
+
+/// Pod/Secret bindings this provider may safely observe, adopt, and collect.
+/// Persistent workspace claims are deliberately excluded from this legacy
+/// compatibility surface and must carry [`BINDING_VERSION`] exactly.
+pub const SUPPORTED_READ_BINDING_VERSIONS: &[&str] = &[LEGACY_BINDING_VERSION, BINDING_VERSION];
 
 /// Label key: truncated pubkey, the reconciliation and GC selector.
 pub const LABEL_AGENT_PUBKEY: &str = "buzz.block.xyz/agent-pubkey";

--- a/crates/buzz-backend-kubernetes/src/naming.rs
+++ b/crates/buzz-backend-kubernetes/src/naming.rs
@@ -76,6 +76,12 @@ impl AgentIdentity {
         format!("buzz-agent-{}", &self.pubkey_hex[..12])
     }
 
+    /// Deterministic persistent workspace claim. Unlike the per-attempt
+    /// Secret, this name deliberately survives every pod generation.
+    pub fn workspace_claim_name(&self) -> String {
+        format!("{}-workspace", self.pod_name())
+    }
+
     /// Per-attempt Secret name. `generation` is a fresh random token per
     /// create attempt — never reused — which is what makes payload and Secret
     /// atomic at the pod-spec boundary (§K8s Secrets).
@@ -186,6 +192,17 @@ mod tests {
             .pod_name()
             .chars()
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'));
+    }
+
+    #[test]
+    fn workspace_claim_name_is_identity_stable_and_dns_safe() {
+        let id = identity();
+        assert_eq!(id.workspace_claim_name(), id.workspace_claim_name());
+        assert_eq!(
+            id.workspace_claim_name(),
+            format!("{}-workspace", id.pod_name())
+        );
+        assert!(id.workspace_claim_name().len() <= 253);
     }
 
     /// Two attempts must never share a Secret name — that uniqueness is what

--- a/crates/buzz-backend-kubernetes/src/observe.rs
+++ b/crates/buzz-backend-kubernetes/src/observe.rs
@@ -13,8 +13,8 @@
 use crate::classify::{Fence, PullFailure, Startup, VerifiedPod};
 use crate::intent::Fingerprint;
 use crate::naming::{
-    AgentIdentity, ANNOTATION_CREATE_INTENT, ANNOTATION_PUBKEY_FULL, BINDING_VERSION,
-    LABEL_BINDING_VERSION, LABEL_MANAGED_BY, MANAGED_BY,
+    AgentIdentity, ANNOTATION_CREATE_INTENT, ANNOTATION_PUBKEY_FULL, LABEL_BINDING_VERSION,
+    LABEL_MANAGED_BY, MANAGED_BY, SUPPORTED_READ_BINDING_VERSIONS,
 };
 use k8s_openapi::api::core::v1::{Pod, Secret};
 
@@ -39,10 +39,22 @@ pub enum StartupObservation {
 ///
 /// Identity labels prove identity; the marker asserts protocol ownership.
 /// Without it an object that merely matches our schema fails closed.
-fn has_marker(labels: Option<&std::collections::BTreeMap<String, String>>) -> bool {
+fn has_marker_for_binding(
+    labels: Option<&std::collections::BTreeMap<String, String>>,
+    binding_version: &str,
+) -> bool {
     let Some(labels) = labels else { return false };
     labels.get(LABEL_MANAGED_BY).map(String::as_str) == Some(MANAGED_BY)
-        && labels.get(LABEL_BINDING_VERSION).map(String::as_str) == Some(BINDING_VERSION)
+        && labels.get(LABEL_BINDING_VERSION).map(String::as_str) == Some(binding_version)
+}
+
+/// New writers adopt v1 Pods and Secrets so an upgrade can converge them to a
+/// v2 generation on the next owner-driven replacement. Unknown and future
+/// bindings still fail closed.
+fn has_supported_marker(labels: Option<&std::collections::BTreeMap<String, String>>) -> bool {
+    SUPPORTED_READ_BINDING_VERSIONS
+        .iter()
+        .any(|version| has_marker_for_binding(labels, version))
 }
 
 /// Does the full-pubkey annotation equal the derived pubkey?
@@ -62,7 +74,7 @@ fn annotation_matches(
 /// Is this Secret ours and this identity's? The same fence GC applies before
 /// deleting anything.
 pub fn secret_is_ours(secret: &Secret, identity: &AgentIdentity) -> bool {
-    has_marker(secret.metadata.labels.as_ref())
+    has_supported_marker(secret.metadata.labels.as_ref())
         && annotation_matches(secret.metadata.annotations.as_ref(), identity)
 }
 
@@ -251,7 +263,7 @@ pub fn condition(pod: &Pod) -> Option<String> {
 /// `CreateContainerConfigError` needs a most-recent Secret read the pure layer
 /// must not perform.
 pub fn verify(pod: &Pod, identity: &AgentIdentity, startup: Startup) -> Option<VerifiedPod> {
-    if !has_marker(pod.metadata.labels.as_ref()) {
+    if !has_supported_marker(pod.metadata.labels.as_ref()) {
         return None;
     }
     if !annotation_matches(pod.metadata.annotations.as_ref(), identity) {
@@ -296,6 +308,24 @@ mod tests {
                 name: Some(id.pod_name()),
                 uid: Some("uid-1".into()),
                 resource_version: Some("100".into()),
+                labels: Some(id.labels()),
+                annotations: Some(
+                    [(
+                        ANNOTATION_PUBKEY_FULL.to_string(),
+                        id.pubkey_hex().to_string(),
+                    )]
+                    .into_iter()
+                    .collect::<BTreeMap<_, _>>(),
+                ),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn base_secret(id: &AgentIdentity) -> Secret {
+        Secret {
+            metadata: ObjectMeta {
                 labels: Some(id.labels()),
                 annotations: Some(
                     [(
@@ -517,6 +547,38 @@ mod tests {
         assert!(
             verify(&base_pod(&id), &id, Startup::Started).is_some(),
             "own pod rejected"
+        );
+    }
+
+    #[test]
+    fn current_reader_accepts_legacy_v1_pods_and_secrets() {
+        let id = identity();
+        let mut pod = base_pod(&id);
+        pod.metadata.labels.as_mut().unwrap().insert(
+            LABEL_BINDING_VERSION.to_string(),
+            crate::naming::LEGACY_BINDING_VERSION.to_string(),
+        );
+        assert!(verify(&pod, &id, Startup::Started).is_some());
+
+        let mut secret = base_secret(&id);
+        secret.metadata.labels.as_mut().unwrap().insert(
+            LABEL_BINDING_VERSION.to_string(),
+            crate::naming::LEGACY_BINDING_VERSION.to_string(),
+        );
+        assert!(secret_is_ours(&secret, &id));
+    }
+
+    #[test]
+    fn legacy_v1_reader_would_refuse_current_v2_state() {
+        let id = identity();
+        let pod = base_pod(&id);
+        assert!(has_supported_marker(pod.metadata.labels.as_ref()));
+        assert!(
+            !has_marker_for_binding(
+                pod.metadata.labels.as_ref(),
+                crate::naming::LEGACY_BINDING_VERSION,
+            ),
+            "a v1 reader must fail closed on a v2 deterministic-name collision"
         );
     }
 

--- a/crates/buzz-backend-kubernetes/src/pod.rs
+++ b/crates/buzz-backend-kubernetes/src/pod.rs
@@ -12,9 +12,10 @@ use crate::naming::{
     AgentIdentity, ANNOTATION_CREATE_INTENT, ANNOTATION_IMAGE, ANNOTATION_PUBKEY_FULL,
 };
 use k8s_openapi::api::core::v1::{
-    Capabilities, Container, EmptyDirVolumeSource, EnvFromSource, Pod, PodSecurityContext, PodSpec,
+    Capabilities, Container, EmptyDirVolumeSource, EnvFromSource, PersistentVolumeClaim,
+    PersistentVolumeClaimSpec, PersistentVolumeClaimVolumeSource, Pod, PodSecurityContext, PodSpec,
     ResourceRequirements, SeccompProfile, Secret, SecretEnvSource, SecurityContext, Volume,
-    VolumeMount,
+    VolumeMount, VolumeResourceRequirements,
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -25,6 +26,46 @@ const WORKSPACE_VOLUME: &str = "workspace";
 
 /// The container name. Fixed: log and exec tooling addresses it by name.
 const CONTAINER_NAME: &str = "agent";
+
+/// Build the identity-owned persistent workspace claim requested by this
+/// configuration. The deterministic name is intentionally generation-free:
+/// pods are disposable, the workspace is not.
+pub fn build_workspace_claim(
+    identity: &AgentIdentity,
+    cfg: &ProviderConfig,
+) -> Option<PersistentVolumeClaim> {
+    let storage = cfg.workspace_storage.as_ref()?;
+    let requests = [("storage".to_string(), Quantity(storage.clone()))]
+        .into_iter()
+        .collect();
+
+    Some(PersistentVolumeClaim {
+        metadata: ObjectMeta {
+            name: Some(identity.workspace_claim_name()),
+            namespace: Some(cfg.namespace.clone()),
+            labels: Some(identity.labels()),
+            annotations: Some(
+                [(
+                    ANNOTATION_PUBKEY_FULL.to_string(),
+                    identity.pubkey_hex().to_string(),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        },
+        spec: Some(PersistentVolumeClaimSpec {
+            access_modes: Some(vec!["ReadWriteOnce".to_string()]),
+            resources: Some(VolumeResourceRequirements {
+                requests: Some(requests),
+                ..Default::default()
+            }),
+            storage_class_name: cfg.workspace_storage_class.clone(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    })
+}
 
 /// Build the per-attempt Secret holding the resolved environment.
 ///
@@ -171,14 +212,29 @@ pub fn build_pod(
                 }),
                 ..Default::default()
             }),
-            volumes: Some(vec![Volume {
-                name: WORKSPACE_VOLUME.to_string(),
-                empty_dir: Some(EmptyDirVolumeSource::default()),
-                ..Default::default()
-            }]),
+            volumes: Some(vec![workspace_volume(identity, cfg)]),
             ..Default::default()
         }),
         ..Default::default()
+    }
+}
+
+fn workspace_volume(identity: &AgentIdentity, cfg: &ProviderConfig) -> Volume {
+    if cfg.workspace_storage.is_some() {
+        Volume {
+            name: WORKSPACE_VOLUME.to_string(),
+            persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource {
+                claim_name: identity.workspace_claim_name(),
+                read_only: Some(false),
+            }),
+            ..Default::default()
+        }
+    } else {
+        Volume {
+            name: WORKSPACE_VOLUME.to_string(),
+            empty_dir: Some(EmptyDirVolumeSource::default()),
+            ..Default::default()
+        }
     }
 }
 
@@ -192,6 +248,8 @@ pub fn intent_template(
         &cfg.image,
         &cfg.resources,
         cfg.service_account.as_deref(),
+        cfg.workspace_storage.as_deref(),
+        cfg.workspace_storage_class.as_deref(),
         env_keys,
     )
 }
@@ -307,7 +365,7 @@ mod tests {
     }
 
     #[test]
-    fn workspace_is_an_emptydir_mounted_at_home() {
+    fn workspace_defaults_to_an_emptydir_mounted_at_home() {
         let pod = pod();
         let spec = spec(&pod);
         let volume = &spec.volumes.as_ref().unwrap()[0];
@@ -316,6 +374,57 @@ mod tests {
         let mount = &spec.containers[0].volume_mounts.as_ref().unwrap()[0];
         assert_eq!(mount.name, volume.name);
         assert_eq!(mount.mount_path, WORKSPACE_PATH);
+    }
+
+    #[test]
+    fn persistent_workspace_claim_and_pod_share_the_identity_stable_name() {
+        let id = identity();
+        let mut cfg = provider_config();
+        cfg.workspace_storage = Some("20Gi".into());
+        cfg.workspace_storage_class = Some("fast-ssd".into());
+
+        let claim = build_workspace_claim(&id, &cfg).expect("persistent claim");
+        assert_eq!(
+            claim.metadata.name.as_deref(),
+            Some(id.workspace_claim_name().as_str())
+        );
+        assert_eq!(claim.metadata.labels.as_ref(), Some(&id.labels()));
+        assert_eq!(
+            claim.metadata.annotations.as_ref().unwrap()[ANNOTATION_PUBKEY_FULL],
+            id.pubkey_hex()
+        );
+        let claim_spec = claim.spec.as_ref().unwrap();
+        assert_eq!(
+            claim_spec.access_modes.as_deref(),
+            Some(["ReadWriteOnce".to_string()].as_slice())
+        );
+        assert_eq!(
+            claim_spec
+                .resources
+                .as_ref()
+                .unwrap()
+                .requests
+                .as_ref()
+                .unwrap()["storage"],
+            Quantity("20Gi".into())
+        );
+        assert_eq!(claim_spec.storage_class_name.as_deref(), Some("fast-ssd"));
+
+        let pod = build_pod(&id, &cfg, "g", &Fingerprint::from_annotation("f"));
+        let volume = &spec(&pod).volumes.as_ref().unwrap()[0];
+        assert!(volume.empty_dir.is_none());
+        let source = volume
+            .persistent_volume_claim
+            .as_ref()
+            .expect("persistent workspace volume");
+        assert_eq!(source.claim_name, id.workspace_claim_name());
+        assert_eq!(source.read_only, Some(false));
+    }
+
+    #[test]
+    fn ephemeral_workspace_does_not_create_a_claim() {
+        let id = identity();
+        assert!(build_workspace_claim(&id, &provider_config()).is_none());
     }
 
     #[test]

--- a/crates/buzz-backend-kubernetes/src/reconcile.rs
+++ b/crates/buzz-backend-kubernetes/src/reconcile.rs
@@ -23,7 +23,7 @@ use crate::gc;
 use crate::naming::AgentIdentity;
 use crate::observe::{self, StartupObservation};
 use chrono::{DateTime, Utc};
-use k8s_openapi::api::core::v1::{Pod, Secret};
+use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod, Secret};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
@@ -58,6 +58,13 @@ pub trait Substrate {
     /// literal `kubectl create namespace <name>` command and MUST NOT fall
     /// back to `default` (`:1002-1005`).
     async fn ensure_namespace(&self, namespace: &str) -> Result<(), String>;
+
+    /// Create or verify the identity-owned persistent workspace claim. `None`
+    /// keeps the legacy ephemeral workspace and performs no substrate write.
+    async fn ensure_workspace_claim(
+        &self,
+        claim: Option<&PersistentVolumeClaim>,
+    ) -> Result<(), String>;
 
     /// Most-recent read of the pods matching this identity's selector, plus
     /// the apiserver's clock from the same call's HTTP `Date` header. `None`
@@ -444,6 +451,13 @@ pub async fn deploy(
             }
 
             Action::Create => {
+                // A running v1 pod remains a strict zero-mutation no-op. Only
+                // the create edge may introduce or verify the durable claim.
+                let workspace_claim = crate::pod::build_workspace_claim(identity, cfg);
+                substrate
+                    .ensure_workspace_claim(workspace_claim.as_ref())
+                    .await?;
+
                 let generation = crate::naming::new_generation();
                 let secret_name = identity.secret_name(&generation);
 
@@ -568,6 +582,19 @@ mod tests {
             }
         }
 
+        async fn ensure_workspace_claim(
+            &self,
+            claim: Option<&PersistentVolumeClaim>,
+        ) -> Result<(), String> {
+            if let Some(claim) = claim {
+                self.log(format!(
+                    "ensure_workspace_claim {}",
+                    claim.metadata.name.as_deref().unwrap_or_default()
+                ));
+            }
+            Ok(())
+        }
+
         async fn list_pods(
             &self,
             _selector: &str,
@@ -684,6 +711,8 @@ mod tests {
             resources: Resources::default(),
             inactivity_seconds: Some(7200),
             service_account: None,
+            workspace_storage: None,
+            workspace_storage_class: None,
         }
     }
 
@@ -806,6 +835,46 @@ mod tests {
         );
     }
 
+    #[test]
+    fn persistent_workspace_is_ensured_before_the_pod_is_created() {
+        let id = identity();
+        let mut cfg = config();
+        cfg.workspace_storage = Some("20Gi".into());
+        let fake = Fake::default();
+        fake.on_poll.borrow_mut().push({
+            let name = id.pod_name();
+            Box::new(move |pods: &mut BTreeMap<String, Pod>| {
+                if let Some(pod) = pods.get_mut(&name) {
+                    pod.status = Some(PodStatus {
+                        phase: Some("Running".into()),
+                        container_statuses: Some(vec![ContainerStatus {
+                            name: crate::observe::CONTAINER_NAME.into(),
+                            state: Some(running()),
+                            ..Default::default()
+                        }]),
+                        ..Default::default()
+                    });
+                }
+            })
+        });
+
+        assert_eq!(run(&fake, &id, &cfg).unwrap(), id.pod_name());
+        let calls = fake.mutations();
+        let claim_at = calls
+            .iter()
+            .position(|call| call.starts_with("ensure_workspace_claim"))
+            .expect("workspace claim was not ensured");
+        let pod_at = calls
+            .iter()
+            .position(|call| call.starts_with("create_pod"))
+            .expect("pod was not created");
+        assert!(claim_at < pod_at, "pod preceded its claim: {calls:?}");
+        assert_eq!(
+            calls[claim_at],
+            format!("ensure_workspace_claim {}", id.workspace_claim_name())
+        );
+    }
+
     /// The strict no-op row: a started pod returns its id having mutated
     /// nothing at all. Asserted on the *call log*, not on final state — a
     /// delete-then-recreate would leave identical final state.
@@ -820,6 +889,26 @@ mod tests {
             fake.mutations(),
             [format!("ensure_namespace {}", cfg.namespace)],
             "the no-op row mutated something"
+        );
+    }
+
+    #[test]
+    fn started_ephemeral_pod_does_not_create_a_newly_requested_claim() {
+        let id = identity();
+        let running_cfg = config();
+        let fake = Fake::default().with_pod(our_pod(&id, &running_cfg, Some(running())));
+        let mut desired_cfg = running_cfg.clone();
+        desired_cfg.workspace_storage = Some("20Gi".into());
+
+        assert_eq!(
+            run(&fake, &id, &desired_cfg).unwrap(),
+            id.pod_name(),
+            "running v1 pod should remain the active generation"
+        );
+        assert_eq!(
+            fake.mutations(),
+            [format!("ensure_namespace {}", desired_cfg.namespace)],
+            "a running generation must not introduce its successor's claim"
         );
     }
 
@@ -1536,6 +1625,12 @@ mod tests {
         impl Substrate for GcDenied {
             async fn ensure_namespace(&self, ns: &str) -> Result<(), String> {
                 self.0.ensure_namespace(ns).await
+            }
+            async fn ensure_workspace_claim(
+                &self,
+                claim: Option<&PersistentVolumeClaim>,
+            ) -> Result<(), String> {
+                self.0.ensure_workspace_claim(claim).await
             }
             async fn list_pods(
                 &self,

--- a/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   getManagedAgentPrimaryActionLabel,
+  isManagedAgentLifecycleActionReady,
   isManagedAgentLive,
   startManagedAgentWithRules,
   respawnManagedAgentWithRules,
@@ -107,6 +108,18 @@ test("local liveness stays process-status based", () => {
     isManagedAgentLive(agent({ status: "stopped" }), "online"),
     false,
   );
+});
+
+test("provider lifecycle actions wait for presence while local actions do not", () => {
+  const remote = agent({
+    backend: { type: "provider", id: "kubernetes", config: {} },
+    backendAgentId: "buzz-agent-deadbeef",
+    status: "deployed",
+  });
+
+  assert.equal(isManagedAgentLifecycleActionReady(remote, false), false);
+  assert.equal(isManagedAgentLifecycleActionReady(remote, true), true);
+  assert.equal(isManagedAgentLifecycleActionReady(agent(), false), true);
 });
 
 // --- respawnManagedAgentWithRules: stop→clear→start boundary tests -----------

--- a/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  getManagedAgentPrimaryActionLabel,
+  isManagedAgentLive,
   startManagedAgentWithRules,
   respawnManagedAgentWithRules,
 } from "./managedAgentControlActions.ts";
@@ -79,6 +81,32 @@ test("ordinary local agents still start normally", async () => {
     },
   });
   assert.equal(calledWith, "deadbeef".repeat(8));
+});
+
+test("provider liveness and primary action follow relay presence", () => {
+  const remote = agent({
+    backend: { type: "provider", id: "kubernetes", config: {} },
+    backendAgentId: "buzz-agent-deadbeef",
+    status: "deployed",
+  });
+
+  assert.equal(isManagedAgentLive(remote, undefined), false);
+  assert.equal(isManagedAgentLive(remote, "offline"), false);
+  assert.equal(getManagedAgentPrimaryActionLabel(remote, "offline"), "Deploy");
+  assert.equal(isManagedAgentLive(remote, "online"), true);
+  assert.equal(getManagedAgentPrimaryActionLabel(remote, "online"), "Shutdown");
+  assert.equal(isManagedAgentLive(remote, "away"), true);
+});
+
+test("local liveness stays process-status based", () => {
+  assert.equal(
+    isManagedAgentLive(agent({ status: "running" }), "offline"),
+    true,
+  );
+  assert.equal(
+    isManagedAgentLive(agent({ status: "stopped" }), "online"),
+    false,
+  );
 });
 
 // --- respawnManagedAgentWithRules: stop→clear→start boundary tests -----------

--- a/desktop/src/features/agents/lib/managedAgentControlActions.ts
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.ts
@@ -3,6 +3,7 @@ import type {
   Channel,
   ManagedAgent,
   PresenceLookup,
+  PresenceStatus,
   RelayAgent,
 } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
@@ -35,9 +36,26 @@ export function isManagedAgentActive(agent: Pick<ManagedAgent, "status">) {
   return agent.status === "running" || agent.status === "deployed";
 }
 
-export function getManagedAgentPrimaryActionLabel(agent: ManagedAgent) {
+/**
+ * Conversational liveness. Provider deployment bookkeeping is deliberately
+ * not a health signal; relay presence is the only live axis for remote agents.
+ */
+export function isManagedAgentLive(
+  agent: ManagedAgent,
+  presenceStatus?: PresenceStatus | null,
+) {
   if (agent.backend.type === "provider") {
-    return isManagedAgentActive(agent) ? "Shutdown" : "Deploy";
+    return presenceStatus === "online" || presenceStatus === "away";
+  }
+  return isManagedAgentActive(agent);
+}
+
+export function getManagedAgentPrimaryActionLabel(
+  agent: ManagedAgent,
+  presenceStatus?: PresenceStatus | null,
+) {
+  if (agent.backend.type === "provider") {
+    return isManagedAgentLive(agent, presenceStatus) ? "Shutdown" : "Deploy";
   }
 
   if (isManagedAgentActive(agent)) {

--- a/desktop/src/features/agents/lib/managedAgentControlActions.ts
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.ts
@@ -50,6 +50,18 @@ export function isManagedAgentLive(
   return isManagedAgentActive(agent);
 }
 
+/**
+ * Provider lifecycle intent depends on relay presence. Until that query has
+ * settled, neither Deploy nor Shutdown is truthful enough to offer. Local
+ * agents continue to use their process status and do not need presence.
+ */
+export function isManagedAgentLifecycleActionReady(
+  agent: ManagedAgent,
+  presenceLoaded: boolean,
+) {
+  return agent.backend.type !== "provider" || presenceLoaded;
+}
+
 export function getManagedAgentPrimaryActionLabel(
   agent: ManagedAgent,
   presenceStatus?: PresenceStatus | null,

--- a/desktop/src/features/agents/ui/AgentRuntimeAvatarControl.tsx
+++ b/desktop/src/features/agents/ui/AgentRuntimeAvatarControl.tsx
@@ -12,6 +12,7 @@ import { Spinner } from "@/shared/ui/spinner";
 import { IdentityInitialsAvatar } from "./IdentityInitialsAvatar";
 
 type AgentRuntimeAvatarControlProps = {
+  actionDisabled?: boolean;
   activeTestId: string;
   avatarUrl?: string | null;
   errorLabel?: string | null;
@@ -126,6 +127,7 @@ const MASK_TRANSITION = {
 } as const;
 
 export function AgentRuntimeAvatarControl({
+  actionDisabled = false,
   activeTestId,
   avatarUrl,
   errorLabel,
@@ -142,14 +144,20 @@ export function AgentRuntimeAvatarControl({
   const shouldReduceMotion = useReducedMotion();
   const trimmedAvatarUrl = avatarUrl?.trim() || null;
   const isRestartAction = requiresRestart || isRestarting;
-  const actionLabel = isRestarting
-    ? "Restarting Agent"
-    : isStarting
-      ? "Starting Agent"
-      : isRestartAction
-        ? "Restart Agent"
-        : "Start Agent";
-  const actionText = isRestartAction ? "Restart" : "Start";
+  const actionLabel = actionDisabled
+    ? "Checking Agent Status"
+    : isRestarting
+      ? "Restarting Agent"
+      : isStarting
+        ? "Starting Agent"
+        : isRestartAction
+          ? "Restart Agent"
+          : "Start Agent";
+  const actionText = actionDisabled
+    ? "Wait"
+    : isRestartAction
+      ? "Restart"
+      : "Start";
   const isPending = isStarting || isRestarting;
   const showRunningDot = isActive && !isRestartAction;
   const hasError = !isActive && !isPending && Boolean(errorLabel);
@@ -190,7 +198,7 @@ export function AgentRuntimeAvatarControl({
                     : "bg-primary text-primary-foreground hover:bg-primary/90",
               )}
               data-testid={hasError ? errorTestId : startTestId}
-              disabled={isPending}
+              disabled={isPending || (actionDisabled && !hasError)}
               onClick={(event) => {
                 event.stopPropagation();
                 if (hasError) {

--- a/desktop/src/features/agents/ui/AgentStatusBadge.tsx
+++ b/desktop/src/features/agents/ui/AgentStatusBadge.tsx
@@ -29,7 +29,10 @@ export function AgentStatusBadge({
     return () => clearTimeout(timer);
   }, []);
 
-  const isActive = status === "running" || status === "deployed";
+  const isRemote = status === "deployed" || status === "not_deployed";
+  const isActive = isRemote
+    ? presenceStatus === "online" || presenceStatus === "away"
+    : status === "running";
   const isStarting =
     !inGracePeriod &&
     presenceLoaded &&
@@ -44,11 +47,19 @@ export function AgentStatusBadge({
         ? "default"
         : "secondary";
 
+  const remoteLabel =
+    status === "not_deployed"
+      ? "not deployed"
+      : !presenceLoaded
+        ? "checking…"
+        : (presenceStatus ?? "offline");
   const rawLabel = isWorking
     ? "Working"
     : isStarting
       ? "Starting\u2026"
-      : status.replace(/_/g, " ");
+      : isRemote
+        ? remoteLabel
+        : status.replace(/_/g, " ");
   const label = sentenceCase
     ? `${rawLabel.charAt(0).toUpperCase()}${rawLabel.slice(1)}`
     : rawLabel;

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -25,7 +25,7 @@ import { usePersonaActions } from "./usePersonaActions";
 import { useTeamActions } from "./useTeamActions";
 import { useProfilePanel } from "@/shared/context/ProfilePanelContext";
 import { useBakedBuildEnvQuery } from "@/features/agents/hooks";
-import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
+import { isManagedAgentLive } from "@/features/agents/lib/managedAgentControlActions";
 import { useGlobalAgentConfig } from "@/features/agents/useGlobalAgentConfig";
 import { Button } from "@/shared/ui/button";
 import {
@@ -88,7 +88,10 @@ export function AgentsView() {
     teamActions.updateTeamMutation.isPending ||
     teamActions.deleteTeamMutation.isPending;
   const runningAgentCount = agents.managedAgents.filter((agent) =>
-    isManagedAgentActive(agent),
+    isManagedAgentLive(
+      agent,
+      agents.managedPresenceQuery.data?.[agent.pubkey.trim().toLowerCase()],
+    ),
   ).length;
   const hasSavedAgentDefaults = Boolean(
     globalConfig.preferred_runtime?.trim() ||
@@ -220,6 +223,7 @@ export function AgentsView() {
               }
               isActionPending={isActionPending}
               isAgentsLoading={agents.managedAgentsQuery.isLoading}
+              presenceLookup={agents.managedPresenceQuery.data ?? {}}
               startingAgentPubkey={agents.startingAgentPubkey}
               restartingAgentPubkey={agents.restartingAgentPubkey}
               startingPersonaIds={agents.startingPersonaIds}

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -223,6 +223,7 @@ export function AgentsView() {
               }
               isActionPending={isActionPending}
               isAgentsLoading={agents.managedAgentsQuery.isLoading}
+              presenceLoaded={agents.managedPresenceQuery.isSuccess}
               presenceLookup={agents.managedPresenceQuery.data ?? {}}
               startingAgentPubkey={agents.startingAgentPubkey}
               restartingAgentPubkey={agents.restartingAgentPubkey}

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -7,11 +7,16 @@ import {
 } from "@/features/agents/lib/agentCardAvatar";
 import { resolveAgentCardModelLabel } from "@/features/agents/lib/agentCardModelLabel";
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
-import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
+import { isManagedAgentLive } from "@/features/agents/lib/managedAgentControlActions";
 import { pickProfileAgent } from "@/features/agents/lib/pickProfileAgent";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useUserProfileQuery } from "@/features/profile/hooks";
-import type { AgentPersona, ManagedAgent } from "@/shared/api/types";
+import type {
+  AgentPersona,
+  ManagedAgent,
+  PresenceLookup,
+} from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 import type { ProfilePanelOpenOptions } from "@/shared/context/ProfilePanelContext";
 import { useFeedbackToasts } from "@/shared/hooks/useToastEffect";
 import { Badge } from "@/shared/ui/badge";
@@ -30,6 +35,7 @@ type UnifiedAgentsSectionProps = {
   agentsError: Error | null;
   isActionPending: boolean;
   isAgentsLoading: boolean;
+  presenceLookup?: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
   startingPersonaIds: ReadonlySet<string>;
@@ -73,6 +79,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
     agentsError,
     isActionPending,
     isAgentsLoading,
+    presenceLookup = {},
     restartingAgentPubkey,
     startingAgentPubkey,
     startingPersonaIds,
@@ -155,6 +162,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
                   defaultModel={defaultModel}
                   key={group.persona.id}
                   persona={group.persona}
+                  presenceLookup={presenceLookup}
                   restartingAgentPubkey={restartingAgentPubkey}
                   startingAgentPubkey={startingAgentPubkey}
                   startingPersonaIds={startingPersonaIds}
@@ -175,6 +183,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
               defaultModel={defaultModel}
               groupKey="__unknown__"
               label="Unknown agents"
+              presenceLookup={presenceLookup}
               restartingAgentPubkey={restartingAgentPubkey}
               startingAgentPubkey={startingAgentPubkey}
               onToggle={toggle}
@@ -190,6 +199,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
               defaultModel={defaultModel}
               groupKey="__ungrouped__"
               label="Custom agents"
+              presenceLookup={presenceLookup}
               restartingAgentPubkey={restartingAgentPubkey}
               startingAgentPubkey={startingAgentPubkey}
               onToggle={toggle}
@@ -224,6 +234,7 @@ function AgentPersonaCard({
   agent,
   defaultModel,
   persona,
+  presenceLookup,
   restartingAgentPubkey,
   startingAgentPubkey,
   startingPersonaIds,
@@ -240,6 +251,7 @@ function AgentPersonaCard({
   agent: ManagedAgent | undefined;
   defaultModel: string;
   persona: AgentPersona;
+  presenceLookup: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
   startingPersonaIds: ReadonlySet<string>;
@@ -259,7 +271,9 @@ function AgentPersonaCard({
     provider: persona.provider,
     defaultModel,
   });
-  const isActive = agent ? isManagedAgentActive(agent) : false;
+  const isActive = agent
+    ? isManagedAgentLive(agent, presenceLookup[normalizePubkey(agent.pubkey)])
+    : false;
   const profileQuery = useUserProfileQuery(agent?.pubkey);
   const avatarUrl = agent
     ? resolveAgentCardAvatarUrl(profileQuery.data?.avatarUrl, persona.avatarUrl)
@@ -340,6 +354,7 @@ function AgentPersonaCard({
 function StandaloneAgentCard({
   agent,
   defaultModel,
+  presenceLookup,
   restartingAgentPubkey,
   startingAgentPubkey,
   onOpenAgentProfile,
@@ -348,6 +363,7 @@ function StandaloneAgentCard({
 }: {
   agent: ManagedAgent;
   defaultModel: string;
+  presenceLookup: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
   onOpenAgentProfile: (
@@ -363,7 +379,10 @@ function StandaloneAgentCard({
     agent.lastError,
     agent.lastErrorCode,
   )?.copy;
-  const isActive = isManagedAgentActive(agent);
+  const isActive = isManagedAgentLive(
+    agent,
+    presenceLookup[normalizePubkey(agent.pubkey)],
+  );
   const opensRuntimeTab = Boolean(friendlyError && !isActive);
 
   return (
@@ -443,6 +462,7 @@ function CollapsibleAgentGroup({
   agents,
   collapsed,
   defaultModel,
+  presenceLookup,
   restartingAgentPubkey,
   startingAgentPubkey,
   onToggle,
@@ -455,6 +475,7 @@ function CollapsibleAgentGroup({
   agents: ManagedAgent[];
   collapsed: ReadonlySet<string>;
   defaultModel: string;
+  presenceLookup: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
   onToggle: (key: string) => void;
@@ -487,6 +508,7 @@ function CollapsibleAgentGroup({
             <StandaloneAgentCard
               agent={agent}
               defaultModel={defaultModel}
+              presenceLookup={presenceLookup}
               key={agent.pubkey}
               restartingAgentPubkey={restartingAgentPubkey}
               startingAgentPubkey={startingAgentPubkey}

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -7,7 +7,10 @@ import {
 } from "@/features/agents/lib/agentCardAvatar";
 import { resolveAgentCardModelLabel } from "@/features/agents/lib/agentCardModelLabel";
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
-import { isManagedAgentLive } from "@/features/agents/lib/managedAgentControlActions";
+import {
+  isManagedAgentLifecycleActionReady,
+  isManagedAgentLive,
+} from "@/features/agents/lib/managedAgentControlActions";
 import { pickProfileAgent } from "@/features/agents/lib/pickProfileAgent";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useUserProfileQuery } from "@/features/profile/hooks";
@@ -35,6 +38,7 @@ type UnifiedAgentsSectionProps = {
   agentsError: Error | null;
   isActionPending: boolean;
   isAgentsLoading: boolean;
+  presenceLoaded: boolean;
   presenceLookup?: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
@@ -79,6 +83,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
     agentsError,
     isActionPending,
     isAgentsLoading,
+    presenceLoaded,
     presenceLookup = {},
     restartingAgentPubkey,
     startingAgentPubkey,
@@ -162,6 +167,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
                   defaultModel={defaultModel}
                   key={group.persona.id}
                   persona={group.persona}
+                  presenceLoaded={presenceLoaded}
                   presenceLookup={presenceLookup}
                   restartingAgentPubkey={restartingAgentPubkey}
                   startingAgentPubkey={startingAgentPubkey}
@@ -183,6 +189,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
               defaultModel={defaultModel}
               groupKey="__unknown__"
               label="Unknown agents"
+              presenceLoaded={presenceLoaded}
               presenceLookup={presenceLookup}
               restartingAgentPubkey={restartingAgentPubkey}
               startingAgentPubkey={startingAgentPubkey}
@@ -199,6 +206,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
               defaultModel={defaultModel}
               groupKey="__ungrouped__"
               label="Custom agents"
+              presenceLoaded={presenceLoaded}
               presenceLookup={presenceLookup}
               restartingAgentPubkey={restartingAgentPubkey}
               startingAgentPubkey={startingAgentPubkey}
@@ -234,6 +242,7 @@ function AgentPersonaCard({
   agent,
   defaultModel,
   persona,
+  presenceLoaded,
   presenceLookup,
   restartingAgentPubkey,
   startingAgentPubkey,
@@ -251,6 +260,7 @@ function AgentPersonaCard({
   agent: ManagedAgent | undefined;
   defaultModel: string;
   persona: AgentPersona;
+  presenceLoaded: boolean;
   presenceLookup: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
@@ -292,6 +302,9 @@ function AgentPersonaCard({
       avatar={
         agent ? (
           <AgentRuntimeAvatarControl
+            actionDisabled={
+              !isManagedAgentLifecycleActionReady(agent, presenceLoaded)
+            }
             activeTestId={`agent-runtime-active-${agent.pubkey}`}
             avatarUrl={avatarUrl}
             errorLabel={friendlyError}
@@ -354,6 +367,7 @@ function AgentPersonaCard({
 function StandaloneAgentCard({
   agent,
   defaultModel,
+  presenceLoaded,
   presenceLookup,
   restartingAgentPubkey,
   startingAgentPubkey,
@@ -363,6 +377,7 @@ function StandaloneAgentCard({
 }: {
   agent: ManagedAgent;
   defaultModel: string;
+  presenceLoaded: boolean;
   presenceLookup: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
@@ -390,6 +405,9 @@ function StandaloneAgentCard({
       ariaLabel={`${title} agent profile`}
       avatar={
         <AgentRuntimeAvatarControl
+          actionDisabled={
+            !isManagedAgentLifecycleActionReady(agent, presenceLoaded)
+          }
           activeTestId={`agent-runtime-active-${agent.pubkey}`}
           avatarUrl={profileQuery.data?.avatarUrl}
           errorLabel={friendlyError}
@@ -462,6 +480,7 @@ function CollapsibleAgentGroup({
   agents,
   collapsed,
   defaultModel,
+  presenceLoaded,
   presenceLookup,
   restartingAgentPubkey,
   startingAgentPubkey,
@@ -475,6 +494,7 @@ function CollapsibleAgentGroup({
   agents: ManagedAgent[];
   collapsed: ReadonlySet<string>;
   defaultModel: string;
+  presenceLoaded: boolean;
   presenceLookup: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
@@ -508,6 +528,7 @@ function CollapsibleAgentGroup({
             <StandaloneAgentCard
               agent={agent}
               defaultModel={defaultModel}
+              presenceLoaded={presenceLoaded}
               presenceLookup={presenceLookup}
               key={agent.pubkey}
               restartingAgentPubkey={restartingAgentPubkey}

--- a/desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs
@@ -54,6 +54,7 @@ function agent(overrides = {}) {
     name: "Instance",
     personaId: "persona-1",
     status: "stopped",
+    backend: { type: "local" },
     model: null,
     modelSource: "global",
     lastError: null,

--- a/desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs
@@ -86,6 +86,7 @@ function baseProps(overrides = {}) {
     agentsError: null,
     isActionPending: false,
     isAgentsLoading: false,
+    presenceLoaded: true,
     restartingAgentPubkey: null,
     startingAgentPubkey: null,
     startingPersonaIds: new Set(),
@@ -226,6 +227,27 @@ test("persona card main click records a persona target, never an explicit pubkey
 
   assert.ok(recordedPersona, "the click must record a persona target");
   assert.equal(recordedPersona.id, "persona-1");
+});
+
+test("provider start action stays disabled until presence is known", async () => {
+  installFailOpenIpc();
+  const remote = agent({
+    backend: { type: "provider", id: "kubernetes", config: {} },
+    personaId: null,
+  });
+
+  await act(async () => {
+    renderSection(
+      baseProps({
+        agents: [remote],
+        presenceLoaded: false,
+      }),
+    );
+  });
+
+  const action = screen.getByTestId(`agent-runtime-start-${remote.pubkey}`);
+  assert.equal(action.disabled, true);
+  assert.equal(action.getAttribute("aria-label"), "Checking Agent Status");
 });
 
 test("persona card main click records a persona target even for a stopped errored agent", async () => {

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -21,6 +21,7 @@ import { removeChannelMember } from "@/shared/api/tauri";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import {
   deleteManagedAgentWithRules,
+  isManagedAgentLifecycleActionReady,
   isManagedAgentLive,
   respawnManagedAgentWithRules,
   startManagedAgentWithRules,
@@ -161,6 +162,14 @@ export function useManagedAgentActions() {
     try {
       const agent = managedAgents.find((c) => c.pubkey === pubkey);
       if (!agent) return;
+      if (
+        !isManagedAgentLifecycleActionReady(
+          agent,
+          managedPresenceQuery.isSuccess,
+        )
+      ) {
+        throw new Error("Agent status is still loading. Try again shortly.");
+      }
       await startManagedAgentWithRules({
         agent,
         startManagedAgent: startMutation.mutateAsync,
@@ -181,6 +190,14 @@ export function useManagedAgentActions() {
         (candidate) => candidate.pubkey === pubkey,
       );
       if (!agent) return;
+      if (
+        !isManagedAgentLifecycleActionReady(
+          agent,
+          managedPresenceQuery.isSuccess,
+        )
+      ) {
+        throw new Error("Agent status is still loading. Try again shortly.");
+      }
       await respawnManagedAgentWithRules({
         agent,
         startManagedAgent: startMutation.mutateAsync,

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -21,7 +21,7 @@ import { removeChannelMember } from "@/shared/api/tauri";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import {
   deleteManagedAgentWithRules,
-  isManagedAgentActive,
+  isManagedAgentLive,
   respawnManagedAgentWithRules,
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
@@ -389,7 +389,12 @@ export function useManagedAgentActions() {
 
   async function handleBulkStopRunning() {
     await runBulkAction(
-      managedAgents.filter((a) => isManagedAgentActive(a)),
+      managedAgents.filter((agent) =>
+        isManagedAgentLive(
+          agent,
+          managedPresenceQuery.data?.[normalizePubkey(agent.pubkey)],
+        ),
+      ),
       "Stop",
       "stop",
       async (a) => {

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -514,6 +514,7 @@ export function MembersSidebar({
     removableManagedBots,
     currentPubkey,
     onOpenChange,
+    presenceLookup: memberPresenceQuery.data ?? {},
     relayUrl,
   });
 

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -514,6 +514,7 @@ export function MembersSidebar({
     removableManagedBots,
     currentPubkey,
     onOpenChange,
+    presenceLoaded: memberPresenceQuery.isSuccess,
     presenceLookup: memberPresenceQuery.data ?? {},
     relayUrl,
   });
@@ -672,6 +673,7 @@ export function MembersSidebar({
               : undefined
           }
           pairAction={pairAction}
+          presenceLoaded={memberPresenceQuery.isSuccess}
           presenceStatus={
             memberPresenceQuery.data?.[member.pubkey.toLowerCase()] ?? null
           }

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -16,7 +16,7 @@ import {
 
 import {
   getManagedAgentPrimaryActionLabel,
-  isManagedAgentActive,
+  isManagedAgentLive,
 } from "@/features/agents/lib/managedAgentControlActions";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
@@ -215,14 +215,16 @@ export function MembersSidebarMemberCard({
                   ? agentCommunityAvailability(managedAgentRuntime) === "Here"
                     ? "default"
                     : "secondary"
-                  : managedAgent && isManagedAgentActive(managedAgent)
+                  : managedAgent &&
+                      isManagedAgentLive(managedAgent, presenceStatus)
                     ? "default"
                     : "secondary"
               }
             >
               {managedAgentRuntime
                 ? agentCommunityAvailability(managedAgentRuntime)
-                : managedAgent && isManagedAgentActive(managedAgent)
+                : managedAgent &&
+                    isManagedAgentLive(managedAgent, presenceStatus)
                   ? "Running"
                   : "Stopped"}
             </Badge>
@@ -282,6 +284,7 @@ export function MembersSidebarMemberCard({
           onUntimeout={onUntimeout}
           onViewActivity={onViewActivity}
           pairAction={pairAction}
+          presenceStatus={presenceStatus}
         />
       ) : null}
     </div>
@@ -310,6 +313,7 @@ function MemberActionsMenu({
   onUntimeout,
   onViewActivity,
   pairAction,
+  presenceStatus,
 }: {
   canChangeRole: boolean;
   canModerateMember: boolean;
@@ -330,6 +334,7 @@ function MemberActionsMenu({
   onUntimeout: (member: ChannelMember) => void;
   onViewActivity?: (pubkey: string) => void;
   pairAction?: ManagedAgentPairAction;
+  presenceStatus?: PresenceStatus | null;
 }) {
   const showChangeRole =
     canChangeRole && !memberIsBot && member.role !== "owner";
@@ -370,10 +375,13 @@ function MemberActionsMenu({
             >
               {pairAction
                 ? getPairActionIcon(pairAction)
-                : getManagedAgentActionIcon(managedAgent)}
+                : getManagedAgentActionIcon(managedAgent, presenceStatus)}
               {pairAction
                 ? MANAGED_AGENT_PAIR_ACTION_LABELS[pairAction]
-                : getManagedAgentPrimaryActionLabel(managedAgent)}
+                : getManagedAgentPrimaryActionLabel(
+                    managedAgent,
+                    presenceStatus,
+                  )}
             </DropdownMenuItem>
             {onEditRespondTo ? (
               <DropdownMenuItem
@@ -504,8 +512,11 @@ function getPairActionIcon(action: ManagedAgentPairAction) {
   return <Play className="h-4 w-4" />;
 }
 
-function getManagedAgentActionIcon(agent: ManagedAgent) {
-  if (isManagedAgentActive(agent)) {
+function getManagedAgentActionIcon(
+  agent: ManagedAgent,
+  presenceStatus?: PresenceStatus | null,
+) {
+  if (isManagedAgentLive(agent, presenceStatus)) {
     return <Square className="h-4 w-4" />;
   }
 

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -16,6 +16,7 @@ import {
 
 import {
   getManagedAgentPrimaryActionLabel,
+  isManagedAgentLifecycleActionReady,
   isManagedAgentLive,
 } from "@/features/agents/lib/managedAgentControlActions";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
@@ -71,6 +72,7 @@ type MembersSidebarMemberCardProps = {
   onUnban: (member: ChannelMember) => void;
   onUntimeout: (member: ChannelMember) => void;
   onViewActivity?: (pubkey: string) => void;
+  presenceLoaded: boolean;
   presenceStatus?: PresenceStatus | null;
   profileAvatarUrl?: string | null;
   viewerIsOwner: boolean;
@@ -139,12 +141,16 @@ export function MembersSidebarMemberCard({
   onUnban,
   onUntimeout,
   onViewActivity,
+  presenceLoaded,
   presenceStatus,
   profileAvatarUrl,
   viewerIsOwner,
 }: MembersSidebarMemberCardProps) {
   const roleLabel = formatRoleLabel(member, memberIsBot);
   const disabled = isActionPending || isArchived;
+  const lifecycleActionReady = managedAgent
+    ? isManagedAgentLifecycleActionReady(managedAgent, presenceLoaded)
+    : true;
   const canViewActivity =
     memberIsBot &&
     (viewerIsOwner || managedAgent?.backend.type === "local") &&
@@ -223,10 +229,13 @@ export function MembersSidebarMemberCard({
             >
               {managedAgentRuntime
                 ? agentCommunityAvailability(managedAgentRuntime)
-                : managedAgent &&
-                    isManagedAgentLive(managedAgent, presenceStatus)
-                  ? "Running"
-                  : "Stopped"}
+                : managedAgent?.backend.type === "provider" &&
+                    !lifecycleActionReady
+                  ? "Checking…"
+                  : managedAgent &&
+                      isManagedAgentLive(managedAgent, presenceStatus)
+                    ? "Running"
+                    : "Stopped"}
             </Badge>
             {managedAgent ? (
               <Badge
@@ -284,6 +293,7 @@ export function MembersSidebarMemberCard({
           onUntimeout={onUntimeout}
           onViewActivity={onViewActivity}
           pairAction={pairAction}
+          presenceLoaded={presenceLoaded}
           presenceStatus={presenceStatus}
         />
       ) : null}
@@ -313,6 +323,7 @@ function MemberActionsMenu({
   onUntimeout,
   onViewActivity,
   pairAction,
+  presenceLoaded,
   presenceStatus,
 }: {
   canChangeRole: boolean;
@@ -334,8 +345,12 @@ function MemberActionsMenu({
   onUntimeout: (member: ChannelMember) => void;
   onViewActivity?: (pubkey: string) => void;
   pairAction?: ManagedAgentPairAction;
+  presenceLoaded: boolean;
   presenceStatus?: PresenceStatus | null;
 }) {
+  const lifecycleActionReady = managedAgent
+    ? isManagedAgentLifecycleActionReady(managedAgent, presenceLoaded)
+    : true;
   const showChangeRole =
     canChangeRole && !memberIsBot && member.role !== "owner";
   const isBanned = moderationState?.banned ?? false;
@@ -370,7 +385,7 @@ function MemberActionsMenu({
             {canViewActivity ? <DropdownMenuSeparator /> : null}
             <DropdownMenuItem
               data-testid={`sidebar-agent-action-${member.pubkey}`}
-              disabled={disabled}
+              disabled={disabled || !lifecycleActionReady}
               onClick={() => onManagedAgentAction(managedAgent)}
             >
               {pairAction

--- a/desktop/src/features/channels/ui/useMembersSidebarActions.ts
+++ b/desktop/src/features/channels/ui/useMembersSidebarActions.ts
@@ -7,6 +7,7 @@ import {
 } from "@/features/agents/hooks";
 import {
   respawnManagedAgentWithRules,
+  isManagedAgentLifecycleActionReady,
   isManagedAgentLive,
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
@@ -34,6 +35,7 @@ type UseMembersSidebarActionsOptions = {
   removableManagedBots: readonly ManagedAgent[];
   currentPubkey?: string;
   onOpenChange: (open: boolean) => void;
+  presenceLoaded: boolean;
   presenceLookup: PresenceLookup;
   /** Active community relay. When set, local-agent lifecycle actions are
    * scoped to this agent+community pair instead of the whole agent. */
@@ -55,6 +57,7 @@ export function useMembersSidebarActions({
   removableManagedBots,
   currentPubkey,
   onOpenChange,
+  presenceLoaded,
   presenceLookup,
   relayUrl,
 }: UseMembersSidebarActionsOptions) {
@@ -157,6 +160,10 @@ export function useMembersSidebarActions({
     setActiveActionKey(`agent:${agent.pubkey}`);
 
     try {
+      if (!isManagedAgentLifecycleActionReady(agent, presenceLoaded)) {
+        throw new Error("Agent status is still loading. Try again shortly.");
+      }
+
       // Local agents run one harness per agent+community pair. Scope the
       // action to the active community so stopping the agent here never
       // touches its runtimes in other communities. Provider agents keep the

--- a/desktop/src/features/channels/ui/useMembersSidebarActions.ts
+++ b/desktop/src/features/channels/ui/useMembersSidebarActions.ts
@@ -7,7 +7,7 @@ import {
 } from "@/features/agents/hooks";
 import {
   respawnManagedAgentWithRules,
-  isManagedAgentActive,
+  isManagedAgentLive,
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
 } from "@/features/agents/lib/managedAgentControlActions";
@@ -25,6 +25,7 @@ import type {
   ChannelMember,
   ManagedAgent,
   ManagedAgentRuntimeStatus,
+  PresenceLookup,
 } from "@/shared/api/types";
 
 type UseMembersSidebarActionsOptions = {
@@ -33,6 +34,7 @@ type UseMembersSidebarActionsOptions = {
   removableManagedBots: readonly ManagedAgent[];
   currentPubkey?: string;
   onOpenChange: (open: boolean) => void;
+  presenceLookup: PresenceLookup;
   /** Active community relay. When set, local-agent lifecycle actions are
    * scoped to this agent+community pair instead of the whole agent. */
   relayUrl?: string;
@@ -53,6 +55,7 @@ export function useMembersSidebarActions({
   removableManagedBots,
   currentPubkey,
   onOpenChange,
+  presenceLookup,
   relayUrl,
 }: UseMembersSidebarActionsOptions) {
   const queryClient = useQueryClient();
@@ -72,8 +75,13 @@ export function useMembersSidebarActions({
 
   const stoppableManagedBots = React.useMemo(
     () =>
-      controllableManagedBots.filter((agent) => isManagedAgentActive(agent)),
-    [controllableManagedBots],
+      controllableManagedBots.filter((agent) =>
+        isManagedAgentLive(
+          agent,
+          presenceLookup[agent.pubkey.trim().toLowerCase()],
+        ),
+      ),
+    [controllableManagedBots, presenceLookup],
   );
 
   const isActionPending =
@@ -170,7 +178,12 @@ export function useMembersSidebarActions({
         return;
       }
 
-      if (isManagedAgentActive(agent)) {
+      if (
+        isManagedAgentLive(
+          agent,
+          presenceLookup[agent.pubkey.trim().toLowerCase()],
+        )
+      ) {
         await stopManagedAgentWithRules({
           agent,
           ...EMPTY_AGENT_CONTEXT,

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -455,6 +455,7 @@ export function UserProfilePanel({
     useAgentLifecycleActions({
       channels: channelsQuery.data,
       managedAgent,
+      presenceLoaded: presenceQuery.isSuccess,
       presenceStatus,
       relayAgents: relayAgentsQuery.data,
       startManagedAgent: startAgentMutation.mutateAsync,
@@ -839,6 +840,7 @@ export function UserProfilePanel({
           onOpenDiagnostics={() => setView("diagnostics")}
           onStickyChromeChange={handleStickyChromeChange}
           onTabChange={setTab}
+          presenceLoaded={presenceQuery.isSuccess}
           presenceStatus={presenceStatus}
           profile={profile}
           pubkey={effectivePubkey}

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -455,6 +455,7 @@ export function UserProfilePanel({
     useAgentLifecycleActions({
       channels: channelsQuery.data,
       managedAgent,
+      presenceStatus,
       relayAgents: relayAgentsQuery.data,
       startManagedAgent: startAgentMutation.mutateAsync,
       stopManagedAgent: stopAgentMutation.mutateAsync,

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -935,45 +935,43 @@ export function UserProfilePanel({
     />
   ) : null;
   const personaDialogs = (
-    <>
-      <UserProfilePersonaDialogs
-        cardMintTarget={cardMint.target}
-        createError={
-          createPersonaMutation.error instanceof Error
-            ? createPersonaMutation.error
-            : null
-        }
-        instanceCount={personaDeleteInstanceCount}
-        isPending={
-          createPersonaMutation.isPending ||
-          updatePersonaMutation.isPending ||
-          updateManagedAgentMutation.isPending ||
-          createAgentMutation.isPending
-        }
-        linkedAgentPubkey={managedAgent?.pubkey ?? null}
-        personaDialogState={personaDialogState}
-        personaToDelete={personaToDelete}
-        personaToExportSnapshot={personaToExportSnapshot}
-        resolvedPersona={resolvedPersona}
-        runtimes={acpRuntimesQuery.data ?? []}
-        runtimesError={acpRuntimesQuery.isError}
-        runtimesLoading={acpRuntimesQuery.isLoading}
-        updateError={
-          updatePersonaMutation.error instanceof Error
-            ? updatePersonaMutation.error
-            : null
-        }
-        onCloseCardMint={cardMint.close}
-        onCloseDelete={() => setPersonaToDelete(null)}
-        onCloseDialog={() => setPersonaDialogState(null)}
-        onCloseExportSnapshot={() => setPersonaToExportSnapshot(null)}
-        onConfirmDelete={(selectedPersona) => {
-          void handleConfirmDeletePersona(selectedPersona);
-        }}
-        onExportSnapshot={setPersonaToExportSnapshot}
-        onSubmit={handleSubmitPersona}
-      />
-    </>
+    <UserProfilePersonaDialogs
+      cardMintTarget={cardMint.target}
+      createError={
+        createPersonaMutation.error instanceof Error
+          ? createPersonaMutation.error
+          : null
+      }
+      instanceCount={personaDeleteInstanceCount}
+      isPending={
+        createPersonaMutation.isPending ||
+        updatePersonaMutation.isPending ||
+        updateManagedAgentMutation.isPending ||
+        createAgentMutation.isPending
+      }
+      linkedAgentPubkey={managedAgent?.pubkey ?? null}
+      personaDialogState={personaDialogState}
+      personaToDelete={personaToDelete}
+      personaToExportSnapshot={personaToExportSnapshot}
+      resolvedPersona={resolvedPersona}
+      runtimes={acpRuntimesQuery.data ?? []}
+      runtimesError={acpRuntimesQuery.isError}
+      runtimesLoading={acpRuntimesQuery.isLoading}
+      updateError={
+        updatePersonaMutation.error instanceof Error
+          ? updatePersonaMutation.error
+          : null
+      }
+      onCloseCardMint={cardMint.close}
+      onCloseDelete={() => setPersonaToDelete(null)}
+      onCloseDialog={() => setPersonaDialogState(null)}
+      onCloseExportSnapshot={() => setPersonaToExportSnapshot(null)}
+      onConfirmDelete={(selectedPersona) => {
+        void handleConfirmDeletePersona(selectedPersona);
+      }}
+      onExportSnapshot={setPersonaToExportSnapshot}
+      onSubmit={handleSubmitPersona}
+    />
   );
   return (
     <UserProfilePanelFrame

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -4,7 +4,7 @@ import { ChevronDown, ChevronUp, Pencil } from "lucide-react";
 import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
 import {
   getManagedAgentPrimaryActionLabel,
-  isManagedAgentActive,
+  isManagedAgentLive,
 } from "@/features/agents/lib/managedAgentControlActions";
 import { RestartDiffBadge } from "@/features/agents/ui/RestartDiffBadge";
 import { AgentConfigPanel } from "@/features/agents/ui/AgentConfigPanel";
@@ -191,7 +191,7 @@ export function ProfileSummaryView({
   const activeTurns = useAgentWorking(isBot ? pubkey : null).channels;
   const avatarStatus = isBot
     ? managedAgent
-      ? isManagedAgentActive(managedAgent)
+      ? isManagedAgentLive(managedAgent, presenceStatus)
         ? "online"
         : "offline"
       : (presenceStatus ?? "offline")
@@ -429,12 +429,13 @@ export function ProfileSummaryView({
           agentActionDisabled={isAgentActionPending}
           agentActionLabel={
             isOwner === true && managedAgent
-              ? getManagedAgentPrimaryActionLabel(managedAgent)
+              ? getManagedAgentPrimaryActionLabel(managedAgent, presenceStatus)
               : undefined
           }
           agentActionLive={
-            managedAgent?.status === "running" ||
-            managedAgent?.status === "deployed"
+            managedAgent
+              ? isManagedAgentLive(managedAgent, presenceStatus)
+              : false
           }
           onAgentPrimaryAction={
             isOwner === true && managedAgent

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronUp, Pencil } from "lucide-react";
 import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
 import {
   getManagedAgentPrimaryActionLabel,
+  isManagedAgentLifecycleActionReady,
   isManagedAgentLive,
 } from "@/features/agents/lib/managedAgentControlActions";
 import { RestartDiffBadge } from "@/features/agents/ui/RestartDiffBadge";
@@ -105,6 +106,7 @@ export type ProfileSummaryViewProps = {
   onOpenDiagnostics: () => void;
   onStickyChromeChange: (state: { active: boolean; height: number }) => void;
   onTabChange: (tab: ProfilePanelTab, options?: { replace?: boolean }) => void;
+  presenceLoaded: boolean;
   presenceStatus: "online" | "away" | "offline" | undefined;
   profile: ReturnType<typeof useUserProfileQuery>["data"];
   pubkey: string | null;
@@ -180,6 +182,7 @@ export function ProfileSummaryView({
   onOpenDiagnostics,
   onStickyChromeChange,
   onTabChange,
+  presenceLoaded,
   presenceStatus,
   profile,
   pubkey,
@@ -189,11 +192,16 @@ export function ProfileSummaryView({
   userStatus,
 }: ProfileSummaryViewProps) {
   const activeTurns = useAgentWorking(isBot ? pubkey : null).channels;
+  const lifecycleActionReady = managedAgent
+    ? isManagedAgentLifecycleActionReady(managedAgent, presenceLoaded)
+    : true;
   const avatarStatus = isBot
     ? managedAgent
-      ? isManagedAgentLive(managedAgent, presenceStatus)
-        ? "online"
-        : "offline"
+      ? !lifecycleActionReady
+        ? undefined
+        : isManagedAgentLive(managedAgent, presenceStatus)
+          ? "online"
+          : "offline"
       : (presenceStatus ?? "offline")
     : presenceStatus;
   const stickyLayoutRef = React.useRef<HTMLDivElement>(null);
@@ -426,7 +434,7 @@ export function ProfileSummaryView({
           className={primaryActionsMotionClassName}
           concealed={primaryActionsConcealed}
           followMutation={followMutation}
-          agentActionDisabled={isAgentActionPending}
+          agentActionDisabled={isAgentActionPending || !lifecycleActionReady}
           agentActionLabel={
             isOwner === true && managedAgent
               ? getManagedAgentPrimaryActionLabel(managedAgent, presenceStatus)

--- a/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
+++ b/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import { toast } from "sonner";
 
 import {
+  isManagedAgentLifecycleActionReady,
   isManagedAgentLive,
   respawnManagedAgentWithRules,
   startManagedAgentWithRules,
@@ -14,6 +15,7 @@ import type { PresenceStatus } from "@/shared/api/types";
 export function useAgentLifecycleActions({
   channels,
   managedAgent,
+  presenceLoaded,
   presenceStatus,
   relayAgents,
   startManagedAgent,
@@ -21,6 +23,7 @@ export function useAgentLifecycleActions({
 }: {
   channels: readonly Channel[] | undefined;
   managedAgent: ManagedAgent | undefined;
+  presenceLoaded: boolean;
   presenceStatus?: PresenceStatus;
   relayAgents: readonly RelayAgent[] | undefined;
   startManagedAgent: (pubkey: string) => Promise<unknown>;
@@ -30,6 +33,10 @@ export function useAgentLifecycleActions({
     if (!managedAgent) return;
 
     try {
+      if (!isManagedAgentLifecycleActionReady(managedAgent, presenceLoaded)) {
+        throw new Error("Agent status is still loading. Try again shortly.");
+      }
+
       if (isManagedAgentLive(managedAgent, presenceStatus)) {
         const result = await stopManagedAgentWithRules({
           agent: managedAgent,
@@ -61,6 +68,7 @@ export function useAgentLifecycleActions({
   }, [
     channels,
     managedAgent,
+    presenceLoaded,
     presenceStatus,
     relayAgents,
     startManagedAgent,

--- a/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
+++ b/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
@@ -2,23 +2,26 @@ import * as React from "react";
 import { toast } from "sonner";
 
 import {
-  isManagedAgentActive,
+  isManagedAgentLive,
   respawnManagedAgentWithRules,
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
 } from "@/features/agents/lib/managedAgentControlActions";
 import { clearActiveTurnsForAgentOnStop } from "@/features/agents/managedAgentRuntimeHooks";
 import type { Channel, ManagedAgent, RelayAgent } from "@/shared/api/types";
+import type { PresenceStatus } from "@/shared/api/types";
 
 export function useAgentLifecycleActions({
   channels,
   managedAgent,
+  presenceStatus,
   relayAgents,
   startManagedAgent,
   stopManagedAgent,
 }: {
   channels: readonly Channel[] | undefined;
   managedAgent: ManagedAgent | undefined;
+  presenceStatus?: PresenceStatus;
   relayAgents: readonly RelayAgent[] | undefined;
   startManagedAgent: (pubkey: string) => Promise<unknown>;
   stopManagedAgent: (pubkey: string) => Promise<unknown>;
@@ -27,7 +30,7 @@ export function useAgentLifecycleActions({
     if (!managedAgent) return;
 
     try {
-      if (isManagedAgentActive(managedAgent)) {
+      if (isManagedAgentLive(managedAgent, presenceStatus)) {
         const result = await stopManagedAgentWithRules({
           agent: managedAgent,
           channels: channels ?? [],
@@ -58,6 +61,7 @@ export function useAgentLifecycleActions({
   }, [
     channels,
     managedAgent,
+    presenceStatus,
     relayAgents,
     startManagedAgent,
     stopManagedAgent,

--- a/docs/remote-agents.md
+++ b/docs/remote-agents.md
@@ -1016,6 +1016,12 @@ namespace does not exist the provider attempts to create it; on RBAC denial
 it MUST fail with the literal `kubectl create namespace <name>` command to
 run — it MUST NOT fall back to `default`.
 
+Persistent workspaces add one ambient permission boundary: the provider's
+cluster identity needs `get` and `create` on `persistentvolumeclaims` in the
+selected namespace, in addition to its existing namespace, Pod, and Secret
+permissions. Claim verification happens before any per-attempt Secret is
+written, so an RBAC refusal cannot leave a new identity Secret behind.
+
 ### Image
 
 `ghcr.io/block/buzz-sprig`: Alpine base + `bash` (required by the dev-MCP
@@ -1176,6 +1182,12 @@ regardless of `HOME`.
     destructive repair or GC action**. Identity labels/annotations prove
     identity; the marker asserts protocol ownership — without it, an object
     that merely matches our schema fails closed to the operator
+    - the current writer emits binding `2`. Its reader accepts legacy binding
+      `1` only for Pods and Secrets, allowing an in-place upgrade to observe
+      and collect old generations. PersistentVolumeClaims require binding `2`
+      plus the exact full-pubkey annotation; a v1 claim is never adopted. A v1
+      provider, in turn, refuses a v2 deterministic-name collision instead of
+      recreating the body with its old `emptyDir` pod shape
   - annotation `buzz.block.xyz/agent-pubkey-full: <full-64-hex>` —
     **load-bearing**: per §Deploy State Machine step 1, every label-selected
     object's annotation MUST equal the derived pubkey before the provider
@@ -1248,7 +1260,11 @@ regardless of `HOME`.
   claim. The claim carries the same management labels and full-pubkey
   annotation as the pod, and a same-named foreign claim is a hard refusal.
   Capacity or StorageClass drift is also refused rather than silently
-  pointing a new body at a different workspace. Agent memory remains
+  pointing a new body at a different workspace. The PVC has no Pod
+  owner-reference and is never deleted by provider GC: it survives clean exit,
+  crash, Pod deletion, and redeploy, and it continues to consume billable
+  storage until an operator explicitly deletes the PVC or its namespace.
+  Agent memory remains
   relay-persisted (NIP-AE) either way. [DECISION A — how remote pods get the nest workspace
   (AGENTS.md etc.) that local agents get from the desktop's `ensure_nest`;
   current recommendation is a desktop-stated protocol field, not

--- a/docs/remote-agents.md
+++ b/docs/remote-agents.md
@@ -1111,9 +1111,10 @@ paths. This is a harness interface limitation the binding inherits and
 matches, not one it introduces; a provider MUST NOT invent a private
 escaping scheme the harness would not decode.
 
-**Working directory.** `HOME` is set to a writable path backed by the
-workspace `emptyDir` (e.g. `/home/agent`), and the harness runs with cwd =
-`HOME` — mirroring the local spawn's agent-workdir convention. The baked
+**Working directory.** `HOME` is set to a writable workspace path (e.g.
+`/home/agent`) backed by `emptyDir` by default or by the identity-owned PVC
+when `provider_config.workspace_storage` is set, and the harness runs with
+cwd = `HOME` — mirroring the local spawn's agent-workdir convention. The baked
 system gitconfig references the nostr helpers by absolute path so it works
 regardless of `HOME`.
 
@@ -1161,6 +1162,9 @@ regardless of `HOME`.
   pubkey is 64 chars, one over):
   - pod name: `buzz-agent-<first-12-hex-of-pubkey>` — also the returned
     `agent_id`
+  - persistent workspace claim, when enabled:
+    `buzz-agent-<first-12-hex-of-pubkey>-workspace` — generation-free by
+    design so every replacement pod for the identity reattaches it
   - label `buzz.block.xyz/agent-pubkey: <first-32-hex>` — the selector key
     for reconciliation and GC. 128 bits is collision-*resistant*, not
     collision-free, which is why the annotation check below is normative,
@@ -1238,9 +1242,14 @@ regardless of `HOME`.
 - **Resources**: requests 1 cpu / 2Gi, limits 2 cpu / 4Gi, all four
   configurable (`cargo build` in an agent workspace makes 500m/1Gi requests
   unrealistic).
-- **Workspace**: `emptyDir`. Checkouts and scratch die with the pod; agent
-  memory is relay-persisted (NIP-AE) and unaffected. PVC support is a
-  deferred knob. [DECISION A — how remote pods get the nest workspace
+- **Workspace**: `emptyDir` by default. When `workspace_storage` is set, the
+  provider creates or verifies one deterministic `ReadWriteOnce` PVC per
+  agent identity and mounts it at `HOME`; pod/Secret GC never deletes that
+  claim. The claim carries the same management labels and full-pubkey
+  annotation as the pod, and a same-named foreign claim is a hard refusal.
+  Capacity or StorageClass drift is also refused rather than silently
+  pointing a new body at a different workspace. Agent memory remains
+  relay-persisted (NIP-AE) either way. [DECISION A — how remote pods get the nest workspace
   (AGENTS.md etc.) that local agents get from the desktop's `ensure_nest`;
   current recommendation is a desktop-stated protocol field, not
   image-side scaffolding — §Open Decisions.]
@@ -1393,12 +1402,15 @@ also self-heals the missing
 residue is one Completed pod that never restarts (I5) plus one Secret,
 removable with `kubectl delete`.
 
-### `provider_config` v1 fields
+### `provider_config` fields
 
 `context`, `namespace`, `image`, `cpu_request`, `memory_request`,
-`cpu_limit`, `memory_limit`, `inactivity_seconds`, `service_account` —
-9 of the 20-field validation cap. Node selectors, tolerations, and PVCs are
-deliberately baked out of v1 to preserve budget.
+`cpu_limit`, `memory_limit`, `inactivity_seconds`, `service_account`,
+`workspace_storage`, `workspace_storage_class` — 11 of the 20-field
+validation cap. `workspace_storage` is a Kubernetes quantity such as `20Gi`;
+`workspace_storage_class` is optional and invalid without a storage request.
+Node selectors and tolerations remain deliberately baked out to preserve
+budget.
 
 ### Distribution
 

--- a/scripts/test-k8s-sprig-image-live.sh
+++ b/scripts/test-k8s-sprig-image-live.sh
@@ -22,7 +22,7 @@ case "$PULL_POLICY" in
 esac
 
 MANAGED_BY="buzz-backend-kubernetes"
-BINDING_VERSION="v1"
+BINDING_VERSION="2"
 NAMESPACE="buzz-k8s-sprig-$(date +%s)-$RANDOM"
 CREATED=0
 
@@ -38,7 +38,7 @@ cleanup() {
         return 1
     fi
     foreign="$(kubectl --context "$CONTEXT" --namespace "$NAMESPACE" get pods -o json \
-        | jq '[.items[] | select(.metadata.labels["app.kubernetes.io/managed-by"] != "buzz-backend-kubernetes" or .metadata.labels["buzz.block.xyz/binding-version"] != "v1")] | length')"
+        | jq '[.items[] | select(.metadata.labels["app.kubernetes.io/managed-by"] != "buzz-backend-kubernetes" or .metadata.labels["buzz.block.xyz/binding-version"] != "2")] | length')"
     if [[ "$foreign" != 0 ]]; then
         echo "REFUSING cleanup: namespace contains an unowned pod: $NAMESPACE" >&2
         return 1


### PR DESCRIPTION
## Summary

- add optional identity-owned persistent workspaces for Kubernetes remote agents via `workspace_storage`
- create or safely adopt the PVC before Secret/Pod creation, with strict v2/full-pubkey ownership fencing
- retain read compatibility for existing v1 Pod and Secret bindings while refusing unsafe v1 PVC adoption
- derive Desktop lifecycle state from relay presence and disable lifecycle actions while presence is unknown
- document the required PVC RBAC, storage costs, and manual cleanup contract

## Root cause

Remote agents ran as bare Pods with `restartPolicy: Never`, so a terminal Pod required an owner redeploy. Their `emptyDir` workspace disappeared whenever the Pod was replaced. The Desktop also treated stored deployment metadata as live state, which could present a dead agent as healthy and offer the wrong lifecycle action.

## Validation

- `just ci` passed at rebased HEAD `4d586acd7f46bb2a271f83c93b12e2349dfd0e4b`
- `git diff --check origin/main...HEAD` passed
- all three branch commits include matching `Co-authored-by` and `Signed-off-by` trailers
- live disposable-cluster recovery matrix passed before the clean rebase at `c70d0818287b35bdafee027ed517e9052917020f`, using provider binary SHA-256 `56a98a8b0c680aefbad3d3420ad21fd604520e7ea4b4af87a0fc27db9b14e85e`
- identity continuity: `73feead7f81c13ae02c71a5d30e17aeca0a3a9c94cf8c169220e25e74e774652`
- PVC continuity: UID `1b6e67b3-c331-4de3-82b2-cb450e2ab688`
- replacement Pods: initial `5a2ccade-136d-4e18-9323-a8220744eb9d`, concurrent recovery `2f11c923-2ece-4241-a8a6-c62195ad002e`, crash recovery `25878d8e-008b-4747-bbe4-23817685726e`
- verified v1 rollback refusal, concurrent deploy singleton convergence, Pod deletion recovery, exit-137 crash recovery, identity/PVC/canary/git-branch retention, storage drift refusal, foreign-PVC refusal before Secret creation, inactivity exit 0, and presence-unknown UI gating

## Known limitation and rollout

The owner-signed `!shutdown` live-cluster case remains to be exercised; inactivity shutdown, Pod deletion, and crash recovery are covered. This PR does not migrate any production hive identity. Production remains on the Mini until review, merge, and a separately controlled single-identity pilot pass.

Version-Decision: not-required — this is unreleased remote-agent provider behavior; no package release is requested in this PR.
