### PR TITLE
fix(huddle): fade partial streaming TTS on inference failure

### DIFF
--- a/desktop/src-tauri/src/huddle/tts.rs
+++ b/desktop/src-tauri/src/huddle/tts.rs
@@ -741,6 +741,16 @@ fn tts_worker(
                         player: &player,
                         first_append: &mut first_append,
                         route_id,
+                        clear_audio: &mut || {
+                            let _ops = lock_player_ops(&player_ops);
+                            player.clear();
+                            player.play();
+                            tts_active.store(false, Ordering::Release);
+                            active_speaker
+                                .lock()
+                                .unwrap_or_else(|error| error.into_inner())
+                                .take();
+                        },
                     },
                     &mut |prepared| {
                         if !append_audio(

--- a/desktop/src-tauri/src/huddle/tts.rs
+++ b/desktop/src-tauri/src/huddle/tts.rs
@@ -741,16 +741,6 @@ fn tts_worker(
                         player: &player,
                         first_append: &mut first_append,
                         route_id,
-                        clear_audio: &mut || {
-                            let _ops = lock_player_ops(&player_ops);
-                            player.clear();
-                            player.play();
-                            tts_active.store(false, Ordering::Release);
-                            active_speaker
-                                .lock()
-                                .unwrap_or_else(|error| error.into_inner())
-                                .take();
-                        },
                     },
                     &mut |prepared| {
                         if !append_audio(

--- a/desktop/src-tauri/src/huddle/tts_audio.rs
+++ b/desktop/src-tauri/src/huddle/tts_audio.rs
@@ -165,4 +165,27 @@ mod tests {
             .iter()
             .all(|sample| *sample == 0.0));
     }
+
+    #[test]
+    fn only_the_final_stream_block_receives_a_fade() {
+        let mut chunk = PlaybackChunkAudio::new();
+        let mut first_append = true;
+        let first_samples = vec![0.5; FADE_OUT_SAMPLES * 2];
+        let final_samples = vec![0.75; FADE_OUT_SAMPLES * 2];
+
+        assert!(chunk
+            .push(first_samples.clone(), 0, &mut first_append, false)
+            .is_none());
+        let first = chunk
+            .push(final_samples.clone(), 1, &mut first_append, false)
+            .expect("first stream block");
+        let final_block = chunk
+            .finish(&mut first_append, false)
+            .expect("final stream block");
+
+        assert_eq!(first.buffer, first_samples);
+        assert_eq!(final_block.buffer[0], 0.75);
+        assert_eq!(final_block.buffer.last(), Some(&0.0));
+        assert_ne!(final_block.buffer, final_samples);
+    }
 }

--- a/desktop/src-tauri/src/huddle/tts_streaming.rs
+++ b/desktop/src-tauri/src/huddle/tts_streaming.rs
@@ -30,7 +30,6 @@ pub(super) struct StreamingPlayback<'a> {
     pub(super) player: &'a rodio::Player,
     pub(super) first_append: &'a mut bool,
     pub(super) route_id: u64,
-    pub(super) clear_audio: &'a mut dyn FnMut(),
 }
 
 /// Synthesize one text chunk through `synth_chunk_streaming`, appending PCM
@@ -71,11 +70,9 @@ fn drive_streaming(
         player,
         first_append,
         route_id,
-        clear_audio,
     } = playback;
     let mut playback_audio = PlaybackChunkAudio::new();
     let mut delta_index = 0usize;
-    let mut appended_audio = false;
     let stream_result = synthesize(&mut |samples| {
         if cancel.load(Ordering::Acquire)
             || voice_cancel.load(Ordering::Acquire)
@@ -91,7 +88,6 @@ fn drive_streaming(
             if !append_audio(prepared) {
                 return false;
             }
-            appended_audio = true;
         }
         true
     });
@@ -113,13 +109,13 @@ fn drive_streaming(
             Some("cancelled")
         }
         Err(_) => {
-            if appended_audio {
-                // Earlier deltas from this chunk are already queued. Letting
-                // them drain would play a truncated phrase with no final fade,
-                // so fail closed at the same serialized player boundary used
-                // by Stop/cancellation.
-                clear_audio();
-                *first_append = true;
+            // Preserve earlier queued speech, but finish the retained tail so
+            // a partial phrase ends with the same fade as a completed stream.
+            if let Some(prepared) = playback_audio.finish(first_append, player.empty()) {
+                if !append_audio(prepared) {
+                    *first_append = true;
+                    return Some("cancelled");
+                }
             }
             eprintln!(
                 "buzz-desktop: tts stage=synthesis status=failed reason=inference route_id={route_id}"
@@ -134,14 +130,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn inference_failure_clears_already_queued_audio() {
+    fn inference_failure_fades_the_retained_final_block() {
         let cancel = AtomicBool::new(false);
         let voice_cancel = AtomicBool::new(false);
         let shutdown = AtomicBool::new(false);
         let mut first_append = true;
         let (player, _output) = rodio::Player::new();
-        let mut appended = 0;
-        let mut cleared = 0;
+        let mut appended = Vec::new();
 
         let outcome = drive_streaming(
             |on_audio| {
@@ -154,18 +149,20 @@ mod tests {
                 player: &player,
                 first_append: &mut first_append,
                 route_id: 7,
-                clear_audio: &mut || cleared += 1,
             },
-            &mut |_| {
-                appended += 1;
+            &mut |prepared| {
+                appended.push(prepared);
                 true
             },
         );
 
         assert_eq!(outcome, Some("failed"));
-        assert_eq!(appended, 1, "the first delta was already accepted");
-        assert_eq!(cleared, 1, "partial playback must fail closed");
-        assert!(first_append, "the next utterance needs a fresh lead-in");
+        assert_eq!(appended.len(), 2);
+        assert!(appended[0].buffer.ends_with(&[0.4; 16]));
+        let final_samples = &appended[1].buffer[appended[1].buffer.len() - 16..];
+        assert_eq!(final_samples.first(), Some(&0.5));
+        assert_eq!(final_samples.last(), Some(&0.0));
+        assert!(!first_append, "the partial phrase remains queued");
     }
 
     #[test]
@@ -175,7 +172,6 @@ mod tests {
         let shutdown = AtomicBool::new(false);
         let mut first_append = false;
         let (player, _output) = rodio::Player::new();
-        let mut cleared = 0;
 
         let outcome = drive_streaming(
             |_| Err("inference failed before output".into()),
@@ -184,13 +180,11 @@ mod tests {
                 player: &player,
                 first_append: &mut first_append,
                 route_id: 7,
-                clear_audio: &mut || cleared += 1,
             },
             &mut |_| panic!("no audio should be appended"),
         );
 
         assert_eq!(outcome, Some("failed"));
-        assert_eq!(cleared, 0, "unrelated queued playback must survive");
         assert!(!first_append, "the existing utterance still owns playback");
     }
 
@@ -205,7 +199,6 @@ mod tests {
             let mut first_append = true;
             let (player, _output) = rodio::Player::new();
             let mut appended = 0;
-            let mut cleared = 0;
 
             let outcome = drive_streaming(
                 |on_audio| {
@@ -219,7 +212,6 @@ mod tests {
                     player: &player,
                     first_append: &mut first_append,
                     route_id: 7,
-                    clear_audio: &mut || cleared += 1,
                 },
                 &mut |_| {
                     appended += 1;
@@ -229,7 +221,6 @@ mod tests {
 
             assert_eq!(outcome, Some("cancelled"));
             assert_eq!(appended, 0, "no retained block may escape after Stop");
-            assert_eq!(cleared, 0, "the existing cancellation path owns clearing");
             assert!(first_append);
         }
     }
@@ -242,7 +233,6 @@ mod tests {
         let mut first_append = true;
         let (player, _output) = rodio::Player::new();
         let mut append_attempts = 0;
-        let mut cleared = 0;
 
         let outcome = drive_streaming(
             |on_audio| {
@@ -255,7 +245,6 @@ mod tests {
                 player: &player,
                 first_append: &mut first_append,
                 route_id: 7,
-                clear_audio: &mut || cleared += 1,
             },
             &mut |_| {
                 append_attempts += 1;
@@ -265,7 +254,6 @@ mod tests {
 
         assert_eq!(outcome, Some("cancelled"));
         assert_eq!(append_attempts, 1);
-        assert_eq!(cleared, 0);
         assert!(first_append);
     }
 }

--- a/desktop/src-tauri/src/huddle/tts_streaming.rs
+++ b/desktop/src-tauri/src/huddle/tts_streaming.rs
@@ -30,6 +30,7 @@ pub(super) struct StreamingPlayback<'a> {
     pub(super) player: &'a rodio::Player,
     pub(super) first_append: &'a mut bool,
     pub(super) route_id: u64,
+    pub(super) clear_audio: &'a mut dyn FnMut(),
 }
 
 /// Synthesize one text chunk through `synth_chunk_streaming`, appending PCM
@@ -51,15 +52,31 @@ pub(super) fn synthesize_streaming(
     playback: StreamingPlayback<'_>,
     append_audio: &mut dyn FnMut(PreparedModelAudio) -> bool,
 ) -> Option<&'static str> {
+    drive_streaming(
+        |on_audio| engine.synth_chunk_streaming(text, style, emit_frames, on_audio),
+        signals,
+        playback,
+        append_audio,
+    )
+}
+
+fn drive_streaming(
+    synthesize: impl FnOnce(&mut dyn FnMut(Vec<f32>) -> bool) -> Result<bool, String>,
+    signals: (&AtomicBool, &AtomicBool, &AtomicBool),
+    playback: StreamingPlayback<'_>,
+    append_audio: &mut dyn FnMut(PreparedModelAudio) -> bool,
+) -> Option<&'static str> {
     let (cancel, voice_cancel, shutdown) = signals;
     let StreamingPlayback {
         player,
         first_append,
         route_id,
+        clear_audio,
     } = playback;
     let mut playback_audio = PlaybackChunkAudio::new();
     let mut delta_index = 0usize;
-    let stream_result = engine.synth_chunk_streaming(text, style, emit_frames, &mut |samples| {
+    let mut appended_audio = false;
+    let stream_result = synthesize(&mut |samples| {
         if cancel.load(Ordering::Acquire)
             || voice_cancel.load(Ordering::Acquire)
             || shutdown.load(Ordering::Acquire)
@@ -74,6 +91,7 @@ pub(super) fn synthesize_streaming(
             if !append_audio(prepared) {
                 return false;
             }
+            appended_audio = true;
         }
         true
     });
@@ -95,10 +113,159 @@ pub(super) fn synthesize_streaming(
             Some("cancelled")
         }
         Err(_) => {
+            if appended_audio {
+                // Earlier deltas from this chunk are already queued. Letting
+                // them drain would play a truncated phrase with no final fade,
+                // so fail closed at the same serialized player boundary used
+                // by Stop/cancellation.
+                clear_audio();
+                *first_append = true;
+            }
             eprintln!(
                 "buzz-desktop: tts stage=synthesis status=failed reason=inference route_id={route_id}"
             );
             Some("failed")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inference_failure_clears_already_queued_audio() {
+        let cancel = AtomicBool::new(false);
+        let voice_cancel = AtomicBool::new(false);
+        let shutdown = AtomicBool::new(false);
+        let mut first_append = true;
+        let (player, _output) = rodio::Player::new();
+        let mut appended = 0;
+        let mut cleared = 0;
+
+        let outcome = drive_streaming(
+            |on_audio| {
+                assert!(on_audio(vec![0.4; 16]));
+                assert!(on_audio(vec![0.5; 16]));
+                Err("inference failed after output".into())
+            },
+            (&cancel, &voice_cancel, &shutdown),
+            StreamingPlayback {
+                player: &player,
+                first_append: &mut first_append,
+                route_id: 7,
+                clear_audio: &mut || cleared += 1,
+            },
+            &mut |_| {
+                appended += 1;
+                true
+            },
+        );
+
+        assert_eq!(outcome, Some("failed"));
+        assert_eq!(appended, 1, "the first delta was already accepted");
+        assert_eq!(cleared, 1, "partial playback must fail closed");
+        assert!(first_append, "the next utterance needs a fresh lead-in");
+    }
+
+    #[test]
+    fn inference_failure_before_output_preserves_existing_playback() {
+        let cancel = AtomicBool::new(false);
+        let voice_cancel = AtomicBool::new(false);
+        let shutdown = AtomicBool::new(false);
+        let mut first_append = false;
+        let (player, _output) = rodio::Player::new();
+        let mut cleared = 0;
+
+        let outcome = drive_streaming(
+            |_| Err("inference failed before output".into()),
+            (&cancel, &voice_cancel, &shutdown),
+            StreamingPlayback {
+                player: &player,
+                first_append: &mut first_append,
+                route_id: 7,
+                clear_audio: &mut || cleared += 1,
+            },
+            &mut |_| panic!("no audio should be appended"),
+        );
+
+        assert_eq!(outcome, Some("failed"));
+        assert_eq!(cleared, 0, "unrelated queued playback must survive");
+        assert!(!first_append, "the existing utterance still owns playback");
+    }
+
+    #[test]
+    fn each_stop_signal_prevents_later_stream_output() {
+        for signal_index in 0..3 {
+            let signals = [
+                AtomicBool::new(false),
+                AtomicBool::new(false),
+                AtomicBool::new(false),
+            ];
+            let mut first_append = true;
+            let (player, _output) = rodio::Player::new();
+            let mut appended = 0;
+            let mut cleared = 0;
+
+            let outcome = drive_streaming(
+                |on_audio| {
+                    assert!(on_audio(vec![0.4; 16]));
+                    signals[signal_index].store(true, Ordering::Release);
+                    assert!(!on_audio(vec![0.5; 16]));
+                    Ok(false)
+                },
+                (&signals[0], &signals[1], &signals[2]),
+                StreamingPlayback {
+                    player: &player,
+                    first_append: &mut first_append,
+                    route_id: 7,
+                    clear_audio: &mut || cleared += 1,
+                },
+                &mut |_| {
+                    appended += 1;
+                    true
+                },
+            );
+
+            assert_eq!(outcome, Some("cancelled"));
+            assert_eq!(appended, 0, "no retained block may escape after Stop");
+            assert_eq!(cleared, 0, "the existing cancellation path owns clearing");
+            assert!(first_append);
+        }
+    }
+
+    #[test]
+    fn rejected_append_never_flushes_the_retained_final_block() {
+        let cancel = AtomicBool::new(false);
+        let voice_cancel = AtomicBool::new(false);
+        let shutdown = AtomicBool::new(false);
+        let mut first_append = true;
+        let (player, _output) = rodio::Player::new();
+        let mut append_attempts = 0;
+        let mut cleared = 0;
+
+        let outcome = drive_streaming(
+            |on_audio| {
+                assert!(on_audio(vec![0.4; 16]));
+                assert!(!on_audio(vec![0.5; 16]));
+                Ok(false)
+            },
+            (&cancel, &voice_cancel, &shutdown),
+            StreamingPlayback {
+                player: &player,
+                first_append: &mut first_append,
+                route_id: 7,
+                clear_audio: &mut || cleared += 1,
+            },
+            &mut |_| {
+                append_attempts += 1;
+                false
+            },
+        );
+
+        assert_eq!(outcome, Some("cancelled"));
+        assert_eq!(append_attempts, 1);
+        assert_eq!(cleared, 0);
+        assert!(first_append);
     }
 }


### PR DESCRIPTION
## Context

PR #5671 added an env-gated Pocket TTS streaming path that queues decoded audio while synthesis continues. If inference fails after emitting multiple blocks, the existing error path drops the retained final block. Already queued audio then ends abruptly without the normal fade-out.

This is a bug fix for the streaming path. It also carries forward the error and cancellation hardening worth preserving from #3257 without reusing that PR's older synthesis implementation.

## Summary

Finish a partially emitted stream through the existing playback-boundary decorator when inference fails. The retained tail receives the normal final fade, while previously queued speech remains intact.

## Changes

- Extracts the streaming state machine behind a private test seam that can inject exact callback outcomes.
- Appends and fades the retained final block on inference failure.
- Preserves prior queued speech instead of clearing the shared persistent player.
- Keeps cancellation fail-closed: a rejected append or stop signal never flushes retained audio.
- Covers all three stop signals, append rejection, failures before output, failures after output, and final-block fade behavior.

## Related issue

No issue found. Follow-up to #5671. Supersedes the streaming error and cancellation hardening from #3257.

## Testing

The deterministic regression harness simulates a Pocket inference error after two audio callbacks. The target behavior queues one block and drops the retained tail; this branch queues both blocks and fades the final sample to zero.

The live desktop app has no safe deterministic control for forcing an inference failure after audio has already been emitted, so this specific error path was not manually injected in a real huddle. Normal streaming behavior remains env-gated in this PR.

## Screenshots

Not applicable. This changes the native audio pipeline and has no visual UI change.

## Reviewer-reproducible examples

The reproduction branch is `origin/main` plus only the private test seam and regression assertions. It intentionally retains the old error behavior.

### Red: target behavior drops the retained tail

```bash
git fetch origin main jtennant/repro-pocket-tts-streaming-failure
git switch --detach origin/jtennant/repro-pocket-tts-streaming-failure
. ./bin/activate-hermit
just _ensure-sidecar-stubs
cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib \
  inference_failure_fades_the_retained_final_block
```

Observed output:

```text
test huddle::tts::streaming::tests::inference_failure_fades_the_retained_final_block ... FAILED
assertion `left == right` failed
  left: 1
 right: 2
```

### Green: the retained tail is queued with a fade

```bash
git fetch origin jtennant/harden-pocket-tts-streaming
git switch --detach origin/jtennant/harden-pocket-tts-streaming
. ./bin/activate-hermit
just _ensure-sidecar-stubs
cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib \
  inference_failure_fades_the_retained_final_block
```

Observed output:

```text
running 1 test
test huddle::tts::streaming::tests::inference_failure_fades_the_retained_final_block ... ok

test result: ok. 1 passed; 0 failed
```
