### PR TITLE
fix(desktop): distinguish duplicate agent devices

### DIFF
--- a/desktop/src/features/messages/lib/mentionSuggestionMapping.test.mjs
+++ b/desktop/src/features/messages/lib/mentionSuggestionMapping.test.mjs
@@ -24,25 +24,28 @@ function suggestion(overrides = {}) {
   });
 }
 
-test("labels locally managed agent identities as this device", () => {
-  assert.equal(suggestion({ isManagedAgent: true }).agentDevice, "this");
+test("labels Desktop-managed agent identities as managed here", () => {
+  assert.equal(
+    suggestion({ isManagedAgent: true }).agentProvenance,
+    "managed-here",
+  );
 });
 
-test("labels same-owner relay agent identities as another device", () => {
-  assert.equal(suggestion().agentDevice, "other");
+test("labels same-owner relay agent identities as managed elsewhere", () => {
+  assert.equal(suggestion().agentProvenance, "managed-elsewhere");
 });
 
 test("does not attribute another owner's agent to a device", () => {
   assert.equal(
-    suggestion({ ownerPubkey: "c".repeat(64) }).agentDevice,
+    suggestion({ ownerPubkey: "c".repeat(64) }).agentProvenance,
     undefined,
   );
 });
 
 test("does not attribute people or personas to a device", () => {
-  assert.equal(suggestion({ isAgent: false }).agentDevice, undefined);
+  assert.equal(suggestion({ isAgent: false }).agentProvenance, undefined);
   assert.equal(
-    suggestion({ kind: "persona", pubkey: undefined }).agentDevice,
+    suggestion({ kind: "persona", pubkey: undefined }).agentProvenance,
     undefined,
   );
 });

--- a/desktop/src/features/messages/lib/mentionSuggestionMapping.test.mjs
+++ b/desktop/src/features/messages/lib/mentionSuggestionMapping.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mapMentionCandidateToSuggestion } from "./mentionSuggestionMapping.ts";
+
+const OWNER = "a".repeat(64);
+
+function candidate(overrides = {}) {
+  return {
+    kind: "identity",
+    pubkey: "b".repeat(64),
+    isAgent: true,
+    isMember: true,
+    ownerPubkey: OWNER,
+    ...overrides,
+  };
+}
+
+function suggestion(overrides = {}) {
+  return mapMentionCandidateToSuggestion({
+    candidate: candidate(overrides),
+    currentPubkey: OWNER,
+    label: "Carl",
+  });
+}
+
+test("labels locally managed agent identities as this device", () => {
+  assert.equal(suggestion({ isManagedAgent: true }).agentDevice, "this");
+});
+
+test("labels same-owner relay agent identities as another device", () => {
+  assert.equal(suggestion().agentDevice, "other");
+});
+
+test("does not attribute another owner's agent to a device", () => {
+  assert.equal(
+    suggestion({ ownerPubkey: "c".repeat(64) }).agentDevice,
+    undefined,
+  );
+});
+
+test("does not attribute people or personas to a device", () => {
+  assert.equal(suggestion({ isAgent: false }).agentDevice, undefined);
+  assert.equal(
+    suggestion({ kind: "persona", pubkey: undefined }).agentDevice,
+    undefined,
+  );
+});

--- a/desktop/src/features/messages/lib/mentionSuggestionMapping.ts
+++ b/desktop/src/features/messages/lib/mentionSuggestionMapping.ts
@@ -13,6 +13,7 @@ export type MentionSuggestionCandidate = {
   teamMembers?: TeamMentionMember[];
   avatarUrl?: string | null;
   isAgent: boolean;
+  isManagedAgent?: boolean;
   isMember: boolean;
   role?: ChannelRole | null;
   ownerPubkey?: string | null;
@@ -52,6 +53,17 @@ export function mapMentionCandidateToSuggestion(opts: {
         : null) ??
       null,
     isAgent: candidate.isAgent,
+    agentDevice:
+      candidate.kind === "identity" && candidate.isAgent
+        ? candidate.isManagedAgent
+          ? "this"
+          : candidate.ownerPubkey &&
+              currentPubkey &&
+              normalizePubkey(candidate.ownerPubkey) ===
+                normalizePubkey(currentPubkey)
+            ? "other"
+            : undefined
+        : undefined,
     notInChannel:
       candidate.kind !== "team" &&
       channelType !== "dm" &&

--- a/desktop/src/features/messages/lib/mentionSuggestionMapping.ts
+++ b/desktop/src/features/messages/lib/mentionSuggestionMapping.ts
@@ -53,15 +53,15 @@ export function mapMentionCandidateToSuggestion(opts: {
         : null) ??
       null,
     isAgent: candidate.isAgent,
-    agentDevice:
+    agentProvenance:
       candidate.kind === "identity" && candidate.isAgent
         ? candidate.isManagedAgent
-          ? "this"
+          ? "managed-here"
           : candidate.ownerPubkey &&
               currentPubkey &&
               normalizePubkey(candidate.ownerPubkey) ===
                 normalizePubkey(currentPubkey)
-            ? "other"
+            ? "managed-elsewhere"
             : undefined
         : undefined,
     notInChannel:

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -349,7 +349,7 @@ export function useMentions(
         personaId:
           managedAgentPersonaIdsByPubkey.get(pubkey) ??
           (activePersonaById.has(pubkey) ? pubkey : undefined),
-        ownerPubkey: null,
+        ownerPubkey: agent.ownerPubkey,
         isAgent: true,
       });
     }
@@ -515,13 +515,14 @@ export function useMentions(
     searchableNamesLowerRef.current = searchableNamesLower;
   }, [searchableNamesLower]);
 
-  React.useEffect(() => {
-    return () => {
+  React.useEffect(
+    () => () => {
       if (debounceTimerRef.current !== null) {
         clearTimeout(debounceTimerRef.current);
       }
-    };
-  }, []);
+    },
+    [],
+  );
 
   const matchingSuggestions = React.useMemo<MentionSuggestion[]>(() => {
     if (mentionQuery === null) {

--- a/desktop/src/features/messages/ui/MentionAutocomplete.test.mjs
+++ b/desktop/src/features/messages/ui/MentionAutocomplete.test.mjs
@@ -3,28 +3,28 @@ import test from "node:test";
 
 import { mentionAgentLabel } from "./MentionAutocomplete.tsx";
 
-function suggestion(agentDevice) {
+function suggestion(agentProvenance) {
   return {
     pubkey: "1".repeat(64),
     displayName: "Carl",
     isAgent: true,
-    agentDevice,
+    agentProvenance,
   };
 }
 
-test("duplicate owned agents show their device provenance", () => {
+test("duplicate owned agents show their management provenance", () => {
   assert.equal(
-    mentionAgentLabel(suggestion("this"), true),
-    "agent · this device",
+    mentionAgentLabel(suggestion("managed-here"), true),
+    "agent · managed here",
   );
   assert.equal(
-    mentionAgentLabel(suggestion("other"), true),
-    "agent · other device",
+    mentionAgentLabel(suggestion("managed-elsewhere"), true),
+    "agent · managed elsewhere",
   );
 });
 
 test("unique agents keep the compact generic label", () => {
-  assert.equal(mentionAgentLabel(suggestion("this"), false), "agent");
+  assert.equal(mentionAgentLabel(suggestion("managed-here"), false), "agent");
 });
 
 test("agents without trustworthy provenance keep the generic label", () => {

--- a/desktop/src/features/messages/ui/MentionAutocomplete.test.mjs
+++ b/desktop/src/features/messages/ui/MentionAutocomplete.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mentionAgentLabel } from "./MentionAutocomplete.tsx";
+
+function suggestion(agentDevice) {
+  return {
+    pubkey: "1".repeat(64),
+    displayName: "Carl",
+    isAgent: true,
+    agentDevice,
+  };
+}
+
+test("duplicate owned agents show their device provenance", () => {
+  assert.equal(
+    mentionAgentLabel(suggestion("this"), true),
+    "agent · this device",
+  );
+  assert.equal(
+    mentionAgentLabel(suggestion("other"), true),
+    "agent · other device",
+  );
+});
+
+test("unique agents keep the compact generic label", () => {
+  assert.equal(mentionAgentLabel(suggestion("this"), false), "agent");
+});
+
+test("agents without trustworthy provenance keep the generic label", () => {
+  assert.equal(mentionAgentLabel(suggestion(undefined), true), "agent");
+});

--- a/desktop/src/features/messages/ui/MentionAutocomplete.tsx
+++ b/desktop/src/features/messages/ui/MentionAutocomplete.tsx
@@ -22,7 +22,7 @@ export type MentionSuggestion = {
   displayName: string;
   avatarUrl?: string | null;
   isAgent?: boolean;
-  agentDevice?: "this" | "other";
+  agentProvenance?: "managed-here" | "managed-elsewhere";
   notInChannel?: boolean;
   ownerLabel?: string | null;
   role?: string | null;
@@ -40,10 +40,10 @@ export function mentionAgentLabel(
   suggestion: MentionSuggestion,
   hasNameCollision: boolean,
 ) {
-  if (!hasNameCollision || !suggestion.agentDevice) return "agent";
-  return suggestion.agentDevice === "this"
-    ? "agent · this device"
-    : "agent · other device";
+  if (!hasNameCollision || !suggestion.agentProvenance) return "agent";
+  return suggestion.agentProvenance === "managed-here"
+    ? "agent · managed here"
+    : "agent · managed elsewhere";
 }
 
 export const MentionAutocomplete = React.memo(function MentionAutocomplete({

--- a/desktop/src/features/messages/ui/MentionAutocomplete.tsx
+++ b/desktop/src/features/messages/ui/MentionAutocomplete.tsx
@@ -22,6 +22,7 @@ export type MentionSuggestion = {
   displayName: string;
   avatarUrl?: string | null;
   isAgent?: boolean;
+  agentDevice?: "this" | "other";
   notInChannel?: boolean;
   ownerLabel?: string | null;
   role?: string | null;
@@ -34,6 +35,16 @@ type MentionAutocompleteProps = {
   onSelect: (suggestion: MentionSuggestion) => void;
   position?: "above" | "below";
 };
+
+export function mentionAgentLabel(
+  suggestion: MentionSuggestion,
+  hasNameCollision: boolean,
+) {
+  if (!hasNameCollision || !suggestion.agentDevice) return "agent";
+  return suggestion.agentDevice === "this"
+    ? "agent · this device"
+    : "agent · other device";
+}
 
 export const MentionAutocomplete = React.memo(function MentionAutocomplete({
   suggestions,
@@ -100,9 +111,9 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
             (suggestion.personaId ? `persona-${suggestion.personaId}` : null) ??
             (suggestion.teamId ? `team-${suggestion.teamId}` : null) ??
             suggestion.displayName;
-          const agentLabel = "agent";
           const hasNameCollision =
             (nameCounts.get(suggestion.displayName.toLowerCase()) ?? 0) > 1;
+          const agentLabel = mentionAgentLabel(suggestion, hasNameCollision);
           const collisionNpub =
             hasNameCollision && suggestion.pubkey
               ? safeNpub(suggestion.pubkey)

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -320,6 +320,112 @@ test("@ trigger prioritizes channel members before runnable personas and other m
   expect(fizzIndex).toBeLessThan(charlieIndex);
 });
 
+test("duplicate owned agents preserve provenance and exact pubkey selection", async ({
+  page,
+}) => {
+  const managedPubkey = IN_CHANNEL_MANAGED_AGENT_PUBKEY;
+  const relayPubkey = ALLOWLIST_RELAY_AGENT_PUBKEY;
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: managedPubkey,
+        name: "carl",
+        status: "running",
+        channelNames: ["general"],
+        backend: {
+          type: "provider",
+          id: "mock",
+          config: {},
+        },
+      },
+    ],
+    relayAgents: [
+      {
+        pubkey: relayPubkey,
+        ownerPubkey: MOCK_VIEWER_PUBKEY,
+        name: "carl",
+        respondTo: "owner-only",
+        channelNames: ["general"],
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await page.evaluate(
+    async ({ channelId, pubkey }) => {
+      const invoke = window.__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
+      if (!invoke) throw new Error("Mock bridge is not installed.");
+      await invoke("add_channel_members", {
+        channelId,
+        pubkeys: [pubkey],
+        role: "bot",
+      });
+      await window.__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries({
+        queryKey: ["channels"],
+      });
+    },
+    { channelId: GENERAL_CHANNEL_ID, pubkey: relayPubkey },
+  );
+
+  const input = page.getByTestId("message-input");
+  await input.fill("@carl");
+  const dropdown = autocomplete(page);
+  const managedRow = dropdown.getByTestId(
+    `mention-suggestion-${managedPubkey}`,
+  );
+  const relayRow = dropdown.getByTestId(`mention-suggestion-${relayPubkey}`);
+  await expect(managedRow).toContainText("agent · managed here");
+  await expect(relayRow).toContainText("agent · managed elsewhere");
+
+  const collisionKeys = dropdown.getByTestId("mention-collision-npub");
+  await expect(collisionKeys).toHaveCount(2);
+  const fullNpubs = await collisionKeys.evaluateAll((nodes) =>
+    nodes.map((node) => node.getAttribute("title")),
+  );
+  expect(fullNpubs).toHaveLength(2);
+  expect(new Set(fullNpubs).size).toBe(2);
+
+  const initialRows = dropdown.locator("button");
+  const managedIndex = await initialRows.evaluateAll(
+    (buttons, pubkey) =>
+      buttons.findIndex(
+        (button) =>
+          button.getAttribute("data-testid") === `mention-suggestion-${pubkey}`,
+      ),
+    managedPubkey,
+  );
+  expect(managedIndex).toBeGreaterThanOrEqual(0);
+  for (let index = 0; index < managedIndex; index += 1) {
+    await input.press("ArrowDown");
+  }
+  await input.press("Enter");
+  await page.keyboard.type("local");
+  await page.getByTestId("send-message").click();
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, "@carl local"))
+    .toEqual([managedPubkey]);
+  await expect(input).toBeEmpty();
+
+  await input.fill("@carl");
+  const reopenedDropdown = autocomplete(page);
+  await expect(reopenedDropdown).toBeVisible();
+  await reopenedDropdown
+    .getByTestId(`mention-suggestion-${relayPubkey}`)
+    .click();
+  await page.keyboard.type("remote");
+  await page.getByTestId("send-message").click();
+  const sendWithoutInviting = page.getByRole("button", { name: "Do nothing" });
+  try {
+    await sendWithoutInviting.waitFor({ state: "visible", timeout: 2_000 });
+    await sendWithoutInviting.click();
+  } catch {
+    // In-channel selections send immediately without opening the prompt.
+  }
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, "@carl remote"))
+    .toEqual([relayPubkey]);
+});
+
 test("relay-only shared agents emit an outbound mention tag when selected", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- distinguish same-name owned agents by management provenance: `managed here` for Desktop-managed identities and `managed elsewhere` for same-owner relay identities
- show provenance only when same-name suggestions collide, alongside each identity's short npub
- preserve exact-pubkey selection and keep unique-agent autocomplete unchanged
- add a composed mock-bridge regression covering relay owner propagation, rendered labels, keyboard/pointer selection, and outbound mention pubkeys

## Testing

- focused mention suggestion mapping and label tests
- composed Desktop E2E passes for both same-name identities and exact-pubkey routing
- causal mutation verified: replacing the relay candidate's `ownerPubkey` with `null` makes the composed E2E fail on the `managed elsewhere` assertion
- pre-push Desktop checks: Biome, TypeScript, file-size ratchet, and 5,103 Desktop tests

## Manual test

With two same-name owned agents visible in a channel, type `@<name>`. Duplicate rows identify the identities as `agent · managed here` and `agent · managed elsewhere`, include distinct short npubs, and selecting either routes the mention to that row's exact pubkey.
