### PR TITLE
Size Workstream Board cards to their content

### DIFF
--- a/desktop/src/features/workstream-board/ui/WorkstreamCard.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamCard.tsx
@@ -91,7 +91,7 @@ export function WorkstreamCard({
   return (
     <div
       className={cn(
-        "group relative min-h-48 w-full overflow-hidden rounded-2xl border border-border/70 bg-muted/50 p-5 text-left text-foreground shadow-xs transition-all hover:-translate-y-0.5 hover:border-border hover:bg-muted/65 hover:shadow-md",
+        "group relative w-full self-start overflow-hidden rounded-2xl border border-border/70 bg-muted/50 p-5 text-left text-foreground shadow-xs transition-all hover:-translate-y-0.5 hover:border-border hover:bg-muted/65 hover:shadow-md",
         waitingOnPrincipal && "border-t-4 border-t-amber-400/70",
       )}
       data-testid={`workstream-card-${channel.id}`}
@@ -108,7 +108,7 @@ export function WorkstreamCard({
           Priority
         </span>
       ) : null}
-      <div className="pointer-events-none relative z-10 flex h-full min-h-40 flex-col">
+      <div className="pointer-events-none relative z-10 flex flex-col">
         <button
           className="pointer-events-auto flex max-w-[calc(100%-4rem)] items-center gap-1.5 text-xs font-semibold text-muted-foreground hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
           onClick={() => onSelect(channel.id)}
@@ -122,7 +122,7 @@ export function WorkstreamCard({
             <p className="mt-3 line-clamp-3 text-sm leading-relaxed text-foreground">
               {viewModel.card.synopsis}
             </p>
-            <div className="mt-auto flex flex-col gap-2 pt-4">
+            <div className="flex flex-col gap-2 pt-4">
               <p className="truncate text-2xs text-muted-foreground">
                 Orchestrator:{" "}
                 <span className="text-foreground">


### PR DESCRIPTION
🤖
## Summary

Workstream Board cards with little content were mostly empty space because every card was forced to a shared minimum height. Cards now size to their own content and stay top-aligned within each grid row, preserving a clear card shape without artificial whitespace.

This Desktop-only layout chore is stacked over #6326. The board remains off by default behind Settings → Experiments.

### Related issue

None found. This is experiment-gated polish for the Workstream Board stack.

### Testing

At exact head `d52d53d67f5629854d4b300c78d3ed4c202294f5` on Blox workstation `1873489`:

- Desktop tests: **5,148/5,148 passed**
- Desktop typecheck: passed
- Desktop check: zero errors (existing two warnings and two infos)
- Changed-file Biome check: passed

### Stack

- Base: `workstream-board/05-card-details-repair` (#6326)
- Head: `workstream-board/06-content-height` at `d52d53d67f5629854d4b300c78d3ed4c202294f5`
- Position: **Slice 6**, top of the current stack
- Discussion: [Workstream Board card-height thread](buzz://message?channel=156498d7-62a1-499d-bcfe-b73227d6a2a4&id=592fd6e5eda6ba083a403a7b7c45660ea97f6d639266ae7d9c46c538239e6d6b)

Draft only; auto-merge is off.

### Screenshots

**Before — cards are forced to equal height, leaving large empty areas:**

![Before: Workstream Board cards forced to equal height](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6336/before-equal-height.png)

**After — each card sizes to its content and stays top-aligned:**

![After: content-sized Workstream Board cards aligned to the top of each row](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6336/after-content-height.png)
