### PR TITLE
fix(tooling): strip AI attribution at commit time instead of at review time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,17 @@ rewrite hook commands to compensate for an unconfigured shell `PATH`.
 
 **Commit with `git commit -s`.** The required **DCO Check** fails any PR with a commit missing a `Signed-off-by` trailer, and `just hooks` installs a `commit-msg` hook that adds it to commits you create locally (`git rebase` and `git cherry-pick` still need `--signoff`) — if you build commit commands programmatically, include `-s` every time. To repair a branch that already has unsigned commits: `git rebase --signoff main`, then force-push.
 
+**No AI attribution in commit messages.** Buzz history does not carry
+`Co-authored-by:` trailers naming an AI assistant, or `Generated with <tool>`
+footers. Several agent harnesses add one by default, so this is easy to do
+without noticing — the `commit-msg` hook installed by `just hooks` strips them
+for commits you create locally. Git runs `commit-msg` only for `git commit` and
+`git merge`, so a `git rebase` or `git cherry-pick` can still carry a trailer
+through; check with `git log --format='%(trailers)' origin/main..HEAD` before
+opening a PR. Human `Co-authored-by:` trailers are legitimate and are never
+stripped. To repair a branch that already carries one, rewrite the affected
+commits (`git rebase -i --signoff`) and force-push with `--force-with-lease`.
+
 Additional rules:
 - No `unsafe` code
 - Do not introduce new `unwrap()` or `expect()` in production paths — use `?` and proper error types

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -47,8 +47,13 @@ pre-commit:
 # `--if-exists doNothing` makes it idempotent and preserves an existing
 # sign-off (including `git commit -s` and a different signer's trailer).
 commit-msg:
+  # Ordered, not parallel: `strip-ai-attribution` rewrites the message file and
+  # `signoff` appends to it, so running them concurrently would race on {1}.
+  piped: true
   commands:
-    signoff:
+    1_strip-ai-attribution:
+      run: ./scripts/strip-ai-attribution.sh {1}
+    2_signoff:
       run: 'git interpret-trailers --if-exists doNothing --trailer "Signed-off-by: $(git var GIT_COMMITTER_IDENT | sed ''s/ [0-9]* [+-][0-9]*$//'')" --in-place {1}'
 
 pre-push:

--- a/scripts/strip-ai-attribution.sh
+++ b/scripts/strip-ai-attribution.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Remove AI-assistant attribution from a commit message in place.
+#
+# Buzz does not carry AI attribution in its history. The rule was enforced only
+# at review time, which caught it late: a reviewer had to notice the trailer,
+# and the author then had to rewrite already-pushed history to remove it. This
+# strips it at the point it is introduced instead.
+#
+# What it removes:
+#   - `Co-authored-by:` trailers naming an AI assistant or an assistant's
+#     noreply address.
+#   - `Generated with <tool>` footers, with or without a markdown link.
+#
+# What it deliberately leaves alone:
+#   - `Co-authored-by:` trailers naming a human. Pair-programming attribution is
+#     legitimate and this must never eat it.
+#   - `Signed-off-by:` trailers. DCO is required; the sibling `signoff` hook
+#     command adds one, and dropping it would fail the DCO Check.
+#
+# Usage: strip-ai-attribution.sh <commit-msg-file>
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <commit-msg-file>" >&2
+  exit 2
+fi
+
+file="$1"
+[ -f "$file" ] || exit 0
+
+# Matched case-insensitively: Git trailer keys are case-insensitive in practice
+# and tools emit both `Co-Authored-By` and `Co-authored-by`.
+#
+# The assistant patterns are matched on the *identity*, not on the word "AI":
+# a human legitimately named e.g. "Claudia" must not be stripped, so the
+# patterns require either a known assistant name in the name position or a
+# known assistant noreply address.
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+sed -E \
+  -e '/^[[:space:]]*co-authored-by:[[:space:]]*(claude|chatgpt|copilot|cursor|codex|devin|gemini)\b/Id' \
+  -e '/^[[:space:]]*co-authored-by:.*(noreply@anthropic\.com|users\.noreply\.github\.com\/copilot|noreply@openai\.com)/Id' \
+  -e '/^[[:space:]]*(🤖[[:space:]]*)?generated with[[:space:]]/Id' \
+  "$file" >"$tmp"
+
+# Collapse the blank-line runs the deletions leave behind, then drop leading and
+# trailing blanks. This is the same normalization Git's own default message
+# cleanup performs, applied here so the result is identical no matter which
+# order a Git version runs cleanup and this hook in.
+awk '
+  /^[[:space:]]*$/ { blank = 1; next }
+  { if (blank && seen) print ""; blank = 0; seen = 1; print }
+' "$tmp" >"$file"

