### PR TITLE
fix(acp): require an actual prompt for mid-turn signals

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2959,9 +2959,17 @@ async fn tokio_main() -> Result<()> {
                                 });
                             }
                             // Event is already queued. If mode requires it AND
-                            // the channel has an in-flight task, fire cancel —
-                            // OR take the non-cancelling (ACP steer) fork for Steer signals.
-                            if accepted && queue.is_channel_in_flight(buzz_event.channel_id) {
+                            // the channel has an actual ACP prompt in flight,
+                            // fire cancel — OR take the non-cancelling (ACP
+                            // steer) fork for Steer signals. Queue ownership
+                            // starts earlier during session setup and context
+                            // fetches, when there is no prompt to steer yet.
+                            if mid_turn_signal_allowed(
+                                accepted,
+                                buzz_event.channel_id,
+                                &queue,
+                                &pool,
+                            ) {
                                 // Author eligibility (owner ∪ allowlist ∪ siblings)
                                 // is already enforced by the inbound author gate
                                 // above, so the mid-turn signal fires for every
@@ -3693,6 +3701,22 @@ fn mode_gate_signal(
     }
 }
 
+/// Whether a newly queued event may be routed through a mid-turn control path.
+///
+/// Queue ownership spans the whole task lifecycle, while the pool's prompt
+/// marker tracks the narrower period where the `session/prompt` future is
+/// being polled and can actually be steered or interrupted. Keep both
+/// predicates so a broken queue/task invariant fails closed instead of
+/// targeting the wrong turn.
+fn mid_turn_signal_allowed(
+    accepted: bool,
+    channel_id: Uuid,
+    queue: &EventQueue,
+    pool: &AgentPool,
+) -> bool {
+    accepted && queue.is_channel_in_flight(channel_id) && pool.has_in_flight_prompt(channel_id)
+}
+
 /// Send a control signal to the in-flight task for `channel_id`.
 /// Returns `true` if a signal was sent, `false` if no in-flight task was found.
 fn signal_in_flight_task(
@@ -3867,7 +3891,7 @@ fn dispatch_pending(
 
         // Mid-turn non-cancelling steer seam: install the per-turn steer
         // receiver on the read loop so the main loop's mode-gate fork
-        // (see the `if accepted && queue.is_channel_in_flight(...)` block
+        // (see the `mid_turn_signal_allowed(...)` block
         // in the relay event branch of the main `select!` loop) can drive
         // it via the matching sender stored in `TaskMeta.steer_tx`.
         // Installed for every prompt task: the read loop picks the steer
@@ -3881,6 +3905,7 @@ fn dispatch_pending(
         // Prompt text is now built inside run_prompt_task (needs async for
         // context fetching). Pass None for prompt_text; batch carries the data.
         let (control_tx, control_rx) = tokio::sync::oneshot::channel::<ControlSignal>();
+        let (prompt_control, prompt_in_flight) = pool::PromptControl::new(control_rx);
         let turn_id = Uuid::new_v4().to_string();
         let task_turn_id = turn_id.clone();
 
@@ -3891,7 +3916,7 @@ fn dispatch_pending(
                 None,
                 ctx_clone,
                 result_tx,
-                Some(control_rx),
+                Some(prompt_control),
                 task_turn_id,
             )
             .await;
@@ -3904,6 +3929,7 @@ fn dispatch_pending(
                 channel_id: Some(channel_id),
                 turn_id,
                 recoverable_batch,
+                prompt_in_flight,
                 control_tx: Some(control_tx),
                 steer_tx,
                 successful_steer_deliveries: HashSet::new(),
@@ -4519,6 +4545,7 @@ fn dispatch_heartbeat(
     let agent_index = agent.index;
     let turn_id = Uuid::new_v4().to_string();
     let task_turn_id = turn_id.clone();
+    let prompt_in_flight = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     let abort_handle = pool.join_set.spawn(async move {
         pool::run_prompt_task(
@@ -4540,6 +4567,7 @@ fn dispatch_heartbeat(
             channel_id: None,
             turn_id,
             recoverable_batch: None,
+            prompt_in_flight,
             control_tx: None,
             steer_tx: None,
             successful_steer_deliveries: HashSet::new(),
@@ -5284,6 +5312,54 @@ mod owner_control_command_tests {
         ));
     }
 
+    #[tokio::test]
+    async fn mid_turn_signal_requires_an_actual_prompt() {
+        // Queue ownership spans session setup and context fetches, so it can
+        // be true while there is no ACP prompt to steer. The event must remain
+        // queued for ordinary dispatch. #3282 may exercise this state, but its
+        // reporter log does not expose the ACP prompt ID and cannot prove it.
+        let channel_id = Uuid::new_v4();
+        let event = make_event(KIND_STREAM_MESSAGE, "queued prompt", None);
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        assert!(queue.push(QueuedEvent {
+            channel_id,
+            event,
+            received_at: std::time::Instant::now(),
+            prompt_tag: "test".into(),
+        }));
+        let _batch = queue.flush_next().expect("queue should own the channel");
+
+        let (_control_tx, control_rx) = tokio::sync::oneshot::channel();
+        let (_control, prompt_in_flight) = pool::PromptControl::new(control_rx);
+        let mut pool = AgentPool::from_slots(vec![]);
+        let task_id = pool.join_set.spawn(async {}).id();
+        pool.task_map_mut().insert(
+            task_id,
+            pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                turn_id: "test-turn-id".into(),
+                recoverable_batch: None,
+                prompt_in_flight: Arc::clone(&prompt_in_flight),
+                control_tx: None,
+                steer_tx: None,
+                successful_steer_deliveries: HashSet::new(),
+            },
+        );
+
+        assert!(!mid_turn_signal_allowed(true, channel_id, &queue, &pool));
+
+        prompt_in_flight.store(true, std::sync::atomic::Ordering::Release);
+        assert!(mid_turn_signal_allowed(true, channel_id, &queue, &pool));
+        assert!(!mid_turn_signal_allowed(false, channel_id, &queue, &pool));
+
+        // Queue ownership is normally a superset of prompt activity. If the
+        // queue's stale-task deadline breaks that invariant, fail closed rather
+        // than target a task after the queue has released its channel.
+        queue.mark_complete(channel_id);
+        assert!(!mid_turn_signal_allowed(true, channel_id, &queue, &pool));
+    }
+
     #[test]
     fn mode_gate_signal_maps_handling_to_control_signal() {
         let owner = "a".repeat(64);
@@ -5339,6 +5415,7 @@ mod owner_control_command_tests {
                 channel_id: Some(channel_id),
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                prompt_in_flight: Arc::default(),
                 control_tx: Some(control_tx),
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -7465,6 +7542,7 @@ mod error_outcome_emission_tests {
                 channel_id: Some(channel_id),
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
+                prompt_in_flight: Arc::default(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::from([
@@ -7537,6 +7615,7 @@ mod error_outcome_emission_tests {
                 channel_id: Some(channel_id),
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
+                prompt_in_flight: Arc::default(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::from([
@@ -7652,6 +7731,7 @@ mod error_outcome_emission_tests {
                 channel_id: Some(channel_id),
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
+                prompt_in_flight: Arc::default(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::from([
@@ -7717,6 +7797,7 @@ mod error_outcome_emission_tests {
                 channel_id: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                prompt_in_flight: Arc::default(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -7794,6 +7875,7 @@ mod error_outcome_emission_tests {
                 channel_id: Some(channel_id),
                 turn_id: "panic-turn-id".to_string(),
                 recoverable_batch: None,
+                prompt_in_flight: Arc::default(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -7887,6 +7969,7 @@ mod error_outcome_emission_tests {
                     channel_id: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
+                    prompt_in_flight: Arc::default(),
                     control_tx: None,
                     steer_tx: None,
                     successful_steer_deliveries: HashSet::new(),
@@ -7979,6 +8062,7 @@ mod error_outcome_emission_tests {
                     channel_id: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
+                    prompt_in_flight: Arc::default(),
                     control_tx: None,
                     steer_tx: None,
                     successful_steer_deliveries: HashSet::new(),
@@ -8085,6 +8169,7 @@ mod error_outcome_emission_tests {
                     channel_id: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
+                    prompt_in_flight: Arc::default(),
                     control_tx: None,
                     steer_tx: None,
                     successful_steer_deliveries: HashSet::new(),
@@ -8162,6 +8247,7 @@ mod error_outcome_emission_tests {
                 channel_id: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                prompt_in_flight: Arc::default(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -8257,6 +8343,7 @@ mod error_outcome_emission_tests {
                 channel_id: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                prompt_in_flight: Arc::default(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -8374,6 +8461,7 @@ mod error_outcome_emission_tests {
                 channel_id: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                prompt_in_flight: Arc::default(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -8514,6 +8602,7 @@ mod error_outcome_emission_tests {
                 channel_id: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                prompt_in_flight: Arc::default(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -8703,6 +8792,7 @@ mod error_outcome_emission_tests {
                 channel_id: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                prompt_in_flight: Arc::default(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
@@ -8789,6 +8879,7 @@ mod error_outcome_emission_tests {
                 channel_id: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
+                prompt_in_flight: Arc::default(),
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -21,7 +21,10 @@
 
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -63,6 +66,12 @@ pub struct TaskMeta {
     pub turn_id: String,
     /// Clone of batch for Queue mode panic recovery.
     pub recoverable_batch: Option<FlushBatch>,
+    /// True only while this task is polling an actual `session/prompt`.
+    ///
+    /// Queue ownership begins earlier, while session setup and context fetches
+    /// are still running, so `EventQueue::is_channel_in_flight` cannot answer
+    /// whether a mid-turn control signal has a prompt to target.
+    pub prompt_in_flight: Arc<AtomicBool>,
     /// Control signal for the in-flight prompt task.
     /// `None` for heartbeat tasks (not controllable) and after signal is consumed.
     pub control_tx: Option<tokio::sync::oneshot::Sender<ControlSignal>>,
@@ -371,6 +380,30 @@ pub enum ControlSignal {
         model_id: String,
         request_id: Option<String>,
     },
+}
+
+/// Control-plane state shared between a channel prompt task and the main loop.
+pub struct PromptControl {
+    /// Receives the first cancel, interrupt, rotate, or model-switch signal.
+    rx: tokio::sync::oneshot::Receiver<ControlSignal>,
+    /// Shared marker for the narrower lifetime of the ACP `session/prompt`.
+    prompt_in_flight: Arc<AtomicBool>,
+}
+
+impl PromptControl {
+    /// Build the task-side control state and its main-loop activity handle from
+    /// one shared allocation so dispatch cannot accidentally register a
+    /// different marker in [`TaskMeta`].
+    pub fn new(rx: tokio::sync::oneshot::Receiver<ControlSignal>) -> (Self, Arc<AtomicBool>) {
+        let prompt_in_flight = Arc::new(AtomicBool::new(false));
+        (
+            Self {
+                rx,
+                prompt_in_flight: Arc::clone(&prompt_in_flight),
+            },
+            prompt_in_flight,
+        )
+    }
 }
 
 /// Goose-native non-cancelling steer request, sent from the main loop to an
@@ -731,6 +764,17 @@ impl AgentPool {
 
     pub fn task_map_mut(&mut self) -> &mut HashMap<tokio::task::Id, TaskMeta> {
         &mut self.task_map
+    }
+
+    /// Whether `channel_id` currently has an actual ACP prompt in flight.
+    ///
+    /// A task can own the channel before it reaches `session/prompt` while it
+    /// creates a session or fetches context. Mid-turn steering must not target
+    /// that pre-prompt phase.
+    pub fn has_in_flight_prompt(&self, channel_id: Uuid) -> bool {
+        self.task_map.values().any(|meta| {
+            meta.channel_id == Some(channel_id) && meta.prompt_in_flight.load(Ordering::Acquire)
+        })
     }
 
     /// Try to send a goose-native steer request to the in-flight task for
@@ -1754,6 +1798,26 @@ fn send_prompt_result(
     });
 }
 
+struct PromptInFlightGuard<'a>(&'a AtomicBool);
+
+impl Drop for PromptInFlightGuard<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
+/// Mark only the lifetime during which the ACP `session/prompt` future is
+/// actually being polled. The guard clears the marker on completion,
+/// cancellation, or panic.
+async fn track_prompt_in_flight<F>(state: &AtomicBool, future: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    state.store(true, Ordering::Release);
+    let _guard = PromptInFlightGuard(state);
+    future.await
+}
+
 /// Core async function spawned for each prompt.
 ///
 /// Lifecycle:
@@ -1772,7 +1836,7 @@ pub async fn run_prompt_task(
     prompt_text: Option<String>,
     ctx: Arc<PromptContext>,
     result_tx: mpsc::UnboundedSender<PromptResult>,
-    control_rx: Option<tokio::sync::oneshot::Receiver<ControlSignal>>,
+    control: Option<PromptControl>,
     turn_id: String,
 ) {
     // Is this a channel prompt or a heartbeat?
@@ -2476,11 +2540,11 @@ pub async fn run_prompt_task(
         prompt_label(&source)
     );
 
-    // When control_rx is Some (channel tasks), wrap the prompt in select! so
+    // When control is Some (channel tasks), wrap the prompt in select! so
     // the main loop can cancel, interrupt, or rotate it. Heartbeats
-    // (control_rx=None) take the simple await path — they are not controllable.
+    // (`control=None`) take the simple await path — they are not controllable.
     //
-    let prompt_result = match control_rx {
+    let prompt_result = match control {
         None => {
             // Heartbeat / non-cancellable path.
             tokio::select! {
@@ -2493,16 +2557,19 @@ pub async fn run_prompt_task(
                 ) => result,
             }
         }
-        Some(rx) => {
+        Some(control) => {
             tokio::select! {
                 biased;
-                result = agent.acp.session_prompt_blocks_with_idle_timeout(
-                    &session_id,
-                    &prompt_blocks,
-                    ctx.idle_timeout,
-                    ctx.max_turn_duration,
+                result = track_prompt_in_flight(
+                    &control.prompt_in_flight,
+                    agent.acp.session_prompt_blocks_with_idle_timeout(
+                        &session_id,
+                        &prompt_blocks,
+                        ctx.idle_timeout,
+                        ctx.max_turn_duration,
+                    ),
                 ) => result,
-                mode = rx => {
+                mode = control.rx => {
                     let control_signal = mode.unwrap_or(ControlSignal::Cancel);
                     // Land the model switch before any cancel/requeue work: setting
                     // `desired_model` here means the fresh session created by the
@@ -4699,6 +4766,54 @@ mod tests {
     use super::*;
     use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
     use serde_json::json;
+
+    #[tokio::test]
+    async fn pool_distinguishes_task_ownership_from_prompt_activity() {
+        let channel_id = Uuid::new_v4();
+        let (_control_tx, control_rx) = tokio::sync::oneshot::channel();
+        let (_control, prompt_in_flight) = PromptControl::new(control_rx);
+        let mut pool = AgentPool::from_slots(vec![]);
+        let task_id = pool.join_set.spawn(async {}).id();
+        pool.task_map.insert(
+            task_id,
+            TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                turn_id: "test-turn-id".into(),
+                recoverable_batch: None,
+                prompt_in_flight: Arc::clone(&prompt_in_flight),
+                control_tx: None,
+                steer_tx: None,
+                successful_steer_deliveries: HashSet::new(),
+            },
+        );
+
+        assert!(!pool.has_in_flight_prompt(channel_id));
+        prompt_in_flight.store(true, Ordering::Release);
+        assert!(pool.has_in_flight_prompt(channel_id));
+    }
+
+    #[tokio::test]
+    async fn prompt_activity_marker_clears_when_prompt_future_is_cancelled() {
+        let (_control_tx, control_rx) = tokio::sync::oneshot::channel();
+        let (control, prompt_in_flight) = PromptControl::new(control_rx);
+        let task = tokio::spawn(async move {
+            track_prompt_in_flight(&control.prompt_in_flight, std::future::pending::<()>()).await;
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !prompt_in_flight.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("prompt future was never polled");
+        assert!(prompt_in_flight.load(Ordering::Acquire));
+
+        task.abort();
+        let _ = task.await;
+        assert!(!prompt_in_flight.load(Ordering::Acquire));
+    }
 
     fn test_mcp_server() -> McpServer {
         McpServer {

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -674,7 +674,11 @@ impl EventQueue {
         ids
     }
 
-    /// Whether a prompt is currently in-flight for the given channel.
+    /// Whether the queue currently has a task owning the given channel.
+    ///
+    /// Ownership begins before `session/prompt` while the task performs setup
+    /// and context enrichment. Callers that need to target an active prompt
+    /// must also consult `AgentPool::has_in_flight_prompt`.
     pub fn is_channel_in_flight(&self, channel_id: Uuid) -> bool {
         self.in_flight_channels.contains(&channel_id)
     }


### PR DESCRIPTION
# fix(acp): require an actual prompt for mid-turn signals

**Verdict:** stop sending steer / interrupt / cancel during session setup.
Those signals are only valid while a `session/prompt` future is in flight.
A queued task is not the same thing as a prompt.

Does **not** close [#3282](https://github.com/block/buzz/issues/3282) or
[#3071](https://github.com/block/buzz/issues/3071). Candidate for both;
needs a reproduction that shows the prompt future had not started.

## User story (one exact huddle, word for word)

**Room:** `huddle-turn-taking`, hands-free. The speaker is User. The agent is Cursor [grok-fast]. User is looking at two draft files and wants Cursor to open them on screen.

**0:00.0 — User speaks, then pauses ~300 ms. VAD flushes this as message 1:**

> @Cursor [grok-fast] open the RFC in Cursor

What User sees: that line appears in the huddle. Maybe a 👀 on it.

What Buzz does: accepts the event, `flush_next` owns the channel, starts an ACP task. That task is still creating a session and fetching the last huddle messages. **No `session/prompt` has been written.** Cursor has not started thinking. It is lacing its shoes.

**0:01.4 — User keeps talking, same thought. VAD flushes this as message 2:**

> and put the PR next to it so I can compare the charts

User meant one request: open both files. The huddle heard two messages because User paused after the first sentence.

### Before this PR — 0:01.4 onward

What Buzz does: channel already has a queue task, so message 2 is a mid-turn steer / cancel. Cursor still has no prompt to steer.

What User sees:

```
User:      @Cursor [grok-fast] open the RFC in Cursor
User:      and put the PR next to it so I can compare the charts
Cursor:    (nothing)
```

Cursor never opens either file. The first ask never becomes a prompt. The second ask is burned as a control signal aimed at nothing. User waits. It feels like Cursor ignored them. User did nothing wrong.

### After this PR — 0:01.4 onward

What Buzz does: message 2 stays in the ordinary queue. Cursor finishes setup, then is prompted with message 1, then message 2 (or both in one batch).

What User sees:

```
User:      @Cursor [grok-fast] open the RFC in Cursor
User:      and put the PR next to it so I can compare the charts
Cursor:    Cursor is in front. Two tabs:
           1. RFC (on screen) — OUTBOX/RFC_HUDDLE_HANDS_FREE_TURN.md
           2. Setup-window PR — OUTBOX/PR_ACP_STEER_REQUIRES_PROMPT.md
```

### Same huddle, later — still unchanged

Cursor is already typing that reply. User cuts in:

> stop — just the RFC, skip the PR

That *is* a mid-turn steer. Prompt is in flight. This PR still sends steer / cancel. We only stop doing that during the shoe-lacing window before the first prompt.

## Before vs after

Left is today's gate. Right is this PR.
Grey is unchanged. **Red is the premature steer we remove. Green is
the new question.**

```mermaid
flowchart LR
  subgraph B["Before"]
    direction TB
    b1[Event accepted] --> b2{Queue owns channel?}
    b2 -->|no| b3[Ordinary dispatch]
    b2 -->|yes| b4[Steer / cancel]
  end
  subgraph A["After"]
    direction TB
    a1[Event accepted] --> a2{Queue owns channel?}
    a2 -->|no| a3[Ordinary dispatch]
    a2 -->|yes| a4{Prompt future polling?}
    a4 -->|no| a5[Ordinary dispatch]
    a4 -->|yes| a6[Steer / cancel]
  end
  classDef removed fill:#fdecea,stroke:#c0392b,color:#000
  classDef added fill:#e8f8f5,stroke:#1e8449,color:#000
  classDef same fill:#f4f6f7,stroke:#7f8c8d,color:#000
  class b4 removed
  class a4,a5 added
  class b1,b2,b3,a1,a2,a3,a6 same
```

Same story as a timeline. Red note is the bug. Green note is the fix.

```mermaid
sequenceDiagram
    participant You
    participant Queue
    participant Agent as ACP task

    You->>Queue: first @mention accepted
    Queue->>Agent: flush_next owns the channel
    Note over Agent: setup: session + history
    Note over Agent: prompt future not polling yet
    You->>Queue: second transcript
    Note over Queue,Agent: Before: steer/cancel at nothing
    Note over Queue,Agent: After: stay queued as a normal message
    Agent->>Agent: start polling session/prompt
    Note over Agent: After: only now may steer/cancel fire
    Agent->>Agent: inside the future: last_prompt_id is set
    Note over Agent: ACP cancel guard reads that field
    Note over Agent: the mid-turn gate does not
```

| Window | Queue owns channel? | Prompt future polling? | Before | After |
| --- | --- | --- | --- | --- |
| Idle | no | no | ordinary dispatch | ordinary dispatch |
| Session setup / context fetch | **yes** | **no** | **steer / cancel at nothing** | ordinary dispatch |
| `session/prompt` future being polled | yes | yes | steer / cancel | steer / cancel |
| After prompt returns | no | no | ordinary dispatch | ordinary dispatch |

## Why the two predicates are not the same

At this branch's base (`93114c9c6`), the gate is:

```rust
if accepted && queue.is_channel_in_flight(buzz_event.channel_id)
```

Permalink:
[crates/buzz-acp/src/lib.rs#L2961-L2964](https://github.com/block/buzz/blob/93114c9c65138397de39729fde0a816eb9f314ab/crates/buzz-acp/src/lib.rs#L2961-L2964)

`is_channel_in_flight` is set membership for the channel UUID. It becomes
true when `flush_next` drains a batch and inserts the channel:

- [queue.rs#L335-L360](https://github.com/block/buzz/blob/93114c9c65138397de39729fde0a816eb9f314ab/crates/buzz-acp/src/queue.rs#L335-L360)
  — drain up to `MAX_BATCH_EVENTS`, then `in_flight_channels.insert`
- [queue.rs#L677-L680](https://github.com/block/buzz/blob/93114c9c65138397de39729fde0a816eb9f314ab/crates/buzz-acp/src/queue.rs#L677-L680)
  — `in_flight_channels.contains(&channel_id)`

After that, the task still has work that is **not** a prompt:

- [pool.rs#L2335-L2372](https://github.com/block/buzz/blob/93114c9c65138397de39729fde0a816eb9f314ab/crates/buzz-acp/src/pool.rs#L2335-L2372)
  — resolve channel info, fetch conversation context, fetch profile lookup

The ACP client's own "is there a prompt?" predicate is narrower:
`last_prompt_id.is_some()`, set inside the future immediately before the
`session/prompt` write
([acp.rs#L794-L810](https://github.com/block/buzz/blob/93114c9c65138397de39729fde0a816eb9f314ab/crates/buzz-acp/src/acp.rs#L794-L810),
[acp.rs#L856-L859](https://github.com/block/buzz/blob/93114c9c65138397de39729fde0a816eb9f314ab/crates/buzz-acp/src/acp.rs#L856-L859)).
This PR's mid-turn gate does **not** read that field. It reads a pool-side
marker that goes true when the prompt future starts polling.

An event in the queue-owned / pre-prompt window should stay queued.
Sending steer, interrupt, or cancel there targets no ACP prompt.

## What the patch does

One extra conjunct on the gate: queue ownership **and** prompt-future
activity. Keeping both means a broken queue/task invariant fails closed
(no steer after the queue has released the channel).

Mechanics:

- `PromptControl::new` creates the task-side control state and the
  `TaskMeta.prompt_in_flight` handle from one `Arc`, so dispatch cannot
  register a different marker.
- A drop guard marks only the lifetime in which the `session/prompt`
  future is polled, and clears the marker on success, error, cancellation,
  or panic. This is prompt-future lifetime instrumentation. It does not
  read `AcpClient.last_prompt_id` (that assignment stays inside the future).
- `AgentPool::has_in_flight_prompt(channel_id)` exposes the shared marker
  to the main loop. This is **not** `AcpClient::has_in_flight_prompt`,
  which reads `last_prompt_id`. The gate uses the pool method. The ACP
  method remains the cancel guard inside the control arm: it cancels only
  while the ACP request marker is set.

No event or ACP wire format changes.

## How to test

The regression test flushes a real `EventQueue`, installs the shared
marker in a real `TaskMeta`, and asserts that queue ownership without
prompt-future activity does **not** enter the mid-turn path.

| Case | Queue owns channel | Prompt marker | Expect |
| --- | --- | --- | --- |
| Setup window | true | false | **no** mid-turn signal |
| Prompt running | true | true | mid-turn signal allowed |
| Event not accepted | true | true | **no** mid-turn signal |
| Queue released, marker still true | false | true | **no** mid-turn signal (fail closed) |

```bash
. ./bin/activate-hermit
cargo test -p buzz-acp mid_turn_signal_requires_an_actual_prompt -- --nocapture
```

Red check: restore the old queue-only predicate → that test fails.
Green: `cargo test -p buzz-acp` (819 unit + 9 lifecycle, 0 failed),
`cargo clippy -p buzz-acp --all-targets --all-features -- -D warnings`,
`just ci`.

Pool tests also prove task ownership can exist while prompt activity is
false, and that aborting a prompt future clears the marker. As a second
negative proof, making `PromptControl::new` return a different `Arc`
caused the cancel-clear test to fail because the pool-side handle never
observed the task-side store.

## What this does **not** prove

[#3282](https://github.com/block/buzz/issues/3282) shows the existing
fallback being selected and a control signal being sent, followed by
silence. That proves the fallback did not recover the reported event.
It does **not** prove this predicate mismatch was the cause:
`ExpectedRunIdMissing` refers to Goose `active_run_id`, not ACP
`last_prompt_id`
([acp.rs#L856-L868](https://github.com/block/buzz/blob/93114c9c65138397de39729fde0a816eb9f314ab/crates/buzz-acp/src/acp.rs#L856-L868)).

This PR fixes a proven pre-prompt misrouting state. It is a candidate
for #3282 and the original race in
[#3071](https://github.com/block/buzz/issues/3071). Do not close either
until a reproduction confirms the prompt future had not started at the
failure. If `last_prompt_id` is already set while Goose is still missing
its run ID, this patch deliberately leaves that active-prompt path
unchanged.

## Deferred (not this PR)

- Reproduce #3282 with one diagnostic snapshot covering queue ownership,
  channel task ownership, ACP prompt activity, and Goose `active_run_id`.
- Investigate a leak or hung pre-prompt task only if that snapshot
  demonstrates one. One context-fetch attempt is 3 s; with one retry
  plus delay the worst case is about 6.5 s
  ([pool.rs#L927-L936](https://github.com/block/buzz/blob/93114c9c65138397de39729fde0a816eb9f314ab/crates/buzz-acp/src/pool.rs#L927-L936)).
- Push-to-talk mention behaviour and VAD turn detection are separate
  desktop concerns.
