### PR TITLE
feat(desktop): add persistent pinned Thread Rail

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -86,6 +86,7 @@ export default defineConfig({
         "**/community-rail.spec.ts",
         "**/boot-splash.spec.ts",
         "**/thread-reply-anchor-roleplay.spec.ts",
+        "**/thread-rail.spec.ts",
         "**/threadpane-ultrawide.spec.ts",
         "**/thread-focus-mode.spec.ts",
         "**/animated-avatar.spec.ts",

--- a/desktop/src-tauri/src/observed_unread.rs
+++ b/desktop/src-tauri/src/observed_unread.rs
@@ -128,6 +128,7 @@ pub(crate) struct ChannelProjection {
     channel_id: String,
     latest: u64,
     count: u64,
+    unread_root_ids: Vec<String>,
     badge_count: u64,
     app_badge_count: u64,
     top_level_unread: bool,
@@ -356,6 +357,7 @@ fn projections(tx: &Transaction<'_>, scope: &str) -> Result<Vec<ChannelProjectio
                 channel_id,
                 latest,
                 count: 0,
+                unread_root_ids: Vec::new(),
                 badge_count: 0,
                 app_badge_count: 0,
                 top_level_unread: false,
@@ -393,6 +395,7 @@ fn projections(tx: &Transaction<'_>, scope: &str) -> Result<Vec<ChannelProjectio
                 channel_id: channel,
                 latest: 0,
                 count: 0,
+                unread_root_ids: Vec::new(),
                 badge_count: 0,
                 app_badge_count: 0,
                 top_level_unread: false,
@@ -400,12 +403,20 @@ fn projections(tx: &Transaction<'_>, scope: &str) -> Result<Vec<ChannelProjectio
             });
         entry.latest = entry.latest.max(created);
         entry.count += 1;
+        if let Some(root) = root.as_ref() {
+            if !entry.unread_root_ids.contains(root) {
+                entry.unread_root_ids.push(root.clone());
+            }
+        }
         entry.badge_count += u64::from(badge);
         entry.app_badge_count += u64::from(app);
         entry.top_level_unread |= root.is_none();
         entry.high_priority_unread |= high;
     }
     let mut result: Vec<_> = by_channel.into_values().collect();
+    for entry in &mut result {
+        entry.unread_root_ids.sort();
+    }
     result.sort_by(|a, b| a.channel_id.cmp(&b.channel_id));
     Ok(result)
 }
@@ -870,6 +881,7 @@ mod tests {
                 channel_id: "ch".into(),
                 latest: 42,
                 count: 2,
+                unread_root_ids: vec!["root-a".into()],
                 badge_count: 1,
                 app_badge_count: 1,
                 top_level_unread: true,
@@ -878,7 +890,7 @@ mod tests {
             removed: vec!["old".into()],
         })
         .unwrap();
-        let expected = serde_json::json!({"kind":"delta","scope":{"pubkey":"PK","relayUrl":"wss://relay/"},"generation":"gen","baseRevision":4,"revision":5,"ackedSequence":7,"upserts":[{"channelId":"ch","latest":42,"count":2,"badgeCount":1,"appBadgeCount":1,"topLevelUnread":true,"highPriorityUnread":false}],"removed":["old"]});
+        let expected = serde_json::json!({"kind":"delta","scope":{"pubkey":"PK","relayUrl":"wss://relay/"},"generation":"gen","baseRevision":4,"revision":5,"ackedSequence":7,"upserts":[{"channelId":"ch","latest":42,"count":2,"unreadRootIds":["root-a"],"badgeCount":1,"appBadgeCount":1,"topLevelUnread":true,"highPriorityUnread":false}],"removed":["old"]});
         assert_eq!(actual, expected);
     }
 }

--- a/desktop/src/app/AppHuddleShell.tsx
+++ b/desktop/src/app/AppHuddleShell.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { AppHuddleBar } from "@/app/AppHuddleBar";
+import { appHuddleSurfaceClassName } from "@/app/appHuddleSurfaceLayout";
 import * as BuzzTheme from "@/app/BuzzThemeSurfaces";
 import { HuddleProvider, useHuddle } from "@/features/huddle";
 import { HUDDLE_SHORTCUT_EVENT } from "@/shared/lib/keyboard-shortcuts";
