### PR TITLE
feat(buzz-acp): terse-register toggle for agents-only turns

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -47,7 +47,20 @@ For explicit changes to an existing personal agent, use `buzz agents draft-updat
 
 ## Communication Patterns
 
-### Mentions
+### Register
+
+When `[Context]` includes an `Audience:` line, match your message register to it:
+
+- `Audience: agents-only` — every reader is an agent. Write telegraphic English: drop greetings, hedging, restated context, social padding, and transition prose. Standard engineering shorthand is encouraged (`PR up`, `deploy OK`, `2 tests failing in auth`, `<10min`, `blocked on #4521`). State facts, deltas, asks, and blockers; omit everything else.
+- `Audience: human-facing` — a human sent the triggering message or is mentioned. Use your normal register and persona voice.
+
+Hard rules for `agents-only`, in priority order over brevity:
+
+1. IDs, event ids, pubkeys, file paths, URLs, `buzz://` links, numbers, and command invocations stay full and verbatim. Never truncate, abbreviate, or paraphrase an identifier — a corrupted reference costs more than the tokens it saves.
+2. Use only common engineering shorthand a new team member would recognize. Do not invent codes, custom abbreviation schemes, or non-English tokens to compress further.
+3. All other communication rules (mentions, threading, callback mentions, no bare acknowledgements) apply unchanged.
+
+When no `Audience:` line is present, use your normal register.
 
 - For a notifying `@mention`, use the person's **exact display name as shown in Buzz** (e.g., `@Will Pfleger`, not `@Will`, when the displayed name is `Will Pfleger`). Do not expand a short display name, infer a surname, or spend tool calls looking for a “fuller” name merely to address someone. Partial names fail silently.
 - Do NOT format mentions with bold, italic, or backticks — it breaks notification delivery.

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -424,6 +424,12 @@ pub struct CliArgs {
     )]
     pub base_prompt_file: Option<PathBuf>,
 
+    /// Emit an `Audience:` line in each turn's `[Context]` block so agents
+    /// use terse telegraphic English on agents-only turns (see the Register
+    /// section of the base prompt). Human-facing turns are unaffected.
+    #[arg(long, env = "BUZZ_ACP_TERSE_REGISTER", default_value_t = false)]
+    pub terse_register: bool,
+
     /// Desired LLM model ID. Applied to every new ACP session after creation.
     /// Use `buzz-acp models` to discover available model IDs.
     #[arg(long, env = "BUZZ_ACP_MODEL")]
@@ -599,6 +605,9 @@ pub struct Config {
     /// `from_cli()`. `None` when using the compiled-in default or when
     /// `--no-base-prompt` is set.
     pub base_prompt_content: Option<String>,
+    /// Emit `Audience:` lines in `[Context]` blocks — enables the base
+    /// prompt's terse register on agents-only turns. Off by default.
+    pub terse_register: bool,
 }
 
 /// Maximum length, in characters, of a session title sent to the adapter.
@@ -1143,6 +1152,7 @@ impl Config {
             agent_owner: args.agent_owner.map(|s| s.trim().to_ascii_lowercase()),
             no_base_prompt: args.no_base_prompt,
             base_prompt_content,
+            terse_register: args.terse_register,
         };
 
         Ok(config)
@@ -1516,6 +1526,7 @@ mod tests {
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
+            terse_register: false,
         }
     }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2207,6 +2207,7 @@ async fn tokio_main() -> Result<()> {
         memory_enabled: config.memory_enabled,
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
         relay_url: config.relay_url.clone(),
+        terse_register: config.terse_register,
     });
 
     if !config.memory_enabled {
@@ -4438,6 +4439,22 @@ mod agent_draft_prompt_tests {
         assert!(prompt.contains("what it should do day-to-day"));
         assert!(prompt.contains("owner saves it"));
         assert!(prompt.contains("Do not ask about runtime, provider, model, credentials"));
+    }
+
+    #[test]
+    fn shared_base_prompt_teaches_terse_register() {
+        let prompt = include_str!("base_prompt.md");
+        // Register keys off the [Context] Audience line emitted by
+        // format_context_hints when --terse-register is enabled.
+        assert!(prompt.contains("`Audience: agents-only`"));
+        assert!(prompt.contains("`Audience: human-facing`"));
+        assert!(prompt.contains("telegraphic English"));
+        // Identifier-integrity hard rule: terse mode must never compress IDs.
+        assert!(prompt.contains("Never truncate, abbreviate, or paraphrase an identifier"));
+        // Anti-drift fence: no invented compression schemes.
+        assert!(prompt.contains("Do not invent codes"));
+        // Toggle-off behavior is explicit.
+        assert!(prompt.contains("When no `Audience:` line is present"));
     }
 
     #[test]
@@ -6787,6 +6804,7 @@ mod build_mcp_servers_tests {
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
+            terse_register: false,
         }
     }
 
