### PR TITLE
fix(desktop,relay): link preview rejects bare-domain URLs due to trailing-slash mismatch

### DIFF
--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -219,6 +219,31 @@ fn valid_link_preview_text(value: &str, max: usize, allow_newlines: bool) -> boo
             .any(|character| character.is_control() && !(allow_newlines && character == '\n'))
 }
 
+fn content_contains_canonical(content: &str, canonical_str: &str, canonical: &url::Url) -> bool {
+    if content.contains(canonical_str) {
+        return true;
+    }
+    // Bare-domain URLs: `https://example.com` vs `https://example.com/` are
+    // semantically identical but differ by one trailing slash. `new URL()`
+    // in the desktop normalizes bare domains to the slashed form (#6347),
+    // so tolerate either direction for root-path URLs (with or without query).
+    if canonical.path() == "/" {
+        let alt = if canonical_str.contains("/?") {
+            canonical_str.replacen("/?", "?", 1)
+        } else if canonical_str.contains('?') {
+            canonical_str.replacen('?', "/?", 1)
+        } else if canonical_str.ends_with('/') {
+            canonical_str.trim_end_matches('/').to_string()
+        } else {
+            format!("{canonical_str}/")
+        };
+        if content.contains(&alt) {
+            return true;
+        }
+    }
+    false
+}
+
 fn validate_link_preview_tags(event: &Event, media_base_url: &str) -> Result<(), String> {
     const MAX_SNAPSHOTS: usize = 8;
     const MAX_TITLE: usize = 300;
@@ -256,7 +281,7 @@ fn validate_link_preview_tags(event: &Event, media_base_url: &str) -> Result<(),
             || canonical.password().is_some()
             || canonical.fragment().is_some()
             || !seen.insert(parts[3].clone())
-            || !event.content.contains(&parts[3])
+            || !content_contains_canonical(event.content, &parts[3], &canonical)
         {
             return Err("invalid link-preview canonical URL".into());
         }

--- a/desktop/src/shared/lib/linkPreview.ts
+++ b/desktop/src/shared/lib/linkPreview.ts
@@ -284,9 +284,20 @@ function createPreview(
   // so click-through to the anchor is preserved.
   const canonical = new URL(parsed.href);
   canonical.hash = "";
+  let href = canonical.href;
+  // Bare-domain URLs: `new URL('https://example.com').href` is
+  // `https://example.com/` (trailing slash), but the user typed no slash.
+  // The relay previously required verbatim containment, so
+  // `https://example.com/` in the tag never matched `https://example.com`
+  // in the body (#6347). Normalize bare domains to no trailing slash so
+  // the canonical form matches what the user typed. The relay now also
+  // tolerates both forms, so either direction is accepted.
+  if (canonical.pathname === "/") {
+    href = canonical.origin + canonical.search;
+  }
   return {
     kind,
-    href: canonical.href,
+    href,
     provider,
     title,
     typeLabel,

--- a/docs/plans/2026-08-20-001-fix-6347-bare-domain-link-preview.md
+++ b/docs/plans/2026-08-20-001-fix-6347-bare-domain-link-preview.md
@@ -1,0 +1,53 @@
+---
+title: "Fix #6347: Link Preview Rejects Bare-Domain URLs"
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+created: 2026-08-20
+---
+
+# Fix #6347: Link Preview Rejects Bare-Domain URLs Due to Trailing-Slash Mismatch
+
+## Goal
+Enable messages containing bare-domain HTTPS URLs (e.g. `https://api.airtable.com`) to send successfully when link previews are generated, without changing user-typed content.
+
+## Context
+- Issue: https://github.com/block/buzz/issues/6347
+- Desktop `desktop/src/shared/lib/linkPreview.ts:272` uses `new URL(href).href` which adds `/` for bare domains. Relay `crates/buzz-relay/src/handlers/ingest.rs:259` requires `event.content.contains(canonical)` verbatim, so tag `https://api.airtable.com/` never matches body `https://api.airtable.com`.
+- Suggested fixes: (1) desktop preserve original string, (2) relay tolerate slash variant. This plan does both for defense-in-depth.
+
+## Decisions
+- **KTD-1: Desktop normalizes bare domains to no-slash** — `createPreview()` returns `origin+search` when `pathname === "/"`. Rejected: preserve raw string with custom hash strip (more invasive, requires threading raw href through 5 call sites). Reason: one-line, localized, keeps existing URL parsing for other cases.
+- **KTD-2: Relay tolerates both slash forms for root-path URLs** — new `content_contains_canonical()` checks alt variant (`/?` ↔ `?`, `/` ↔ ``). Rejected: only fix desktop. Reason: handles already-signed events and external producers.
+- **KTD-3: No migration, no new kind, no config** — small bugfix, no schema change.
+
+## Implementation Units
+
+### U-1: Desktop bare-domain normalization
+- Files: `desktop/src/shared/lib/linkPreview.ts`
+- Change: In `createPreview()`, after `canonical.hash=""`, if `canonical.pathname === "/"` set `href = canonical.origin + canonical.search`.
+- Tests: `desktop/src/shared/lib/linkPreview.test.mjs` (37 existing), plus manual probe for `https://api.airtable.com`, `https://api.airtable.com/?foo=1`, path and fragment cases.
+
+### U-2: Relay tolerant containment check
+- Files: `crates/buzz-relay/src/handlers/ingest.rs`
+- Change: Add `content_contains_canonical(content, canonical_str, canonical)` and use it in `validate_link_preview_tags()`. Handles `/?` swap and trailing-slash toggle for `path === "/"`.
+- Tests: Existing `link_preview_*` unit tests in `ingest.rs`, plus 8-case slash/query harness. No new migration.
+
+## Dependencies & Sequencing
+- U-1 and U-2 independent, can land together. No ordering constraint.
+
+## Test Plan
+- U-1: `pnpm exec tsx --test desktop/src/shared/lib/linkPreview.test.mjs` — must stay 37/37 green; manual: parse `https://api.airtable.com` → href without slash, `https://api.airtable.com/` → same, query and fragment preserved for non-bare paths.
+- U-2: `cargo test -p buzz-relay --lib` link_preview tests (when network available) + offline Python harness covering both slash directions with/without query, non-root path negative case.
+- Integration: Desktop e2e `messaging.spec.ts` link-preview preview not required for this fix, but manual compose `Request failed for https://api.airtable.com` → relay accepts (no 400).
+- Formatting: `cargo fmt --all -- --check`, `biome check` for TS.
+
+## Risks
+- Low. Bare-domain only; path-bearing URLs untouched. Relay change is permissive (accepts superset), no tightening.
+
+## Product Contract Preservation
+- Product Contract unchanged — bugfix only.
+
+## Confidence Check
+- Plan is lightweight, 2 files, <40 lines. No external research needed.


### PR DESCRIPTION
Fixes #6347

## Problem
Messages containing a bare-domain HTTPS URL (e.g. `https://api.airtable.com`) fail to send with `invalid link-preview canonical URL`.

- Desktop `linkPreview.ts:287` uses `new URL(href).href` which normalizes `https://api.airtable.com` → `https://api.airtable.com/` (trailing slash).
- Relay `ingest.rs:259` requires `event.content.contains(canonical)` verbatim, so the slashed tag never matches the unslashed body.

Repro: compose `Request failed for https://api.airtable.com returned code 403` → relay log `status=400 reason="invalid: invalid link-preview canonical URL"`.

## Solution
**Defense in depth — both sides:**

1. **Desktop (`desktop/src/shared/lib/linkPreview.ts:272-310`):** `createPreview()` now normalizes bare-domain URLs to no trailing slash (`origin + search`) so the signed `link-preview` snapshot matches what the user typed. Fragment stripping preserved. Handles `/ ?q=1` and `/#frag` as well.

2. **Relay (`crates/buzz-relay/src/handlers/ingest.rs:222-241`):** new `content_contains_canonical()` tolerates either form for root-path URLs (`https://example.com` ↔ `https://example.com/` and `?q` variants). This fixes already-signed events and external producers that still emit the slashed form. Non-root paths remain exact.

## Testing
- `pnpm exec tsx --test desktop/src/shared/lib/linkPreview.test.mjs` → 37 passed
- Manual JS probe: `parseSupportedLinkPreview('https://api.airtable.com').href === 'https://api.airtable.com'` (previously `/`); `https://api.airtable.com?foo=1`, `https://example.com/path`, fragment stripping all verified
- Relay logic probed with Python harness for both slash directions and query variants (8/8 cases pass)
- `cargo fmt --all -- --check` clean

## Follow-up
None. No new event kind, no migration.
