### PR TITLE
fix(desktop): separate account and community actions

### DIFF
--- a/desktop/src/features/communities/ui/CommunitySwitcher.tsx
+++ b/desktop/src/features/communities/ui/CommunitySwitcher.tsx
@@ -339,21 +339,8 @@ export function CommunitySwitcher({
                     {leaveError}
                   </p>
                 ) : null}
-                <hr className="-mx-1 my-1 h-px border-0 bg-muted" />
               </>
             ) : null}
-            <button
-              className="flex min-h-9 w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm outline-hidden transition-colors hover:bg-muted/50 focus:bg-muted/50 focus:outline-none focus-visible:bg-muted/50 focus-visible:outline-none"
-              onClick={() => {
-                setDropdownOpen(false);
-                onAddCommunity();
-              }}
-              role="menuitem"
-              type="button"
-            >
-              <Plus className="h-4 w-4" />
-              <span>Add a community</span>
-            </button>
           </div>
         </PopoverContent>
       </Popover>

--- a/desktop/src/features/profile/ui/ProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/ProfilePopover.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Smile } from "lucide-react";
+import { Plus, Smile } from "lucide-react";
 
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
@@ -32,6 +32,7 @@ interface ProfilePopoverProps {
   onSetUserStatus: (text: string, emoji: string) => void;
   onClearUserStatus: () => void;
   onOpenSettings: (section?: "profile" | "appearance") => void;
+  onAddCommunity: () => void;
   onSendFeedback?: () => void;
   children: React.ReactNode;
   // Optional outer container whose clicks should NOT close the popover.
@@ -62,6 +63,7 @@ export function ProfilePopover({
   onSetUserStatus,
   onClearUserStatus,
   onOpenSettings,
+  onAddCommunity,
   onSendFeedback,
   children,
   triggerContainerRef,
@@ -240,6 +242,21 @@ export function ProfilePopover({
                 <hr className="my-1 h-px border-0 bg-border/60" />
               </>
             ) : null}
+
+            <button
+              className={MENU_ITEM_CLASS}
+              onClick={() => {
+                closePopover();
+                window.requestAnimationFrame(() => {
+                  onAddCommunity();
+                });
+              }}
+              role="menuitem"
+              type="button"
+            >
+              <Plus className="h-4 w-4" />
+              <span>Add a community</span>
+            </button>
 
             {onSendFeedback ? (
               <button

--- a/desktop/src/features/sidebar/ui/SidebarProfileCard.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarProfileCard.tsx
@@ -155,6 +155,7 @@ export function SidebarProfileCard({
             displayName={resolvedDisplayName}
             isStatusPending={isPresencePending}
             onClearUserStatus={onClearUserStatus}
+            onAddCommunity={onOpenAddCommunity}
             onOpenSettings={onOpenSettings}
             onSendFeedback={onSendFeedback}
             onSetStatus={onSetPresenceStatus ?? (() => {})}

--- a/desktop/tests/e2e/sidebar.spec.ts
+++ b/desktop/tests/e2e/sidebar.spec.ts
@@ -35,8 +35,10 @@ async function loadTheme(page: Page, theme: string) {
 
 async function openAddCommunityDialog(page: Page) {
   await page.getByTestId("sidebar-profile-avatar-button").click();
-  await page.getByTestId("community-switcher").click();
-  await page.getByRole("menuitem", { name: "Add a community" }).click();
+  await page
+    .getByTestId("profile-popover")
+    .getByRole("menuitem", { name: "Add a community" })
+    .click();
 }
 
 // Regression guard for the "Leave channel" lockup: with two bundled copies of
@@ -193,6 +195,18 @@ test("sidebar rows separate hover, selected, and reorder states", async ({
       draggableRow.evaluate((element) => getComputedStyle(element).transform),
     )
     .toBe("none");
+});
+
+test("keeps Add a community in the account profile menu", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("sidebar-profile-avatar-button").click();
+
+  const profileMenu = page.getByTestId("profile-popover");
+  await expect(
+    profileMenu.getByRole("menuitem", { name: "Add a community" }),
+  ).toBeVisible();
+  await profileMenu.getByRole("menuitem", { name: "Add a community" }).click();
+  await expect(page.getByTestId("add-community-dialog")).toBeVisible();
 });
 
 test("add community starts with create and join choices", async ({ page }) => {


### PR DESCRIPTION
## Summary
- move **Add a community** into the account-level profile menu
- keep the community submenu limited to community-specific actions
- add a Playwright regression test for opening the add-community dialog from the account menu

Fixes #6107

## Verification
- `just ci`
- `pnpm exec playwright test --project=integration tests/e2e/sidebar.spec.ts`
- `just desktop-screenshot --name issue-6107-profile-menu --click sidebar-profile-avatar-button --clip 0,250,450,470 --outdir test-results/issue-6107`