--- a/scripts/strip-ai-attribution.test.mjs
+++ b/scripts/strip-ai-attribution.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const script = fileURLToPath(
+  new URL("./strip-ai-attribution.sh", import.meta.url),
+);
+
+/** Run the hook over `message` and return the rewritten text. */
+function strip(message) {
+  const dir = mkdtempSync(join(tmpdir(), "strip-ai-"));
+  try {
+    const file = join(dir, "COMMIT_EDITMSG");
+    writeFileSync(file, message, "utf8");
+    execFileSync("bash", [script, file], { stdio: "pipe" });
+    return readFileSync(file, "utf8");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("removes an assistant co-author trailer", () => {
+  const out = strip(
+    "feat: thing\n\nCo-Authored-By: Claude Opus 5 <noreply@anthropic.com>\n",
+  );
+  assert.ok(!/claude/i.test(out), out);
+  assert.ok(!/co-authored-by/i.test(out), out);
+});
+
+test("removes an assistant trailer identified only by its noreply address", () => {
+  const out = strip(
+    "feat: thing\n\nCo-authored-by: Some Bot <noreply@anthropic.com>\n",
+  );
+  assert.ok(!/co-authored-by/i.test(out), out);
+});
+
+test("removes a Generated with footer, with or without the emoji", () => {
+  const withEmoji = strip(
+    "feat: thing\n\n\u{1F916} Generated with [Claude Code](https://claude.com/claude-code)\n",
+  );
+  assert.ok(!/generated with/i.test(withEmoji), withEmoji);
+
+  const plain = strip("feat: thing\n\nGenerated with Some Tool\n");
+  assert.ok(!/generated with/i.test(plain), plain);
+});
+
+// The whole point of matching on identity rather than on the word "AI": eating a
+// human's pair-programming credit would be a worse failure than leaving a bot
+// trailer in.
+test("keeps a human co-author trailer", () => {
+  const out = strip(
+    "feat: thing\n\nCo-authored-by: Jane Developer <jane@example.com>\n",
+  );
+  assert.match(out, /Co-authored-by: Jane Developer <jane@example\.com>/);
+});
+
+// Dropping this would fail the repository's required DCO Check.
+test("keeps the DCO signoff", () => {
+  const out = strip(
+    "feat: thing\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nSigned-off-by: Real Person <real@example.com>\n",
+  );
+  assert.match(out, /Signed-off-by: Real Person <real@example\.com>/);
+  assert.ok(!/claude/i.test(out), out);
+});
+
+test("leaves an unrelated message untouched apart from normalization", () => {
+  const out = strip("fix: unrelated\n\nA normal body.\n");
+  assert.equal(out, "fix: unrelated\n\nA normal body.\n");
+});
+
+test("collapses the blank run a stripped footer leaves behind", () => {
+  const out = strip(
+    "feat: thing\n\nBody.\n\n\u{1F916} Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nSigned-off-by: Real Person <real@example.com>\n",
+  );
+  assert.ok(!/\n\n\n/.test(out), `unexpected blank run:\n${out}`);
+  assert.match(out, /Signed-off-by: Real Person/);
+});


### PR DESCRIPTION
## The problem

Buzz history does not carry AI-assistant attribution — no `Co-authored-by:`
trailer naming an assistant, no `Generated with <tool>` footer. But that rule
lived only in reviewers' heads, which made it expensive to enforce: a reviewer
had to spot the trailer, and the author then had to rewrite already-pushed
history to remove it. It has now blocked at least two PRs (#6036, #6077) for
exactly this.

Two gaps kept it recurring, and this closes both.

**It was undocumented.** `AGENTS.md` said nothing about it — not on `main`, not
anywhere in the repo. An agent following the contributor guide faithfully would
still emit the trailer, because several harnesses add one by default. So the
rule was, in practice, discoverable only by having a PR rejected.

**Nothing enforced it.** The `commit-msg` hook already rewrites the message to
append the DCO signoff, so the machinery was there; it just wasn't used for
this.

## What this does

- `scripts/strip-ai-attribution.sh` removes assistant `Co-authored-by:`
  trailers and `Generated with <tool>` footers from a commit message in place.
- `lefthook.yml` runs it in the existing `commit-msg` hook, now marked `piped`
  so the strip completes before the signoff append rather than racing it on the
  same file.
- `AGENTS.md` states the rule, names the hook, and gives the repair path for a
  branch that already carries a trailer.

## Two things it deliberately does not do

**It never eats a human co-author.** Matching is on assistant *identity* — a
known assistant name in the name position, or a known noreply address — not on
the word "AI". Stripping a real person's pair-programming credit would be a
worse failure than leaving a bot trailer in, so `Co-authored-by: Jane Developer
<jane@example.com>` survives untouched. Tested.

**It never touches `Signed-off-by:`.** Dropping it would fail the required DCO
Check. Tested.

## Known limitation, stated rather than hidden

Git runs `commit-msg` only for `git commit` and `git merge`. A `git rebase` or
`git cherry-pick` can still carry a trailer through — the same caveat the
existing signoff command already carries, and which `lefthook.yml` documents at
the hook. `AGENTS.md` now names it explicitly and gives the pre-PR check:

```bash
git log --format='%(trailers)' origin/main..HEAD
```

A CI-side guard would close this properly and is the obvious follow-up. It is
not in this PR because making a new check *required* needs a ruleset change,
and an unrequired check that silently passes would give false confidence.

## Verification

| Gate | Result |
|---|---|
| `node --test scripts/strip-ai-attribution.test.mjs` | 7 passed, 0 failed |
| `lefthook.yml` parses; `commit-msg` ordering confirmed (`piped: true`, strip before signoff) | verified |
| This PR's own commit carries a DCO signoff and no attribution trailer | verified via `git log --format='%(trailers)'` |

The tests cover both directions: assistant trailer removed, noreply-address-only
trailer removed, `Generated with` footer removed with and without the emoji,
human co-author preserved, DCO signoff preserved, unrelated message unchanged,
and the blank-line run left by a stripped footer collapsed.

**Not verified here:** lefthook's own dispatch was not executed in this
environment — Hermit fails to bootstrap on this Windows box (`HERMIT_STATE_DIR_RAW:
unbound variable`), so `just hooks` could not install the hook to exercise it
end to end. The script itself is tested directly, and the wiring was checked by
parsing `lefthook.yml`. Worth a reviewer confirming the hook fires on a machine
with a working Hermit.
