### PR TITLE
feat: let a relay govern who may mention its agents, with no client setup

### DIFF
--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -217,6 +217,10 @@ pub struct Config {
     ///
     /// Default: `false`. Set via `BUZZ_ALLOW_NIP_OA_AUTH=true`.
     pub allow_nip_oa_auth: bool,
+    /// Whether an agent's published `respond_to` policy governs who may mention
+    /// it, rather than each client's own build-time policy. Operator-set,
+    /// advertised in NIP-11 as the `agent-access-published-policy` extension.
+    pub agent_access_published_policy: bool,
 
     /// Media storage configuration (S3/MinIO).
     pub media: buzz_media::MediaConfig,
@@ -628,6 +632,13 @@ impl Config {
             .map(|v| v == "true" || v == "1")
             .unwrap_or(false);
 
+        // Whether this deployment lets an agent's own published, NIP-OA-attested
+        // access policy decide who may mention it. Advertised in NIP-11 so a
+        // stock client needs no local configuration; see `nip11.rs`.
+        let agent_access_published_policy = std::env::var("BUZZ_AGENT_ACCESS_PUBLISHED_POLICY")
+            .map(|v| v == "true" || v == "1")
+            .unwrap_or(false);
+
         // Note: intentionally not prefixed with BUZZ_ — this is a relay-identity
         // config that may be shared across multiple services (e.g., ACP agent).
         let relay_owner_pubkey = std::env::var("RELAY_OWNER_PUBKEY")
@@ -1019,6 +1030,7 @@ impl Config {
             relay_operator_api_origin,
             relay_operator_pubkeys,
             allow_nip_oa_auth,
+            agent_access_published_policy,
             media,
             media_max_concurrent_uploads,
             media_max_concurrent_uploads_per_pubkey,

--- a/crates/buzz-relay/src/nip11.rs
+++ b/crates/buzz-relay/src/nip11.rs
@@ -5,6 +5,13 @@ use serde::{Deserialize, Serialize};
 #[cfg(test)]
 use crate::config::DEFAULT_MAX_FRAME_BYTES;
 
+/// NIP-11 `supported_extensions` identifier for [`crate::config::Config::agent_access_published_policy`].
+///
+/// A client that sees this MAY let an agent's published `respond_to` /
+/// `respond_to_allowlist` decide who can mention it, in place of its own
+/// build-time policy. Absent, clients keep whatever default they ship with.
+pub const AGENT_ACCESS_PUBLISHED_POLICY_EXTENSION: &str = "agent-access-published-policy";
+
 /// NIPs unconditionally supported by this relay, advertised in the NIP-11
 /// document. Kept as a module-level constant so tests can verify it without
 /// constructing a full `Config` (which reads env vars and races with
@@ -255,6 +262,17 @@ pub(crate) async fn nip11_document(state: &crate::state::AppState, raw_host: &st
     } else {
         None
     };
+    // Operator opt-in: this deployment defers to each agent's own published,
+    // NIP-OA-attested access policy for who may mention it. Advertised here so
+    // that honouring it costs a client nothing but reading NIP-11 — a relay's
+    // users must not each have to configure their own app for the operator's
+    // decision to take effect.
+    if state.config.agent_access_published_policy {
+        info.supported_extensions
+            .get_or_insert_default()
+            .push(AGENT_ACCESS_PUBLISHED_POLICY_EXTENSION.to_string());
+    }
+
     if let Some(push) = push_descriptor(
         state.config.push_gateway_delivery_url.is_some(),
         &state.config.relay_url,

--- a/desktop/src-tauri/src/commands/agent_access.rs
+++ b/desktop/src-tauri/src/commands/agent_access.rs
@@ -1,11 +1,88 @@
-/// Return whether this build enforces owner-only managed-agent access.
+use crate::app_state::AppState;
+
+/// NIP-11 `supported_extensions` identifier a relay advertises when it defers
+/// to each agent's own published access policy. Mirrors
+/// `buzz-relay`'s `AGENT_ACCESS_PUBLISHED_POLICY_EXTENSION`.
+const AGENT_ACCESS_PUBLISHED_POLICY_EXTENSION: &str = "agent-access-published-policy";
+
+/// Whether a NIP-11 document advertises the published-policy extension.
+///
+/// Split from the fetch so the parse is testable without a relay, and so a
+/// malformed or partial document is a plain `false` rather than an error the
+/// caller has to decide what to do with.
+fn advertises_published_policy(document: &serde_json::Value) -> bool {
+    document
+        .get("supported_extensions")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|extensions| {
+            extensions
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .any(|extension| extension == AGENT_ACCESS_PUBLISHED_POLICY_EXTENSION)
+        })
+}
+
+/// Ask the workspace relay whether it governs agent access by published policy.
+///
+/// Fails closed: any transport, status, or parse problem answers `false`, which
+/// leaves the build default in place. A relay that cannot be reached must never
+/// widen what this client will show.
+async fn relay_defers_to_published_policy(state: &AppState) -> bool {
+    let url = crate::relay::relay_api_base_url_with_override(state);
+    let Ok(response) = state
+        .http_client
+        .get(&url)
+        .header("Accept", "application/nostr+json")
+        .send()
+        .await
+    else {
+        return false;
+    };
+    if !response.status().is_success() {
+        return false;
+    }
+    match response.json::<serde_json::Value>().await {
+        Ok(document) => advertises_published_policy(&document),
+        Err(_) => false,
+    }
+}
+
+/// Return whether this client should hide relay agents owned by someone else.
+///
+/// Two inputs, and the distinction matters:
+///
+/// - **The build.** A marked release compiles
+///   `BUZZ_DESKTOP_BUILD_AGENT_ACCESS_OWNER_ONLY` and defaults to hiding them.
+///   OSS builds do not and never did.
+/// - **The relay.** A deployment that advertises
+///   `agent-access-published-policy` in NIP-11 has declared that an agent's own
+///   published, NIP-OA-attested `respond_to` decides who may mention it. On such
+///   a relay a marked build defers to that, because the operator and the agent
+///   owner are the ones who set the policy and carry the risk — and because a
+///   relay's users must not each have to configure their own app for their
+///   operator's decision to take effect.
+///
+/// Scope is deliberately narrow. This feeds the mention gate only. Local spawn
+/// and provider deployment still clamp through
+/// [`crate::managed_agents::owner_only`], so an agent this build *runs* is
+/// unaffected and its harness-side guard stays pinned.
+///
+/// Never returns `Err`: the frontend treats an errored policy query as
+/// "unknown" and hides every agent, so a relay hiccup must not empty the
+/// mention list. Unreachable or silent relays yield the build default.
 #[tauri::command]
-pub fn agent_access_owner_only() -> bool {
-    crate::managed_agents::owner_only_access_build()
+pub async fn agent_access_owner_only(state: tauri::State<'_, AppState>) -> Result<bool, String> {
+    if !crate::managed_agents::owner_only_access_build() {
+        return Ok(false);
+    }
+    Ok(!relay_defers_to_published_policy(&state).await)
 }
 
 #[cfg(test)]
 mod tests {
+    use super::{advertises_published_policy, AGENT_ACCESS_PUBLISHED_POLICY_EXTENSION};
+    use serde_json::json;
+
     #[test]
     #[ignore = "requires BUZZ_TEST_EXPECTED_AGENT_ACCESS_OWNER_ONLY"]
     fn compiled_policy_matches_expected() {
@@ -13,6 +90,45 @@ mod tests {
             .expect("BUZZ_TEST_EXPECTED_AGENT_ACCESS_OWNER_ONLY must be set")
             .parse::<bool>()
             .expect("BUZZ_TEST_EXPECTED_AGENT_ACCESS_OWNER_ONLY must be true or false");
-        assert_eq!(super::agent_access_owner_only(), expected);
+        assert_eq!(
+            crate::managed_agents::owner_only_access_build(),
+            expected,
+            "build flag drives the default; the relay only relaxes it"
+        );
+    }
+
+    #[test]
+    fn advertised_extension_is_recognised() {
+        let document = json!({
+            "supported_extensions": ["nip-er", AGENT_ACCESS_PUBLISHED_POLICY_EXTENSION]
+        });
+        assert!(advertises_published_policy(&document));
+    }
+
+    #[test]
+    fn a_relay_that_stays_silent_keeps_the_build_default() {
+        for document in [
+            json!({}),
+            json!({ "supported_extensions": [] }),
+            json!({ "supported_extensions": ["nip-er", "nip-pl"] }),
+            // Wrong shapes must not be read as consent.
+            json!({ "supported_extensions": AGENT_ACCESS_PUBLISHED_POLICY_EXTENSION }),
+            json!({ "supported_extensions": [{ "name": AGENT_ACCESS_PUBLISHED_POLICY_EXTENSION }] }),
+        ] {
+            assert!(
+                !advertises_published_policy(&document),
+                "unexpected opt-in for {document}"
+            );
+        }
+    }
+
+    #[test]
+    fn extension_id_matches_the_relay_constant() {
+        // Kept in sync by hand across crates; assert the literal so a rename on
+        // either side fails here rather than silently disabling the feature.
+        assert_eq!(
+            AGENT_ACCESS_PUBLISHED_POLICY_EXTENSION,
+            "agent-access-published-policy"
+        );
     }
 }

--- a/desktop/src-tauri/src/managed_agents/access_policy.rs
+++ b/desktop/src-tauri/src/managed_agents/access_policy.rs
@@ -43,6 +43,14 @@ pub(crate) type RespondToEnv = (Vec<(&'static str, String)>, Vec<&'static str>);
 
 /// Release packaging sets `BUZZ_BUILD_AGENT_ACCESS_OWNER_ONLY`; OSS/custom
 /// builds do not.
+///
+/// This is the *enforcement* source, used by local spawn and provider
+/// deployment. The mention gate reads
+/// [`crate::commands::agent_access_owner_only`] instead, which additionally
+/// defers to a relay advertising the `agent-access-published-policy` NIP-11
+/// extension — see that function. Keep the two apart: what Desktop *displays*
+/// for an agent it does not run is a different question from what it clamps on
+/// an agent it starts, and relaxing the first must never relax the second.
 pub(crate) fn owner_only_access_build() -> bool {
     option_env!("BUZZ_DESKTOP_BUILD_AGENT_ACCESS_OWNER_ONLY").is_some()
 }

--- a/desktop/src/features/agents/useAgentAccessOwnerOnly.ts
+++ b/desktop/src/features/agents/useAgentAccessOwnerOnly.ts
@@ -1,9 +1,15 @@
 /**
- * React hook: report whether this build forces owner-only agent access.
+ * React hook: report whether this client hides relay agents owned by others.
  *
- * The value is baked at build time, so it cannot change while the app runs.
- * The query key is stable and the result never goes stale, which keeps one
- * fetch per QueryClient lifetime and gives every caller the same answer.
+ * Two inputs: the build flag, and whether the workspace relay advertises the
+ * `agent-access-published-policy` NIP-11 extension — a deployment saying it
+ * defers to each agent's own published access policy. A marked build honours
+ * that, so an operator's decision reaches their users without any of them
+ * configuring anything locally.
+ *
+ * Still one fetch per QueryClient lifetime: the pair is stable for a session
+ * on a given relay. Switching workspace relays mid-session therefore keeps the
+ * previous answer until the query is invalidated.
  */
 import { useQuery } from "@tanstack/react-query";
 


### PR DESCRIPTION
## Summary

Fixes #6329.

A marked release build hides every relay agent whose NIP-OA owner is not the current user — including agents whose owner deliberately published `respond_to: "anyone"`, or an allowlist naming that user. On a self-hosted relay that leaves **no** configuration in which a team can share an agent:

- not the **operator**, who runs the relay but does not make the decision;
- not the **agent owner**, whose published, signed policy is discarded;
- not the **user**, since the gate is evaluated per viewer — opting out would mean *every* teammate building and running an unsigned desktop app.

That last point is why this is not a client setting. Asking each member of a community to configure their own app so their operator's decision takes effect is not a fix; most people cannot and should not have to. The decision belongs to the deployment, and it has to arrive on its own.

## Approach

The relay carries it.

```
BUZZ_AGENT_ACCESS_PUBLISHED_POLICY=true
```

makes a deployment advertise `agent-access-published-policy` in its NIP-11 `supported_extensions`, alongside the existing `nip-er` and `nip-pl` entries. A marked build that sees it lets each agent's own published, NIP-OA-attested policy decide who may mention it.

That is already exactly what `mentionableAgentPubkeys` encodes — every relay agent reaching the owner-only branch has *already* passed `relayAgentCanRespondInChannel` — so this introduces no new trust, no new event and no new field. **Stock clients, nothing to install, nothing to set.**

The desktop already reads NIP-11 in two places (`pairing.rs`, `identity_archive.rs`), so this follows an established path rather than adding a new one.

## The split this preserves

| Path | Source | Effect |
|---|---|---|
| Local spawn, provider deployment | `managed_agents::owner_only` | **None.** An agent this build *runs* is still clamped, and `BUZZ_ACP_ALLOWED_RESPOND_TO` stays pinned. |
| Mention gate | `commands::agent_access_owner_only` | Defers to the relay when it advertises the extension. |

So the guarantee #4053 set out to make — agents Desktop *runs* answer only their owner — is untouched. What changes is only what Desktop *displays* for agents it does not run, and only where the operator has said so.

## Defaults and failure behaviour

Unchanged on both sides. The relay flag is off unless set, so a deployment that says nothing behaves exactly as today.

The client **fails closed**, keeping the build default whenever the document is unreachable, returns non-success, is unparseable, or simply silent. The command never returns `Err`, because the frontend reads an errored policy query as `unknown` and hides *every* agent — a relay hiccup must not empty the mention list.

Wrong shapes are not read as consent: a bare string, or an array of objects, in `supported_extensions` leaves the default in place. Both are covered by tests. The extension id is asserted literally on the client so a rename on either side fails a test rather than silently disabling the feature.

## Validation

- `cargo check -p buzz-relay` — clean.
- `cargo check --lib --tests` on `desktop/src-tauri` — clean, test code included.
- New unit tests: the advertised extension is recognised; empty, absent, unrelated, and malformed `supported_extensions` all keep the build default; the id matches the relay constant.
- **I could not execute the Rust test binary locally.** Linking `buzz-desktop` needs an arm64 `libopus`; this machine only has an x86_64 build under Intel Homebrew, so the link fails inside the `opus` crate before reaching any of this code. Compilation of the tests is covered above; CI will run them.
- Behaviour verified end-to-end against a self-hosted relay (0.5.17 release client, relay `sha-1b3dbca`): the relay serves a kind 10100 with `respond_to: "anyone"` to a plain member with no auth tag, and the packaged client discards it — the case this restores.

## Known gap

The policy query keeps `staleTime: Infinity`, so switching workspace relays mid-session keeps the previous answer until something invalidates it. Happy to wire that invalidation if you want it here rather than in a follow-up.

Naming, the env var, and whether this should be a NIP-11 extension versus a community settings event are all things I am happy to change — the shape that matters is that the operator sets it once, server-side, and their users need do nothing.