@@ -81,7 +82,7 @@ export function AppHuddleShell({
             />
             <div
               className={cn(
-                "buzz-huddle-app-surface z-10 flex min-h-0 flex-row overflow-hidden bg-background",
+                appHuddleSurfaceClassName(isRoom),
                 isDrawerOpen &&
                   (isRoom
                     ? "buzz-huddle-app-surface-room-open"

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -954,6 +954,7 @@ export function AppShell() {
                         onNavigate={(destination) =>
                           void goChannel(destination.channelId, destination)
                         }
+                        onRename={threadRail.rename}
                         onToggleCollapsed={threadRail.toggleCollapsed}
                         onUnpin={threadRail.unpin}
                         openThreadRootId={openThreadRootId}

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -34,10 +34,15 @@ import {
   useHideDmMutation,
   useOpenDmMutation,
 } from "@/features/channels/hooks";
+import { ThreadRailProvider } from "@/features/channels/ThreadRailContext";
+import { threadRailRootIdFromSearch } from "@/features/channels/threadRailNavigation";
+import { ThreadRail } from "@/features/channels/ui/ThreadRail";
+import { useThreadRail } from "@/features/channels/useThreadRail";
 import { useUnreadChannels } from "@/features/channels/useUnreadChannels";
 import { useMembershipNotifications } from "@/features/channels/useMembershipNotifications";
 import { useFeedItemState } from "@/features/home/useFeedItemState";
 import { useThreadFollows } from "@/features/messages/lib/useThreadFollows";
+import { getThreadReference } from "@/features/messages/lib/threading";
 import {
   useHomeFeedNotifications,
   useHomeFeedNotificationState,
@@ -178,6 +183,11 @@ export function AppShell() {
     : DEFAULT_SETTINGS_SECTION;
   const startupReady = useDeferredStartup();
   const identityQuery = useIdentityQuery();
+  const threadRail = useThreadRail(
+    identityQuery.data?.pubkey,
+    communitiesHook.activeCommunity?.relayUrl,
+  );
+  const openThreadRootId = threadRailRootIdFromSearch(location.search);
   const { mutedChannelIds, muteChannel, unmuteChannel } = useChannelMutes(
     identityQuery.data?.pubkey,
     communitiesHook.activeCommunity?.relayUrl,
@@ -424,6 +434,16 @@ export function AppShell() {
     threadActivityItems,
     mutedRootIds,
   });
+  const unreadThreadRootIds = React.useMemo(
+    () =>
+      new Set(
+        unreadThreadFeedItems.flatMap((item) => {
+          const rootId = getThreadReference(item.tags).rootId;
+          return rootId ? [rootId] : [];
+        }),
+      ) as ReadonlySet<string>,
+    [unreadThreadFeedItems],
+  );
   const markAllChannelsRead = React.useCallback(() => {
     markAllReadSources({
       activeChannelId: activeChannel?.id ?? null,
@@ -923,9 +943,25 @@ export function AppShell() {
                           <TerminalBootstrap {...effectiveTerminalContext} />
                         }
                       >
-                        <Outlet />
+                        <ThreadRailProvider rail={threadRail}>
+                          <Outlet />
+                        </ThreadRailProvider>
                       </AppShellChannelSurface>
                     </TerminalContextOverrideProvider>
+                    {!isHuddleRoom ? (
+                      <ThreadRail
+                        collapsed={threadRail.collapsed}
+                        onNavigate={(destination) =>
+                          void goChannel(destination.channelId, destination)
+                        }
+                        onToggleCollapsed={threadRail.toggleCollapsed}
+                        onUnpin={threadRail.unpin}
+                        openThreadRootId={openThreadRootId}
+                        pins={threadRail.pins}
+                        selectedChannelId={selectedChannelId}
+                        unreadRootIds={unreadThreadRootIds}
+                      />
+                    ) : null}
                     {!isHuddleRoom ? (
                       <RelayConnectionOverlay
                         card={relayConnectionCard}

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -42,7 +42,7 @@ import { useUnreadChannels } from "@/features/channels/useUnreadChannels";
 import { useMembershipNotifications } from "@/features/channels/useMembershipNotifications";
 import { useFeedItemState } from "@/features/home/useFeedItemState";
 import { useThreadFollows } from "@/features/messages/lib/useThreadFollows";
-import { getThreadReference } from "@/features/messages/lib/threading";
+
 import {
   useHomeFeedNotifications,
   useHomeFeedNotificationState,
@@ -379,6 +379,7 @@ export function AppShell() {
     markChannelUnread,
     clearChannelUnreadSource,
     unreadChannelIds,
+    unreadThreadRootIds,
     topLevelUnreadChannelIds,
     unreadChannelCounts,
     highPriorityUnreadChannelIds,
@@ -434,16 +435,7 @@ export function AppShell() {
     threadActivityItems,
     mutedRootIds,
   });
-  const unreadThreadRootIds = React.useMemo(
-    () =>
-      new Set(
-        unreadThreadFeedItems.flatMap((item) => {
-          const rootId = getThreadReference(item.tags).rootId;
-          return rootId ? [rootId] : [];
-        }),
-      ) as ReadonlySet<string>,
-    [unreadThreadFeedItems],
-  );
+
   const markAllChannelsRead = React.useCallback(() => {
     markAllReadSources({
       activeChannelId: activeChannel?.id ?? null,

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -780,7 +780,7 @@ export function AppShell() {
               />
             ) : null}
             <SidebarProvider
-              className="relative z-10 min-h-0 min-w-0 flex-1 flex-col overflow-visible"
+              className="relative z-10 min-h-0 min-w-0 flex-1 flex-col overflow-visible !bg-transparent"
               data-testid="app-sidebar-layer"
             >
               <AppProfilePanelProvider>

--- a/desktop/src/app/appHuddleSurfaceLayout.test.mjs
+++ b/desktop/src/app/appHuddleSurfaceLayout.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { appHuddleSurfaceClassName } from "./appHuddleSurfaceLayout.ts";
+
+test("normal app surface extends the sidebar substrate behind inset panels", () => {
+  const className = appHuddleSurfaceClassName(false);
+  assert.match(className, /\bbg-sidebar\b/);
+  assert.doesNotMatch(className, /\bbg-background\b/);
+});
+
+test("dedicated Huddle room keeps its content background", () => {
+  const className = appHuddleSurfaceClassName(true);
+  assert.match(className, /\bbg-background\b/);
+  assert.doesNotMatch(className, /\bbg-sidebar\b/);
+});

--- a/desktop/src/app/appHuddleSurfaceLayout.ts
+++ b/desktop/src/app/appHuddleSurfaceLayout.ts
@@ -1,0 +1,6 @@
+export function appHuddleSurfaceClassName(isRoom: boolean): string {
+  return [
+    "buzz-huddle-app-surface z-10 flex min-h-0 flex-row overflow-hidden",
+    isRoom ? "bg-background" : "bg-sidebar",
+  ].join(" ");
+}

--- a/desktop/src/app/navigation/useAppNavigation.ts
+++ b/desktop/src/app/navigation/useAppNavigation.ts
@@ -191,6 +191,7 @@ export function useAppNavigation() {
         replace?: boolean;
         /** Open this thread panel directly without waiting for a timeline row. */
         thread?: string;
+        threadRail?: boolean;
         threadRootId?: string | null;
       },
     ) =>
@@ -211,6 +212,7 @@ export function useAppNavigation() {
               ? { agentSession: options.agentSession }
               : {}),
             ...(options?.thread ? { thread: options.thread } : {}),
+            ...(options?.threadRail ? { threadRail: "1" } : {}),
             ...(options?.autoSend ? { autoSend: options.autoSend } : {}),
           },
         },

--- a/desktop/src/app/routes/ChannelRouteScreen.tsx
+++ b/desktop/src/app/routes/ChannelRouteScreen.tsx
@@ -118,6 +118,14 @@ export function ChannelRouteScreen({
     const cachedTarget = getCachedSearchHitEvent(targetMessageId);
     return cachedTarget ? [cachedTarget] : [];
   });
+  const routeTargetKey = `${targetMessageId ?? ""}\u0000${targetThreadRootId ?? ""}`;
+  const [routeLoadState, setRouteLoadState] = React.useState(() => ({
+    key: routeTargetKey,
+    settled:
+      (!targetMessageId && !targetThreadRootId) || Boolean(selectedPostId),
+  }));
+  const targetMessageLoadSettled =
+    routeLoadState.key === routeTargetKey && routeLoadState.settled;
 
   // Reset spliced target events when the channel context changes (channel
   // switch or entering/leaving a forum post). Tied to channel identity rather
@@ -138,6 +146,9 @@ export function ChannelRouteScreen({
 
   React.useEffect(() => {
     let isCancelled = false;
+    const shouldFetchTarget =
+      Boolean(targetMessageId || targetThreadRootId) && !selectedPostId;
+    setRouteLoadState({ key: routeTargetKey, settled: !shouldFetchTarget });
 
     // Don't wipe already-spliced target events just because the route target
     // cleared (e.g. `onTargetReached` clears the `messageId` URL param once the
@@ -145,7 +156,7 @@ export function ChannelRouteScreen({
     // deep-linked message, the spliced event is the only copy — dropping it on
     // param-clear blanks the timeline. Resetting on channel / forum-post change
     // is handled by the effect below; here we only fetch when there's a target.
-    if ((!targetMessageId && !targetThreadRootId) || selectedPostId) {
+    if (!shouldFetchTarget) {
       return () => {
         isCancelled = true;
       };
@@ -167,26 +178,28 @@ export function ChannelRouteScreen({
         : null,
     ].filter((eventId): eventId is string => eventId !== null);
 
-    void fetchRouteTargetEvents(
-      eventIds,
-      targetMessageId,
-      targetThreadRootId,
-    ).then((events) => {
-      if (!isCancelled) {
-        setTargetMessageEvents((currentEvents) => {
-          const eventsById = new Map<string, RelayEvent>();
-          for (const event of [...currentEvents, ...events]) {
-            eventsById.set(event.id, event);
-          }
-          return Array.from(eventsById.values());
-        });
-      }
-    });
+    void fetchRouteTargetEvents(eventIds, targetMessageId, targetThreadRootId)
+      .then((events) => {
+        if (!isCancelled) {
+          setTargetMessageEvents((currentEvents) => {
+            const eventsById = new Map<string, RelayEvent>();
+            for (const event of [...currentEvents, ...events]) {
+              eventsById.set(event.id, event);
+            }
+            return Array.from(eventsById.values());
+          });
+        }
+      })
+      .finally(() => {
+        if (!isCancelled) {
+          setRouteLoadState({ key: routeTargetKey, settled: true });
+        }
+      });
 
     return () => {
       isCancelled = true;
     };
-  }, [selectedPostId, targetMessageId, targetThreadRootId]);
+  }, [routeTargetKey, selectedPostId, targetMessageId, targetThreadRootId]);
 
   if (channelsQuery.isPending && !activeChannel) {
     if (isHuddleTranscript) {
@@ -216,6 +229,7 @@ export function ChannelRouteScreen({
       targetForumReplyId={targetReplyId}
       targetMessageEvents={targetMessageEvents}
       targetMessageId={targetMessageId}
+      targetMessageLoadSettled={targetMessageLoadSettled}
     />
   );
 }

--- a/desktop/src/app/routes/ChannelRouteScreen.tsx
+++ b/desktop/src/app/routes/ChannelRouteScreen.tsx
@@ -23,13 +23,32 @@ type ChannelRouteScreenProps = {
   targetMessageId: string | null;
   targetReplyId: string | null;
   targetThreadRootId: string | null;
+  threadRailNavigation?: boolean;
 };
 
 const MAX_ROUTE_ANCESTOR_HOPS = 50;
+const MAX_ROUTE_EVENT_CACHE = 500;
+const routeEventCache = new Map<string, RelayEvent>();
+
+function cacheRouteEvent(event: RelayEvent): void {
+  routeEventCache.delete(event.id);
+  routeEventCache.set(event.id, event);
+  if (routeEventCache.size > MAX_ROUTE_EVENT_CACHE) {
+    routeEventCache.delete(routeEventCache.keys().next().value as string);
+  }
+}
+
+function getCachedRouteEvent(eventId: string): RelayEvent | null {
+  return routeEventCache.get(eventId) ?? null;
+}
 
 async function fetchRouteEvent(eventId: string): Promise<RelayEvent | null> {
+  const cached = getCachedRouteEvent(eventId);
+  if (cached) return cached;
   try {
-    return await getEventById(eventId);
+    const event = await getEventById(eventId);
+    if (event) cacheRouteEvent(event);
+    return event;
   } catch (error) {
     console.error("Failed to load route event", eventId, error);
     return null;
@@ -103,6 +122,7 @@ export function ChannelRouteScreen({
   targetMessageId,
   targetReplyId,
   targetThreadRootId,
+  threadRailNavigation = false,
 }: ChannelRouteScreenProps) {
   const isHuddleTranscript = huddleWindowChannelId() !== null;
   const { closeForumPost, goForumPost } = useAppNavigation();
@@ -230,6 +250,7 @@ export function ChannelRouteScreen({
       targetMessageEvents={targetMessageEvents}
       targetMessageId={targetMessageId}
       targetMessageLoadSettled={targetMessageLoadSettled}
+      threadRailNavigation={threadRailNavigation}
     />
   );
 }

--- a/desktop/src/app/routes/channels.$channelId.tsx
+++ b/desktop/src/app/routes/channels.$channelId.tsx
@@ -24,6 +24,7 @@ type ChannelRouteSearch = {
   profileTab?: ProfilePanelTab;
   profileView?: ProfilePanelView;
   thread?: string;
+  threadRail?: boolean;
   threadRootId?: string;
 };
 
@@ -42,6 +43,7 @@ function validateChannelSearch(
     profileTab: parseProfilePanelTab(search.profileTab) ?? undefined,
     profileView: parseProfilePanelView(search.profileView) ?? undefined,
     thread: nonEmptyString(search.thread),
+    threadRail: search.threadRail === "1",
     threadRootId: nonEmptyString(search.threadRootId),
   };
 }
@@ -78,6 +80,7 @@ function ChannelRouteComponent() {
         targetMessageId={search.messageId ?? null}
         targetReplyId={null}
         targetThreadRootId={search.threadRootId ?? search.thread ?? null}
+        threadRailNavigation={search.threadRail ?? false}
       />
     </React.Suspense>
   );

--- a/desktop/src/features/channels/ThreadRailContext.tsx
+++ b/desktop/src/features/channels/ThreadRailContext.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+
+import type { ThreadRailPin } from "./threadRailStorage";
+import type { ThreadRail } from "./useThreadRail";
+
+const EMPTY_RAIL: ThreadRail = {
+  pins: [],
+  collapsed: false,
+  isScoped: false,
+  pin: () => {},
+  unpin: () => {},
+  updateAnchor: () => {},
+  updateExpandedReplyIds: () => {},
+  toggleCollapsed: () => {},
+};
+
+const ThreadRailContext = React.createContext<ThreadRail>(EMPTY_RAIL);
+
+export function ThreadRailProvider({
+  children,
+  rail,
+}: {
+  children: React.ReactNode;
+  rail: ThreadRail;
+}) {
+  return (
+    <ThreadRailContext.Provider value={rail}>
+      {children}
+    </ThreadRailContext.Provider>
+  );
+}
+
+export function useThreadRailContext(): ThreadRail {
+  return React.useContext(ThreadRailContext);
+}
+
+export function makeThreadRailPin({
+  channelId,
+  channelName,
+  expandedReplyIds,
+  returnAnchorId,
+  rootExcerpt,
+  rootId,
+}: Omit<ThreadRailPin, "pinnedAt">): ThreadRailPin {
+  return {
+    channelId,
+    channelName,
+    expandedReplyIds,
+    returnAnchorId,
+    rootExcerpt,
+    rootId,
+    pinnedAt: Date.now(),
+  };
+}

--- a/desktop/src/features/channels/ThreadRailContext.tsx
+++ b/desktop/src/features/channels/ThreadRailContext.tsx
@@ -8,6 +8,7 @@ const EMPTY_RAIL: ThreadRail = {
   collapsed: false,
   isScoped: false,
   pin: () => {},
+  rename: () => {},
   unpin: () => {},
   updateAnchor: () => {},
   updateExpandedReplyIds: () => {},

--- a/desktop/src/features/channels/threadRailAnchor.test.mjs
+++ b/desktop/src/features/channels/threadRailAnchor.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getThreadRailAnchorUpdate } from "./threadRailAnchor.ts";
+
+const PIN = { channelId: "channel-a", rootId: "root-a", pinnedAt: 100 };
+
+test("returns an anchor update only for a pinned nested reply in the open thread", () => {
+  assert.deepEqual(
+    getThreadRailAnchorUpdate([PIN], "channel-a", "root-a", {
+      id: "nested-a",
+      rootId: "root-a",
+    }),
+    { pin: PIN, returnAnchorId: "nested-a" },
+  );
+});
+
+test("does not anchor roots, other threads, channels, or unpinned threads", () => {
+  assert.equal(
+    getThreadRailAnchorUpdate([PIN], "channel-a", "root-a", {
+      id: "root-a",
+      rootId: "root-a",
+    }),
+    null,
+  );
+  assert.equal(
+    getThreadRailAnchorUpdate([PIN], "channel-a", "root-a", {
+      id: "other-thread-reply",
+      rootId: "root-b",
+    }),
+    null,
+  );
+  assert.equal(
+    getThreadRailAnchorUpdate([PIN], "channel-b", "root-a", {
+      id: "nested-a",
+      rootId: "root-a",
+    }),
+    null,
+  );
+  assert.equal(
+    getThreadRailAnchorUpdate([], "channel-a", "root-a", {
+      id: "nested-a",
+      rootId: "root-a",
+    }),
+    null,
+  );
+});

--- a/desktop/src/features/channels/threadRailAnchor.ts
+++ b/desktop/src/features/channels/threadRailAnchor.ts
@@ -1,0 +1,25 @@
+import type { ThreadRailPin } from "./threadRailStorage";
+
+type ThreadRailAnchorTarget = { id: string; rootId?: string | null };
+
+/** Returns a local nested reply anchor only when it belongs to a pinned open thread. */
+export function getThreadRailAnchorUpdate(
+  pins: ThreadRailPin[],
+  channelId: string | null,
+  rootId: string | null,
+  target: ThreadRailAnchorTarget,
+): { pin: ThreadRailPin; returnAnchorId: string } | null {
+  if (
+    !channelId ||
+    !rootId ||
+    target.id === rootId ||
+    target.rootId !== rootId
+  ) {
+    return null;
+  }
+  const pin = pins.find(
+    (candidate) =>
+      candidate.channelId === channelId && candidate.rootId === rootId,
+  );
+  return pin ? { pin, returnAnchorId: target.id } : null;
+}

--- a/desktop/src/features/channels/threadRailLayout.test.mjs
+++ b/desktop/src/features/channels/threadRailLayout.test.mjs
@@ -17,15 +17,14 @@ test("isThreadRailVisible hides the rail at and below the desktop breakpoint", (
   assert.equal(isThreadRailVisible(601, 0), false);
 });
 
-test("Thread Rail column replaces exposed sidebar paint without adding corners", () => {
+test("Thread Rail column is layout-only and owns no paint", () => {
   const className = threadRailColumnClassName();
 
-  assert.match(className, /buzz-theme-gradient-underlay/);
   assert.match(className, /self-stretch/);
   assert.match(className, /shrink-0/);
+  assert.doesNotMatch(className, /buzz-theme-gradient-underlay/);
   assert.doesNotMatch(className, /rounded/);
-  assert.doesNotMatch(className, /bg-background/);
-  assert.doesNotMatch(className, /bg-sidebar/);
+  assert.doesNotMatch(className, /bg-/);
   assert.doesNotMatch(className, /shadow/);
   assert.doesNotMatch(className, /ring/);
 });

--- a/desktop/src/features/channels/threadRailLayout.test.mjs
+++ b/desktop/src/features/channels/threadRailLayout.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   isThreadRailVisible,
   projectThreadRailLayout,
+  threadRailColumnClassName,
   threadRailEntryClassName,
   threadRailHeaderClassName,
   threadRailShellClassName,
@@ -14,6 +15,19 @@ test("isThreadRailVisible hides the rail at and below the desktop breakpoint", (
   assert.equal(isThreadRailVisible(599, 1), false);
   assert.equal(isThreadRailVisible(601, 1), true);
   assert.equal(isThreadRailVisible(601, 0), false);
+});
+
+test("Thread Rail column replaces exposed sidebar paint without adding corners", () => {
+  const className = threadRailColumnClassName();
+
+  assert.match(className, /buzz-theme-gradient-underlay/);
+  assert.match(className, /self-stretch/);
+  assert.match(className, /shrink-0/);
+  assert.doesNotMatch(className, /rounded/);
+  assert.doesNotMatch(className, /bg-background/);
+  assert.doesNotMatch(className, /bg-sidebar/);
+  assert.doesNotMatch(className, /shadow/);
+  assert.doesNotMatch(className, /ring/);
 });
 
 test("Thread Rail paints a compact rounded card capped at the content bounds", () => {

--- a/desktop/src/features/channels/threadRailLayout.test.mjs
+++ b/desktop/src/features/channels/threadRailLayout.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isThreadRailVisible,
+  projectThreadRailLayout,
+  threadRailEntryClassName,
+  threadRailHeaderClassName,
+  threadRailShellClassName,
+} from "./threadRailLayout.ts";
+
+test("isThreadRailVisible hides the rail at and below the desktop breakpoint", () => {
+  assert.equal(isThreadRailVisible(600, 1), false);
+  assert.equal(isThreadRailVisible(599, 1), false);
+  assert.equal(isThreadRailVisible(601, 1), true);
+  assert.equal(isThreadRailVisible(601, 0), false);
+});
+
+test("Thread Rail uses one native rounded surface at the content bounds", () => {
+  for (const collapsed of [false, true]) {
+    const className = threadRailShellClassName(collapsed);
+
+    assert.match(className, /mt-px/);
+    assert.match(className, /mb-2/);
+    assert.match(className, /h-\[calc\(100%-0\.5625rem\)\]/);
+    assert.match(className, /self-start/);
+    assert.match(className, /rounded-2xl/);
+    assert.match(className, /overflow-hidden/);
+    assert.match(className, /bg-background(?!\/)/);
+    assert.match(className, /shadow-content-edge/);
+    assert.match(className, /ring-border\/30/);
+    assert.match(className, /ring-inset/);
+    assert.doesNotMatch(className, /clip-path/);
+    assert.doesNotMatch(className, /self-stretch/);
+    assert.doesNotMatch(className, /\bmy-2\b/);
+  }
+});
+
+test("Thread Rail header and rows use native panel density and one full-width selection surface", () => {
+  const headerClassName = threadRailHeaderClassName();
+  assert.match(headerClassName, /min-h-13/);
+  assert.doesNotMatch(headerClassName, /border-b/);
+
+  const idleEntryClassName = threadRailEntryClassName(false);
+  const activeEntryClassName = threadRailEntryClassName(true);
+  assert.match(idleEntryClassName, /rounded-lg/);
+  assert.match(idleEntryClassName, /hover:bg-muted/);
+  assert.match(activeEntryClassName, /bg-muted/);
+});
+
+test("projectThreadRailLayout keeps pin count and exposes collapse state", () => {
+  const pins = [
+    { channelId: "channel-a", rootId: "root-a", pinnedAt: 100 },
+    { channelId: "channel-b", rootId: "root-b", pinnedAt: 200 },
+  ];
+
+  assert.deepEqual(projectThreadRailLayout({ collapsed: false, pins }, 800), {
+    visible: true,
+    pinCount: 2,
+    collapsed: false,
+    collapseControl: { expanded: true, label: "Collapse pinned threads" },
+  });
+  assert.deepEqual(projectThreadRailLayout({ collapsed: true, pins }, 800), {
+    visible: true,
+    pinCount: 2,
+    collapsed: true,
+    collapseControl: { expanded: false, label: "Expand 2 pinned threads" },
+  });
+});

--- a/desktop/src/features/channels/threadRailLayout.test.mjs
+++ b/desktop/src/features/channels/threadRailLayout.test.mjs
@@ -4,7 +4,6 @@ import test from "node:test";
 import {
   isThreadRailVisible,
   projectThreadRailLayout,
-  threadRailColumnClassName,
   threadRailEntryClassName,
   threadRailHeaderClassName,
   threadRailShellClassName,
@@ -15,18 +14,6 @@ test("isThreadRailVisible hides the rail at and below the desktop breakpoint", (
   assert.equal(isThreadRailVisible(599, 1), false);
   assert.equal(isThreadRailVisible(601, 1), true);
   assert.equal(isThreadRailVisible(601, 0), false);
-});
-
-test("Thread Rail column is layout-only and owns no paint", () => {
-  const className = threadRailColumnClassName();
-
-  assert.match(className, /self-stretch/);
-  assert.match(className, /shrink-0/);
-  assert.doesNotMatch(className, /buzz-theme-gradient-underlay/);
-  assert.doesNotMatch(className, /rounded/);
-  assert.doesNotMatch(className, /bg-/);
-  assert.doesNotMatch(className, /shadow/);
-  assert.doesNotMatch(className, /ring/);
 });
 
 test("Thread Rail paints one full-height rounded panel inside the unframed column", () => {

--- a/desktop/src/features/channels/threadRailLayout.test.mjs
+++ b/desktop/src/features/channels/threadRailLayout.test.mjs
@@ -30,13 +30,13 @@ test("Thread Rail column replaces exposed sidebar paint without adding corners",
   assert.doesNotMatch(className, /ring/);
 });
 
-test("Thread Rail paints a compact rounded card capped at the content bounds", () => {
+test("Thread Rail paints one full-height rounded panel inside the unframed column", () => {
   for (const collapsed of [false, true]) {
     const className = threadRailShellClassName(collapsed);
 
     assert.match(className, /mt-px/);
     assert.match(className, /mb-2/);
-    assert.match(className, /max-h-\[calc\(100%-0\.5625rem\)\]/);
+    assert.match(className, /(?<!max-)h-\[calc\(100%-0\.5625rem\)\]/);
     assert.match(className, /self-start/);
     assert.match(className, /rounded-2xl/);
     assert.match(className, /overflow-hidden/);
@@ -44,7 +44,7 @@ test("Thread Rail paints a compact rounded card capped at the content bounds", (
     assert.match(className, /shadow-content-edge/);
     assert.match(className, /ring-border\/30/);
     assert.match(className, /ring-inset/);
-    assert.doesNotMatch(className, /(?<!max-)h-\[calc\(100%-0\.5625rem\)\]/);
+    assert.doesNotMatch(className, /max-h-\[calc\(100%-0\.5625rem\)\]/);
     assert.doesNotMatch(className, /clip-path/);
     assert.doesNotMatch(className, /self-stretch/);
     assert.doesNotMatch(className, /\bmy-2\b/);

--- a/desktop/src/features/channels/threadRailLayout.test.mjs
+++ b/desktop/src/features/channels/threadRailLayout.test.mjs
@@ -16,13 +16,13 @@ test("isThreadRailVisible hides the rail at and below the desktop breakpoint", (
   assert.equal(isThreadRailVisible(601, 0), false);
 });
 
-test("Thread Rail uses one native rounded surface at the content bounds", () => {
+test("Thread Rail paints a compact rounded card capped at the content bounds", () => {
   for (const collapsed of [false, true]) {
     const className = threadRailShellClassName(collapsed);
 
     assert.match(className, /mt-px/);
     assert.match(className, /mb-2/);
-    assert.match(className, /h-\[calc\(100%-0\.5625rem\)\]/);
+    assert.match(className, /max-h-\[calc\(100%-0\.5625rem\)\]/);
     assert.match(className, /self-start/);
     assert.match(className, /rounded-2xl/);
     assert.match(className, /overflow-hidden/);
@@ -30,6 +30,7 @@ test("Thread Rail uses one native rounded surface at the content bounds", () => 
     assert.match(className, /shadow-content-edge/);
     assert.match(className, /ring-border\/30/);
     assert.match(className, /ring-inset/);
+    assert.doesNotMatch(className, /(?<!max-)h-\[calc\(100%-0\.5625rem\)\]/);
     assert.doesNotMatch(className, /clip-path/);
     assert.doesNotMatch(className, /self-stretch/);
     assert.doesNotMatch(className, /\bmy-2\b/);

--- a/desktop/src/features/channels/threadRailLayout.ts
+++ b/desktop/src/features/channels/threadRailLayout.ts
@@ -1,0 +1,53 @@
+export const THREAD_RAIL_DESKTOP_BREAKPOINT_PX = 600;
+
+export function threadRailShellClassName(_collapsed: boolean): string {
+  return [
+    "hidden mb-2 mr-2 mt-px h-[calc(100%-0.5625rem)] min-h-0 shrink-0 self-start overflow-hidden rounded-2xl bg-background shadow-content-edge ring-1 ring-border/30 ring-inset",
+    "min-[601px]:flex min-[601px]:flex-col",
+  ].join(" ");
+}
+
+export function threadRailHeaderClassName(): string {
+  return "flex min-h-13 shrink-0 items-center px-3";
+}
+
+export function threadRailEntryClassName(active: boolean): string {
+  return [
+    "group flex items-center rounded-lg transition-colors hover:bg-muted/70 focus-within:ring-2 focus-within:ring-ring",
+    active ? "bg-muted text-foreground" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+type ThreadRailLayoutStore = {
+  collapsed: boolean;
+  pins: readonly unknown[];
+};
+
+export function isThreadRailVisible(
+  viewportWidth: number,
+  pinCount: number,
+): boolean {
+  return viewportWidth > THREAD_RAIL_DESKTOP_BREAKPOINT_PX && pinCount > 0;
+}
+
+export function projectThreadRailLayout(
+  store: ThreadRailLayoutStore,
+  viewportWidth: number,
+) {
+  const pinCount = store.pins.length;
+  const collapsed = store.collapsed;
+
+  return {
+    visible: isThreadRailVisible(viewportWidth, pinCount),
+    pinCount,
+    collapsed,
+    collapseControl: {
+      expanded: !collapsed,
+      label: collapsed
+        ? `Expand ${pinCount} pinned threads`
+        : "Collapse pinned threads",
+    },
+  };
+}

--- a/desktop/src/features/channels/threadRailLayout.ts
+++ b/desktop/src/features/channels/threadRailLayout.ts
@@ -2,7 +2,7 @@ export const THREAD_RAIL_DESKTOP_BREAKPOINT_PX = 600;
 
 export function threadRailShellClassName(_collapsed: boolean): string {
   return [
-    "hidden mb-2 mr-2 mt-px h-[calc(100%-0.5625rem)] min-h-0 shrink-0 self-start overflow-hidden rounded-2xl bg-background shadow-content-edge ring-1 ring-border/30 ring-inset",
+    "hidden mb-2 mr-2 mt-px max-h-[calc(100%-0.5625rem)] min-h-0 shrink-0 self-start overflow-hidden rounded-2xl bg-background shadow-content-edge ring-1 ring-border/30 ring-inset",
     "min-[601px]:flex min-[601px]:flex-col",
   ].join(" ");
 }

--- a/desktop/src/features/channels/threadRailLayout.ts
+++ b/desktop/src/features/channels/threadRailLayout.ts
@@ -1,5 +1,9 @@
 export const THREAD_RAIL_DESKTOP_BREAKPOINT_PX = 600;
 
+export function threadRailColumnClassName(): string {
+  return "buzz-theme-gradient-underlay hidden min-h-0 shrink-0 self-stretch min-[601px]:flex min-[601px]:flex-col";
+}
+
 export function threadRailShellClassName(_collapsed: boolean): string {
   return [
     "hidden mb-2 mr-2 mt-px max-h-[calc(100%-0.5625rem)] min-h-0 shrink-0 self-start overflow-hidden rounded-2xl bg-background shadow-content-edge ring-1 ring-border/30 ring-inset",

--- a/desktop/src/features/channels/threadRailLayout.ts
+++ b/desktop/src/features/channels/threadRailLayout.ts
@@ -1,9 +1,5 @@
 export const THREAD_RAIL_DESKTOP_BREAKPOINT_PX = 600;
 
-export function threadRailColumnClassName(): string {
-  return "hidden min-h-0 shrink-0 self-stretch min-[601px]:flex min-[601px]:flex-col";
-}
-
 export function threadRailShellClassName(_collapsed: boolean): string {
   return [
     "hidden mb-2 mr-2 mt-px h-[calc(100%-0.5625rem)] min-h-0 shrink-0 self-start overflow-hidden rounded-2xl bg-background shadow-content-edge ring-1 ring-border/30 ring-inset",

--- a/desktop/src/features/channels/threadRailLayout.ts
+++ b/desktop/src/features/channels/threadRailLayout.ts
@@ -1,7 +1,7 @@
 export const THREAD_RAIL_DESKTOP_BREAKPOINT_PX = 600;
 
 export function threadRailColumnClassName(): string {
-  return "buzz-theme-gradient-underlay hidden min-h-0 shrink-0 self-stretch min-[601px]:flex min-[601px]:flex-col";
+  return "hidden min-h-0 shrink-0 self-stretch min-[601px]:flex min-[601px]:flex-col";
 }
 
 export function threadRailShellClassName(_collapsed: boolean): string {

--- a/desktop/src/features/channels/threadRailLayout.ts
+++ b/desktop/src/features/channels/threadRailLayout.ts
@@ -6,7 +6,7 @@ export function threadRailColumnClassName(): string {
 
 export function threadRailShellClassName(_collapsed: boolean): string {
   return [
-    "hidden mb-2 mr-2 mt-px max-h-[calc(100%-0.5625rem)] min-h-0 shrink-0 self-start overflow-hidden rounded-2xl bg-background shadow-content-edge ring-1 ring-border/30 ring-inset",
+    "hidden mb-2 mr-2 mt-px h-[calc(100%-0.5625rem)] min-h-0 shrink-0 self-start overflow-hidden rounded-2xl bg-background shadow-content-edge ring-1 ring-border/30 ring-inset",
     "min-[601px]:flex min-[601px]:flex-col",
   ].join(" ");
 }

--- a/desktop/src/features/channels/threadRailNavigation.test.mjs
+++ b/desktop/src/features/channels/threadRailNavigation.test.mjs
@@ -23,6 +23,7 @@ test("threadRailPinToChannelNavigation restores a nested return anchor under the
       channelId: "channel-a",
       thread: "root-a",
       messageId: "nested-reply-a",
+      threadRail: true,
       threadRootId: "root-a",
     },
   );
@@ -33,6 +34,7 @@ test("threadRailPinToChannelNavigation opens the pin canonical root", () => {
     channelId: "channel-a",
     thread: "root-a",
     messageId: "root-a",
+    threadRail: true,
     threadRootId: "root-a",
   });
 });

--- a/desktop/src/features/channels/threadRailNavigation.test.mjs
+++ b/desktop/src/features/channels/threadRailNavigation.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isThreadRailPinActive,
+  threadRailPinToChannelNavigation,
+  threadRailRootIdFromSearch,
+} from "./threadRailNavigation.ts";
+
+const PIN = {
+  channelId: "channel-a",
+  rootId: "root-a",
+  pinnedAt: 100,
+};
+
+test("threadRailPinToChannelNavigation restores a nested return anchor under the canonical root", () => {
+  assert.deepEqual(
+    threadRailPinToChannelNavigation({
+      ...PIN,
+      returnAnchorId: "nested-reply-a",
+    }),
+    {
+      channelId: "channel-a",
+      thread: "root-a",
+      messageId: "nested-reply-a",
+      threadRootId: "root-a",
+    },
+  );
+});
+
+test("threadRailPinToChannelNavigation opens the pin canonical root", () => {
+  assert.deepEqual(threadRailPinToChannelNavigation(PIN), {
+    channelId: "channel-a",
+    thread: "root-a",
+    messageId: "root-a",
+    threadRootId: "root-a",
+  });
+});
+
+test("threadRailRootIdFromSearch prefers the canonical thread route", () => {
+  assert.equal(
+    threadRailRootIdFromSearch({ thread: "root-a", threadRootId: "legacy" }),
+    "root-a",
+  );
+  assert.equal(
+    threadRailRootIdFromSearch({ threadRootId: "legacy" }),
+    "legacy",
+  );
+  assert.equal(threadRailRootIdFromSearch({ thread: 42 }), null);
+});
+
+test("isThreadRailPinActive matches the selected channel and open root", () => {
+  assert.equal(isThreadRailPinActive(PIN, "channel-a", "root-a"), true);
+  assert.equal(isThreadRailPinActive(PIN, "channel-a", "root-b"), false);
+  assert.equal(isThreadRailPinActive(PIN, "channel-b", "root-a"), false);
+  assert.equal(isThreadRailPinActive(PIN, "channel-a", null), false);
+});

--- a/desktop/src/features/channels/threadRailNavigation.ts
+++ b/desktop/src/features/channels/threadRailNavigation.ts
@@ -12,6 +12,7 @@ export function threadRailPinToChannelNavigation(pin: ThreadRailPin) {
     channelId: pin.channelId,
     thread: pin.rootId,
     messageId: pin.returnAnchorId ?? pin.rootId,
+    threadRail: true,
     threadRootId: pin.rootId,
   };
 }

--- a/desktop/src/features/channels/threadRailNavigation.ts
+++ b/desktop/src/features/channels/threadRailNavigation.ts
@@ -1,0 +1,25 @@
+import type { ThreadRailPin } from "./threadRailStorage";
+
+export function threadRailRootIdFromSearch(search: unknown): string | null {
+  if (!search || typeof search !== "object") return null;
+  const route = search as { thread?: unknown; threadRootId?: unknown };
+  const rootId = route.thread ?? route.threadRootId;
+  return typeof rootId === "string" ? rootId : null;
+}
+
+export function threadRailPinToChannelNavigation(pin: ThreadRailPin) {
+  return {
+    channelId: pin.channelId,
+    thread: pin.rootId,
+    messageId: pin.returnAnchorId ?? pin.rootId,
+    threadRootId: pin.rootId,
+  };
+}
+
+export function isThreadRailPinActive(
+  pin: ThreadRailPin,
+  selectedChannelId: string | null,
+  openThreadRootId: string | null,
+): boolean {
+  return pin.channelId === selectedChannelId && pin.rootId === openThreadRootId;
+}

--- a/desktop/src/features/channels/threadRailStorage.test.mjs
+++ b/desktop/src/features/channels/threadRailStorage.test.mjs
@@ -248,6 +248,23 @@ test("renames a pin locally, bounds its title, and clears it without changing id
   );
 });
 
+test("parse normalizes persisted custom titles and rejects non-string titles", () => {
+  const parsed = parseThreadRailStore({
+    version: 1,
+    collapsed: false,
+    pins: [
+      { ...PIN_A, customTitle: `  ${"T".repeat(140)}  ` },
+      { ...PIN_B, customTitle: {} },
+      { ...PIN_B, channelId: "channel-c", customTitle: "   " },
+    ],
+  });
+
+  assert.deepEqual(parsed?.pins, [
+    { ...PIN_A, customTitle: "T".repeat(128) },
+    { ...PIN_B, channelId: "channel-c" },
+  ]);
+});
+
 test("write failure leaves the caller-owned in-memory store usable", () => {
   const original = window.localStorage.setItem;
   window.localStorage.setItem = () => {

--- a/desktop/src/features/channels/threadRailStorage.test.mjs
+++ b/desktop/src/features/channels/threadRailStorage.test.mjs
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  addThreadRailPin,
+  DEFAULT_THREAD_RAIL_STORE,
+  MAX_THREAD_RAIL_PINS,
+  parseThreadRailStore,
+  readThreadRailStore,
+  removeThreadRailPin,
+  updateThreadRailExpandedReplyIds,
+  updateThreadRailPinAnchor,
+  threadRailStorageKey,
+  toggleThreadRailCollapsed,
+  writeThreadRailStore,
+} from "./threadRailStorage.ts";
+
+if (typeof globalThis.window === "undefined") {
+  const storage = new Map();
+  globalThis.window = {
+    localStorage: {
+      getItem: (key) => storage.get(key) ?? null,
+      setItem: (key, value) => storage.set(key, value),
+      removeItem: (key) => storage.delete(key),
+    },
+  };
+}
+
+const SCOPE = { pubkey: "identity-a", relayUrl: "https://relay.example" };
+const PIN_A = {
+  channelId: "channel-a",
+  rootId: "root-a",
+  channelName: "general",
+  rootExcerpt: "A useful thread",
+  pinnedAt: 100,
+};
+const PIN_B = { channelId: "channel-b", rootId: "root-b", pinnedAt: 200 };
+
+test("threadRailStorageKey scopes pins to normalized relay and identity", () => {
+  assert.equal(
+    threadRailStorageKey(SCOPE),
+    "buzz-thread-rail.v1:https%3A%2F%2Frelay.example:identity-a",
+  );
+  assert.notEqual(
+    threadRailStorageKey(SCOPE),
+    threadRailStorageKey({ ...SCOPE, pubkey: "identity-b" }),
+  );
+  assert.equal(
+    threadRailStorageKey(SCOPE),
+    threadRailStorageKey({ ...SCOPE, relayUrl: "https://RELAY.example/" }),
+  );
+});
+
+test("pinning is idempotent per channel and canonical root", () => {
+  const once = addThreadRailPin(DEFAULT_THREAD_RAIL_STORE, PIN_A);
+  const twice = addThreadRailPin(once, { ...PIN_A, pinnedAt: 999 });
+  assert.equal(once.pins.length, 1);
+  assert.equal(twice, once);
+});
+
+test("pins with the same root in different channels remain distinct", () => {
+  const once = addThreadRailPin(DEFAULT_THREAD_RAIL_STORE, PIN_A);
+  const twice = addThreadRailPin(once, { ...PIN_A, channelId: "channel-b" });
+  assert.equal(twice.pins.length, 2);
+});
+
+test("updating a pin return anchor preserves canonical identity and order", () => {
+  const store = {
+    collapsed: false,
+    pins: [PIN_A, PIN_B],
+    version: 1,
+  };
+
+  assert.deepEqual(updateThreadRailPinAnchor(store, PIN_A, "nested-reply-a"), {
+    collapsed: false,
+    pins: [{ ...PIN_A, returnAnchorId: "nested-reply-a" }, PIN_B],
+    version: 1,
+  });
+  assert.equal(
+    updateThreadRailPinAnchor(store, PIN_A, "nested-reply-a").pins.length,
+    2,
+  );
+  assert.equal(updateThreadRailPinAnchor(store, PIN_A, ""), store);
+  assert.equal(
+    updateThreadRailPinAnchor(
+      store,
+      { ...PIN_A, rootId: "missing" },
+      "nested-reply-a",
+    ),
+    store,
+  );
+});
+
+test("updates a pinned thread's expanded branches with a bounded stable local set", () => {
+  const store = {
+    collapsed: false,
+    pins: [PIN_A, PIN_B],
+    version: 1,
+  };
+
+  assert.deepEqual(
+    updateThreadRailExpandedReplyIds(store, PIN_A, [
+      "branch-a",
+      "branch-a",
+      "branch-b",
+      "",
+    ]),
+    {
+      collapsed: false,
+      pins: [{ ...PIN_A, expandedReplyIds: ["branch-a", "branch-b"] }, PIN_B],
+      version: 1,
+    },
+  );
+});
+
+test("unpin removes only the exact local rail entry and keeps collapse preference", () => {
+  const store = {
+    collapsed: true,
+    pins: [PIN_A, PIN_B],
+    version: 1,
+  };
+  assert.deepEqual(removeThreadRailPin(store, PIN_A), {
+    collapsed: true,
+    pins: [PIN_B],
+    version: 1,
+  });
+});
+
+test("collapse preference toggles without changing pins", () => {
+  const store = addThreadRailPin(DEFAULT_THREAD_RAIL_STORE, PIN_A);
+  assert.deepEqual(toggleThreadRailCollapsed(store), {
+    collapsed: true,
+    pins: [PIN_A],
+    version: 1,
+  });
+});
+
+test("parseThreadRailStore rejects malformed payloads while retaining valid pins", () => {
+  assert.equal(parseThreadRailStore(null), null);
+  assert.equal(parseThreadRailStore({ version: 2, pins: [] }), null);
+  assert.deepEqual(
+    parseThreadRailStore({
+      version: 1,
+      collapsed: true,
+      pins: [
+        { ...PIN_A, returnAnchorId: "nested-reply-a" },
+        { channelId: 3, rootId: "bad" },
+        { channelId: "c", rootId: "" },
+        { ...PIN_B, returnAnchorId: 3 },
+      ],
+    }),
+    {
+      version: 1,
+      collapsed: true,
+      pins: [{ ...PIN_A, returnAnchorId: "nested-reply-a" }],
+    },
+  );
+});
+
+test("read/write round-trip persists collapse and isolates each identity and relay", () => {
+  const written = {
+    ...addThreadRailPin(DEFAULT_THREAD_RAIL_STORE, PIN_A),
+    collapsed: true,
+  };
+  assert.equal(writeThreadRailStore(SCOPE, written), true);
+  assert.deepEqual(readThreadRailStore(SCOPE), written);
+  assert.deepEqual(
+    readThreadRailStore({ ...SCOPE, pubkey: "identity-b" }),
+    DEFAULT_THREAD_RAIL_STORE,
+  );
+  assert.deepEqual(
+    readThreadRailStore({ ...SCOPE, relayUrl: "https://other-relay.example" }),
+    DEFAULT_THREAD_RAIL_STORE,
+  );
+  window.localStorage.setItem(
+    threadRailStorageKey({ ...SCOPE, pubkey: "broken" }),
+    "{",
+  );
+  assert.deepEqual(
+    readThreadRailStore({ ...SCOPE, pubkey: "broken" }),
+    DEFAULT_THREAD_RAIL_STORE,
+  );
+});
+
+test("read normalizes duplicate persisted pins by exact channel and root", () => {
+  window.localStorage.setItem(
+    threadRailStorageKey({ ...SCOPE, pubkey: "duplicate-pins" }),
+    JSON.stringify({
+      version: 1,
+      collapsed: false,
+      pins: [PIN_A, { ...PIN_A, pinnedAt: 999 }, PIN_B],
+    }),
+  );
+  assert.deepEqual(
+    readThreadRailStore({ ...SCOPE, pubkey: "duplicate-pins" }),
+    {
+      version: 1,
+      collapsed: false,
+      pins: [PIN_A, PIN_B],
+    },
+  );
+});
+
+test("pin collection and persisted labels stay bounded", () => {
+  let store = DEFAULT_THREAD_RAIL_STORE;
+  for (let index = 0; index < MAX_THREAD_RAIL_PINS + 5; index += 1) {
+    store = addThreadRailPin(store, {
+      channelId: `channel-${index}`,
+      rootId: `root-${index}`,
+      channelName: "c".repeat(200),
+      rootExcerpt: "e".repeat(800),
+      pinnedAt: index,
+    });
+  }
+
+  assert.equal(store.pins.length, MAX_THREAD_RAIL_PINS);
+  assert.equal(store.pins[0].rootId, "root-5");
+  assert.equal(store.pins.at(-1).channelName.length, 128);
+  assert.equal(store.pins.at(-1).rootExcerpt.length, 512);
+});
+
+test("parse rejects oversized durable identifiers", () => {
+  const parsed = parseThreadRailStore({
+    version: 1,
+    collapsed: false,
+    pins: [PIN_A, { ...PIN_B, rootId: "r".repeat(257) }],
+  });
+  assert.deepEqual(parsed?.pins, [PIN_A]);
+});
+
+test("write failure leaves the caller-owned in-memory store usable", () => {
+  const original = window.localStorage.setItem;
+  window.localStorage.setItem = () => {
+    throw new Error("storage unavailable");
+  };
+  try {
+    assert.equal(
+      writeThreadRailStore(
+        SCOPE,
+        addThreadRailPin(DEFAULT_THREAD_RAIL_STORE, PIN_A),
+      ),
+      false,
+    );
+  } finally {
+    window.localStorage.setItem = original;
+  }
+});

--- a/desktop/src/features/channels/threadRailStorage.test.mjs
+++ b/desktop/src/features/channels/threadRailStorage.test.mjs
@@ -7,6 +7,7 @@ import {
   MAX_THREAD_RAIL_PINS,
   parseThreadRailStore,
   readThreadRailStore,
+  renameThreadRailPin,
   removeThreadRailPin,
   updateThreadRailExpandedReplyIds,
   updateThreadRailPinAnchor,
@@ -226,6 +227,25 @@ test("parse rejects oversized durable identifiers", () => {
     pins: [PIN_A, { ...PIN_B, rootId: "r".repeat(257) }],
   });
   assert.deepEqual(parsed?.pins, [PIN_A]);
+});
+
+test("renames a pin locally, bounds its title, and clears it without changing identity", () => {
+  const store = { collapsed: false, pins: [PIN_A, PIN_B], version: 1 };
+  const renamed = renameThreadRailPin(store, PIN_A, `  ${"T".repeat(140)}  `);
+
+  assert.equal(renamed.pins[0].customTitle, "T".repeat(128));
+  assert.deepEqual(renamed.pins[1], PIN_B);
+  assert.equal(renamed.pins[0].channelId, PIN_A.channelId);
+  assert.equal(renamed.pins[0].rootId, PIN_A.rootId);
+  assert.deepEqual(renameThreadRailPin(renamed, PIN_A, "   "), {
+    collapsed: false,
+    pins: [PIN_A, PIN_B],
+    version: 1,
+  });
+  assert.equal(
+    renameThreadRailPin(store, { ...PIN_A, rootId: "missing" }, "Name"),
+    store,
+  );
 });
 
 test("write failure leaves the caller-owned in-memory store usable", () => {

--- a/desktop/src/features/channels/threadRailStorage.ts
+++ b/desktop/src/features/channels/threadRailStorage.ts
@@ -1,0 +1,247 @@
+import { normalizeRelayUrl } from "@/features/profile/lib/selfProfileStorage";
+import { setLocalStorageItemWithRecovery } from "@/shared/lib/localStorageQuota";
+
+const STORAGE_PREFIX = "buzz-thread-rail.v1";
+export const MAX_THREAD_RAIL_PINS = 50;
+const MAX_EXPANDED_REPLY_IDS_PER_PIN = 100;
+const MAX_THREAD_RAIL_ID_LENGTH = 256;
+const MAX_THREAD_RAIL_CHANNEL_NAME_LENGTH = 128;
+const MAX_THREAD_RAIL_EXCERPT_LENGTH = 512;
+
+export type ThreadRailScope = {
+  pubkey: string;
+  relayUrl: string;
+};
+
+export type ThreadRailPin = {
+  channelId: string;
+  rootId: string;
+  /** Local nested reply to restore when revisiting this canonical thread. */
+  returnAnchorId?: string;
+  /** Local branch expansion state for this pinned canonical thread. */
+  expandedReplyIds?: string[];
+  channelName?: string;
+  rootExcerpt?: string;
+  pinnedAt: number;
+};
+
+export type ThreadRailStore = {
+  version: 1;
+  pins: ThreadRailPin[];
+  collapsed: boolean;
+};
+
+export const DEFAULT_THREAD_RAIL_STORE: ThreadRailStore = Object.freeze({
+  version: 1,
+  pins: [],
+  collapsed: false,
+});
+
+export function threadRailStorageKey({
+  pubkey,
+  relayUrl,
+}: ThreadRailScope): string {
+  return `${STORAGE_PREFIX}:${encodeURIComponent(normalizeRelayUrl(relayUrl))}:${pubkey}`;
+}
+
+function isBoundedId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= MAX_THREAD_RAIL_ID_LENGTH
+  );
+}
+
+function normalizeExpandedReplyIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const id of value) {
+    if (!isBoundedId(id) || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+    if (ids.length === MAX_EXPANDED_REPLY_IDS_PER_PIN) break;
+  }
+  return ids;
+}
+
+function isPin(value: unknown): value is ThreadRailPin {
+  if (typeof value !== "object" || value === null) return false;
+  const pin = value as Record<string, unknown>;
+  return (
+    isBoundedId(pin.channelId) &&
+    isBoundedId(pin.rootId) &&
+    (pin.returnAnchorId === undefined || isBoundedId(pin.returnAnchorId)) &&
+    (pin.expandedReplyIds === undefined ||
+      (Array.isArray(pin.expandedReplyIds) &&
+        pin.expandedReplyIds.every(isBoundedId))) &&
+    typeof pin.pinnedAt === "number" &&
+    Number.isFinite(pin.pinnedAt) &&
+    pin.pinnedAt >= 0 &&
+    (pin.channelName === undefined || typeof pin.channelName === "string") &&
+    (pin.rootExcerpt === undefined || typeof pin.rootExcerpt === "string")
+  );
+}
+
+function samePin(
+  left: ThreadRailPin,
+  right: Pick<ThreadRailPin, "channelId" | "rootId">,
+): boolean {
+  return left.channelId === right.channelId && left.rootId === right.rootId;
+}
+
+function normalizePin(pin: ThreadRailPin): ThreadRailPin {
+  const {
+    channelName,
+    expandedReplyIds,
+    returnAnchorId,
+    rootExcerpt,
+    ...base
+  } = pin;
+  const normalizedExpandedReplyIds =
+    normalizeExpandedReplyIds(expandedReplyIds);
+  return {
+    ...base,
+    ...(returnAnchorId
+      ? { returnAnchorId: returnAnchorId.slice(0, MAX_THREAD_RAIL_ID_LENGTH) }
+      : {}),
+    ...(normalizedExpandedReplyIds.length > 0
+      ? { expandedReplyIds: normalizedExpandedReplyIds }
+      : {}),
+    ...(channelName
+      ? {
+          channelName: channelName.slice(
+            0,
+            MAX_THREAD_RAIL_CHANNEL_NAME_LENGTH,
+          ),
+        }
+      : {}),
+    ...(rootExcerpt
+      ? { rootExcerpt: rootExcerpt.slice(0, MAX_THREAD_RAIL_EXCERPT_LENGTH) }
+      : {}),
+  };
+}
+
+function normalizePins(pins: readonly ThreadRailPin[]): ThreadRailPin[] {
+  const normalized: ThreadRailPin[] = [];
+  const seen = new Set<string>();
+  for (const rawPin of pins) {
+    if (!isPin(rawPin)) continue;
+    const pin = normalizePin(rawPin);
+    const key = `${pin.channelId}\u0000${pin.rootId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(pin);
+  }
+  return normalized.slice(-MAX_THREAD_RAIL_PINS);
+}
+
+export function parseThreadRailStore(payload: unknown): ThreadRailStore | null {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload))
+    return null;
+  const record = payload as Record<string, unknown>;
+  if (record.version !== 1 || !Array.isArray(record.pins)) return null;
+  return {
+    version: 1,
+    collapsed: record.collapsed === true,
+    pins: normalizePins(record.pins.filter(isPin)),
+  };
+}
+
+export function readThreadRailStore(scope: ThreadRailScope): ThreadRailStore {
+  try {
+    const raw = window.localStorage.getItem(threadRailStorageKey(scope));
+    if (!raw) return DEFAULT_THREAD_RAIL_STORE;
+    return parseThreadRailStore(JSON.parse(raw)) ?? DEFAULT_THREAD_RAIL_STORE;
+  } catch {
+    return DEFAULT_THREAD_RAIL_STORE;
+  }
+}
+
+export function writeThreadRailStore(
+  scope: ThreadRailScope,
+  store: ThreadRailStore,
+): boolean {
+  try {
+    return setLocalStorageItemWithRecovery(
+      threadRailStorageKey(scope),
+      JSON.stringify({
+        version: 1,
+        collapsed: store.collapsed,
+        pins: normalizePins(store.pins),
+      }),
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function addThreadRailPin(
+  store: ThreadRailStore,
+  pin: ThreadRailPin,
+): ThreadRailStore {
+  if (store.pins.some((existing) => samePin(existing, pin))) return store;
+  return {
+    ...store,
+    pins: normalizePins([...store.pins, pin]),
+  };
+}
+
+/** Updates the local return point for an existing canonical thread pin. */
+export function updateThreadRailPinAnchor(
+  store: ThreadRailStore,
+  pin: Pick<ThreadRailPin, "channelId" | "rootId">,
+  returnAnchorId: string,
+): ThreadRailStore {
+  if (!isBoundedId(returnAnchorId)) return store;
+  const index = store.pins.findIndex((existing) => samePin(existing, pin));
+  if (index < 0 || store.pins[index].returnAnchorId === returnAnchorId)
+    return store;
+  const pins = [...store.pins];
+  pins[index] = { ...pins[index], returnAnchorId };
+  return { ...store, pins };
+}
+
+export function updateThreadRailExpandedReplyIds(
+  store: ThreadRailStore,
+  pin: Pick<ThreadRailPin, "channelId" | "rootId">,
+  expandedReplyIds: readonly string[],
+): ThreadRailStore {
+  const index = store.pins.findIndex((existing) => samePin(existing, pin));
+  if (index < 0) return store;
+  const nextExpandedReplyIds = normalizeExpandedReplyIds(expandedReplyIds);
+  const currentExpandedReplyIds = store.pins[index].expandedReplyIds ?? [];
+  if (
+    currentExpandedReplyIds.length === nextExpandedReplyIds.length &&
+    currentExpandedReplyIds.every(
+      (id, index) => id === nextExpandedReplyIds[index],
+    )
+  ) {
+    return store;
+  }
+  const pins = [...store.pins];
+  if (nextExpandedReplyIds.length === 0) {
+    const {
+      expandedReplyIds: _expandedReplyIds,
+      ...pinWithoutExpandedReplies
+    } = pins[index];
+    pins[index] = pinWithoutExpandedReplies;
+  } else {
+    pins[index] = { ...pins[index], expandedReplyIds: nextExpandedReplyIds };
+  }
+  return { ...store, pins };
+}
+
+export function removeThreadRailPin(
+  store: ThreadRailStore,
+  pin: Pick<ThreadRailPin, "channelId" | "rootId">,
+): ThreadRailStore {
+  const pins = store.pins.filter((existing) => !samePin(existing, pin));
+  return pins.length === store.pins.length ? store : { ...store, pins };
+}
+
+export function toggleThreadRailCollapsed(
+  store: ThreadRailStore,
+): ThreadRailStore {
+  return { ...store, collapsed: !store.collapsed };
+}

--- a/desktop/src/features/channels/threadRailStorage.ts
+++ b/desktop/src/features/channels/threadRailStorage.ts
@@ -4,6 +4,7 @@ import { setLocalStorageItemWithRecovery } from "@/shared/lib/localStorageQuota"
 const STORAGE_PREFIX = "buzz-thread-rail.v1";
 export const MAX_THREAD_RAIL_PINS = 50;
 const MAX_EXPANDED_REPLY_IDS_PER_PIN = 100;
+const MAX_THREAD_RAIL_CUSTOM_TITLE_LENGTH = 128;
 const MAX_THREAD_RAIL_ID_LENGTH = 256;
 const MAX_THREAD_RAIL_CHANNEL_NAME_LENGTH = 128;
 const MAX_THREAD_RAIL_EXCERPT_LENGTH = 512;
@@ -20,6 +21,7 @@ export type ThreadRailPin = {
   returnAnchorId?: string;
   /** Local branch expansion state for this pinned canonical thread. */
   expandedReplyIds?: string[];
+  customTitle?: string;
   channelName?: string;
   rootExcerpt?: string;
   pinnedAt: number;
@@ -228,6 +230,27 @@ export function updateThreadRailExpandedReplyIds(
     pins[index] = pinWithoutExpandedReplies;
   } else {
     pins[index] = { ...pins[index], expandedReplyIds: nextExpandedReplyIds };
+  }
+  return { ...store, pins };
+}
+
+export function renameThreadRailPin(
+  store: ThreadRailStore,
+  pin: Pick<ThreadRailPin, "channelId" | "rootId">,
+  customTitle: string,
+): ThreadRailStore {
+  const index = store.pins.findIndex((existing) => samePin(existing, pin));
+  if (index < 0) return store;
+  const normalizedTitle = customTitle
+    .trim()
+    .slice(0, MAX_THREAD_RAIL_CUSTOM_TITLE_LENGTH);
+  if ((store.pins[index].customTitle ?? "") === normalizedTitle) return store;
+  const pins = [...store.pins];
+  if (normalizedTitle) {
+    pins[index] = { ...pins[index], customTitle: normalizedTitle };
+  } else {
+    const { customTitle: _customTitle, ...pinWithoutCustomTitle } = pins[index];
+    pins[index] = pinWithoutCustomTitle;
   }
   return { ...store, pins };
 }

--- a/desktop/src/features/channels/threadRailStorage.ts
+++ b/desktop/src/features/channels/threadRailStorage.ts
@@ -67,6 +67,12 @@ function normalizeExpandedReplyIds(value: unknown): string[] {
   return ids;
 }
 
+function normalizeCustomTitle(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const title = value.trim().slice(0, MAX_THREAD_RAIL_CUSTOM_TITLE_LENGTH);
+  return title || undefined;
+}
+
 function isPin(value: unknown): value is ThreadRailPin {
   if (typeof value !== "object" || value === null) return false;
   const pin = value as Record<string, unknown>;
@@ -80,6 +86,7 @@ function isPin(value: unknown): value is ThreadRailPin {
     typeof pin.pinnedAt === "number" &&
     Number.isFinite(pin.pinnedAt) &&
     pin.pinnedAt >= 0 &&
+    (pin.customTitle === undefined || typeof pin.customTitle === "string") &&
     (pin.channelName === undefined || typeof pin.channelName === "string") &&
     (pin.rootExcerpt === undefined || typeof pin.rootExcerpt === "string")
   );
@@ -95,6 +102,7 @@ function samePin(
 function normalizePin(pin: ThreadRailPin): ThreadRailPin {
   const {
     channelName,
+    customTitle,
     expandedReplyIds,
     returnAnchorId,
     rootExcerpt,
@@ -102,8 +110,10 @@ function normalizePin(pin: ThreadRailPin): ThreadRailPin {
   } = pin;
   const normalizedExpandedReplyIds =
     normalizeExpandedReplyIds(expandedReplyIds);
+  const normalizedCustomTitle = normalizeCustomTitle(customTitle);
   return {
     ...base,
+    ...(normalizedCustomTitle ? { customTitle: normalizedCustomTitle } : {}),
     ...(returnAnchorId
       ? { returnAnchorId: returnAnchorId.slice(0, MAX_THREAD_RAIL_ID_LENGTH) }
       : {}),

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -148,6 +148,7 @@ export const ChannelPane = React.memo(function ChannelPane({
   profilePanelView,
   targetMessageId,
   threadAllMessages,
+  threadExpandedReplyIds,
   threadHeadMessage,
   threadMessages,
   threadMessagesPending = false,
@@ -826,6 +827,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                 scrollTargetHighlights={!layoutScrollTargetId}
                 scrollTargetId={layoutScrollTargetId ?? threadScrollTargetId}
                 threadHead={threadHeadMessage}
+                expandedReplyIds={threadExpandedReplyIds}
                 videoReviewPresentation={threadVideoReviewPresentation}
                 widthPx={threadPanelWidthPx}
                 threadReplies={threadMessages}

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -505,17 +505,20 @@ export const ChannelPane = React.memo(function ChannelPane({
     ) : (
       <React.Fragment key={options.key ?? testId}>{panel}</React.Fragment>
     );
+  const threadSurfaceKey = threadHeadMessage
+    ? `${THREAD_SURFACE_KEY}:${activeChannelId}:${threadHeadMessage.id}`
+    : THREAD_SURFACE_KEY;
   const wrapThreadPanel = (panel: React.ReactNode) =>
     useFocusThreadDrawer ? (
       <FocusThreadDrawer
         channelName={activeChannel?.name ?? "channel"}
-        key={THREAD_SURFACE_KEY}
+        key={threadSurfaceKey}
         onClose={onCloseThread}
       >
         {panel}
       </FocusThreadDrawer>
     ) : (
-      wrapAux(panel, "message-thread-panel", { key: THREAD_SURFACE_KEY })
+      wrapAux(panel, "message-thread-panel", { key: threadSurfaceKey })
     );
   const threadHeaderLeading = useSplitAuxiliaryPane ? (
     <ThreadViewModeToggle onChange={changeThreadViewMode} />

--- a/desktop/src/features/channels/ui/ChannelPane.types.ts
+++ b/desktop/src/features/channels/ui/ChannelPane.types.ts
@@ -168,6 +168,7 @@ export type ChannelPaneProps = {
   profilePanelView: ProfilePanelView;
   threadHeadMessage: TimelineMessage | null;
   threadAllMessages: TimelineMessage[];
+  threadExpandedReplyIds: ReadonlySet<string>;
   threadMessages: MainTimelineEntry[];
   threadMessagesPending?: boolean;
   threadPanelWidthPx: number;

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -101,6 +101,7 @@ export function ChannelScreen({
   targetMessageEvents,
   targetMessageId,
   targetMessageLoadSettled,
+  threadRailNavigation,
 }: ChannelScreenProps) {
   const { goHome } = useAppNavigation();
   const threadRail = useThreadRailContext();
@@ -651,6 +652,11 @@ export function ChannelScreen({
   React.useEffect(() => {
     resetComposerTargets(activeChannelId);
   }, [activeChannelId, resetComposerTargets]);
+  const threadRailTargetKey = threadRailNavigation ? targetMessageId : null;
+  React.useLayoutEffect(() => {
+    if (!threadRailTargetKey) return;
+    resetComposerTargets(activeChannelId);
+  }, [activeChannelId, resetComposerTargets, threadRailTargetKey]);
   const { mainTimelineTargetMessageId, routeTargetReady } =
     useChannelRouteTarget({
       activeChannel,
@@ -663,6 +669,7 @@ export function ChannelScreen({
       setThreadReplyTargetId,
       setThreadScrollTargetId,
       targetMessageId,
+      suppressReplyTarget: threadRailNavigation,
       timelineMessages,
     });
   useThreadTargetSync({
@@ -677,6 +684,7 @@ export function ChannelScreen({
     setOpenThreadHeadId,
     setThreadReplyTargetId,
     setThreadScrollTargetId,
+    suppressDefaultReplyTarget: threadRailNavigation,
     threadReplyTargetId,
     threadReplyTargetMessage,
   });

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -79,8 +79,14 @@ import { useMessageProfiles } from "./useMessageProfiles";
 import { useChannelPanelHistoryState } from "./useChannelPanelHistoryState";
 import { useChannelProfilePanel } from "./useChannelProfilePanel";
 import { useChannelRouteTarget } from "./useChannelRouteTarget";
+import useChannelTargetCallbacks from "./useChannelTargetCallbacks";
 import { useChannelOpenReadState } from "./useChannelOpenReadState";
 import { useChannelUnreadState } from "./useChannelUnreadState";
+import { useThreadRailContext } from "../ThreadRailContext";
+import {
+  usePinnedThreadExpandedReplyIdsChange,
+  useRestorePinnedThreadExpansion,
+} from "../usePinnedThreadExpansionPersistence";
 import type { ChannelScreenProps } from "./ChannelScreen.types";
 const EMPTY_RELAY_EVENTS: RelayEvent[] = [];
 export function ChannelScreen({
@@ -94,8 +100,10 @@ export function ChannelScreen({
   targetForumReplyId,
   targetMessageEvents,
   targetMessageId,
+  targetMessageLoadSettled,
 }: ChannelScreenProps) {
   const { goHome } = useAppNavigation();
+  const threadRail = useThreadRailContext();
   const { activeCommunity } = useCommunities();
   const {
     clearChannelUnreadSource,
@@ -171,6 +179,12 @@ export function ChannelScreen({
     openThreadHeadId,
     optimisticOpenThreadHeadId,
   });
+  const handlePinnedThreadExpandedReplyIdsChange =
+    usePinnedThreadExpandedReplyIdsChange({
+      activeChannelId,
+      effectiveOpenThreadHeadId,
+      threadRail,
+    });
   const isNotifiedForEffectiveThread =
     effectiveOpenThreadHeadId != null
       ? isNotifiedForThread(effectiveOpenThreadHeadId)
@@ -485,6 +499,7 @@ export function ChannelScreen({
     getFirstReplyIdForMessage,
     getReplyDescendantIdsForMessage,
     markRevealedRepliesRead,
+    onExpandedThreadReplyIdsChange: handlePinnedThreadExpandedReplyIdsChange,
     profiles: messageProfiles,
     recordThreadInteraction,
     openThreadHeadId: effectiveOpenThreadHeadId,
@@ -631,28 +646,25 @@ export function ChannelScreen({
     },
     [],
   );
-  const handleThreadScrollTargetResolved = React.useCallback(() => {
-    setThreadScrollTargetId(null);
-  }, []);
-  const handleTargetReached = React.useCallback(() => {
-    clearMessageRouteTarget({ replace: true });
-  }, [clearMessageRouteTarget]);
+  const { handleTargetReached, handleThreadScrollTargetResolved } =
+    useChannelTargetCallbacks(clearMessageRouteTarget, setThreadScrollTargetId);
   React.useEffect(() => {
     resetComposerTargets(activeChannelId);
   }, [activeChannelId, resetComposerTargets]);
-  const mainTimelineTargetMessageId = useChannelRouteTarget({
-    activeChannel,
-    activeChannelId,
-    closeAgentSession: handleCloseAgentSession,
-    setEditTargetId,
-    setExpandedThreadReplyIds,
-    setOpenThreadHeadId,
-    setProfilePanelPubkey,
-    setThreadReplyTargetId,
-    setThreadScrollTargetId,
-    targetMessageId,
-    timelineMessages,
-  });
+  const { mainTimelineTargetMessageId, routeTargetReady } =
+    useChannelRouteTarget({
+      activeChannel,
+      activeChannelId,
+      closeAgentSession: handleCloseAgentSession,
+      setEditTargetId,
+      setExpandedThreadReplyIds,
+      setOpenThreadHeadId,
+      setProfilePanelPubkey,
+      setThreadReplyTargetId,
+      setThreadScrollTargetId,
+      targetMessageId,
+      timelineMessages,
+    });
   useThreadTargetSync({
     clearOptimisticThreadOverride,
     editTargetId,
@@ -667,6 +679,13 @@ export function ChannelScreen({
     setThreadScrollTargetId,
     threadReplyTargetId,
     threadReplyTargetMessage,
+  });
+  useRestorePinnedThreadExpansion({
+    activeChannelId,
+    effectiveOpenThreadHeadId,
+    setExpandedThreadReplyIds,
+    threadRail,
+    threadRouteTargetReady: routeTargetReady || targetMessageLoadSettled,
   });
   const hasAuxiliaryPanel = Boolean(
     effectiveOpenThreadHeadId ||
@@ -944,6 +963,7 @@ export function ChannelScreen({
                   unreadCount={unreadCount}
                   targetMessageId={mainTimelineTargetMessageId}
                   threadAllMessages={displayedThreadAllMessages}
+                  threadExpandedReplyIds={expandedThreadReplyIds}
                   threadHeadMessage={displayedThreadHeadMessage}
                   threadMessages={displayedThreadMessages}
                   threadMessagesPending={threadRepliesQuery.isPending}

--- a/desktop/src/features/channels/ui/ChannelScreen.types.ts
+++ b/desktop/src/features/channels/ui/ChannelScreen.types.ts
@@ -22,4 +22,5 @@ export type ChannelScreenProps = {
   targetForumReplyId: string | null;
   targetMessageEvents: RelayEvent[];
   targetMessageId: string | null;
+  targetMessageLoadSettled: boolean;
 };

--- a/desktop/src/features/channels/ui/ChannelScreen.types.ts
+++ b/desktop/src/features/channels/ui/ChannelScreen.types.ts
@@ -23,4 +23,5 @@ export type ChannelScreenProps = {
   targetMessageEvents: RelayEvent[];
   targetMessageId: string | null;
   targetMessageLoadSettled: boolean;
+  threadRailNavigation: boolean;
 };

--- a/desktop/src/features/channels/ui/ThreadRail.tsx
+++ b/desktop/src/features/channels/ui/ThreadRail.tsx
@@ -1,0 +1,146 @@
+import { ChevronLeft, ChevronRight, MessageSquareText, X } from "lucide-react";
+
+import {
+  threadRailEntryClassName,
+  threadRailHeaderClassName,
+  threadRailShellClassName,
+} from "@/features/channels/threadRailLayout";
+import {
+  isThreadRailPinActive,
+  threadRailPinToChannelNavigation,
+} from "@/features/channels/threadRailNavigation";
+import type { ThreadRailPin } from "@/features/channels/threadRailStorage";
+import { Button } from "@/shared/ui/button";
+import { cn } from "@/shared/lib/cn";
+
+export function ThreadRail({
+  collapsed,
+  onNavigate,
+  onToggleCollapsed,
+  onUnpin,
+  openThreadRootId,
+  pins,
+  selectedChannelId,
+  unreadRootIds,
+}: {
+  collapsed: boolean;
+  onNavigate: (
+    destination: ReturnType<typeof threadRailPinToChannelNavigation>,
+  ) => void;
+  onToggleCollapsed: () => void;
+  onUnpin: (pin: Pick<ThreadRailPin, "channelId" | "rootId">) => void;
+  openThreadRootId: string | null;
+  pins: ThreadRailPin[];
+  selectedChannelId: string | null;
+  unreadRootIds: ReadonlySet<string>;
+}) {
+  if (pins.length === 0) return null;
+  return (
+    <aside
+      aria-label="Pinned threads"
+      className={cn(
+        threadRailShellClassName(collapsed),
+        collapsed ? "min-[601px]:w-10" : "min-[601px]:w-56",
+      )}
+      data-collapsed={collapsed}
+      data-testid="thread-rail"
+    >
+      <div
+        className={cn(
+          threadRailHeaderClassName(),
+          collapsed ? "justify-center px-1" : "justify-between",
+        )}
+        data-testid="thread-rail-header"
+      >
+        {!collapsed ? (
+          <span className="truncate text-base font-semibold leading-6 tracking-tight">
+            Pinned threads
+          </span>
+        ) : null}
+        <Button
+          aria-expanded={!collapsed}
+          aria-label={
+            collapsed
+              ? `Expand ${pins.length} pinned threads`
+              : "Collapse pinned threads"
+          }
+          data-testid="thread-rail-toggle"
+          onClick={onToggleCollapsed}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          {collapsed ? (
+            <ChevronLeft aria-hidden />
+          ) : (
+            <ChevronRight aria-hidden />
+          )}
+        </Button>
+      </div>
+      {!collapsed ? (
+        <div className="min-h-0 space-y-1 overflow-y-auto px-2 pb-2 pt-1">
+          {pins.map((pin) => {
+            const active = isThreadRailPinActive(
+              pin,
+              selectedChannelId,
+              openThreadRootId,
+            );
+            const hasUnread = unreadRootIds.has(pin.rootId);
+            const label = `${pin.channelName ? `#${pin.channelName}: ` : ""}${
+              pin.rootExcerpt || "Pinned thread"
+            }`;
+            return (
+              <div
+                className={threadRailEntryClassName(active)}
+                data-testid={`thread-rail-row-${pin.rootId}`}
+                key={`${pin.channelId}:${pin.rootId}`}
+              >
+                <button
+                  aria-current={active ? "page" : undefined}
+                  aria-label={hasUnread ? `${label}, unread reply` : label}
+                  className="min-w-0 flex-1 px-2.5 py-2 text-left text-sm focus-visible:outline-hidden"
+                  data-testid={`thread-rail-entry-${pin.rootId}`}
+                  onClick={() =>
+                    onNavigate(threadRailPinToChannelNavigation(pin))
+                  }
+                  title={label}
+                  type="button"
+                >
+                  <span className="flex items-center gap-2">
+                    <MessageSquareText
+                      aria-hidden
+                      className="size-3.5 shrink-0 text-muted-foreground"
+                    />
+                    <span className="min-w-0 flex-1 truncate">{label}</span>
+                    {hasUnread ? (
+                      <span
+                        aria-hidden
+                        className="size-2 shrink-0 rounded-full bg-primary"
+                        data-testid={`thread-rail-unread-${pin.rootId}`}
+                      />
+                    ) : null}
+                  </span>
+                </button>
+                <Button
+                  aria-label={`Unpin ${label}`}
+                  className="mr-1 shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+                  data-testid={`unpin-thread-rail-${pin.rootId}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onUnpin(pin);
+                  }}
+                  size="icon-xs"
+                  title="Unpin thread"
+                  type="button"
+                  variant="ghost"
+                >
+                  <X aria-hidden />
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </aside>
+  );
+}

--- a/desktop/src/features/channels/ui/ThreadRail.tsx
+++ b/desktop/src/features/channels/ui/ThreadRail.tsx
@@ -115,7 +115,6 @@ export function ThreadRail({
                 {editing ? (
                   <input
                     aria-label={`Rename ${fallbackLabel}`}
-                    autoFocus
                     className="min-w-0 flex-1 bg-transparent px-2.5 py-2 text-sm outline-none"
                     data-testid={`thread-rail-title-input-${pin.rootId}`}
                     onBlur={() => {

--- a/desktop/src/features/channels/ui/ThreadRail.tsx
+++ b/desktop/src/features/channels/ui/ThreadRail.tsx
@@ -1,7 +1,6 @@
 import { ChevronLeft, ChevronRight, MessageSquareText, X } from "lucide-react";
 
 import {
-  threadRailColumnClassName,
   threadRailEntryClassName,
   threadRailHeaderClassName,
   threadRailShellClassName,
@@ -37,116 +36,111 @@ export function ThreadRail({
 }) {
   if (pins.length === 0) return null;
   return (
-    <div
-      className={threadRailColumnClassName()}
-      data-testid="thread-rail-column"
+    <aside
+      aria-label="Pinned threads"
+      className={cn(
+        threadRailShellClassName(collapsed),
+        collapsed ? "min-[601px]:w-10" : "min-[601px]:w-56",
+      )}
+      data-collapsed={collapsed}
+      data-testid="thread-rail"
     >
-      <aside
-        aria-label="Pinned threads"
+      <div
         className={cn(
-          threadRailShellClassName(collapsed),
-          collapsed ? "min-[601px]:w-10" : "min-[601px]:w-56",
+          threadRailHeaderClassName(),
+          collapsed ? "justify-center px-1" : "justify-between",
         )}
-        data-collapsed={collapsed}
-        data-testid="thread-rail"
+        data-testid="thread-rail-header"
       >
-        <div
-          className={cn(
-            threadRailHeaderClassName(),
-            collapsed ? "justify-center px-1" : "justify-between",
-          )}
-          data-testid="thread-rail-header"
-        >
-          {!collapsed ? (
-            <span className="truncate text-base font-semibold leading-6 tracking-tight">
-              Pinned threads
-            </span>
-          ) : null}
-          <Button
-            aria-expanded={!collapsed}
-            aria-label={
-              collapsed
-                ? `Expand ${pins.length} pinned threads`
-                : "Collapse pinned threads"
-            }
-            data-testid="thread-rail-toggle"
-            onClick={onToggleCollapsed}
-            size="icon"
-            type="button"
-            variant="ghost"
-          >
-            {collapsed ? (
-              <ChevronLeft aria-hidden />
-            ) : (
-              <ChevronRight aria-hidden />
-            )}
-          </Button>
-        </div>
         {!collapsed ? (
-          <div className="min-h-0 space-y-1 overflow-y-auto px-2 pb-2 pt-1">
-            {pins.map((pin) => {
-              const active = isThreadRailPinActive(
-                pin,
-                selectedChannelId,
-                openThreadRootId,
-              );
-              const hasUnread = unreadRootIds.has(pin.rootId);
-              const label = `${pin.channelName ? `#${pin.channelName}: ` : ""}${
-                pin.rootExcerpt || "Pinned thread"
-              }`;
-              return (
-                <div
-                  className={threadRailEntryClassName(active)}
-                  data-testid={`thread-rail-row-${pin.rootId}`}
-                  key={`${pin.channelId}:${pin.rootId}`}
-                >
-                  <button
-                    aria-current={active ? "page" : undefined}
-                    aria-label={hasUnread ? `${label}, unread reply` : label}
-                    className="min-w-0 flex-1 px-2.5 py-2 text-left text-sm focus-visible:outline-hidden"
-                    data-testid={`thread-rail-entry-${pin.rootId}`}
-                    onClick={() =>
-                      onNavigate(threadRailPinToChannelNavigation(pin))
-                    }
-                    title={label}
-                    type="button"
-                  >
-                    <span className="flex items-center gap-2">
-                      <MessageSquareText
-                        aria-hidden
-                        className="size-3.5 shrink-0 text-muted-foreground"
-                      />
-                      <span className="min-w-0 flex-1 truncate">{label}</span>
-                      {hasUnread ? (
-                        <span
-                          aria-hidden
-                          className="size-2 shrink-0 rounded-full bg-primary"
-                          data-testid={`thread-rail-unread-${pin.rootId}`}
-                        />
-                      ) : null}
-                    </span>
-                  </button>
-                  <Button
-                    aria-label={`Unpin ${label}`}
-                    className="mr-1 shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-                    data-testid={`unpin-thread-rail-${pin.rootId}`}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onUnpin(pin);
-                    }}
-                    size="icon-xs"
-                    title="Unpin thread"
-                    type="button"
-                    variant="ghost"
-                  >
-                    <X aria-hidden />
-                  </Button>
-                </div>
-              );
-            })}
-          </div>
+          <span className="truncate text-base font-semibold leading-6 tracking-tight">
+            Pinned threads
+          </span>
         ) : null}
-      </aside>
-    </div>
+        <Button
+          aria-expanded={!collapsed}
+          aria-label={
+            collapsed
+              ? `Expand ${pins.length} pinned threads`
+              : "Collapse pinned threads"
+          }
+          data-testid="thread-rail-toggle"
+          onClick={onToggleCollapsed}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          {collapsed ? (
+            <ChevronLeft aria-hidden />
+          ) : (
+            <ChevronRight aria-hidden />
+          )}
+        </Button>
+      </div>
+      {!collapsed ? (
+        <div className="min-h-0 space-y-1 overflow-y-auto px-2 pb-2 pt-1">
+          {pins.map((pin) => {
+            const active = isThreadRailPinActive(
+              pin,
+              selectedChannelId,
+              openThreadRootId,
+            );
+            const hasUnread = unreadRootIds.has(pin.rootId);
+            const label = `${pin.channelName ? `#${pin.channelName}: ` : ""}${
+              pin.rootExcerpt || "Pinned thread"
+            }`;
+            return (
+              <div
+                className={threadRailEntryClassName(active)}
+                data-testid={`thread-rail-row-${pin.rootId}`}
+                key={`${pin.channelId}:${pin.rootId}`}
+              >
+                <button
+                  aria-current={active ? "page" : undefined}
+                  aria-label={hasUnread ? `${label}, unread reply` : label}
+                  className="min-w-0 flex-1 px-2.5 py-2 text-left text-sm focus-visible:outline-hidden"
+                  data-testid={`thread-rail-entry-${pin.rootId}`}
+                  onClick={() =>
+                    onNavigate(threadRailPinToChannelNavigation(pin))
+                  }
+                  title={label}
+                  type="button"
+                >
+                  <span className="flex items-center gap-2">
+                    <MessageSquareText
+                      aria-hidden
+                      className="size-3.5 shrink-0 text-muted-foreground"
+                    />
+                    <span className="min-w-0 flex-1 truncate">{label}</span>
+                    {hasUnread ? (
+                      <span
+                        aria-hidden
+                        className="size-2 shrink-0 rounded-full bg-primary"
+                        data-testid={`thread-rail-unread-${pin.rootId}`}
+                      />
+                    ) : null}
+                  </span>
+                </button>
+                <Button
+                  aria-label={`Unpin ${label}`}
+                  className="mr-1 shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+                  data-testid={`unpin-thread-rail-${pin.rootId}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onUnpin(pin);
+                  }}
+                  size="icon-xs"
+                  title="Unpin thread"
+                  type="button"
+                  variant="ghost"
+                >
+                  <X aria-hidden />
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </aside>
   );
 }

--- a/desktop/src/features/channels/ui/ThreadRail.tsx
+++ b/desktop/src/features/channels/ui/ThreadRail.tsx
@@ -1,4 +1,11 @@
-import { ChevronLeft, ChevronRight, MessageSquareText, X } from "lucide-react";
+import * as React from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  MessageSquareText,
+  Pencil,
+  X,
+} from "lucide-react";
 
 import {
   threadRailEntryClassName,
@@ -16,6 +23,7 @@ import { cn } from "@/shared/lib/cn";
 export function ThreadRail({
   collapsed,
   onNavigate,
+  onRename,
   onToggleCollapsed,
   onUnpin,
   openThreadRootId,
@@ -27,6 +35,10 @@ export function ThreadRail({
   onNavigate: (
     destination: ReturnType<typeof threadRailPinToChannelNavigation>,
   ) => void;
+  onRename: (
+    pin: Pick<ThreadRailPin, "channelId" | "rootId">,
+    customTitle: string,
+  ) => void;
   onToggleCollapsed: () => void;
   onUnpin: (pin: Pick<ThreadRailPin, "channelId" | "rootId">) => void;
   openThreadRootId: string | null;
@@ -34,6 +46,8 @@ export function ThreadRail({
   selectedChannelId: string | null;
   unreadRootIds: ReadonlySet<string>;
 }) {
+  const [editingPinKey, setEditingPinKey] = React.useState<string | null>(null);
+  const [titleDraft, setTitleDraft] = React.useState("");
   if (pins.length === 0) return null;
   return (
     <aside
@@ -86,41 +100,81 @@ export function ThreadRail({
               openThreadRootId,
             );
             const hasUnread = unreadRootIds.has(pin.rootId);
-            const label = `${pin.channelName ? `#${pin.channelName}: ` : ""}${
+            const pinKey = `${pin.channelId}:${pin.rootId}`;
+            const fallbackLabel = `${pin.channelName ? `#${pin.channelName}: ` : ""}${
               pin.rootExcerpt || "Pinned thread"
             }`;
+            const label = pin.customTitle || fallbackLabel;
+            const editing = editingPinKey === pinKey;
             return (
               <div
                 className={threadRailEntryClassName(active)}
                 data-testid={`thread-rail-row-${pin.rootId}`}
                 key={`${pin.channelId}:${pin.rootId}`}
               >
-                <button
-                  aria-current={active ? "page" : undefined}
-                  aria-label={hasUnread ? `${label}, unread reply` : label}
-                  className="min-w-0 flex-1 px-2.5 py-2 text-left text-sm focus-visible:outline-hidden"
-                  data-testid={`thread-rail-entry-${pin.rootId}`}
-                  onClick={() =>
-                    onNavigate(threadRailPinToChannelNavigation(pin))
-                  }
-                  title={label}
-                  type="button"
-                >
-                  <span className="flex items-center gap-2">
-                    <MessageSquareText
-                      aria-hidden
-                      className="size-3.5 shrink-0 text-muted-foreground"
-                    />
-                    <span className="min-w-0 flex-1 truncate">{label}</span>
-                    {hasUnread ? (
-                      <span
+                {editing ? (
+                  <input
+                    aria-label={`Rename ${fallbackLabel}`}
+                    autoFocus
+                    className="min-w-0 flex-1 bg-transparent px-2.5 py-2 text-sm outline-none"
+                    data-testid={`thread-rail-title-input-${pin.rootId}`}
+                    onBlur={() => {
+                      onRename(pin, titleDraft);
+                      setEditingPinKey(null);
+                    }}
+                    onChange={(event) => setTitleDraft(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        onRename(pin, titleDraft);
+                        setEditingPinKey(null);
+                      }
+                      if (event.key === "Escape") setEditingPinKey(null);
+                    }}
+                    value={titleDraft}
+                  />
+                ) : (
+                  <button
+                    aria-current={active ? "page" : undefined}
+                    aria-label={hasUnread ? `${label}, unread reply` : label}
+                    className="min-w-0 flex-1 px-2.5 py-2 text-left text-sm focus-visible:outline-hidden"
+                    data-testid={`thread-rail-entry-${pin.rootId}`}
+                    onClick={() =>
+                      onNavigate(threadRailPinToChannelNavigation(pin))
+                    }
+                    title={label}
+                    type="button"
+                  >
+                    <span className="flex items-center gap-2">
+                      <MessageSquareText
                         aria-hidden
-                        className="size-2 shrink-0 rounded-full bg-primary"
-                        data-testid={`thread-rail-unread-${pin.rootId}`}
+                        className="size-3.5 shrink-0 text-muted-foreground"
                       />
-                    ) : null}
-                  </span>
-                </button>
+                      <span className="min-w-0 flex-1 truncate">{label}</span>
+                      {hasUnread ? (
+                        <span
+                          aria-hidden
+                          className="size-2 shrink-0 rounded-full bg-primary"
+                          data-testid={`thread-rail-unread-${pin.rootId}`}
+                        />
+                      ) : null}
+                    </span>
+                  </button>
+                )}
+                <Button
+                  aria-label={`Rename ${label}`}
+                  className="shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+                  data-testid={`edit-thread-rail-title-${pin.rootId}`}
+                  onClick={() => {
+                    setTitleDraft(pin.customTitle ?? "");
+                    setEditingPinKey(pinKey);
+                  }}
+                  size="icon-xs"
+                  title="Rename pinned thread"
+                  type="button"
+                  variant="ghost"
+                >
+                  <Pencil aria-hidden />
+                </Button>
                 <Button
                   aria-label={`Unpin ${label}`}
                   className="mr-1 shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"

--- a/desktop/src/features/channels/ui/ThreadRail.tsx
+++ b/desktop/src/features/channels/ui/ThreadRail.tsx
@@ -1,6 +1,7 @@
 import { ChevronLeft, ChevronRight, MessageSquareText, X } from "lucide-react";
 
 import {
+  threadRailColumnClassName,
   threadRailEntryClassName,
   threadRailHeaderClassName,
   threadRailShellClassName,
@@ -36,111 +37,116 @@ export function ThreadRail({
 }) {
   if (pins.length === 0) return null;
   return (
-    <aside
-      aria-label="Pinned threads"
-      className={cn(
-        threadRailShellClassName(collapsed),
-        collapsed ? "min-[601px]:w-10" : "min-[601px]:w-56",
-      )}
-      data-collapsed={collapsed}
-      data-testid="thread-rail"
+    <div
+      className={threadRailColumnClassName()}
+      data-testid="thread-rail-column"
     >
-      <div
+      <aside
+        aria-label="Pinned threads"
         className={cn(
-          threadRailHeaderClassName(),
-          collapsed ? "justify-center px-1" : "justify-between",
+          threadRailShellClassName(collapsed),
+          collapsed ? "min-[601px]:w-10" : "min-[601px]:w-56",
         )}
-        data-testid="thread-rail-header"
+        data-collapsed={collapsed}
+        data-testid="thread-rail"
       >
-        {!collapsed ? (
-          <span className="truncate text-base font-semibold leading-6 tracking-tight">
-            Pinned threads
-          </span>
-        ) : null}
-        <Button
-          aria-expanded={!collapsed}
-          aria-label={
-            collapsed
-              ? `Expand ${pins.length} pinned threads`
-              : "Collapse pinned threads"
-          }
-          data-testid="thread-rail-toggle"
-          onClick={onToggleCollapsed}
-          size="icon"
-          type="button"
-          variant="ghost"
-        >
-          {collapsed ? (
-            <ChevronLeft aria-hidden />
-          ) : (
-            <ChevronRight aria-hidden />
+        <div
+          className={cn(
+            threadRailHeaderClassName(),
+            collapsed ? "justify-center px-1" : "justify-between",
           )}
-        </Button>
-      </div>
-      {!collapsed ? (
-        <div className="min-h-0 space-y-1 overflow-y-auto px-2 pb-2 pt-1">
-          {pins.map((pin) => {
-            const active = isThreadRailPinActive(
-              pin,
-              selectedChannelId,
-              openThreadRootId,
-            );
-            const hasUnread = unreadRootIds.has(pin.rootId);
-            const label = `${pin.channelName ? `#${pin.channelName}: ` : ""}${
-              pin.rootExcerpt || "Pinned thread"
-            }`;
-            return (
-              <div
-                className={threadRailEntryClassName(active)}
-                data-testid={`thread-rail-row-${pin.rootId}`}
-                key={`${pin.channelId}:${pin.rootId}`}
-              >
-                <button
-                  aria-current={active ? "page" : undefined}
-                  aria-label={hasUnread ? `${label}, unread reply` : label}
-                  className="min-w-0 flex-1 px-2.5 py-2 text-left text-sm focus-visible:outline-hidden"
-                  data-testid={`thread-rail-entry-${pin.rootId}`}
-                  onClick={() =>
-                    onNavigate(threadRailPinToChannelNavigation(pin))
-                  }
-                  title={label}
-                  type="button"
-                >
-                  <span className="flex items-center gap-2">
-                    <MessageSquareText
-                      aria-hidden
-                      className="size-3.5 shrink-0 text-muted-foreground"
-                    />
-                    <span className="min-w-0 flex-1 truncate">{label}</span>
-                    {hasUnread ? (
-                      <span
-                        aria-hidden
-                        className="size-2 shrink-0 rounded-full bg-primary"
-                        data-testid={`thread-rail-unread-${pin.rootId}`}
-                      />
-                    ) : null}
-                  </span>
-                </button>
-                <Button
-                  aria-label={`Unpin ${label}`}
-                  className="mr-1 shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-                  data-testid={`unpin-thread-rail-${pin.rootId}`}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onUnpin(pin);
-                  }}
-                  size="icon-xs"
-                  title="Unpin thread"
-                  type="button"
-                  variant="ghost"
-                >
-                  <X aria-hidden />
-                </Button>
-              </div>
-            );
-          })}
+          data-testid="thread-rail-header"
+        >
+          {!collapsed ? (
+            <span className="truncate text-base font-semibold leading-6 tracking-tight">
+              Pinned threads
+            </span>
+          ) : null}
+          <Button
+            aria-expanded={!collapsed}
+            aria-label={
+              collapsed
+                ? `Expand ${pins.length} pinned threads`
+                : "Collapse pinned threads"
+            }
+            data-testid="thread-rail-toggle"
+            onClick={onToggleCollapsed}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            {collapsed ? (
+              <ChevronLeft aria-hidden />
+            ) : (
+              <ChevronRight aria-hidden />
+            )}
+          </Button>
         </div>
-      ) : null}
-    </aside>
+        {!collapsed ? (
+          <div className="min-h-0 space-y-1 overflow-y-auto px-2 pb-2 pt-1">
+            {pins.map((pin) => {
+              const active = isThreadRailPinActive(
+                pin,
+                selectedChannelId,
+                openThreadRootId,
+              );
+              const hasUnread = unreadRootIds.has(pin.rootId);
+              const label = `${pin.channelName ? `#${pin.channelName}: ` : ""}${
+                pin.rootExcerpt || "Pinned thread"
+              }`;
+              return (
+                <div
+                  className={threadRailEntryClassName(active)}
+                  data-testid={`thread-rail-row-${pin.rootId}`}
+                  key={`${pin.channelId}:${pin.rootId}`}
+                >
+                  <button
+                    aria-current={active ? "page" : undefined}
+                    aria-label={hasUnread ? `${label}, unread reply` : label}
+                    className="min-w-0 flex-1 px-2.5 py-2 text-left text-sm focus-visible:outline-hidden"
+                    data-testid={`thread-rail-entry-${pin.rootId}`}
+                    onClick={() =>
+                      onNavigate(threadRailPinToChannelNavigation(pin))
+                    }
+                    title={label}
+                    type="button"
+                  >
+                    <span className="flex items-center gap-2">
+                      <MessageSquareText
+                        aria-hidden
+                        className="size-3.5 shrink-0 text-muted-foreground"
+                      />
+                      <span className="min-w-0 flex-1 truncate">{label}</span>
+                      {hasUnread ? (
+                        <span
+                          aria-hidden
+                          className="size-2 shrink-0 rounded-full bg-primary"
+                          data-testid={`thread-rail-unread-${pin.rootId}`}
+                        />
+                      ) : null}
+                    </span>
+                  </button>
+                  <Button
+                    aria-label={`Unpin ${label}`}
+                    className="mr-1 shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+                    data-testid={`unpin-thread-rail-${pin.rootId}`}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onUnpin(pin);
+                    }}
+                    size="icon-xs"
+                    title="Unpin thread"
+                    type="button"
+                    variant="ghost"
+                  >
+                    <X aria-hidden />
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
+      </aside>
+    </div>
   );
 }

--- a/desktop/src/features/channels/ui/useChannelRouteTarget.test.mjs
+++ b/desktop/src/features/channels/ui/useChannelRouteTarget.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isThreadRouteTargetReady } from "./useChannelRouteTarget.ts";
+
+const ROOT = { id: "root", parentId: null, rootId: null, tags: [] };
+const PARENT = { id: "parent", parentId: "root", rootId: "root", tags: [] };
+const LEAF = { id: "leaf", parentId: "parent", rootId: "root", tags: [] };
+
+test("thread route readiness waits for the routed message and every ancestor", () => {
+  assert.equal(isThreadRouteTargetReady("leaf", null, new Map()), false);
+  assert.equal(
+    isThreadRouteTargetReady("leaf", LEAF, new Map([["leaf", LEAF]])),
+    false,
+  );
+  assert.equal(
+    isThreadRouteTargetReady(
+      "leaf",
+      LEAF,
+      new Map([
+        ["root", ROOT],
+        ["parent", PARENT],
+        ["leaf", LEAF],
+      ]),
+    ),
+    true,
+  );
+});
+
+test("root routes are ready as soon as the root message arrives", () => {
+  assert.equal(
+    isThreadRouteTargetReady("root", ROOT, new Map([["root", ROOT]])),
+    true,
+  );
+  assert.equal(isThreadRouteTargetReady(null, null, new Map()), true);
+});

--- a/desktop/src/features/channels/ui/useChannelRouteTarget.ts
+++ b/desktop/src/features/channels/ui/useChannelRouteTarget.ts
@@ -75,6 +75,7 @@ export function useChannelRouteTarget({
   setProfilePanelPubkey,
   setThreadReplyTargetId,
   setThreadScrollTargetId,
+  suppressReplyTarget = false,
   targetMessageId,
   timelineMessages,
 }: {
@@ -87,6 +88,7 @@ export function useChannelRouteTarget({
   setProfilePanelPubkey: PanelValueSetter;
   setThreadReplyTargetId: React.Dispatch<React.SetStateAction<string | null>>;
   setThreadScrollTargetId: React.Dispatch<React.SetStateAction<string | null>>;
+  suppressReplyTarget?: boolean;
   targetMessageId: string | null;
   timelineMessages: TimelineMessage[];
 }) {
@@ -141,7 +143,7 @@ export function useChannelRouteTarget({
       setProfilePanelPubkey(null, { replace: true });
       setEditTargetId(null);
       setOpenThreadHeadId(targetMessage.id, { replace: true });
-      setThreadReplyTargetId(targetMessage.id);
+      setThreadReplyTargetId(suppressReplyTarget ? null : targetMessage.id);
       setThreadScrollTargetId(null);
       setExpandedThreadReplyIds(new Set());
       handledThreadRouteTargetRef.current = targetKey;
@@ -166,7 +168,9 @@ export function useChannelRouteTarget({
     setProfilePanelPubkey(null, { replace: true });
     setEditTargetId(null);
     setOpenThreadHeadId(routeTarget.threadHeadId, { replace: true });
-    setThreadReplyTargetId(routeTarget.threadHeadId);
+    setThreadReplyTargetId(
+      suppressReplyTarget ? null : routeTarget.threadHeadId,
+    );
     setThreadScrollTargetId(targetMessageId);
     setExpandedThreadReplyIds(routeTarget.expandedReplyIds);
     handledThreadRouteTargetRef.current = targetKey;
@@ -180,6 +184,7 @@ export function useChannelRouteTarget({
     setProfilePanelPubkey,
     setThreadReplyTargetId,
     setThreadScrollTargetId,
+    suppressReplyTarget,
     targetMessageId,
     timelineMessageById,
   ]);

--- a/desktop/src/features/channels/ui/useChannelRouteTarget.ts
+++ b/desktop/src/features/channels/ui/useChannelRouteTarget.ts
@@ -5,7 +5,7 @@ import { isBroadcastReply } from "@/features/messages/lib/threading";
 import type { Channel } from "@/shared/api/types";
 import type { PanelValueSetter } from "./useChannelPanelHistoryState";
 
-function getThreadRouteTarget(
+export function getThreadRouteTarget(
   targetMessage: TimelineMessage,
   messageById: ReadonlyMap<string, TimelineMessage>,
 ): { expandedReplyIds: Set<string>; threadHeadId: string } | null {
@@ -35,6 +35,19 @@ function getThreadRouteTarget(
   }
 
   return { expandedReplyIds, threadHeadId };
+}
+
+export function isThreadRouteTargetReady(
+  targetMessageId: string | null,
+  targetMessage: TimelineMessage | null,
+  messageById: ReadonlyMap<string, TimelineMessage>,
+): boolean {
+  if (!targetMessageId) return true;
+  if (!targetMessage) return false;
+  if (!targetMessage.parentId || isBroadcastReply(targetMessage.tags ?? [])) {
+    return true;
+  }
+  return getThreadRouteTarget(targetMessage, messageById) !== null;
 }
 
 function getRouteMainTimelineTargetId(
@@ -84,6 +97,11 @@ export function useChannelRouteTarget({
   const targetTimelineMessage = targetMessageId
     ? (timelineMessageById.get(targetMessageId) ?? null)
     : null;
+  const threadRouteTargetReady = isThreadRouteTargetReady(
+    targetMessageId,
+    targetTimelineMessage,
+    timelineMessageById,
+  );
   const mainTimelineTargetMessageId = getRouteMainTimelineTargetId(
     targetMessageId,
     targetTimelineMessage,
@@ -166,5 +184,8 @@ export function useChannelRouteTarget({
     timelineMessageById,
   ]);
 
-  return mainTimelineTargetMessageId;
+  return {
+    mainTimelineTargetMessageId,
+    routeTargetReady: threadRouteTargetReady,
+  };
 }

--- a/desktop/src/features/channels/ui/useChannelTargetCallbacks.ts
+++ b/desktop/src/features/channels/ui/useChannelTargetCallbacks.ts
@@ -1,0 +1,14 @@
+import * as React from "react";
+
+export default function useChannelTargetCallbacks(
+  clearMessageRouteTarget: (options: { replace: true }) => void,
+  setThreadScrollTargetId: React.Dispatch<React.SetStateAction<string | null>>,
+) {
+  const handleThreadScrollTargetResolved = React.useCallback(() => {
+    setThreadScrollTargetId(null);
+  }, [setThreadScrollTargetId]);
+  const handleTargetReached = React.useCallback(() => {
+    clearMessageRouteTarget({ replace: true });
+  }, [clearMessageRouteTarget]);
+  return { handleTargetReached, handleThreadScrollTargetResolved };
+}

--- a/desktop/src/features/channels/useChannelPaneHandlers.ts
+++ b/desktop/src/features/channels/useChannelPaneHandlers.ts
@@ -28,6 +28,7 @@ export function useChannelPaneHandlers({
   getFirstReplyIdForMessage,
   getReplyDescendantIdsForMessage,
   markRevealedRepliesRead,
+  onExpandedThreadReplyIdsChange,
   profiles,
   recordThreadInteraction,
   onOptimisticOpenThreadHeadIdChange,
@@ -49,6 +50,9 @@ export function useChannelPaneHandlers({
   getFirstReplyIdForMessage: (messageId: string) => string | null;
   getReplyDescendantIdsForMessage: (messageId: string) => string[];
   markRevealedRepliesRead: (messageId: string) => void;
+  onExpandedThreadReplyIdsChange?: (
+    expandedReplyIds: ReadonlySet<string>,
+  ) => void;
   profiles: UserProfileLookup | undefined;
   recordThreadInteraction: (rootId: string) => void;
   onOptimisticOpenThreadHeadIdChange: React.Dispatch<
@@ -77,6 +81,11 @@ export function useChannelPaneHandlers({
 
   const expandedThreadReplyIdsRef = React.useRef(expandedThreadReplyIds);
   expandedThreadReplyIdsRef.current = expandedThreadReplyIds;
+
+  const onExpandedThreadReplyIdsChangeRef = React.useRef(
+    onExpandedThreadReplyIdsChange,
+  );
+  onExpandedThreadReplyIdsChangeRef.current = onExpandedThreadReplyIdsChange;
 
   const profilesRef = React.useRef(profiles);
   profilesRef.current = profiles;
@@ -244,25 +253,24 @@ export function useChannelPaneHandlers({
 
   const handleExpandThreadReplies = React.useCallback(
     (message: { id: string }) => {
-      if (expandedThreadReplyIdsRef.current.has(message.id)) {
+      const next = new Set(expandedThreadReplyIdsRef.current);
+      if (next.has(message.id)) {
         const descendantIds = getReplyDescendantIdsRef.current(message.id);
-        setExpandedThreadReplyIds((current) => {
-          const next = new Set(current);
-          next.delete(message.id);
-          for (const descendantId of descendantIds) {
-            next.delete(descendantId);
-          }
-          return next;
-        });
+        next.delete(message.id);
+        for (const descendantId of descendantIds) {
+          next.delete(descendantId);
+        }
+      } else {
+        next.add(message.id);
+      }
+      setExpandedThreadReplyIds(next);
+      onExpandedThreadReplyIdsChangeRef.current?.(next);
+
+      if (!next.has(message.id)) {
         return;
       }
 
       const firstReplyId = getFirstReplyIdRef.current(message.id);
-      setExpandedThreadReplyIds((current) => {
-        const next = new Set(current);
-        next.add(message.id);
-        return next;
-      });
 
       // Drilling into a branch reveals only its direct replies (LP4 v3
       // open-at-level): mark exactly those read, never the whole subtree. A

--- a/desktop/src/features/channels/usePinnedThreadExpansionPersistence.ts
+++ b/desktop/src/features/channels/usePinnedThreadExpansionPersistence.ts
@@ -1,0 +1,72 @@
+import * as React from "react";
+
+import type { ThreadRail } from "@/features/channels/useThreadRail";
+
+type PinnedThreadExpansionParams = {
+  activeChannelId: string | null;
+  effectiveOpenThreadHeadId: string | null;
+  threadRail: ThreadRail;
+};
+
+export function usePinnedThreadExpandedReplyIdsChange({
+  activeChannelId,
+  effectiveOpenThreadHeadId,
+  threadRail,
+}: PinnedThreadExpansionParams) {
+  return React.useCallback(
+    (expandedReplyIds: ReadonlySet<string>) => {
+      if (!activeChannelId || !effectiveOpenThreadHeadId) return;
+      const pin = threadRail.pins.find(
+        (candidate) =>
+          candidate.channelId === activeChannelId &&
+          candidate.rootId === effectiveOpenThreadHeadId,
+      );
+      if (pin) {
+        threadRail.updateExpandedReplyIds(pin, [...expandedReplyIds]);
+      }
+    },
+    [activeChannelId, effectiveOpenThreadHeadId, threadRail],
+  );
+}
+
+export function useRestorePinnedThreadExpansion({
+  activeChannelId,
+  effectiveOpenThreadHeadId,
+  setExpandedThreadReplyIds,
+  threadRail,
+  threadRouteTargetReady,
+}: PinnedThreadExpansionParams & {
+  setExpandedThreadReplyIds: React.Dispatch<React.SetStateAction<Set<string>>>;
+  threadRouteTargetReady: boolean;
+}) {
+  const restoredPinKeyRef = React.useRef<string | null>(null);
+
+  React.useEffect(() => {
+    if (!threadRouteTargetReady) return;
+    const pin = threadRail.pins.find(
+      (candidate) =>
+        candidate.channelId === activeChannelId &&
+        candidate.rootId === effectiveOpenThreadHeadId,
+    );
+    if (!pin) {
+      restoredPinKeyRef.current = null;
+      return;
+    }
+
+    const pinKey = `${pin.channelId}\u0000${pin.rootId}`;
+    if (restoredPinKeyRef.current === pinKey) return;
+
+    // Register this after the generic thread-reset hooks: a pinned destination
+    // restores only after ordinary channel navigation has cleared expansion.
+    restoredPinKeyRef.current = pinKey;
+    setExpandedThreadReplyIds(
+      (current) => new Set([...current, ...(pin.expandedReplyIds ?? [])]),
+    );
+  }, [
+    activeChannelId,
+    effectiveOpenThreadHeadId,
+    setExpandedThreadReplyIds,
+    threadRail.pins,
+    threadRouteTargetReady,
+  ]);
+}

--- a/desktop/src/features/channels/useThreadRail.test.mjs
+++ b/desktop/src/features/channels/useThreadRail.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  installDOMShim,
+  installFreshStorage,
+} from "./observedUnreadTestHarness.mjs";
+
+installDOMShim();
+installFreshStorage();
+
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import {
+  readThreadRailStore,
+  threadRailStorageKey,
+  writeThreadRailStore,
+} from "./threadRailStorage.ts";
+import { useThreadRail } from "./useThreadRail.ts";
+
+const RELAY_A = "wss://relay-a.example.com";
+const RELAY_B = "wss://relay-b.example.com";
+const SCOPE_A = { pubkey: "pubkey-a", relayUrl: RELAY_A };
+const SCOPE_B = { pubkey: "pubkey-b", relayUrl: RELAY_A };
+const SCOPE_C = { pubkey: "pubkey-a", relayUrl: RELAY_B };
+const PIN_A = { channelId: "channel-a", rootId: "root-a", pinnedAt: 100 };
+const PIN_B = { channelId: "channel-b", rootId: "root-b", pinnedAt: 200 };
+
+async function mountHook(props) {
+  const apiRef = { current: null };
+
+  function Harness({ pubkey, relayUrl }) {
+    apiRef.current = useThreadRail(pubkey, relayUrl);
+    return null;
+  }
+
+  const root = createRoot(document.createElement("div"));
+  const render = async (nextProps) => {
+    await act(async () => {
+      root.render(React.createElement(Harness, nextProps));
+    });
+  };
+  await render(props);
+
+  return {
+    get api() {
+      return apiRef.current;
+    },
+    render,
+    unmount: async () => {
+      await act(async () => root.unmount());
+    },
+  };
+}
+
+test("no scope exposes empty uncollapsed defaults", async () => {
+  installFreshStorage();
+  const harness = await mountHook({ pubkey: null, relayUrl: RELAY_A });
+
+  assert.deepEqual(harness.api.pins, []);
+  assert.equal(harness.api.collapsed, false);
+  assert.equal(harness.api.isScoped, false);
+
+  await harness.unmount();
+});
+
+test("hydrates pins and collapse preference from the active scope", async () => {
+  installFreshStorage();
+  writeThreadRailStore(SCOPE_A, { version: 1, pins: [PIN_A], collapsed: true });
+
+  const harness = await mountHook({
+    pubkey: SCOPE_A.pubkey,
+    relayUrl: SCOPE_A.relayUrl,
+  });
+
+  assert.deepEqual(harness.api.pins, [PIN_A]);
+  assert.equal(harness.api.collapsed, true);
+  assert.equal(harness.api.isScoped, true);
+
+  await harness.unmount();
+});
+
+test("updates the existing canonical pin return anchor without changing its order", async () => {
+  installFreshStorage();
+  const harness = await mountHook({
+    pubkey: SCOPE_A.pubkey,
+    relayUrl: SCOPE_A.relayUrl,
+  });
+
+  await act(async () => harness.api.pin(PIN_A));
+  await act(async () => harness.api.pin(PIN_B));
+  await act(async () => harness.api.updateAnchor(PIN_A, "nested-reply-a"));
+
+  assert.deepEqual(harness.api.pins, [
+    { ...PIN_A, returnAnchorId: "nested-reply-a" },
+    PIN_B,
+  ]);
+  assert.deepEqual(readThreadRailStore(SCOPE_A).pins, harness.api.pins);
+
+  await harness.unmount();
+});
+
+test("pin, unpin, and toggle persist while retaining in-memory state after a write failure", async () => {
+  const storage = installFreshStorage();
+  const harness = await mountHook({
+    pubkey: SCOPE_A.pubkey,
+    relayUrl: SCOPE_A.relayUrl,
+  });
+
+  await act(async () => harness.api.pin(PIN_A));
+  assert.deepEqual(readThreadRailStore(SCOPE_A).pins, [PIN_A]);
+
+  await act(async () => harness.api.toggleCollapsed());
+  assert.equal(readThreadRailStore(SCOPE_A).collapsed, true);
+
+  await act(async () => harness.api.unpin(PIN_A));
+  assert.deepEqual(readThreadRailStore(SCOPE_A).pins, []);
+
+  const originalSetItem = storage.setItem;
+  const originalConsoleWarn = console.warn;
+  storage.setItem = () => {
+    throw new Error("storage unavailable");
+  };
+  console.warn = () => {};
+  try {
+    await act(async () => harness.api.pin(PIN_B));
+    assert.deepEqual(harness.api.pins, [PIN_B]);
+  } finally {
+    storage.setItem = originalSetItem;
+    console.warn = originalConsoleWarn;
+  }
+
+  await harness.unmount();
+});
+
+test("switching pubkey or relay reloads only the new scope without exposing prior pins", async () => {
+  installFreshStorage();
+  writeThreadRailStore(SCOPE_A, { version: 1, pins: [PIN_A], collapsed: true });
+  writeThreadRailStore(SCOPE_B, {
+    version: 1,
+    pins: [PIN_B],
+    collapsed: false,
+  });
+  writeThreadRailStore(SCOPE_C, { version: 1, pins: [], collapsed: false });
+
+  const harness = await mountHook({
+    pubkey: SCOPE_A.pubkey,
+    relayUrl: SCOPE_A.relayUrl,
+  });
+  assert.deepEqual(harness.api.pins, [PIN_A]);
+
+  await harness.render({ pubkey: SCOPE_B.pubkey, relayUrl: SCOPE_B.relayUrl });
+  assert.deepEqual(harness.api.pins, [PIN_B]);
+  assert.equal(harness.api.collapsed, false);
+
+  await harness.render({ pubkey: SCOPE_C.pubkey, relayUrl: SCOPE_C.relayUrl });
+  assert.deepEqual(harness.api.pins, []);
+  assert.equal(harness.api.collapsed, false);
+  assert.deepEqual(readThreadRailStore(SCOPE_A).pins, [PIN_A]);
+  assert.deepEqual(readThreadRailStore(SCOPE_B).pins, [PIN_B]);
+  assert.equal(
+    globalThis.localStorage.getItem(threadRailStorageKey(SCOPE_C)) !== null,
+    true,
+  );
+
+  await harness.unmount();
+});

--- a/desktop/src/features/channels/useThreadRail.ts
+++ b/desktop/src/features/channels/useThreadRail.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_THREAD_RAIL_STORE,
   addThreadRailPin,
   readThreadRailStore,
+  renameThreadRailPin,
   removeThreadRailPin,
   toggleThreadRailCollapsed,
   updateThreadRailExpandedReplyIds,
@@ -34,6 +35,10 @@ export type ThreadRail = {
   collapsed: boolean;
   isScoped: boolean;
   pin: (pin: ThreadRailPin) => void;
+  rename: (
+    pin: Pick<ThreadRailPin, "channelId" | "rootId">,
+    customTitle: string,
+  ) => void;
   unpin: (pin: Pick<ThreadRailPin, "channelId" | "rootId">) => void;
   updateAnchor: (
     pin: Pick<ThreadRailPin, "channelId" | "rootId">,
@@ -93,6 +98,16 @@ export function useThreadRail(
       updateStore((store) => addThreadRailPin(store, pinToAdd)),
     [updateStore],
   );
+  const rename = React.useCallback(
+    (
+      pinToRename: Pick<ThreadRailPin, "channelId" | "rootId">,
+      customTitle: string,
+    ) =>
+      updateStore((store) =>
+        renameThreadRailPin(store, pinToRename, customTitle),
+      ),
+    [updateStore],
+  );
   const unpin = React.useCallback(
     (pinToRemove: Pick<ThreadRailPin, "channelId" | "rootId">) =>
       updateStore((store) => removeThreadRailPin(store, pinToRemove)),
@@ -133,6 +148,7 @@ export function useThreadRail(
       collapsed: store.collapsed,
       isScoped: scope !== null,
       pin,
+      rename,
       unpin,
       updateAnchor,
       updateExpandedReplyIds,
@@ -140,6 +156,7 @@ export function useThreadRail(
     }),
     [
       pin,
+      rename,
       scope,
       store,
       toggleCollapsed,

--- a/desktop/src/features/channels/useThreadRail.ts
+++ b/desktop/src/features/channels/useThreadRail.ts
@@ -86,8 +86,9 @@ export function useThreadRail(
       setRailState((current) => {
         if (current.scopeKey !== currentScopeKey) return current;
         const store = update(current.store);
+        if (store === current.store) return current;
         writeThreadRailStore(scope, store);
-        return store === current.store ? current : { ...current, store };
+        return { ...current, store };
       });
     },
     [currentScopeKey, scope],

--- a/desktop/src/features/channels/useThreadRail.ts
+++ b/desktop/src/features/channels/useThreadRail.ts
@@ -1,0 +1,151 @@
+import * as React from "react";
+
+import {
+  DEFAULT_THREAD_RAIL_STORE,
+  addThreadRailPin,
+  readThreadRailStore,
+  removeThreadRailPin,
+  toggleThreadRailCollapsed,
+  updateThreadRailExpandedReplyIds,
+  updateThreadRailPinAnchor,
+  writeThreadRailStore,
+  type ThreadRailPin,
+  type ThreadRailScope,
+  type ThreadRailStore,
+} from "./threadRailStorage";
+
+type RailState = {
+  scopeKey: string;
+  store: ThreadRailStore;
+};
+
+const NO_SCOPE_KEY = "";
+
+function scopeKey(
+  pubkey: string | null | undefined,
+  relayUrl: string | null | undefined,
+): string {
+  return pubkey && relayUrl ? `${pubkey}\u0000${relayUrl}` : NO_SCOPE_KEY;
+}
+
+/** Local thread-rail state and mutations for one pubkey-and-relay scope. */
+export type ThreadRail = {
+  pins: ThreadRailPin[];
+  collapsed: boolean;
+  isScoped: boolean;
+  pin: (pin: ThreadRailPin) => void;
+  unpin: (pin: Pick<ThreadRailPin, "channelId" | "rootId">) => void;
+  updateAnchor: (
+    pin: Pick<ThreadRailPin, "channelId" | "rootId">,
+    returnAnchorId: string,
+  ) => void;
+  updateExpandedReplyIds: (
+    pin: Pick<ThreadRailPin, "channelId" | "rootId">,
+    expandedReplyIds: readonly string[],
+  ) => void;
+  toggleCollapsed: () => void;
+};
+
+/**
+ * Keeps thread-rail preferences local to the current identity and relay.
+ * A scope transition hides the previous scope immediately, then hydrates the
+ * new scope from storage. Failed persistence never rolls back local state.
+ */
+export function useThreadRail(
+  pubkey: string | null | undefined,
+  relayUrl: string | null | undefined,
+): ThreadRail {
+  const currentScopeKey = scopeKey(pubkey, relayUrl);
+  const scope = React.useMemo(
+    () =>
+      pubkey && relayUrl
+        ? ({ pubkey, relayUrl } satisfies ThreadRailScope)
+        : null,
+    [pubkey, relayUrl],
+  );
+  const [railState, setRailState] = React.useState<RailState>({
+    scopeKey: NO_SCOPE_KEY,
+    store: DEFAULT_THREAD_RAIL_STORE,
+  });
+
+  React.useEffect(() => {
+    setRailState({
+      scopeKey: currentScopeKey,
+      store: scope ? readThreadRailStore(scope) : DEFAULT_THREAD_RAIL_STORE,
+    });
+  }, [currentScopeKey, scope]);
+
+  const updateStore = React.useCallback(
+    (update: (store: ThreadRailStore) => ThreadRailStore) => {
+      if (!scope) return;
+      setRailState((current) => {
+        if (current.scopeKey !== currentScopeKey) return current;
+        const store = update(current.store);
+        writeThreadRailStore(scope, store);
+        return store === current.store ? current : { ...current, store };
+      });
+    },
+    [currentScopeKey, scope],
+  );
+
+  const pin = React.useCallback(
+    (pinToAdd: ThreadRailPin) =>
+      updateStore((store) => addThreadRailPin(store, pinToAdd)),
+    [updateStore],
+  );
+  const unpin = React.useCallback(
+    (pinToRemove: Pick<ThreadRailPin, "channelId" | "rootId">) =>
+      updateStore((store) => removeThreadRailPin(store, pinToRemove)),
+    [updateStore],
+  );
+  const updateAnchor = React.useCallback(
+    (
+      pinToUpdate: Pick<ThreadRailPin, "channelId" | "rootId">,
+      returnAnchorId: string,
+    ) =>
+      updateStore((store) =>
+        updateThreadRailPinAnchor(store, pinToUpdate, returnAnchorId),
+      ),
+    [updateStore],
+  );
+  const updateExpandedReplyIds = React.useCallback(
+    (
+      pinToUpdate: Pick<ThreadRailPin, "channelId" | "rootId">,
+      expandedReplyIds: readonly string[],
+    ) =>
+      updateStore((store) =>
+        updateThreadRailExpandedReplyIds(store, pinToUpdate, expandedReplyIds),
+      ),
+    [updateStore],
+  );
+  const toggleCollapsed = React.useCallback(
+    () => updateStore(toggleThreadRailCollapsed),
+    [updateStore],
+  );
+
+  const store =
+    railState.scopeKey === currentScopeKey
+      ? railState.store
+      : DEFAULT_THREAD_RAIL_STORE;
+  return React.useMemo(
+    () => ({
+      pins: store.pins,
+      collapsed: store.collapsed,
+      isScoped: scope !== null,
+      pin,
+      unpin,
+      updateAnchor,
+      updateExpandedReplyIds,
+      toggleCollapsed,
+    }),
+    [
+      pin,
+      scope,
+      store,
+      toggleCollapsed,
+      unpin,
+      updateAnchor,
+      updateExpandedReplyIds,
+    ],
+  );
+}

--- a/desktop/src/features/channels/useThreadTargetSync.ts
+++ b/desktop/src/features/channels/useThreadTargetSync.ts
@@ -21,6 +21,7 @@ export function useThreadTargetSync({
   setOpenThreadHeadId,
   setThreadReplyTargetId,
   setThreadScrollTargetId,
+  suppressDefaultReplyTarget = false,
   threadReplyTargetId,
   threadReplyTargetMessage,
 }: {
@@ -35,6 +36,7 @@ export function useThreadTargetSync({
   setOpenThreadHeadId: PanelValueSetter;
   setThreadReplyTargetId: (id: string | null) => void;
   setThreadScrollTargetId: (id: string | null) => void;
+  suppressDefaultReplyTarget?: boolean;
   threadReplyTargetId: string | null;
   threadReplyTargetMessage: TimelineMessage | null;
 }) {
@@ -50,7 +52,11 @@ export function useThreadTargetSync({
       return;
     }
 
-    if (openThreadHeadMessage && !threadReplyTargetId) {
+    if (
+      openThreadHeadMessage &&
+      !threadReplyTargetId &&
+      !suppressDefaultReplyTarget
+    ) {
       setThreadReplyTargetId(openThreadHeadMessage.id);
       return;
     }
@@ -73,6 +79,7 @@ export function useThreadTargetSync({
     setOpenThreadHeadId,
     setThreadReplyTargetId,
     setThreadScrollTargetId,
+    suppressDefaultReplyTarget,
     threadReplyTargetId,
     threadReplyTargetMessage,
   ]);

--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -834,16 +834,19 @@ export function useUnreadChannels(
         const nativeProjection = observedPersistence.isNative()
           ? observedPersistence.projectionsRef.current.get(channel.id)
           : undefined;
+        for (const rootId of nativeProjection?.unreadRootIds ?? []) {
+          unreadThreadRoots.add(rootId);
+        }
         const unreadCount = observedPersistence.isNative()
           ? (nativeProjection?.count ?? 0)
           : latestByChannelRef.current.get(channel.id) === undefined
             ? 0
             : countUnreadObservedEvents(observedEvents, readAtForObservedEvent);
         for (const event of observedEvents?.values() ?? []) {
+          const eventReadAt = readAtForObservedEvent(event);
           if (
             event.rootId !== null &&
-            (readAtForObservedEvent(event) === null ||
-              event.createdAt > readAtForObservedEvent(event)!)
+            (eventReadAt === null || event.createdAt > eventReadAt)
           ) {
             unreadThreadRoots.add(event.rootId);
           }

--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -797,6 +797,7 @@ export function useUnreadChannels(
       if (!isReadStateReady || !observedPersistence.isScopeLoaded()) {
         return {
           unreadChannelIds: new Set<string>(),
+          unreadThreadRootIds: new Set<string>(),
           topLevelUnreadChannelIds: new Set<string>(),
           highPriorityUnreadChannelIds: new Set<string>(),
           unreadChannelCounts: new Map<string, number>(),
@@ -805,6 +806,7 @@ export function useUnreadChannels(
       }
 
       const unread = new Set<string>();
+      const unreadThreadRoots = new Set<string>();
       const topLevelUnread = new Set<string>();
       const highPriority = new Set<string>();
       const counts = new Map<string, number>();
@@ -837,6 +839,15 @@ export function useUnreadChannels(
           : latestByChannelRef.current.get(channel.id) === undefined
             ? 0
             : countUnreadObservedEvents(observedEvents, readAtForObservedEvent);
+        for (const event of observedEvents?.values() ?? []) {
+          if (
+            event.rootId !== null &&
+            (readAtForObservedEvent(event) === null ||
+              event.createdAt > readAtForObservedEvent(event)!)
+          ) {
+            unreadThreadRoots.add(event.rootId);
+          }
+        }
         if (unreadCount === 0) {
           if (!isForcedUnread) continue;
           unread.add(channel.id);
@@ -890,6 +901,7 @@ export function useUnreadChannels(
 
       return {
         unreadChannelIds: unread,
+        unreadThreadRootIds: unreadThreadRoots,
         topLevelUnreadChannelIds: topLevelUnread,
         highPriorityUnreadChannelIds: highPriority,
         unreadChannelCounts: counts,
@@ -906,6 +918,7 @@ export function useUnreadChannels(
     ]);
 
   const unreadChannelIds = useStableSet(rawUnread.unreadChannelIds);
+  const unreadThreadRootIds = useStableSet(rawUnread.unreadThreadRootIds);
   const topLevelUnreadChannelIds = useStableSet(
     rawUnread.topLevelUnreadChannelIds,
   );
@@ -965,6 +978,7 @@ export function useUnreadChannels(
 
   return {
     unreadChannelIds,
+    unreadThreadRootIds,
     topLevelUnreadChannelIds,
     unreadChannelCounts,
     highPriorityUnreadChannelIds,

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -38,10 +38,9 @@ import { Separator } from "@/shared/ui/separator";
 import { ComposerActivityAccessory } from "./ComposerActivityAccessory";
 import { ComposerDockBackdrop } from "./ComposerDockBackdrop";
 import { MessageComposer } from "./MessageComposer";
-import {
-  MessageThreadPanelHeader,
-  ThreadMessageSkeleton,
-} from "./MessageThreadPanelSkeleton";
+import { MessageThreadPanelHeader } from "./MessageThreadPanelHeader";
+import { ThreadMessageSkeleton } from "./MessageThreadPanelSkeleton";
+import { ThreadScrollToLatestButton } from "./ThreadScrollToLatestButton";
 import { MessageRow, type ThreadDepthGuideAction } from "./MessageRow";
 import { MessageThreadSummaryRow } from "./MessageThreadSummaryRow";
 import { TypingIndicatorRow } from "./TypingIndicatorRow";
@@ -49,6 +48,7 @@ import { UnreadDivider } from "./UnreadDivider";
 import { useComposerHeightPadding } from "./useComposerHeightPadding";
 import { useStableSendToChannel } from "./useStableSendToChannel";
 import { useAnchoredScroll } from "./useAnchoredScroll";
+import { usePinnedThreadAnchorTracking } from "./usePinnedThreadAnchorTracking";
 import { selectDeferredListRenderState } from "@/features/messages/lib/timelineSnapshot";
 
 type MessageThreadPanelProps = ThreadPanelLayoutProps & {
@@ -57,6 +57,7 @@ type MessageThreadPanelProps = ThreadPanelLayoutProps & {
   channelName: string;
   currentPubkey?: string;
   disabled?: boolean;
+  expandedReplyIds: ReadonlySet<string>;
   firstUnreadReplyId?: string | null;
   huddleMemberPubkeys?: readonly string[];
   huddleMemberPubkeysPending?: boolean;
@@ -192,6 +193,7 @@ export function MessageThreadPanel({
   columnMaxWidthPx,
   currentPubkey,
   disabled = false,
+  expandedReplyIds,
   firstUnreadReplyId,
   huddleMemberPubkeys,
   huddleMemberPubkeysPending = false,
@@ -261,6 +263,16 @@ export function MessageThreadPanel({
   >(null);
   const isOverlay = useIsThreadPanelOverlay();
   const threadHeadId = threadHead?.id ?? null;
+  const handleSelectReplyTarget = usePinnedThreadAnchorTracking({
+    channelId,
+    onSelectReplyTarget,
+    threadHeadId,
+  });
+  const handleExpandReplies = usePinnedThreadAnchorTracking({
+    channelId,
+    onSelectReplyTarget: onExpandReplies,
+    threadHeadId,
+  });
   useEscapeKey(
     onClose,
     !isHuddleTranscript && (isOverlay || isSinglePanelView || isFocusMode),
@@ -315,9 +327,9 @@ export function MessageThreadPanel({
         return;
       }
 
-      onExpandReplies(message);
+      handleExpandReplies(message);
     },
-    [collapseThreadHeadReplies, onExpandReplies, threadHeadId],
+    [collapseThreadHeadReplies, handleExpandReplies, threadHeadId],
   );
 
   const composerReplyTarget =
@@ -564,6 +576,15 @@ export function MessageThreadPanel({
   if (!threadHead) {
     return null;
   }
+  const pinReturnAnchorId = (() => {
+    const candidateId = scrollTargetId ?? replyTargetMessage?.id;
+    if (!candidateId || candidateId === threadHead.id) return undefined;
+    const candidate =
+      deferredThreadReplies.find((entry) => entry.message.id === candidateId)
+        ?.message ??
+      (replyTargetMessage?.id === candidateId ? replyTargetMessage : null);
+    return candidate ? candidate.id : undefined;
+  })();
   const threadScrollRegion = (
     <AuxiliaryPanelBody
       className="overflow-y-auto overflow-x-hidden overscroll-contain pb-24"
@@ -763,7 +784,7 @@ export function MessageThreadPanel({
                           shouldShowThreadBranchGuides &&
                           connectsToVisibleChild &&
                           !entry.summary
-                            ? onExpandReplies
+                            ? handleExpandReplies
                             : undefined
                         }
                         onCollapseDescendantsHoverChange={
@@ -791,7 +812,7 @@ export function MessageThreadPanel({
                         }
                         onMarkUnread={onMarkUnread}
                         onMarkRead={onMarkRead}
-                        onReply={onSelectReplyTarget}
+                        onReply={handleSelectReplyTarget}
                         onSendToChannel={stableSendToChannel}
                         onToggleReaction={onToggleReaction}
                         profiles={profiles}
@@ -818,7 +839,7 @@ export function MessageThreadPanel({
                           onCollapseDepthGuideHoverChange={
                             handleCollapseBranchHoverChange
                           }
-                          onOpenThread={onExpandReplies}
+                          onOpenThread={handleExpandReplies}
                           summary={entry.summary}
                           summaryIndentOffsetRem={
                             THREAD_PANEL_SUMMARY_INDENT_OFFSET_REM
@@ -857,23 +878,11 @@ export function MessageThreadPanel({
 
   const threadFooter = (
     <>
-      {!isAtBottom ? (
-        <div className="pointer-events-none absolute inset-x-0 bottom-36 z-50 flex justify-center px-4">
-          <Button
-            className="pointer-events-auto h-7 min-h-7 gap-1.5 rounded-full border-border/50 bg-background/85 px-2.5 text-2xs font-medium text-muted-foreground shadow-xs backdrop-blur-sm hover:bg-muted/70 hover:text-foreground [&_svg]:size-4"
-            data-testid="thread-scroll-to-latest"
-            onClick={() => scrollToBottom("smooth")}
-            size="sm"
-            type="button"
-            variant="outline"
-          >
-            <ArrowDown aria-hidden />
-            {newMessageCount > 0
-              ? `${newMessageCount} new message${newMessageCount === 1 ? "" : "s"}`
-              : "Jump to latest"}
-          </Button>
-        </div>
-      ) : null}
+      <ThreadScrollToLatestButton
+        isAtBottom={isAtBottom}
+        newMessageCount={newMessageCount}
+        onScrollToBottom={() => scrollToBottom("smooth")}
+      />
 
       <div
         className="pointer-events-none absolute inset-x-0 bottom-0 z-40 isolate before:absolute before:inset-x-0 before:bottom-0 before:-z-10 before:h-24 before:bg-gradient-to-b before:from-transparent before:to-background before:content-[''] after:absolute after:inset-x-0 after:bottom-0 after:-z-10 after:h-12 after:bg-background after:content-['']"
@@ -970,6 +979,9 @@ export function MessageThreadPanel({
         header={
           isHuddleTranscript ? undefined : (
             <MessageThreadPanelHeader
+              channelId={channelId}
+              channelName={channelName}
+              expandedReplyIds={expandedReplyIds}
               headerLeading={headerLeading}
               headerTitle={headerTitle}
               headerTitleAriaLabel={headerTitleAriaLabel}
@@ -977,7 +989,9 @@ export function MessageThreadPanel({
               isSinglePanelView={isSinglePanelView}
               onClose={onClose}
               onHeaderTitleClick={onHeaderTitleClick}
+              returnAnchorId={pinReturnAnchorId}
               showBackButton={showBackButton}
+              threadHead={threadHead}
             />
           )
         }

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { ArrowDown } from "lucide-react";
 
 import { useKnownAgentPubkeys } from "@/features/agents/useKnownAgentPubkeys";
 import { HuddleTranscriptIntro } from "@/features/huddle/components/HuddleTranscriptIntro";
@@ -33,7 +32,6 @@ import {
   THREAD_PANEL_COMPOSER_GUTTER_CLASS,
   THREAD_PANEL_MESSAGE_GUTTER_CLASS,
 } from "@/features/messages/lib/messageThreadPanelLayout";
-import { Button } from "@/shared/ui/button";
 import { Separator } from "@/shared/ui/separator";
 import { ComposerActivityAccessory } from "./ComposerActivityAccessory";
 import { ComposerDockBackdrop } from "./ComposerDockBackdrop";
@@ -57,7 +55,7 @@ type MessageThreadPanelProps = ThreadPanelLayoutProps & {
   channelName: string;
   currentPubkey?: string;
   disabled?: boolean;
-  expandedReplyIds: ReadonlySet<string>;
+  expandedReplyIds?: ReadonlySet<string>;
   firstUnreadReplyId?: string | null;
   huddleMemberPubkeys?: readonly string[];
   huddleMemberPubkeysPending?: boolean;
@@ -193,7 +191,7 @@ export function MessageThreadPanel({
   columnMaxWidthPx,
   currentPubkey,
   disabled = false,
-  expandedReplyIds,
+  expandedReplyIds = new Set(),
   firstUnreadReplyId,
   huddleMemberPubkeys,
   huddleMemberPubkeysPending = false,

--- a/desktop/src/features/messages/ui/MessageThreadPanelHeader.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanelHeader.tsx
@@ -1,0 +1,108 @@
+import type * as React from "react";
+import { Pin } from "lucide-react";
+
+import {
+  makeThreadRailPin,
+  useThreadRailContext,
+} from "@/features/channels/ThreadRailContext";
+import type { TimelineMessage } from "@/features/messages/types";
+import {
+  AuxiliaryPanelHeader,
+  AuxiliaryPanelHeaderGroup,
+  AuxiliaryPanelTitle,
+} from "@/shared/layout/AuxiliaryPanel";
+import { Button } from "@/shared/ui/button";
+
+export function MessageThreadPanelHeader({
+  channelId,
+  channelName,
+  expandedReplyIds,
+  headerLeading,
+  headerTitle = "Thread",
+  headerTitleAriaLabel,
+  isFocusMode,
+  isSinglePanelView,
+  onClose,
+  onHeaderTitleClick,
+  returnAnchorId,
+  showBackButton,
+  threadHead,
+}: {
+  channelId: string | null;
+  channelName: string;
+  expandedReplyIds: ReadonlySet<string>;
+  headerLeading?: React.ReactNode;
+  headerTitle?: string;
+  headerTitleAriaLabel?: string;
+  isFocusMode: boolean;
+  isSinglePanelView: boolean;
+  onClose: () => void;
+  onHeaderTitleClick?: () => void;
+  returnAnchorId: string | undefined;
+  showBackButton?: boolean;
+  threadHead: TimelineMessage;
+}) {
+  const threadRail = useThreadRailContext();
+  const isPinned =
+    channelId !== null &&
+    threadRail.pins.some(
+      (pin) => pin.channelId === channelId && pin.rootId === threadHead.id,
+    );
+
+  const title = onHeaderTitleClick ? (
+    <button
+      aria-label={headerTitleAriaLabel ?? `Open ${headerTitle}`}
+      className="min-w-0 max-w-full truncate text-left hover:underline"
+      data-testid="message-thread-open-channel"
+      onClick={onHeaderTitleClick}
+      title={headerTitleAriaLabel ?? `Open ${headerTitle}`}
+      type="button"
+    >
+      {headerTitle}
+    </button>
+  ) : (
+    headerTitle
+  );
+
+  return (
+    <AuxiliaryPanelHeader backdrop>
+      <AuxiliaryPanelHeaderGroup
+        backButtonAriaLabel="Back to conversation"
+        backButtonTestId="message-thread-back"
+        leading={headerLeading}
+        onBack={
+          (showBackButton ?? (isSinglePanelView && !isFocusMode))
+            ? onClose
+            : undefined
+        }
+      >
+        <AuxiliaryPanelTitle>{title}</AuxiliaryPanelTitle>
+        {threadRail.isScoped && channelId ? (
+        <Button
+          aria-label={isPinned ? "Thread pinned" : "Pin to thread rail"}
+          aria-pressed={isPinned}
+          data-testid="pin-thread-to-rail"
+          disabled={isPinned}
+          onClick={() =>
+            threadRail.pin(
+              makeThreadRailPin({
+                channelId,
+                channelName,
+                rootExcerpt: threadHead.body.slice(0, 96),
+                rootId: threadHead.id,
+                returnAnchorId: returnAnchorId ?? undefined,
+                expandedReplyIds: [...expandedReplyIds],
+              }),
+            )
+          }
+          size="icon-xs"
+          type="button"
+          variant="ghost"
+        >
+          <Pin aria-hidden />
+        </Button>
+        ) : null}
+      </AuxiliaryPanelHeaderGroup>
+    </AuxiliaryPanelHeader>
+  );
+}

--- a/desktop/src/features/messages/ui/MessageThreadPanelHeader.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanelHeader.tsx
@@ -78,29 +78,29 @@ export function MessageThreadPanelHeader({
       >
         <AuxiliaryPanelTitle>{title}</AuxiliaryPanelTitle>
         {threadRail.isScoped && channelId ? (
-        <Button
-          aria-label={isPinned ? "Thread pinned" : "Pin to thread rail"}
-          aria-pressed={isPinned}
-          data-testid="pin-thread-to-rail"
-          disabled={isPinned}
-          onClick={() =>
-            threadRail.pin(
-              makeThreadRailPin({
-                channelId,
-                channelName,
-                rootExcerpt: threadHead.body.slice(0, 96),
-                rootId: threadHead.id,
-                returnAnchorId: returnAnchorId ?? undefined,
-                expandedReplyIds: [...expandedReplyIds],
-              }),
-            )
-          }
-          size="icon-xs"
-          type="button"
-          variant="ghost"
-        >
-          <Pin aria-hidden />
-        </Button>
+          <Button
+            aria-label={isPinned ? "Thread pinned" : "Pin to thread rail"}
+            aria-pressed={isPinned}
+            data-testid="pin-thread-to-rail"
+            disabled={isPinned}
+            onClick={() =>
+              threadRail.pin(
+                makeThreadRailPin({
+                  channelId,
+                  channelName,
+                  rootExcerpt: threadHead.body.slice(0, 96),
+                  rootId: threadHead.id,
+                  returnAnchorId: returnAnchorId ?? undefined,
+                  expandedReplyIds: [...expandedReplyIds],
+                }),
+              )
+            }
+            size="icon-xs"
+            type="button"
+            variant="ghost"
+          >
+            <Pin aria-hidden />
+          </Button>
         ) : null}
       </AuxiliaryPanelHeaderGroup>
     </AuxiliaryPanelHeader>

--- a/desktop/src/features/messages/ui/ThreadScrollToLatestButton.tsx
+++ b/desktop/src/features/messages/ui/ThreadScrollToLatestButton.tsx
@@ -1,0 +1,33 @@
+import { ArrowDown } from "lucide-react";
+
+import { Button } from "@/shared/ui/button";
+
+export function ThreadScrollToLatestButton({
+  isAtBottom,
+  newMessageCount,
+  onScrollToBottom,
+}: {
+  isAtBottom: boolean;
+  newMessageCount: number;
+  onScrollToBottom: () => void;
+}) {
+  if (isAtBottom) return null;
+
+  return (
+    <div className="pointer-events-none absolute inset-x-0 bottom-36 z-50 flex justify-center px-4">
+      <Button
+        className="pointer-events-auto h-7 min-h-7 gap-1.5 rounded-full border-border/50 bg-background/85 px-2.5 text-2xs font-medium text-muted-foreground shadow-xs backdrop-blur-sm hover:bg-muted/70 hover:text-foreground [&_svg]:size-4"
+        data-testid="thread-scroll-to-latest"
+        onClick={onScrollToBottom}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
+        <ArrowDown aria-hidden />
+        {newMessageCount > 0
+          ? `${newMessageCount} new message${newMessageCount === 1 ? "" : "s"}`
+          : "Jump to latest"}
+      </Button>
+    </div>
+  );
+}

--- a/desktop/src/features/messages/ui/usePinnedThreadAnchorTracking.ts
+++ b/desktop/src/features/messages/ui/usePinnedThreadAnchorTracking.ts
@@ -1,0 +1,35 @@
+import * as React from "react";
+
+import { useThreadRailContext } from "@/features/channels/ThreadRailContext";
+import { getThreadRailAnchorUpdate } from "@/features/channels/threadRailAnchor";
+import type { TimelineMessage } from "@/features/messages/types";
+
+export function usePinnedThreadAnchorTracking({
+  channelId,
+  onSelectReplyTarget,
+  threadHeadId,
+}: {
+  channelId: string | null;
+  onSelectReplyTarget: (message: TimelineMessage) => void;
+  threadHeadId: string | null;
+}) {
+  const threadRail = useThreadRailContext();
+
+  return React.useCallback(
+    (message: TimelineMessage) => {
+      const update = getThreadRailAnchorUpdate(
+        threadRail.pins,
+        channelId,
+        threadHeadId,
+        // Rows rendered here belong to the current canonical thread even when
+        // a locally expanded TimelineMessage omits rootId.
+        { ...message, rootId: threadHeadId },
+      );
+      if (update) {
+        threadRail.updateAnchor(update.pin, update.returnAnchorId);
+      }
+      onSelectReplyTarget(message);
+    },
+    [channelId, onSelectReplyTarget, threadHeadId, threadRail],
+  );
+}

--- a/desktop/src/shared/api/tauriObservedUnread.ts
+++ b/desktop/src/shared/api/tauriObservedUnread.ts
@@ -6,6 +6,7 @@ export type ObservedUnreadProjection = {
   channelId: string;
   latest: number;
   count: number;
+  unreadRootIds: string[];
   badgeCount: number;
   appBadgeCount: number;
   topLevelUnread: boolean;

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -3172,6 +3172,7 @@ function mockObservedUnreadProjections(
       channelId,
       latest,
       count: 0,
+      unreadRootIds: [],
       badgeCount: 0,
       appBadgeCount: 0,
       topLevelUnread: false,
@@ -3194,6 +3195,7 @@ function mockObservedUnreadProjections(
       channelId: event.channelId,
       latest: 0,
       count: 0,
+      unreadRootIds: [],
       badgeCount: 0,
       appBadgeCount: 0,
       topLevelUnread: false,
@@ -3201,6 +3203,9 @@ function mockObservedUnreadProjections(
     };
     projection.latest = Math.max(projection.latest, event.createdAt);
     projection.count += 1;
+    if (event.rootId && !projection.unreadRootIds.includes(event.rootId)) {
+      projection.unreadRootIds.push(event.rootId);
+    }
     projection.badgeCount += event.countsTowardBadge ? 1 : 0;
     projection.appBadgeCount += event.countsTowardAppBadge ? 1 : 0;
     projection.topLevelUnread ||= event.rootId === null;

--- a/desktop/tests/e2e/thread-rail.spec.ts
+++ b/desktop/tests/e2e/thread-rail.spec.ts
@@ -62,18 +62,27 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
     const railColumnElement = document.querySelector<HTMLElement>(
       '[data-testid="thread-rail-column"]',
     );
+    const appSidebarLayer = document.querySelector<HTMLElement>(
+      '[data-testid="app-sidebar-layer"]',
+    );
     const contentElement = document.querySelector<HTMLElement>(
       "[data-buzz-content-surface]:not([data-buzz-content-unframed])",
     );
-    if (!railElement || !railColumnElement || !contentElement) {
+    if (
+      !railElement ||
+      !railColumnElement ||
+      !appSidebarLayer ||
+      !contentElement
+    ) {
       throw new Error(
-        "Thread Rail, rail column, or framed content surface unavailable",
+        "Thread Rail, rail column, app layer, or framed content surface unavailable",
       );
     }
     const railRect = railElement.getBoundingClientRect();
     const contentRect = contentElement.getBoundingClientRect();
     const railStyle = getComputedStyle(railElement);
     const railColumnStyle = getComputedStyle(railColumnElement);
+    const appSidebarLayerStyle = getComputedStyle(appSidebarLayer);
     const contentStyle = getComputedStyle(contentElement);
     return {
       railTop: Math.round(railRect.top),
@@ -83,8 +92,11 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
       railRadius: railStyle.borderTopLeftRadius,
       contentRadius: contentStyle.borderTopLeftRadius,
       railBackground: railStyle.backgroundColor,
+      railColumnBackground: railColumnStyle.backgroundColor,
       railColumnBackgroundImage: railColumnStyle.backgroundImage,
       railColumnRadius: railColumnStyle.borderTopLeftRadius,
+      appSidebarLayerBackground: appSidebarLayerStyle.backgroundColor,
+      appSidebarLayerBackgroundImage: appSidebarLayerStyle.backgroundImage,
       contentBackground: contentStyle.backgroundColor,
       railClipPath: railStyle.clipPath,
     };
@@ -96,7 +108,10 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
   });
   expect(paneGeometry.railBottom).toBe(paneGeometry.contentBottom);
   expect(paneGeometry.railColumnRadius).toBe("0px");
-  expect(paneGeometry.railColumnBackgroundImage).toContain("linear-gradient");
+  expect(paneGeometry.railColumnBackground).toBe("rgba(0, 0, 0, 0)");
+  expect(paneGeometry.railColumnBackgroundImage).toBe("none");
+  expect(paneGeometry.appSidebarLayerBackground).toBe("rgba(0, 0, 0, 0)");
+  expect(paneGeometry.appSidebarLayerBackgroundImage).toBe("none");
   expect(paneGeometry.railClipPath).toBe("none");
   const entry = rail.getByTestId(`thread-rail-entry-${root.id}`);
   await expect(entry).toHaveAttribute("aria-current", "page");

--- a/desktop/tests/e2e/thread-rail.spec.ts
+++ b/desktop/tests/e2e/thread-rail.spec.ts
@@ -1,0 +1,360 @@
+import { expect, test } from "@playwright/test";
+
+import { TEST_IDENTITIES, installMockBridge } from "../helpers/bridge";
+
+async function emitThread(
+  page: import("@playwright/test").Page,
+  channelName: string,
+  content: string,
+  parentEventId?: string,
+  pubkey?: string,
+) {
+  return page.evaluate(
+    ({ channelName: name, message, parentId, pubkey: authorPubkey }) => {
+      const emit = (
+        window as Window & {
+          __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
+            channelName: string;
+            content: string;
+            parentEventId?: string;
+            pubkey?: string;
+          }) => { id: string } | null;
+        }
+      ).__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
+      if (!emit) throw new Error("Mock message emitter unavailable");
+      const event = emit({
+        channelName: name,
+        content: message,
+        parentEventId: parentId,
+        pubkey: authorPubkey,
+      });
+      if (!event) throw new Error("Mock message emission failed");
+      return event;
+    },
+    { channelName, message: content, parentId: parentEventId, pubkey },
+  );
+}
+
+test("pins a canonical thread, switches it from the collapsible rail, and unpins locally", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+
+  const root = await emitThread(page, "general", "Thread rail root");
+  await emitThread(page, "general", "Thread rail reply", root.id);
+  const summary = page.locator(`[data-thread-head-id="${root.id}"]`);
+  await expect(summary).toBeVisible();
+  await summary.click();
+
+  const panel = page.getByTestId("message-thread-panel");
+  await expect(panel).toBeVisible();
+  await panel.getByTestId("pin-thread-to-rail").click();
+
+  const rail = page.getByTestId("thread-rail");
+  await expect(rail).toBeVisible();
+  await expect(rail).toHaveAttribute("aria-label", "Pinned threads");
+  const paneGeometry = await page.evaluate(() => {
+    const railElement = document.querySelector<HTMLElement>(
+      '[data-testid="thread-rail"]',
+    );
+    const contentElement = document.querySelector<HTMLElement>(
+      "[data-buzz-content-surface]:not([data-buzz-content-unframed])",
+    );
+    if (!railElement || !contentElement) {
+      throw new Error("Thread Rail or framed content surface unavailable");
+    }
+    const railRect = railElement.getBoundingClientRect();
+    const contentRect = contentElement.getBoundingClientRect();
+    const railStyle = getComputedStyle(railElement);
+    const contentStyle = getComputedStyle(contentElement);
+    return {
+      railTop: Math.round(railRect.top),
+      contentTop: Math.round(contentRect.top),
+      railBottom: Math.round(railRect.bottom),
+      contentBottom: Math.round(contentRect.bottom),
+      railRadius: railStyle.borderTopLeftRadius,
+      contentRadius: contentStyle.borderTopLeftRadius,
+      railBackground: railStyle.backgroundColor,
+      contentBackground: contentStyle.backgroundColor,
+      railClipPath: railStyle.clipPath,
+    };
+  });
+  expect(paneGeometry).toMatchObject({
+    railTop: paneGeometry.contentTop,
+    railBottom: paneGeometry.contentBottom,
+    railRadius: paneGeometry.contentRadius,
+    railBackground: paneGeometry.contentBackground,
+  });
+  expect(paneGeometry.railClipPath).toBe("none");
+  const entry = rail.getByTestId(`thread-rail-entry-${root.id}`);
+  await expect(entry).toHaveAttribute("aria-current", "page");
+  const visualContract = await page.evaluate((rootId) => {
+    const railElement = document.querySelector<HTMLElement>(
+      '[data-testid="thread-rail"]',
+    );
+    const headerElement = document.querySelector<HTMLElement>(
+      '[data-testid="thread-rail-header"]',
+    );
+    const rowElement = document.querySelector<HTMLElement>(
+      `[data-testid="thread-rail-row-${rootId}"]`,
+    );
+    const entryElement = document.querySelector<HTMLElement>(
+      `[data-testid="thread-rail-entry-${rootId}"]`,
+    );
+    if (!railElement || !headerElement || !rowElement || !entryElement) {
+      throw new Error("Thread Rail visual contract elements unavailable");
+    }
+    return {
+      headerHeight: Math.round(headerElement.getBoundingClientRect().height),
+      headerBorderBottomWidth:
+        getComputedStyle(headerElement).borderBottomWidth,
+      rowInset: Math.round(
+        railElement.getBoundingClientRect().width -
+          rowElement.getBoundingClientRect().width,
+      ),
+      rowBackground: getComputedStyle(rowElement).backgroundColor,
+      entryBackground: getComputedStyle(entryElement).backgroundColor,
+    };
+  }, root.id);
+  expect(visualContract.headerHeight).toBeGreaterThanOrEqual(52);
+  expect(visualContract.headerBorderBottomWidth).toBe("0px");
+  expect(visualContract.rowInset).toBe(16);
+  expect(visualContract.rowBackground).not.toBe("rgba(0, 0, 0, 0)");
+  expect(visualContract.entryBackground).toBe("rgba(0, 0, 0, 0)");
+
+  const expandedWidth = await rail.evaluate((element) =>
+    Math.round(element.getBoundingClientRect().width),
+  );
+  await rail.getByTestId("thread-rail-toggle").click();
+  await expect(rail).toHaveAttribute("data-collapsed", "true");
+  await expect(entry).toBeHidden();
+  await expect(rail).toHaveAttribute("data-collapsed", "true");
+  await expect
+    .poll(() =>
+      rail.evaluate((element) =>
+        Math.round(element.getBoundingClientRect().width),
+      ),
+    )
+    .toBeLessThan(expandedWidth);
+  await rail.getByTestId("thread-rail-toggle").click();
+  await expect(entry).toBeVisible();
+
+  await page.getByTestId("channel-random").click();
+  await entry.click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await expect(panel).toBeVisible();
+  await expect(panel.getByTestId("message-thread-head")).toContainText(
+    "Thread rail root",
+  );
+
+  await rail.getByTestId(`unpin-thread-rail-${root.id}`).click();
+  await expect(rail).toBeHidden();
+  await expect(panel).toBeVisible();
+  await expect(panel.getByTestId("message-input")).toBeVisible();
+  const storedRail = await page.evaluate(() =>
+    Object.keys(localStorage)
+      .filter((key) => key.startsWith("buzz-thread-rail.v1:"))
+      .map((key) => localStorage.getItem(key)),
+  );
+  await expect(storedRail).toContain(
+    '{"version":1,"collapsed":false,"pins":[]}',
+  );
+});
+
+test("shows an unread dot for a pinned thread with a new reply", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+
+  const root = await emitThread(page, "general", "Pinned thread root");
+  await emitThread(page, "general", "Pinned thread reply", root.id);
+  await page.locator(`[data-thread-head-id="${root.id}"]`).click();
+
+  const panel = page.getByTestId("message-thread-panel");
+  await expect(panel).toBeVisible();
+  await panel.getByTestId("pin-thread-to-rail").click();
+
+  const rail = page.getByTestId("thread-rail");
+  const entry = rail.getByTestId(`thread-rail-entry-${root.id}`);
+  await expect(entry).toBeVisible();
+
+  await page.getByTestId("channel-random").click();
+  await emitThread(
+    page,
+    "general",
+    "Unread reply in pinned thread",
+    root.id,
+    TEST_IDENTITIES.alice.pubkey,
+  );
+
+  await expect(rail.getByTestId(`thread-rail-unread-${root.id}`)).toBeVisible();
+});
+
+test("returns to a pinned nested reply with its ancestors expanded", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+
+  const root = await emitThread(page, "general", "Return anchor root");
+  const parent = await emitThread(
+    page,
+    "general",
+    "Return anchor parent",
+    root.id,
+  );
+  const nested = await emitThread(
+    page,
+    "general",
+    "Return anchor nested",
+    parent.id,
+  );
+  await page.locator(`[data-thread-head-id="${root.id}"]`).click();
+
+  const panel = page.getByTestId("message-thread-panel");
+  await expect(panel).toBeVisible();
+  await panel.locator(`[data-thread-head-id="${parent.id}"]`).click();
+  await expect(panel.getByText("Return anchor nested")).toBeVisible();
+  await panel.getByTestId(`reply-message-${nested.id}`).dispatchEvent("click");
+  await expect(panel.getByTestId("reply-target")).toContainText(
+    "Return anchor nested",
+  );
+  await panel.getByTestId("pin-thread-to-rail").click();
+
+  const rail = page.getByTestId("thread-rail");
+  const entry = rail.getByTestId(`thread-rail-entry-${root.id}`);
+  await expect(entry).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        Object.keys(localStorage)
+          .filter((key) => key.startsWith("buzz-thread-rail.v1:"))
+          .map((key) => localStorage.getItem(key))
+          .join(""),
+      ),
+    )
+    .toContain(`"returnAnchorId":"${nested.id}"`);
+
+  await panel.getByTestId(`reply-message-${parent.id}`).dispatchEvent("click");
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        Object.keys(localStorage)
+          .filter((key) => key.startsWith("buzz-thread-rail.v1:"))
+          .map((key) => localStorage.getItem(key))
+          .join(""),
+      ),
+    )
+    .toContain(`"returnAnchorId":"${parent.id}"`);
+  await panel.getByTestId(`reply-message-${nested.id}`).dispatchEvent("click");
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        Object.keys(localStorage)
+          .filter((key) => key.startsWith("buzz-thread-rail.v1:"))
+          .map((key) => localStorage.getItem(key))
+          .join(""),
+      ),
+    )
+    .toContain(`"returnAnchorId":"${nested.id}"`);
+
+  await page.getByTestId("channel-random").click();
+  await entry.click();
+
+  await expect(panel.getByTestId("message-thread-head")).toContainText(
+    "Return anchor root",
+  );
+  await expect(panel.getByText("Return anchor parent")).toBeVisible();
+  await expect(panel.getByText("Return anchor nested")).toBeVisible();
+  await expect(panel.getByTestId("reply-target")).toHaveCount(0);
+});
+
+test("falls back to a pinned root after an unavailable return anchor settles", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await emitThread(
+    page,
+    "general",
+    "Temporary reply used to pin the default root",
+    "mock-general-welcome",
+  );
+  await page.locator('[data-thread-head-id="mock-general-welcome"]').click();
+  await page
+    .getByTestId("message-thread-panel")
+    .getByTestId("pin-thread-to-rail")
+    .click();
+
+  await page.evaluate(() => {
+    const key = Object.keys(localStorage).find((candidate) =>
+      candidate.startsWith("buzz-thread-rail.v1:"),
+    );
+    if (!key) throw new Error("Thread Rail store was not created");
+    const value = JSON.parse(localStorage.getItem(key) ?? "null");
+    value.pins[0].returnAnchorId = "f".repeat(64);
+    localStorage.setItem(key, JSON.stringify(value));
+  });
+  await page.reload();
+
+  await expect(page.getByTestId("thread-rail")).toBeVisible();
+  await page.getByTestId("channel-random").click();
+  await page.getByTestId("thread-rail-entry-mock-general-welcome").click();
+  const panel = page.getByTestId("message-thread-panel");
+  await expect(panel.getByTestId("message-thread-head")).toContainText(
+    "Welcome to general",
+  );
+  await expect(panel.getByTestId("reply-target")).toHaveCount(0);
+});
+
+test("keeps every manually expanded pinned-thread branch open after switching away and back", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+
+  const root = await emitThread(page, "general", "Expansion memory root");
+  const branchA = await emitThread(
+    page,
+    "general",
+    "Expansion branch A",
+    root.id,
+  );
+  await emitThread(page, "general", "Expansion leaf A", branchA.id);
+  const branchB = await emitThread(
+    page,
+    "general",
+    "Expansion branch B",
+    root.id,
+  );
+  await emitThread(page, "general", "Expansion leaf B", branchB.id);
+  await page.locator(`[data-thread-head-id="${root.id}"]`).click();
+
+  const panel = page.getByTestId("message-thread-panel");
+  await panel.locator(`[data-thread-head-id="${branchA.id}"]`).click();
+  await expect(panel.getByText("Expansion leaf A")).toBeVisible();
+  await panel.locator(`[data-thread-head-id="${branchB.id}"]`).click();
+  await expect(panel.getByText("Expansion leaf B")).toBeVisible();
+  await panel.getByTestId("pin-thread-to-rail").click();
+
+  await page.getByTestId("channel-random").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("random");
+  const otherRoot = await emitThread(page, "random", "Other pinned root");
+  await emitThread(page, "random", "Other pinned reply", otherRoot.id);
+  const otherSummary = page.locator(`[data-thread-head-id="${otherRoot.id}"]`);
+  await expect(otherSummary).toBeVisible();
+  await otherSummary.click();
+  await panel.getByTestId("pin-thread-to-rail").click();
+
+  await page.getByTestId(`thread-rail-entry-${root.id}`).click();
+  await expect(panel.getByText("Expansion leaf A")).toBeVisible();
+  await expect(panel.getByText("Expansion leaf B")).toBeVisible();
+  await expect(panel.getByTestId("reply-target")).toHaveCount(0);
+});

--- a/desktop/tests/e2e/thread-rail.spec.ts
+++ b/desktop/tests/e2e/thread-rail.spec.ts
@@ -65,10 +65,22 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
     const appSidebarLayer = document.querySelector<HTMLElement>(
       '[data-testid="app-sidebar-layer"]',
     );
+    const appSurface = document.querySelector<HTMLElement>(
+      ".buzz-huddle-app-surface",
+    );
+    const sidebarSurface = document.querySelector<HTMLElement>(
+      '[data-sidebar="sidebar"]',
+    );
     const contentElement = document.querySelector<HTMLElement>(
       "[data-buzz-content-surface]:not([data-buzz-content-unframed])",
     );
-    if (!railElement || !appSidebarLayer || !contentElement) {
+    if (
+      !railElement ||
+      !appSidebarLayer ||
+      !appSurface ||
+      !sidebarSurface ||
+      !contentElement
+    ) {
       throw new Error(
         "Thread Rail, rail column, app layer, or framed content surface unavailable",
       );
@@ -77,6 +89,8 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
     const contentRect = contentElement.getBoundingClientRect();
     const railStyle = getComputedStyle(railElement);
     const appSidebarLayerStyle = getComputedStyle(appSidebarLayer);
+    const appSurfaceStyle = getComputedStyle(appSurface);
+    const sidebarSurfaceStyle = getComputedStyle(sidebarSurface);
     const contentStyle = getComputedStyle(contentElement);
     return {
       railTop: Math.round(railRect.top),
@@ -89,6 +103,9 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
       hasRailColumn: Boolean(railColumnElement),
       appSidebarLayerBackground: appSidebarLayerStyle.backgroundColor,
       appSidebarLayerBackgroundImage: appSidebarLayerStyle.backgroundImage,
+      appSurfaceBackground: appSurfaceStyle.backgroundColor,
+      appSurfaceBackgroundImage: appSurfaceStyle.backgroundImage,
+      sidebarSurfaceBackground: sidebarSurfaceStyle.backgroundColor,
       contentBackground: contentStyle.backgroundColor,
       railClipPath: railStyle.clipPath,
     };
@@ -102,6 +119,10 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
   expect(paneGeometry.hasRailColumn).toBe(false);
   expect(paneGeometry.appSidebarLayerBackground).toBe("rgba(0, 0, 0, 0)");
   expect(paneGeometry.appSidebarLayerBackgroundImage).toBe("none");
+  expect(paneGeometry.appSurfaceBackground).toBe(
+    paneGeometry.sidebarSurfaceBackground,
+  );
+  expect(paneGeometry.appSurfaceBackgroundImage).toBe("none");
   expect(paneGeometry.railClipPath).toBe("none");
   const entry = rail.getByTestId(`thread-rail-entry-${root.id}`);
   await expect(entry).toHaveAttribute("aria-current", "page");

--- a/desktop/tests/e2e/thread-rail.spec.ts
+++ b/desktop/tests/e2e/thread-rail.spec.ts
@@ -68,12 +68,7 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
     const contentElement = document.querySelector<HTMLElement>(
       "[data-buzz-content-surface]:not([data-buzz-content-unframed])",
     );
-    if (
-      !railElement ||
-      !railColumnElement ||
-      !appSidebarLayer ||
-      !contentElement
-    ) {
+    if (!railElement || !appSidebarLayer || !contentElement) {
       throw new Error(
         "Thread Rail, rail column, app layer, or framed content surface unavailable",
       );
@@ -81,7 +76,6 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
     const railRect = railElement.getBoundingClientRect();
     const contentRect = contentElement.getBoundingClientRect();
     const railStyle = getComputedStyle(railElement);
-    const railColumnStyle = getComputedStyle(railColumnElement);
     const appSidebarLayerStyle = getComputedStyle(appSidebarLayer);
     const contentStyle = getComputedStyle(contentElement);
     return {
@@ -92,9 +86,7 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
       railRadius: railStyle.borderTopLeftRadius,
       contentRadius: contentStyle.borderTopLeftRadius,
       railBackground: railStyle.backgroundColor,
-      railColumnBackground: railColumnStyle.backgroundColor,
-      railColumnBackgroundImage: railColumnStyle.backgroundImage,
-      railColumnRadius: railColumnStyle.borderTopLeftRadius,
+      hasRailColumn: Boolean(railColumnElement),
       appSidebarLayerBackground: appSidebarLayerStyle.backgroundColor,
       appSidebarLayerBackgroundImage: appSidebarLayerStyle.backgroundImage,
       contentBackground: contentStyle.backgroundColor,
@@ -107,9 +99,7 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
     railBackground: paneGeometry.contentBackground,
   });
   expect(paneGeometry.railBottom).toBe(paneGeometry.contentBottom);
-  expect(paneGeometry.railColumnRadius).toBe("0px");
-  expect(paneGeometry.railColumnBackground).toBe("rgba(0, 0, 0, 0)");
-  expect(paneGeometry.railColumnBackgroundImage).toBe("none");
+  expect(paneGeometry.hasRailColumn).toBe(false);
   expect(paneGeometry.appSidebarLayerBackground).toBe("rgba(0, 0, 0, 0)");
   expect(paneGeometry.appSidebarLayerBackgroundImage).toBe("none");
   expect(paneGeometry.railClipPath).toBe("none");

--- a/desktop/tests/e2e/thread-rail.spec.ts
+++ b/desktop/tests/e2e/thread-rail.spec.ts
@@ -94,7 +94,7 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
     railRadius: paneGeometry.contentRadius,
     railBackground: paneGeometry.contentBackground,
   });
-  expect(paneGeometry.railBottom).toBeLessThan(paneGeometry.contentBottom);
+  expect(paneGeometry.railBottom).toBe(paneGeometry.contentBottom);
   expect(paneGeometry.railColumnRadius).toBe("0px");
   expect(paneGeometry.railColumnBackgroundImage).toContain("linear-gradient");
   expect(paneGeometry.railClipPath).toBe("none");

--- a/desktop/tests/e2e/thread-rail.spec.ts
+++ b/desktop/tests/e2e/thread-rail.spec.ts
@@ -83,10 +83,10 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
   });
   expect(paneGeometry).toMatchObject({
     railTop: paneGeometry.contentTop,
-    railBottom: paneGeometry.contentBottom,
     railRadius: paneGeometry.contentRadius,
     railBackground: paneGeometry.contentBackground,
   });
+  expect(paneGeometry.railBottom).toBeLessThan(paneGeometry.contentBottom);
   expect(paneGeometry.railClipPath).toBe("none");
   const entry = rail.getByTestId(`thread-rail-entry-${root.id}`);
   await expect(entry).toHaveAttribute("aria-current", "page");

--- a/desktop/tests/e2e/thread-rail.spec.ts
+++ b/desktop/tests/e2e/thread-rail.spec.ts
@@ -59,15 +59,21 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
     const railElement = document.querySelector<HTMLElement>(
       '[data-testid="thread-rail"]',
     );
+    const railColumnElement = document.querySelector<HTMLElement>(
+      '[data-testid="thread-rail-column"]',
+    );
     const contentElement = document.querySelector<HTMLElement>(
       "[data-buzz-content-surface]:not([data-buzz-content-unframed])",
     );
-    if (!railElement || !contentElement) {
-      throw new Error("Thread Rail or framed content surface unavailable");
+    if (!railElement || !railColumnElement || !contentElement) {
+      throw new Error(
+        "Thread Rail, rail column, or framed content surface unavailable",
+      );
     }
     const railRect = railElement.getBoundingClientRect();
     const contentRect = contentElement.getBoundingClientRect();
     const railStyle = getComputedStyle(railElement);
+    const railColumnStyle = getComputedStyle(railColumnElement);
     const contentStyle = getComputedStyle(contentElement);
     return {
       railTop: Math.round(railRect.top),
@@ -77,6 +83,8 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
       railRadius: railStyle.borderTopLeftRadius,
       contentRadius: contentStyle.borderTopLeftRadius,
       railBackground: railStyle.backgroundColor,
+      railColumnBackgroundImage: railColumnStyle.backgroundImage,
+      railColumnRadius: railColumnStyle.borderTopLeftRadius,
       contentBackground: contentStyle.backgroundColor,
       railClipPath: railStyle.clipPath,
     };
@@ -87,6 +95,8 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
     railBackground: paneGeometry.contentBackground,
   });
   expect(paneGeometry.railBottom).toBeLessThan(paneGeometry.contentBottom);
+  expect(paneGeometry.railColumnRadius).toBe("0px");
+  expect(paneGeometry.railColumnBackgroundImage).toContain("linear-gradient");
   expect(paneGeometry.railClipPath).toBe("none");
   const entry = rail.getByTestId(`thread-rail-entry-${root.id}`);
   await expect(entry).toHaveAttribute("aria-current", "page");

--- a/desktop/tests/e2e/thread-rail.spec.ts
+++ b/desktop/tests/e2e/thread-rail.spec.ts
@@ -160,6 +160,12 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
   expect(visualContract.rowBackground).not.toBe("rgba(0, 0, 0, 0)");
   expect(visualContract.entryBackground).toBe("rgba(0, 0, 0, 0)");
 
+  await rail.getByTestId(`edit-thread-rail-title-${root.id}`).click();
+  const titleInput = rail.getByTestId(`thread-rail-title-input-${root.id}`);
+  await titleInput.fill("Roadmap");
+  await titleInput.press("Enter");
+  await expect(entry).toHaveAttribute("aria-label", "Roadmap");
+
   const expandedWidth = await rail.evaluate((element) =>
     Math.round(element.getBoundingClientRect().width),
   );
@@ -179,6 +185,7 @@ test("pins a canonical thread, switches it from the collapsible rail, and unpins
 
   await page.getByTestId("channel-random").click();
   await entry.click();
+  await expect(entry).toHaveAttribute("aria-label", "Roadmap");
   await expect(page.getByTestId("chat-title")).toHaveText("general");
   await expect(panel).toBeVisible();
   await expect(panel.getByTestId("message-thread-head")).toContainText(


### PR DESCRIPTION
## Tester preview

This is a desktop-only tester preview for the persistent Thread Rail proposed in #4266. It is intentionally a draft while we collect feedback; it does **not** close the issue.

## What it adds

- Personal, local pins scoped to the active identity and community
- Pin/unpin, collapse/expand, local titles, and unread indicators
- Cross-channel switching with nested return-anchor and expanded-branch restoration
- Safe reset of stale `Replying to…` / `Jump to latest` state when switching pinned threads
- Desktop-only presentation; mobile layouts remain unchanged

## Verification

- TypeScript typecheck
- 34 focused Thread Rail tests
- 7 native observed-unread tests
- 5 browser E2E Thread Rail tests
- Desktop check and whitespace validation
- Local installed desktop review

## Tester focus

Please use non-sensitive test data and report OS/build details, exact repro steps, and screenshots or recordings for any issue.

1. Pin several ongoing threads and switch between them.
2. Return to a nested reply after changing channels.
3. Restart and confirm pins remain scoped to the same identity/community.
4. Check unread dots after a new reply in a pinned thread.
5. Confirm stale composer/scroll state from the prior pin does not appear in the next thread.

Relates to #4266