@@ -7011,6 +7029,7 @@ mod error_outcome_emission_tests {
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
+            terse_register: false,
         }
     }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -641,6 +641,10 @@ pub struct PromptContext {
     /// the desktop keys per (agent, relay) pair, e.g. `session_config_captured`,
     /// mirroring the `managed_agent_runtime_lifecycle` frames.
     pub relay_url: String,
+    /// Emit `Audience:` lines in `[Context]` blocks — enables the base
+    /// prompt's terse register on agents-only turns. See
+    /// [`crate::queue::FormatPromptArgs::terse_register`].
+    pub terse_register: bool,
 }
 
 impl AgentPool {
@@ -2402,6 +2406,7 @@ pub async fn run_prompt_task(
                 team_instructions: standing.team_instructions,
                 agent_canvas: standing.agent_canvas,
                 standing_context_sent,
+                terse_register: ctx.terse_register,
             },
         )
     } else {
@@ -7959,6 +7964,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             memory_enabled: false,
             harness_name: "goose".to_string(),
             relay_url: "ws://127.0.0.1:3000".to_string(),
+            terse_register: false,
         }
     }
 

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1308,6 +1308,22 @@ fn append_channel_description(s: &mut String, channel_info: Option<&PromptChanne
     s.push_str(&format!("\nDescription: {truncated}"));
 }
 
+/// Append an `Audience:` line to a `[Context]` block.
+///
+/// `audience` is `None` when the terse-register toggle is off (the line is
+/// omitted entirely, preserving the pre-toggle prompt byte-for-byte), and
+/// `Some(human_facing)` when it is on. The register rules in
+/// `base_prompt.md` key off this line; without it they are inert.
+fn append_audience(s: &mut String, audience: Option<bool>) {
+    if let Some(human_facing) = audience {
+        s.push_str(if human_facing {
+            "\nAudience: human-facing"
+        } else {
+            "\nAudience: agents-only"
+        });
+    }
+}
+
 /// Format a `[Context]` hints section based on event scope.
 ///
 /// `reply_anchor` is the pre-resolved `--reply-to` target for this turn (see
