### PR TITLE
perf(huddle): enable bit-exact streaming TTS by default

### DIFF
--- a/crates/buzz-voice/src/pocket_april.rs
+++ b/crates/buzz-voice/src/pocket_april.rs
@@ -1799,10 +1799,8 @@ mod tests {
             .zip(&streamed)
             .map(|(a, b)| (a - b).abs())
             .fold(0.0f32, f32::max);
-        assert!(
-            max_diff <= 1.0e-4,
-            "incremental decode diverged from batch decode: max |diff| = {max_diff}"
-        );
+        eprintln!("delta_frames={DECODER_CHUNK_FRAMES}: max|diff|={max_diff:.6}");
+        assert_eq!(max_diff, 0.0, "12-frame streaming must remain bit-exact");
     }
 
     #[test]

--- a/desktop/src-tauri/src/huddle/tts.rs
+++ b/desktop/src-tauri/src/huddle/tts.rs
@@ -426,8 +426,8 @@ fn tts_worker(
     // `tts_active` lifecycle: set on the first append while idle, cleared
     // whenever the player has fully drained — either in the idle timeout
     // arm or on item receipt before synthesis begins.
-    // EXPERIMENTAL (latency bench): `Some(emit_frames)` = stream PCM deltas
-    // out of Pocket as they are generated (see tts_streaming.rs).
+    // `Some(emit_frames)` streams PCM deltas out of Pocket as they are
+    // generated (see tts_streaming.rs). `None` is the operational fallback.
     let tts_streaming = streaming_emit_frames();
     // `first_append` = "no audio queued since the player last went idle".
     // Flipped by `build_sentence_append_buffer` on the first real append; the
@@ -728,8 +728,8 @@ fn tts_worker(
                 continue;
             }
 
-            // EXPERIMENTAL (latency bench): streaming synthesis path — see
-            // tts_streaming.rs for the mechanics and exactness constraints.
+            // Streaming synthesis path. See tts_streaming.rs for the mechanics
+            // and exactness constraints.
             if let Some(emit_frames) = tts_streaming {
                 let outcome = synthesize_streaming(
                     &engine,

--- a/desktop/src-tauri/src/huddle/tts_streaming.rs
+++ b/desktop/src-tauri/src/huddle/tts_streaming.rs
@@ -1,7 +1,8 @@
-//! EXPERIMENTAL (latency bench): streaming synthesis path for the TTS worker.
+//! Streaming synthesis path for the TTS worker.
 //!
-//! `BUZZ_TTS_STREAMING=1` streams PCM deltas out of Pocket as they are
-//! generated instead of waiting for the full first-chunk synthesis.
+//! PCM deltas stream out of Pocket as they are generated instead of waiting
+//! for the full first-chunk synthesis. `BUZZ_TTS_STREAMING=0` restores the
+//! batch path as an operational fallback.
 //! `BUZZ_TTS_EMIT_FRAMES` tunes the delta size in Flow LM frames (80 ms of
 //! audio each). Default 12 = the Mimi decoder's native chunk, which keeps
 //! streamed audio bit-identical to the batch path; smaller deltas are faster
@@ -12,17 +13,20 @@ use super::*;
 
 use crate::huddle::pocket::{PocketTts, VoiceStyle};
 
-/// Read the streaming env overrides once per worker: `Some(emit_frames)`
-/// when `BUZZ_TTS_STREAMING=1`, `None` for the production batch path.
+/// Read the streaming env overrides once per worker. Streaming defaults to the
+/// Mimi decoder's native 12-frame chunk; `BUZZ_TTS_STREAMING=0` opts out.
 pub(super) fn streaming_emit_frames() -> Option<usize> {
-    std::env::var("BUZZ_TTS_STREAMING")
-        .is_ok_and(|v| v == "1")
-        .then(|| {
-            std::env::var("BUZZ_TTS_EMIT_FRAMES")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(12)
-        })
+    resolve_streaming_emit_frames(
+        std::env::var("BUZZ_TTS_STREAMING").ok().as_deref(),
+        std::env::var("BUZZ_TTS_EMIT_FRAMES").ok().as_deref(),
+    )
+}
+
+fn resolve_streaming_emit_frames(
+    enabled: Option<&str>,
+    emit_frames: Option<&str>,
+) -> Option<usize> {
+    (enabled != Some("0")).then(|| emit_frames.and_then(|v| v.parse().ok()).unwrap_or(12))
 }
 
 /// Playback context threaded through one streamed chunk.
@@ -128,6 +132,26 @@ fn drive_streaming(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn streaming_defaults_to_the_bit_exact_decoder_chunk() {
+        assert_eq!(resolve_streaming_emit_frames(None, None), Some(12));
+        assert_eq!(resolve_streaming_emit_frames(Some("1"), None), Some(12));
+    }
+
+    #[test]
+    fn streaming_can_be_disabled_for_operational_rollback() {
+        assert_eq!(resolve_streaming_emit_frames(Some("0"), None), None);
+    }
+
+    #[test]
+    fn explicit_emit_frames_remain_available_for_latency_benches() {
+        assert_eq!(resolve_streaming_emit_frames(None, Some("6")), Some(6));
+        assert_eq!(
+            resolve_streaming_emit_frames(None, Some("invalid")),
+            Some(12)
+        );
+    }
 
     #[test]
     fn inference_failure_fades_the_retained_final_block() {

--- a/desktop/src-tauri/src/huddle/tts_streaming.rs
+++ b/desktop/src-tauri/src/huddle/tts_streaming.rs
@@ -1,8 +1,8 @@
 //! Streaming synthesis path for the TTS worker.
 //!
 //! PCM deltas stream out of Pocket as they are generated instead of waiting
-//! for the full first-chunk synthesis. `BUZZ_TTS_STREAMING=0` restores the
-//! batch path as an operational fallback.
+//! for the full first-chunk synthesis. `BUZZ_TTS_STREAMING=0` or `false`
+//! restores the batch path as an operational fallback.
 //! `BUZZ_TTS_EMIT_FRAMES` tunes the delta size in Flow LM frames (80 ms of
 //! audio each). Default 12 = the Mimi decoder's native chunk, which keeps
 //! streamed audio bit-identical to the batch path; smaller deltas are faster
@@ -14,7 +14,8 @@ use super::*;
 use crate::huddle::pocket::{PocketTts, VoiceStyle};
 
 /// Read the streaming env overrides once per worker. Streaming defaults to the
-/// Mimi decoder's native 12-frame chunk; `BUZZ_TTS_STREAMING=0` opts out.
+/// Mimi decoder's native 12-frame chunk; `BUZZ_TTS_STREAMING=0` or `false`
+/// opts out.
 pub(super) fn streaming_emit_frames() -> Option<usize> {
     resolve_streaming_emit_frames(
         std::env::var("BUZZ_TTS_STREAMING").ok().as_deref(),
@@ -26,7 +27,8 @@ fn resolve_streaming_emit_frames(
     enabled: Option<&str>,
     emit_frames: Option<&str>,
 ) -> Option<usize> {
-    (enabled != Some("0")).then(|| emit_frames.and_then(|v| v.parse().ok()).unwrap_or(12))
+    (!matches!(enabled, Some("0" | "false")))
+        .then(|| emit_frames.and_then(|v| v.parse().ok()).unwrap_or(12))
 }
 
 /// Playback context threaded through one streamed chunk.
@@ -142,6 +144,7 @@ mod tests {
     #[test]
     fn streaming_can_be_disabled_for_operational_rollback() {
         assert_eq!(resolve_streaming_emit_frames(Some("0"), None), None);
+        assert_eq!(resolve_streaming_emit_frames(Some("false"), None), None);
     }
 
     #[test]


### PR DESCRIPTION
## Context

PR #5671 reduced Pocket TTS time-to-first-audio by streaming stateful Mimi decoder output, but kept the path disabled by default pending exactness, cancellation, failure, and listening validation.

The 12-frame decoder boundary produces the same samples as batch decoding. The streaming path now also preserves queued speech across inference failures, fades partial tails, and keeps cancellation from flushing retained audio.

## Summary

Enable Pocket TTS streaming by default at the Mimi decoder's native 12-frame boundary. Operators can restore batch synthesis with `BUZZ_TTS_STREAMING=0` or `BUZZ_TTS_STREAMING=false`.

## Changes

- Defaults `streaming_emit_frames()` to 12 instead of requiring `BUZZ_TTS_STREAMING=1`.
- Accepts the repository's standard `0` and `false` values for operational rollback.
- Preserves `BUZZ_TTS_EMIT_FRAMES` for explicit latency experiments.
- Tests default, rollback, explicit, and invalid environment resolution without mutating process-global environment variables.
- Tightens the real Pocket model integration test to require exact equality at 12 frames and print the measured maximum sample difference.

## Related issue

No issue found. Promotion follow-up to #5671.

## Testing

The installed April Pocket model produced `delta_frames=12: max|diff|=0.000000` when the same real latent sequence was decoded through the batch and stateful streaming paths. The integration test now requires exact equality rather than accepting a tolerance.

The default and both rollback values are covered through the pure environment resolver.

A real huddle ear and barge-in soak pass is still required before this draft is marked ready. The current environment can exercise the model and native pipeline deterministically, but cannot independently judge audible quality or conduct a two-party huddle.

## Screenshots

Not applicable. This changes the native audio pipeline and has no visual UI change.

## Reviewer-reproducible examples

From a fresh checkout with the Pocket model installed at `~/.buzz/models/pocket-tts`:

```bash
. ./bin/activate-hermit
BUZZ_POCKET_TEST_MODEL_DIR="$HOME/.buzz/models/pocket-tts" \
  cargo test -p buzz-voice incremental_stateful_decode_matches_batch_decode \
  -- --ignored --nocapture
```

Observed output excerpt:

```text
delta_frames=6: max|diff|=0.211313 rms_err=0.009880 snr_db=21.8
delta_frames=4: max|diff|=0.279904 rms_err=0.011155 snr_db=20.7
delta_frames=2: max|diff|=0.228128 rms_err=0.011197 snr_db=20.7
delta_frames=1: max|diff|=0.231133 rms_err=0.011362 snr_db=20.6
delta_frames=12: max|diff|=0.000000
test pocket::pocket_april::tests::incremental_stateful_decode_matches_batch_decode ... ok
```

For the remaining manual gate, run this branch with no `BUZZ_TTS_STREAMING` environment variable, enable Pocket TTS, and request a long multi-sentence response in a real huddle. Confirm speech begins during synthesis, remains continuous, and stops cleanly for PTT, barge-in, and speaker removal. Repeat with `BUZZ_TTS_STREAMING=false` and confirm batch playback remains available as a rollback.
