### PR TITLE
test(desktop): use a wordlist-safe separator in passphrase word-count test

### DIFF
--- a/desktop/src-tauri/src/key_backup_tests.rs
+++ b/desktop/src-tauri/src/key_backup_tests.rs
@@ -233,7 +233,10 @@ fn generated_passphrase_respects_word_count_and_separator() {
         WORDLIST.lines().filter(|l| !l.is_empty()).collect();
     assert_eq!(words.len(), 1296, "EFF short wordlist 2.0 has 1296 words");
 
-    for (count, separator) in [(3, "-"), (4, "-"), (6, " "), (5, "."), (10, "")] {
+    // Use separators that cannot appear in the EFF wordlist so a generated
+    // word such as "yo-yo" cannot be mistaken for two words (see the same
+    // guard in generated_passphrase_clamps_word_count and issue #6249).
+    for (count, separator) in [(3, "|"), (4, "|"), (6, " "), (5, "."), (10, "")] {
         let phrase = generate_passphrase(count, separator).unwrap();
         if separator.is_empty() {
             // No separator to split on; length gate below still applies.


### PR DESCRIPTION
## Summary

Fixes #6249.

`key_backup::tests::generated_passphrase_respects_word_count_and_separator` joined words with `-` and asserted the phrase splits back into exactly `count` parts. The EFF short wordlist contains exactly one hyphenated entry (`yo-yo`, line 1281 of 1296), so drawing it into either hyphen-joined arm yields one extra part — a ~1-in-186 flake per full suite run (`1 - (1 - 1/1296)^7 ≈ 0.539%`).

This switches the two hyphen arms to `|`, which cannot appear in the wordlist — the exact guard the sibling test `generated_passphrase_clamps_word_count` already documents and uses. The space, dot, and empty-separator arms are untouched (no wordlist entry contains a space or a dot), so the test still covers word count, wordlist membership, and minimum length.

`generate_passphrase` itself is unchanged — a hyphenated word in a hyphen-joined passphrase is not a product defect, only an ambiguity the test's parsing could not handle.

## Verification

At `main` (196d62f), compiled the desktop test binary once and looped it 2000× per state:

| State | Failures / 2000 runs | Expected |
|---|---|---|
| old code | 15 | ~10.8 (P ≈ 0.539%) |
| fixed | 0 | 0 |

Full desktop Tauri suite (`cargo test --workspace` in `desktop/src-tauri`): **2693 passed, 0 failed**.