@@ -1315,6 +1331,12 @@ fn append_channel_description(s: &mut String, channel_info: Option<&PromptChanne
 /// replies; in the channel branch a `Some` anchor means a human-facing
 /// top-level mention whose reply should open a new thread rooted at the
 /// triggering event.
+///
+/// `audience` gates the `Audience:` register line (see [`append_audience`]).
+/// Unlike the reply anchor, audience classification also applies to DMs: an
+/// agent→agent DM with no human mentioned is an agents-only exchange even
+/// though DM replies always anchor.
+#[allow(clippy::too_many_arguments)]
 fn format_context_hints(
     channel_id: Uuid,
     channel_info: Option<&PromptChannelInfo>,
@@ -1323,6 +1345,7 @@ fn format_context_hints(
     has_conversation_context: bool,
     conversation_context_had_delivered_events: bool,
     reply_anchor: Option<&str>,
+    audience: Option<bool>,
 ) -> String {
     let channel_display = match channel_info {
         Some(ci) => format!("{} (#{channel_id})", ci.name),
@@ -1351,9 +1374,10 @@ fn format_context_hints(
         let mut s = format!(
             "[Context]\n\
              Scope: dm\n\
-             Channel: {channel_display}\n\
-             {ctx_hint}"
+             Channel: {channel_display}"
         );
+        append_audience(&mut s, audience);
+        s.push_str(&format!("\n{ctx_hint}"));
         // If this is a DM reply, include thread structural info as supplementary.
         if let Some(ref root) = thread_tags.root_event_id {
             s.push_str(&format!("\nThread root: {root}"));
@@ -1381,6 +1405,7 @@ fn format_context_hints(
              Channel: {channel_display}"
         );
         append_channel_description(&mut s, channel_info);
+        append_audience(&mut s, audience);
         s.push_str(&format!("\nThread root: {root}"));
         if let Some(ref parent) = thread_tags.parent_event_id {
             if parent != root {
@@ -1399,6 +1424,7 @@ fn format_context_hints(
              Channel: {channel_display}"
         );
         append_channel_description(&mut s, channel_info);
+        append_audience(&mut s, audience);
         s.push_str(
             "\nHint: Use `buzz messages get --channel <UUID>` for recent messages if needed.",
         );
@@ -1478,6 +1504,16 @@ pub struct FormatPromptArgs<'a> {
     /// Defaults to `false` so a caller that never sets it behaves as if this
     /// were the session's first message.
     pub standing_context_sent: bool,
+    /// Emit an `Audience:` line in `[Context]` so the base prompt's register
+    /// rules can distinguish agents-only turns (terse telegraphic English)
+    /// from human-facing turns (normal register). Off by default: no line is
+    /// emitted and prompts are byte-identical to the pre-toggle format.
+    ///
+    /// Audience classification reuses [`turn_is_human_facing`]: a turn is
+    /// human-facing when the triggering sender is a human OR any mentioned
+    /// participant is a human, failing open to human-facing for anyone who
+    /// cannot be classified.
+    pub terse_register: bool,
 }
 
 /// The prompt sections that do not change for the life of a session: base
@@ -1625,6 +1661,13 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
             args.profile_lookup,
         )
     };
+    // Audience classification for the terse-register toggle. Computed for
+    // every scope (including DMs, which skip reply-anchor resolution but can
+    // still be agent↔agent exchanges).
+    let audience = args
+        .terse_register
+        .then(|| turn_is_human_facing(&sender_pubkey, &thread_tags, args.profile_lookup));
+
     sections.push(format_context_hints(
         batch.channel_id,
         args.channel_info,
@@ -1633,6 +1676,7 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
         args.conversation_context.is_some(),
         args.conversation_context_had_delivered_events,
         reply_anchor.as_deref(),
+        audience,
     ));
 
     // 3. Conversation context (thread or DM).
@@ -4427,6 +4471,205 @@ mod tests {
         assert!(
             !prompt.contains(&format!("--reply-to {parent_id}")),
             "instruction should NOT anchor to the parent event id"
+        );
+    }
+
+    // ── Terse-register audience line ─────────────────────────────────────────
+
+    /// Sign an event with fresh keys and return it with a profile lookup that
+    /// classifies the signer as agent/human per `sender_is_agent`.
+    fn make_classified_event(
+        content: &str,
+        tags: Vec<Vec<String>>,
+        sender_is_agent: bool,
+    ) -> (Event, PromptProfileLookup) {
+        let keys = Keys::generate();
+        let nostr_tags: Vec<nostr::Tag> = tags
+            .iter()
+            .map(|t| {
+                let strs: Vec<&str> = t.iter().map(|s| s.as_str()).collect();
+                nostr::Tag::parse(strs).unwrap()
+            })
+            .collect();
+        let event = EventBuilder::new(Kind::Custom(9), content)
+            .tags(nostr_tags)
+            .sign_with_keys(&keys)
+            .unwrap();
+        let lookup = HashMap::from([(event.pubkey.to_hex(), profile(sender_is_agent))]);
+        (event, lookup)
+    }
+
+    fn batch_for(ch: Uuid, event: Event) -> FlushBatch {
+        FlushBatch {
+            channel_id: ch,
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "test".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        }
+    }
+
+    #[test]
+    fn test_audience_line_absent_when_toggle_off() {
+        // Off by default: no Audience line anywhere, prompts byte-identical
+        // to the pre-toggle format.
+        let ch = Uuid::new_v4();
+        let (event, lookup) = make_classified_event("agent ping", vec![], true);
+        let prompt = format_prompt(
+            &batch_for(ch, event),
+            &FormatPromptArgs {
+                profile_lookup: Some(&lookup),
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+        assert!(
+            !prompt.contains("Audience:"),
+            "toggle off must not emit an Audience line; got: {prompt}"
+        );
+    }
+
+    #[test]
+    fn test_audience_agents_only_for_agent_sender_no_human_mentions() {
+        // Agent sender, agent-only mentions → agents-only.
+        let (event, mut lookup) =
+            make_classified_event("status?", vec![vec!["p".into(), AGENT_B_PK.into()]], true);
+        lookup.insert(AGENT_B_PK.into(), profile(true));
+        let prompt = format_prompt(
+            &batch_for(Uuid::new_v4(), event),
+            &FormatPromptArgs {
+                profile_lookup: Some(&lookup),
+                terse_register: true,
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+        assert!(
+            prompt.contains("\nAudience: agents-only"),
+            "agent→agent turn should be agents-only; got: {prompt}"
+        );
+    }
+
+    #[test]
+    fn test_audience_human_facing_for_human_sender() {
+        let (event, lookup) = make_classified_event("hey bot", vec![], false);
+        let prompt = format_prompt(
+            &batch_for(Uuid::new_v4(), event),
+            &FormatPromptArgs {
+                profile_lookup: Some(&lookup),
+                terse_register: true,
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+        assert!(
+            prompt.contains("\nAudience: human-facing"),
+            "human sender should be human-facing; got: {prompt}"
+        );
+    }
+
+    #[test]
+    fn test_audience_human_facing_when_agent_mentions_human() {
+        // Agent sender but a human is tagged → human-facing.
+        let (event, mut lookup) =
+            make_classified_event("@human fyi", vec![vec!["p".into(), HUMAN_PK.into()]], true);
+        lookup.insert(HUMAN_PK.into(), profile(false));
+        let prompt = format_prompt(
+            &batch_for(Uuid::new_v4(), event),
+            &FormatPromptArgs {
+                profile_lookup: Some(&lookup),
+                terse_register: true,
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+        assert!(
+            prompt.contains("\nAudience: human-facing"),
+            "human mention should force human-facing; got: {prompt}"
+        );
+    }
+
+    #[test]
+    fn test_audience_fails_open_to_human_facing_without_lookup() {
+        // No profile lookup → unclassifiable sender → human-facing.
+        let event = make_event("who am I talking to");
+        let prompt = format_prompt(
+            &batch_for(Uuid::new_v4(), event),
+            &FormatPromptArgs {
+                terse_register: true,
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+        assert!(
+            prompt.contains("\nAudience: human-facing"),
+            "unclassifiable sender must fail open to human-facing; got: {prompt}"
+        );
+    }
+
+    #[test]
+    fn test_audience_agents_only_in_thread_scope() {
+        // Agent→agent inside a thread: agents-only line rides in the thread
+        // branch of format_context_hints (distinct code path from channel).
+        let root_id = "c".repeat(64);
+        let (event, mut lookup) = make_classified_event(
+            "thread update",
+            vec![
+                vec!["e".into(), root_id.clone(), "".into(), "root".into()],
+                vec!["p".into(), AGENT_B_PK.into()],
+            ],
+            true,
+        );
+        lookup.insert(AGENT_B_PK.into(), profile(true));
+        let prompt = format_prompt(
+            &batch_for(Uuid::new_v4(), event),
+            &FormatPromptArgs {
+                profile_lookup: Some(&lookup),
+                terse_register: true,
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+        assert!(
+            prompt.contains("Scope: thread"),
+            "expected thread scope; got: {prompt}"
+        );
+        assert!(
+            prompt.contains("\nAudience: agents-only"),
+            "thread-scope agent turn should be agents-only; got: {prompt}"
+        );
+    }
+
+    #[test]
+    fn test_audience_agents_only_in_dm_scope() {
+        // Agent→agent DM: DMs always anchor replies, but audience is still
+        // classified — an agent-to-agent DM is an agents-only exchange.
+        let (event, lookup) = make_classified_event("dm ping", vec![], true);
+        let ci = PromptChannelInfo {
+            name: "dm".into(),
+            channel_type: "dm".into(),
+            description: None,
+        };
+        let prompt = format_prompt(
+            &batch_for(Uuid::new_v4(), event),
+            &FormatPromptArgs {
+                channel_info: Some(&ci),
+                profile_lookup: Some(&lookup),
+                terse_register: true,
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+        assert!(
+            prompt.contains("Scope: dm"),
+            "expected dm scope; got: {prompt}"
+        );
+        assert!(
+            prompt.contains("\nAudience: agents-only"),
+            "agent→agent DM should be agents-only; got: {prompt}"
         );
     }
 

--- a/desktop/src/features/settings/ui/ExperimentalFeaturesCard.tsx
+++ b/desktop/src/features/settings/ui/ExperimentalFeaturesCard.tsx
@@ -4,6 +4,7 @@ import type { FeatureDefinition } from "@/shared/features";
 import { Switch } from "@/shared/ui/switch";
 import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
 import { SettingsSectionHeader } from "./SettingsSectionHeader";
+import { TerseRegisterRow } from "./TerseRegisterRow";
 
 function FeatureRow({ feature }: { feature: FeatureDefinition }) {
   const [enabled, toggle] = useFeatureToggle(feature.id);
@@ -60,6 +61,7 @@ export function ExperimentalFeaturesCard() {
         {previewFeatures.map((f) => (
           <FeatureRow feature={f} key={f.id} />
         ))}
+        <TerseRegisterRow />
       </SettingsOptionGroup>
     </section>
   );

--- a/desktop/src/features/settings/ui/TerseRegisterRow.tsx
+++ b/desktop/src/features/settings/ui/TerseRegisterRow.tsx
@@ -1,0 +1,67 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  globalAgentConfigQueryKey,
+  useGlobalAgentConfig,
+} from "@/features/agents/useGlobalAgentConfig";
+import { setGlobalAgentConfig } from "@/shared/api/tauriGlobalAgentConfig";
+import { Switch } from "@/shared/ui/switch";
+import { SettingsOptionRow } from "./SettingsOptionGroup";
+import {
+  isTerseRegisterEnabled,
+  withTerseRegister,
+} from "./terseRegisterLogic";
+
+/**
+ * Experiments row: terse agent-to-agent register.
+ *
+ * Unlike manifest preview features (localStorage-backed, desktop-only UI
+ * gates), this switch controls harness behavior. Its source of truth is the
+ * global agent config's `BUZZ_ACP_TERSE_REGISTER` env var — the exact value
+ * managed agents receive at spawn — so the UI state cannot drift from what
+ * running agents were started with. Saving through `set_global_agent_config`
+ * auto-restarts running local agents whose effective env changed, so the
+ * toggle takes effect without manual restarts.
+ */
+export function TerseRegisterRow() {
+  const { globalConfig, isLoading } = useGlobalAgentConfig();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (enabled: boolean) =>
+      setGlobalAgentConfig(withTerseRegister(globalConfig, enabled)),
+    onSuccess: (result) => {
+      queryClient.setQueryData(globalAgentConfigQueryKey, result.config);
+    },
+    onError: (error) => {
+      console.error("Failed to toggle terse agent register:", error);
+    },
+  });
+
+  const enabled = isTerseRegisterEnabled(globalConfig);
+  const switchId = "feature-toggle-terseRegister";
+
+  return (
+    <SettingsOptionRow>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium" id={`${switchId}-label`}>
+          Terse agent-to-agent messages
+        </p>
+        <p className="text-xs text-muted-foreground/70" data-settings-subcopy>
+          Agents drop social padding and write telegraphic English in agent-only
+          conversations. Messages to humans keep the normal tone. Applies to
+          managed agents and restarts running ones.
+        </p>
+      </div>
+      <Switch
+        aria-labelledby={`${switchId}-label`}
+        checked={enabled}
+        data-testid={switchId}
+        disabled={isLoading || mutation.isPending}
+        onCheckedChange={(value) => {
+          mutation.mutate(value);
+        }}
+      />
+    </SettingsOptionRow>
+  );
+}

--- a/desktop/src/features/settings/ui/terseRegisterLogic.test.mjs
+++ b/desktop/src/features/settings/ui/terseRegisterLogic.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  TERSE_REGISTER_ENV_KEY,
+  isTerseRegisterEnabled,
+  withTerseRegister,
+} from "./terseRegisterLogic.ts";
+
+describe("terseRegisterLogic", () => {
+  it("is disabled for an empty config", () => {
+    assert.equal(isTerseRegisterEnabled({ env_vars: {} }), false);
+  });
+
+  it("is enabled only for the exact value 'true'", () => {
+    assert.equal(
+      isTerseRegisterEnabled({
+        env_vars: { [TERSE_REGISTER_ENV_KEY]: "true" },
+      }),
+      true,
+    );
+    // Any other value — including clap-truthy-looking ones — reads as off in
+    // the UI; the switch repairs it to the canonical shape on next toggle.
+    assert.equal(
+      isTerseRegisterEnabled({ env_vars: { [TERSE_REGISTER_ENV_KEY]: "1" } }),
+      false,
+    );
+    assert.equal(
+      isTerseRegisterEnabled({
+        env_vars: { [TERSE_REGISTER_ENV_KEY]: "false" },
+      }),
+      false,
+    );
+  });
+
+  it("enable writes the canonical 'true' value", () => {
+    const next = withTerseRegister({ env_vars: {} }, true);
+    assert.equal(next.env_vars[TERSE_REGISTER_ENV_KEY], "true");
+  });
+
+  it("disable removes the key entirely", () => {
+    const next = withTerseRegister(
+      { env_vars: { [TERSE_REGISTER_ENV_KEY]: "true" } },
+      false,
+    );
+    assert.equal(TERSE_REGISTER_ENV_KEY in next.env_vars, false);
+  });
+
+  it("preserves unrelated env vars and config fields", () => {
+    const config = {
+      env_vars: { OTHER: "keep", [TERSE_REGISTER_ENV_KEY]: "true" },
+      provider: "anthropic",
+      model: null,
+    };
+    const next = withTerseRegister(config, false);
+    assert.equal(next.env_vars.OTHER, "keep");
+    assert.equal(next.provider, "anthropic");
+    assert.equal(next.model, null);
+  });
+
+  it("does not mutate the input config", () => {
+    const config = { env_vars: {} };
+    withTerseRegister(config, true);
+    assert.deepEqual(config.env_vars, {});
+  });
+});

--- a/desktop/src/features/settings/ui/terseRegisterLogic.ts
+++ b/desktop/src/features/settings/ui/terseRegisterLogic.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure logic for the terse-register experiment toggle.
+ *
+ * The toggle's source of truth is the global agent config's env_vars —
+ * NOT the preview-features localStorage store — because the behavior is
+ * enacted by the `BUZZ_ACP_TERSE_REGISTER` env var baked into every managed
+ * agent at spawn. Deriving the switch state from the same file that controls
+ * the behavior means the UI can never drift from what agents are actually
+ * doing (a localStorage-backed flag could show "off" while a stale env var
+ * kept agents terse).
+ *
+ * Enable = set the env var to "true" (the value shape `buzz-acp`'s clap
+ * bool parsing expects, mirroring BUZZ_ACP_LAZY_POOL). Disable = remove the
+ * key entirely, matching the global config's "absent = inherit default"
+ * semantics; the harness default is off.
+ */
+
+export const TERSE_REGISTER_ENV_KEY = "BUZZ_ACP_TERSE_REGISTER";
+
+/** Minimal structural slice of GlobalAgentConfig this logic needs. */
+export type TerseRegisterEnvConfig = {
+  env_vars: Record<string, string>;
+};
+
+/** True when the global config enables terse register. */
+export function isTerseRegisterEnabled(
+  config: TerseRegisterEnvConfig,
+): boolean {
+  return config.env_vars[TERSE_REGISTER_ENV_KEY] === "true";
+}
+
+/**
+ * Return a copy of `config` with terse register enabled or disabled.
+ *
+ * Never mutates the input. Disabling removes the key (rather than writing
+ * "false") so an explicit user-provided "false" and "toggled off" converge
+ * on the same clean state.
+ */
+export function withTerseRegister<T extends TerseRegisterEnvConfig>(
+  config: T,
+  enabled: boolean,
+): T {
+  const env_vars = { ...config.env_vars };
+  if (enabled) {
+    env_vars[TERSE_REGISTER_ENV_KEY] = "true";
+  } else {
+    delete env_vars[TERSE_REGISTER_ENV_KEY];
+  }
+  return { ...config, env_vars };
+}


### PR DESCRIPTION
## What

End-to-end terse-register experiment for agent-to-agent traffic, in two layers:

**Harness (`buzz-acp`)** — `--terse-register` / `BUZZ_ACP_TERSE_REGISTER` (default **off**). When enabled, each turn's `[Context]` block carries an `Audience:` line:

- `Audience: agents-only` — triggering sender is an agent and no human is mentioned
- `Audience: human-facing` — a human sent the triggering message or is mentioned

A new **Register** section in `base_prompt.md` keys off the line: on agents-only turns, agents write telegraphic English (drop greetings/hedging/restated context; standard engineering shorthand encouraged). Human-facing turns keep the normal register and persona voice.

**Desktop (Settings → Experiments)** — a "Terse agent-to-agent messages" switch so anyone can turn the experiment on/off without touching env vars. The switch's source of truth is the global agent config's `BUZZ_ACP_TERSE_REGISTER` env var — the exact value managed agents receive at spawn — so UI state cannot drift from running-agent behavior. Saving goes through `set_global_agent_config`, which already auto-restarts running local agents whose effective env changed, so toggling takes effect immediately.

## Why

In agent-heavy channels, every message posted is re-read as input by every subsequent turn of every participating agent — message tokens are the O(agents × history) term in channel cost, and the reply itself bills at output rates. Measured on representative coordination messages with the o200k tokenizer, terse register cuts message tokens by **~47%** (details below). Since it's register (style), not a compression scheme, it stays in-distribution, human-readable, and auditable.

Guardrails, in priority order over brevity:

1. **Identifiers are sacred** — event ids, pubkeys, paths, URLs, `buzz://` links, numbers, and command invocations stay full and verbatim. A corrupted reference costs more than the tokens it saves.
2. **No invented codes** — only common engineering shorthand a new team member would recognize. This is the fence against emergent-protocol drift.
3. All other communication rules (mentions, threading, callback mentions, no bare acknowledgements) apply unchanged.

## Design notes

- **Audience classification reuses `turn_is_human_facing()`** — the same NIP-OA-auth-tag identity check that already gates reply-anchor flattening, with the same fail-open-to-human posture for unclassifiable participants. One classification, two consumers, no drift.
- **DMs are classified too.** DMs always anchor replies (existing behavior, untouched), but an agent→agent DM is still an agents-only exchange, so it gets the register line.
- **Prompt-layer by necessity.** Buzz messages are signed Nostr events — middleware can't rewrite them without breaking signatures. Register has to be applied at generation time.
- **Off = byte-identical prompts.** With the toggle off (default), no `Audience:` line is emitted and the `[Context]` block is unchanged from today, byte for byte. The base-prompt Register section is inert without the line.
- **Desktop toggle rides existing rails.** No new Tauri commands, no preview-manifest entry: global env_vars already flow floor→runtime→definition→global→persona→agent into the spawned harness env, `BUZZ_ACP_TERSE_REGISTER` is a behavior knob (not reserved), and `set_global_agent_config` already handles validation + auto-restart. Disable removes the key (absent = inherit default). Per-agent/persona env overrides win on collision, so mixed-register fleets work for free.

## Measurement

8 representative agent-coordination message pairs (pickup, review handoff, status, blocker, result, search report, build confirmation, root-cause analysis), same content in both registers, tokenized with o200k:

| | verbose | terse | savings |
|---|---|---|---|
| total tokens | 471 | 250 | **46.9%** |

Per-message savings ranged 35–54%. The savings apply to the reply's output tokens and to every subsequent re-read of that message as channel-history input. Standing context (system prompt, tool schemas) is unaffected either way and prompt-cached in practice, so channel-level savings on *message* traffic track the per-message rate; total-bill impact depends on the message-tokens : standing-context ratio of the deployment.

`KIND_AGENT_TURN_METRIC` (44200) events give a before/after A/B for free: enable, compare tokens-per-turn for a week, disable if register bleed shows up in human-facing turns.

## Testing

**Harness:**
- 7 new unit tests in `queue.rs`: toggle-off byte-identity, agents-only classification (channel/thread/DM scopes), human-facing for human sender, human-facing when an agent mentions a human, fail-open without profile lookup
- 1 new base-prompt pin test in `lib.rs` (register section teaches both audience values, identifier integrity, no invented codes, toggle-off behavior)
- `cargo test -p buzz-acp`: 810 passed / 0 failed; clippy + fmt clean

**Desktop:**
- 6 new logic tests (`terseRegisterLogic.test.mjs`): enabled-detection strictness, canonical enable value, disable-removes-key, unrelated-field preservation, input immutability
- `pnpm test`: 5082 passed / 0 failed; `tsc --noEmit` clean; biome clean
- e2e bridge already mocks `get/set_global_agent_config` — no test-infra changes needed

## Open questions for review

1. **Default.** Off feels right for a first ship; if the A/B holds up, flipping agents-only turns on by default is a one-line follow-up.
2. **Settings copy.** "Terse agent-to-agent messages" + subcopy — happy to take wording suggestions.
3. **Register-bleed risk.** The per-turn `Audience:` line flipping explicitly is the mitigation for terse style leaking into human-facing turns; the fail-open classification means ambiguous turns always get full register. Watching for bleed is part of the pilot.

🤖 Drafted by Zach's goose agent.
