### PR TITLE
Link Workstream Board blocker messages

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
         "**/key-import-reveal.spec.ts",
         "**/navigation.spec.ts",
         "**/channels.spec.ts",
+        "**/workstream-board-message-link.capture.spec.ts",
         "**/channel-shared-header-backdrop.spec.ts",
         "**/channel-composer-overflow.spec.ts",
         "**/badge.spec.ts",

--- a/desktop/src/features/workstream-board/lib/workstreamWaits.test.mjs
+++ b/desktop/src/features/workstream-board/lib/workstreamWaits.test.mjs
@@ -5,10 +5,48 @@ import {
   deriveReviewerWaits,
   mergeWorkstreamWaits,
   parseManualWorkstreamWaits,
+  parseWorkstreamWaitMessageLink,
   sortWorkstreamCards,
 } from "./workstreamWaits.ts";
 
 const LOGAN = "a".repeat(64);
+
+const CHANNEL = "123e4567-e89b-12d3-a456-426614174000";
+const MESSAGE = "a".repeat(64);
+const THREAD = "b".repeat(64);
+
+test("message-linked manual waits preserve valid exact destinations", () => {
+  const message = `buzz://message?channel=${CHANNEL}&id=${MESSAGE}&thread=${THREAD}`;
+  const [wait] = parseManualWorkstreamWaits([
+    {
+      key: "message",
+      actor: { kind: "person", name: "Logan" },
+      reason: "Need an answer",
+      message,
+    },
+  ]);
+  assert.equal(wait.message, message);
+  assert.deepEqual(parseWorkstreamWaitMessageLink(wait.message), {
+    channelId: CHANNEL,
+    messageId: MESSAGE,
+    threadRootId: THREAD,
+  });
+});
+
+test("message-linked waits fail closed for malformed or non-canonical destinations", () => {
+  const valid = `buzz://message?channel=${CHANNEL}&id=${MESSAGE}`;
+  for (const message of [
+    "not-a-link",
+    `buzz://message?channel=not-a-uuid&id=${MESSAGE}`,
+    `buzz://message?channel=${CHANNEL}&id=short`,
+    `buzz://message?channel=${CHANNEL}&id=${MESSAGE}&thread=short`,
+    `${valid}&extra=ignored`,
+    `buzz://message?id=${MESSAGE}&channel=${CHANNEL}`,
+  ]) {
+    assert.equal(parseWorkstreamWaitMessageLink(message), null, message);
+  }
+  assert.equal(parseWorkstreamWaitMessageLink(undefined), null);
+});
 
 test("manual waits retain simultaneous unique entries and ignore malformed or duplicate keys", () => {
   assert.deepEqual(

--- a/desktop/src/features/workstream-board/lib/workstreamWaits.ts
+++ b/desktop/src/features/workstream-board/lib/workstreamWaits.ts
@@ -21,6 +21,8 @@ export type WorkstreamWait = {
   since?: string;
   /** Optional canonical `buzz://message?...` destination from the canvas. */
   message?: string;
+  /** True when the canvas explicitly supplied a `message` field, even if malformed. */
+  messagePresent?: boolean;
   source: "manual" | "derived";
 };
 
@@ -114,12 +116,15 @@ export function parseManualWorkstreamWaits(
   for (const value of values) {
     if (!isWorkstreamWait(value) || keys.has(value.key)) continue;
     keys.add(value.key);
+    const messagePresent = Object.hasOwn(value, "message");
     const message =
       typeof value.message === "string" ? value.message : undefined;
     waits.push({
-      ...value,
-      ...(message === undefined ? { message: undefined } : { message }),
+      key: value.key,
       actor: { ...value.actor },
+      reason: value.reason,
+      ...(value.since === undefined ? {} : { since: value.since }),
+      ...(messagePresent ? { message, messagePresent: true } : {}),
       source: "manual",
     });
   }

--- a/desktop/src/features/workstream-board/lib/workstreamWaits.ts
+++ b/desktop/src/features/workstream-board/lib/workstreamWaits.ts
@@ -1,5 +1,7 @@
-import { normalizePubkey } from "@/shared/lib/pubkey";
 import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
+import { parseMessageLink } from "@/features/messages/lib/messageLink";
+import type { ParsedMessageLink } from "@/features/messages/lib/messageLink";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 import type { WorkstreamCardV1 } from "@/features/workstream-board/lib/workstreamCardParser";
 import type {
   WorkstreamPullRequestDisplayState,
@@ -17,8 +19,44 @@ export type WorkstreamWait = {
   actor: WorkstreamWaitActor;
   reason: string;
   since?: string;
+  /** Optional canonical `buzz://message?...` destination from the canvas. */
+  message?: string;
   source: "manual" | "derived";
 };
+
+const CHANNEL_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const EVENT_ID_PATTERN = /^[0-9a-f]{64}$/;
+
+/**
+ * Parse and strictly validate a manual Workstream Board message destination.
+ *
+ * `parseMessageLink` intentionally accepts any non-empty route values for
+ * general markdown links. Canvas-authored blockers need the stronger wire
+ * contract: a canonical URL, a UUID channel ID, and 64-hex event IDs.
+ */
+export function parseWorkstreamWaitMessageLink(
+  value: unknown,
+): ParsedMessageLink | null {
+  if (typeof value !== "string") return null;
+  const parsed = parseMessageLink(value);
+  if (!parsed.ok) return null;
+  const { channelId, messageId, threadRootId } = parsed.value;
+  if (
+    !CHANNEL_ID_PATTERN.test(channelId) ||
+    !EVENT_ID_PATTERN.test(messageId) ||
+    (threadRootId !== null && !EVENT_ID_PATTERN.test(threadRootId))
+  ) {
+    return null;
+  }
+
+  // Reject encoded values, unknown query parameters, and non-canonical query
+  // ordering rather than silently navigating to a different destination.
+  const canonical = `buzz://message?channel=${channelId}&id=${messageId}${
+    threadRootId ? `&thread=${threadRootId}` : ""
+  }`;
+  return canonical === value ? parsed.value : null;
+}
 
 export type WorkstreamCardSortInput = {
   channelId: string;
@@ -60,6 +98,8 @@ export function isWorkstreamWait(
     (typeof wait.since !== "string" || !Number.isFinite(Date.parse(wait.since)))
   )
     return false;
+  // Keep malformed destinations attached to an otherwise valid blocker. The
+  // renderer validates the link before making the row interactive.
   return (
     actor.pubkey === undefined ||
     (typeof actor.pubkey === "string" && !!actor.pubkey.trim())
@@ -74,7 +114,14 @@ export function parseManualWorkstreamWaits(
   for (const value of values) {
     if (!isWorkstreamWait(value) || keys.has(value.key)) continue;
     keys.add(value.key);
-    waits.push({ ...value, actor: { ...value.actor }, source: "manual" });
+    const message =
+      typeof value.message === "string" ? value.message : undefined;
+    waits.push({
+      ...value,
+      ...(message === undefined ? { message: undefined } : { message }),
+      actor: { ...value.actor },
+      source: "manual",
+    });
   }
   return waits;
 }

--- a/desktop/src/features/workstream-board/ui/WorkstreamWaits.test.mjs
+++ b/desktop/src/features/workstream-board/ui/WorkstreamWaits.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { waitAge } from "./WorkstreamWaits.tsx";
+import { parseManualWorkstreamWaits } from "../lib/workstreamWaits.ts";
+import { resolveWorkstreamWaitLink, waitAge } from "./WorkstreamWaits.tsx";
 
 const now = Date.parse("2026-08-19T16:00:00Z");
 
@@ -13,4 +14,61 @@ test("waitAge labels age unknown when no trustworthy timestamp exists", () => {
 test("waitAge reports elapsed age for a trustworthy timestamp", () => {
   assert.equal(waitAge("2026-08-19T15:59:30Z", now), "0m");
   assert.equal(waitAge("2026-08-19T14:00:00Z", now), "2h");
+});
+
+const REFERENCE = {
+  kind: "github",
+  rawUrl: "https://github.com/block/buzz/pull/6357",
+  href: "https://github.com/block/buzz/pull/6357",
+  identity: "github:block/buzz#6357",
+  owner: "block",
+  repository: "buzz",
+  number: 6357,
+};
+
+test("malformed present message values stay non-clickable while absent values retain reference fallback", () => {
+  for (const message of [null, {}, 7]) {
+    const [malformed] = parseManualWorkstreamWaits([
+      {
+        key: "github:block/buzz#6357",
+        actor: { kind: "person", name: "Logan" },
+        reason: "Need a decision",
+        message,
+      },
+    ]);
+    assert.equal(malformed.messagePresent, true);
+    assert.equal(resolveWorkstreamWaitLink(malformed, REFERENCE), null);
+  }
+
+  const [absent] = parseManualWorkstreamWaits([
+    {
+      key: "github:block/buzz#6357",
+      actor: { kind: "person", name: "Logan" },
+      reason: "Need a decision",
+    },
+  ]);
+  assert.deepEqual(resolveWorkstreamWaitLink(absent, REFERENCE), {
+    kind: "reference",
+    reference: REFERENCE,
+  });
+});
+
+test("valid present message destination wins over a same-key reference", () => {
+  const message = `buzz://message?channel=123e4567-e89b-12d3-a456-426614174000&id=${"a".repeat(64)}`;
+  const [wait] = parseManualWorkstreamWaits([
+    {
+      key: "github:block/buzz#6357",
+      actor: { kind: "person", name: "Logan" },
+      reason: "Need a decision",
+      message,
+    },
+  ]);
+  assert.deepEqual(resolveWorkstreamWaitLink(wait, REFERENCE), {
+    kind: "message",
+    destination: {
+      channelId: "123e4567-e89b-12d3-a456-426614174000",
+      messageId: "a".repeat(64),
+      threadRootId: null,
+    },
+  });
 });

--- a/desktop/src/features/workstream-board/ui/WorkstreamWaits.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamWaits.tsx
@@ -1,6 +1,8 @@
 import { ExternalLink } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { parseWorkstreamWaitMessageLink } from "@/features/workstream-board/lib/workstreamWaits";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { WorkstreamPullRequestReference } from "@/features/workstream-board/lib/workstreamPullRequestStatus";
 import type { WorkstreamWait } from "@/features/workstream-board/lib/workstreamWaits";
@@ -59,6 +61,7 @@ export function WorkstreamWaits({
 }) {
   const now = useNow(60_000);
   const openEntityLink = useOpenEntityLink();
+  const { goChannel } = useAppNavigation();
   if (waits.length === 0) return null;
   const referencesByIdentity = new Map(
     references.map((reference) => [reference.identity, reference]),
@@ -88,16 +91,28 @@ export function WorkstreamWaits({
         {orderedWaits.map((wait) => {
           const age = waitAge(wait.since, now);
           const reference = referencesByIdentity.get(wait.key);
-          const open = reference
-            ? () => {
-                const parsed =
-                  reference.kind === "buzz"
-                    ? parseEntityLink(reference.href)
-                    : null;
-                if (parsed?.ok) openEntityLink(parsed.value);
-                else void openUrl(reference.href);
-              }
-            : undefined;
+          const messageDestination = parseWorkstreamWaitMessageLink(
+            wait.message,
+          );
+          const open =
+            wait.message !== undefined
+              ? messageDestination
+                ? () =>
+                    void goChannel(messageDestination.channelId, {
+                      messageId: messageDestination.messageId,
+                      threadRootId: messageDestination.threadRootId,
+                    })
+                : undefined
+              : reference
+                ? () => {
+                    const parsed =
+                      reference.kind === "buzz"
+                        ? parseEntityLink(reference.href)
+                        : null;
+                    if (parsed?.ok) openEntityLink(parsed.value);
+                    else void openUrl(reference.href);
+                  }
+                : undefined;
           const content = (
             <>
               <WaitAvatar profiles={profiles} wait={wait} />

--- a/desktop/src/features/workstream-board/ui/WorkstreamWaits.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamWaits.tsx
@@ -2,10 +2,13 @@ import { ExternalLink } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
-import { parseWorkstreamWaitMessageLink } from "@/features/workstream-board/lib/workstreamWaits";
+import {
+  parseWorkstreamWaitMessageLink,
+  type WorkstreamWait,
+} from "@/features/workstream-board/lib/workstreamWaits";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { WorkstreamPullRequestReference } from "@/features/workstream-board/lib/workstreamPullRequestStatus";
-import type { WorkstreamWait } from "@/features/workstream-board/lib/workstreamWaits";
+import type { ParsedMessageLink } from "@/features/messages/lib/messageLink";
 import { parseEntityLink } from "@/shared/lib/entityLink";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { useNow } from "@/shared/lib/useNow";
@@ -21,6 +24,24 @@ export function waitAge(since: string | undefined, now: number): string {
   const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours}h`;
   return `${Math.floor(hours / 24)}d`;
+}
+
+type WorkstreamWaitLinkResolution =
+  | { kind: "message"; destination: ParsedMessageLink }
+  | { kind: "reference"; reference: WorkstreamPullRequestReference }
+  | null;
+
+/** Preserve the distinction between an absent message field and a malformed one. */
+export function resolveWorkstreamWaitLink(
+  wait: Pick<WorkstreamWait, "message" | "messagePresent">,
+  reference: WorkstreamPullRequestReference | undefined,
+): WorkstreamWaitLinkResolution {
+  const messagePresent = wait.messagePresent ?? wait.message !== undefined;
+  if (messagePresent) {
+    const destination = parseWorkstreamWaitMessageLink(wait.message);
+    return destination ? { kind: "message", destination } : null;
+  }
+  return reference ? { kind: "reference", reference } : null;
 }
 
 function WaitAvatar({
@@ -91,26 +112,22 @@ export function WorkstreamWaits({
         {orderedWaits.map((wait) => {
           const age = waitAge(wait.since, now);
           const reference = referencesByIdentity.get(wait.key);
-          const messageDestination = parseWorkstreamWaitMessageLink(
-            wait.message,
-          );
+          const link = resolveWorkstreamWaitLink(wait, reference);
           const open =
-            wait.message !== undefined
-              ? messageDestination
-                ? () =>
-                    void goChannel(messageDestination.channelId, {
-                      messageId: messageDestination.messageId,
-                      threadRootId: messageDestination.threadRootId,
-                    })
-                : undefined
-              : reference
+            link?.kind === "message"
+              ? () =>
+                  void goChannel(link.destination.channelId, {
+                    messageId: link.destination.messageId,
+                    threadRootId: link.destination.threadRootId,
+                  })
+              : link?.kind === "reference"
                 ? () => {
                     const parsed =
-                      reference.kind === "buzz"
-                        ? parseEntityLink(reference.href)
+                      link.reference.kind === "buzz"
+                        ? parseEntityLink(link.reference.href)
                         : null;
                     if (parsed?.ok) openEntityLink(parsed.value);
-                    else void openUrl(reference.href);
+                    else void openUrl(link.reference.href);
                   }
                 : undefined;
           const content = (

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -180,6 +180,14 @@ type MockHuddleSeed = {
   isCreator?: boolean;
 };
 
+type MockWorkstreamBoardFixture = {
+  channelId: string;
+  channelName: string;
+  canvas: string;
+  rootEventId: string;
+  targetEventId: string;
+};
+
 type E2eConfig = {
   mode?: "mock" | "relay";
   mock?: {
@@ -339,6 +347,8 @@ type E2eConfig = {
     deepHistoryMessageCount?: number;
     feedReadError?: string;
     canvasReadError?: string;
+    /** Optional deterministic Workstream Board blocker/thread fixture. */
+    workstreamBoardFixture?: MockWorkstreamBoardFixture;
     /** Delay (ms) for `apply_workspace` so e2e tests can observe the
      *  community-switch gate. 0/undefined = instant. */
     applyCommunityDelayMs?: number;
@@ -3076,6 +3086,40 @@ const mockChannels: MockChannel[] = [
   }),
 ];
 
+function ensureMockWorkstreamBoardFixture(config?: E2eConfig | null) {
+  const fixture = config?.mock?.workstreamBoardFixture;
+  if (!fixture) return;
+
+  if (!mockChannels.some((channel) => channel.id === fixture.channelId)) {
+    mockChannels.push(
+      createMockChannel({
+        id: fixture.channelId,
+        name: fixture.channelName,
+        channel_type: "stream",
+        visibility: "open",
+        description: "Deterministic message-linked blocker fixture",
+        topic: null,
+        purpose: null,
+        last_message_at: isoMinutesAgo(1),
+        archived_at: null,
+        created_by: MOCK_IDENTITY_PUBKEY,
+        topic_set_by: null,
+        topic_set_at: null,
+        purpose_set_by: null,
+        purpose_set_at: null,
+        topic_required: false,
+        max_members: null,
+        nip29_group_id: null,
+        created_minutes_ago: 10,
+        updated_minutes_ago: 1,
+        members: [createMockMember(MOCK_IDENTITY_PUBKEY, "owner", 10)],
+      }),
+    );
+  }
+
+  getMockMessageStore(fixture.channelId);
+}
+
 const mockMessages = new Map<string, RelayEvent[]>();
 const deferredSendMessageLiveEchoes: Array<{
   channelId: string;
@@ -4326,6 +4370,38 @@ function getMockMessageStore(channelId: string): RelayEvent[] {
   const existing = mockMessages.get(channelId);
   if (existing) {
     return existing;
+  }
+
+  const fixture = getConfig()?.mock?.workstreamBoardFixture;
+  if (fixture?.channelId === channelId) {
+    const seeded: RelayEvent[] = [
+      {
+        id: fixture.rootEventId,
+        pubkey: ALICE_PUBKEY,
+        created_at: Math.floor(Date.now() / 1000) - 120,
+        kind: 9,
+        tags: [["h", channelId]],
+        content: "Slice 7 blocker thread root",
+        sig: "mocksig".repeat(20).slice(0, 128),
+      },
+      {
+        id: fixture.targetEventId,
+        pubkey: ALICE_PUBKEY,
+        created_at: Math.floor(Date.now() / 1000) - 60,
+        kind: 9,
+        tags: buildReplyMessageTags(
+          channelId,
+          ALICE_PUBKEY,
+          fixture.rootEventId,
+          fixture.rootEventId,
+          undefined,
+        ),
+        content: "Slice 7 exact reply target",
+        sig: "mocksig".repeat(20).slice(0, 128),
+      },
+    ];
+    mockMessages.set(channelId, seeded);
+    return seeded;
   }
 
   const seeded: RelayEvent[] =
@@ -10645,6 +10721,7 @@ export function maybeInstallE2eTauriMocks() {
   resetMockPendingCommunityDeepLinks(config);
   resetMockPendingNavigationDeepLinks(config);
   resetMockPendingEntityDeepLinks(config);
+  ensureMockWorkstreamBoardFixture(config);
   initializeMockHuddle(config.mock?.huddle, config);
   mockWebsocketSendMutexWedged = false;
   if (config.mock?.windowLabel) {
@@ -13714,8 +13791,17 @@ export function maybeInstallE2eTauriMocks() {
         if (canvasReadError) {
           throw new Error(canvasReadError);
         }
+        const channelId = (payload as { channelId?: string }).channelId;
+        const fixture = activeConfig?.mock?.workstreamBoardFixture;
+        if (fixture && fixture.channelId === channelId) {
+          return {
+            content: fixture.canvas,
+            event_id: "slice7-workstream-fixture-canvas",
+            updated_at: Math.floor(Date.now() / 1000),
+            author: MOCK_IDENTITY_PUBKEY,
+          };
+        }
         if (isRelayMode(activeConfig)) {
-          const channelId = (payload as { channelId?: string }).channelId;
           if (!channelId) {
             throw new Error("get_canvas requires channelId");
           }

--- a/desktop/tests/e2e/workstream-board-message-link.capture.spec.ts
+++ b/desktop/tests/e2e/workstream-board-message-link.capture.spec.ts
@@ -5,8 +5,8 @@ import { installMockBridge } from "../helpers/bridge";
 test.use({ video: "on" });
 
 const CHANNEL_ID = "7b4d3d2e-3c15-4e88-9a11-1c0f7d2b6e44";
-const ROOT_EVENT_ID = "1".repeat(64);
-const TARGET_EVENT_ID = "2".repeat(64);
+const ROOT_EVENT_ID = "a1".repeat(32);
+const TARGET_EVENT_ID = "b2".repeat(32);
 const MESSAGE_LINK = `buzz://message?channel=${CHANNEL_ID}&id=${TARGET_EVENT_ID}&thread=${ROOT_EVENT_ID}`;
 const CANVAS = `# Slice 7 message-linked blocker demo
 

--- a/desktop/tests/e2e/workstream-board-message-link.capture.spec.ts
+++ b/desktop/tests/e2e/workstream-board-message-link.capture.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+test.use({ video: "on" });
+
+const CHANNEL_ID = "7b4d3d2e-3c15-4e88-9a11-1c0f7d2b6e44";
+const ROOT_EVENT_ID = "1".repeat(64);
+const TARGET_EVENT_ID = "2".repeat(64);
+const MESSAGE_LINK = `buzz://message?channel=${CHANNEL_ID}&id=${TARGET_EVENT_ID}&thread=${ROOT_EVENT_ID}`;
+const CANVAS = `# Slice 7 message-linked blocker demo
+
+\`\`\`buzz-workstream-card
+${JSON.stringify({
+  version: 1,
+  synopsis: "Open the exact blocker thread and reply in place.",
+  orchestrator: { pubkey: "3".repeat(64), name: "Other Brother Darryl" },
+  assignees: [{ pubkey: "4".repeat(64), name: "Logan" }],
+  pullRequests: [],
+  waitingOn: [
+    {
+      key: "loganj",
+      actor: { kind: "person", name: "Logan", pubkey: "5".repeat(64) },
+      reason: "Reply with the decision in the cited thread",
+      since: "2026-08-19T21:00:00.000Z",
+      message: MESSAGE_LINK,
+    },
+  ],
+})}
+\`\`\``;
+
+async function openBoard(page: Page) {
+  await installMockBridge(page, {
+    workstreamBoardFixture: {
+      channelId: CHANNEL_ID,
+      channelName: "loganj-ws-s7-message-links",
+      canvas: CANVAS,
+      rootEventId: ROOT_EVENT_ID,
+      targetEventId: TARGET_EVENT_ID,
+    },
+  });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("app-sidebar")).toBeVisible();
+  await page.getByTestId("open-workstream-board-view").click();
+  await expect(page.getByTestId("workstream-board-view")).toBeVisible();
+  const card = page.getByTestId(`workstream-card-${CHANNEL_ID}`);
+  await expect(card).toBeVisible();
+  return card.getByTestId("workstream-wait-loganj");
+}
+
+async function expectTargetThreadAndComposer(page: Page) {
+  await expect(page).toHaveURL(
+    new RegExp(
+      `/channels/${CHANNEL_ID}\\?messageId=${TARGET_EVENT_ID}&threadRootId=${ROOT_EVENT_ID}`,
+    ),
+  );
+  await expect(page.getByTestId("message-thread-panel")).toBeVisible();
+  await expect(page.getByText("Slice 7 exact reply target")).toBeVisible();
+  const composer = page.getByTestId("thread-composer-overlay");
+  await expect(composer).toBeVisible();
+  await expect(composer.getByTestId("message-input")).toBeVisible();
+  await expect(composer.getByTestId("message-input")).toHaveAttribute(
+    "data-placeholder",
+    "Reply in thread to alice",
+  );
+}
+
+test("message-linked blocker opens exact target thread by mouse", async ({
+  page,
+}) => {
+  const blocker = await openBoard(page);
+  await blocker.click();
+  await expectTargetThreadAndComposer(page);
+});
+
+test("message-linked blocker opens exact target thread by keyboard", async ({
+  page,
+}) => {
+  const blocker = await openBoard(page);
+  await blocker.focus();
+  await blocker.press("Enter");
+  await expectTargetThreadAndComposer(page);
+});

--- a/desktop/tests/e2e/workstream-board-message-link.capture.spec.ts
+++ b/desktop/tests/e2e/workstream-board-message-link.capture.spec.ts
@@ -45,7 +45,7 @@ async function openBoard(page: Page) {
   await expect(page.getByTestId("workstream-board-view")).toBeVisible();
   const card = page.getByTestId(`workstream-card-${CHANNEL_ID}`);
   await expect(card).toBeVisible();
-  return card.getByTestId("workstream-wait-loganj");
+  return card.getByTestId("workstream-wait-loganj").locator("button");
 }
 
 async function expectTargetThreadAndComposer(page: Page) {
@@ -60,8 +60,8 @@ async function expectTargetThreadAndComposer(page: Page) {
   await expect(composer).toBeVisible();
   await expect(composer.getByTestId("message-input")).toBeVisible();
   await expect(composer.getByTestId("message-input")).toHaveAttribute(
-    "data-placeholder",
-    "Reply in thread to alice",
+    "contenteditable",
+    "true",
   );
 }
 
@@ -78,6 +78,7 @@ test("message-linked blocker opens exact target thread by keyboard", async ({
 }) => {
   const blocker = await openBoard(page);
   await blocker.focus();
+  await expect(blocker).toBeFocused();
   await blocker.press("Enter");
   await expectTargetThreadAndComposer(page);
 });

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -279,6 +279,14 @@ type MockBridgeOptions = {
   deepHistoryMessageCount?: number;
   feedReadError?: string;
   canvasReadError?: string;
+  /** Optional deterministic Workstream Board blocker/thread fixture. */
+  workstreamBoardFixture?: {
+    channelId: string;
+    channelName: string;
+    canvas: string;
+    rootEventId: string;
+    targetEventId: string;
+  };
   /** Delay (ms) for `apply_workspace`; see e2eBridge mock config. */
   applyCommunityDelayMs?: number;
   /** Reject `clear_pending_navigation_deep_links` with this message. */


### PR DESCRIPTION
🤖 Larry

## Summary

Manual Workstream Board blocker rows can optionally carry a canonical `buzz://message` destination. Valid destinations open the exact channel message/thread where the owner can reply. A present malformed destination of any JSON type remains legible and non-clickable—even when the blocker key also resolves to a pull request—while an absent destination preserves the existing entity/PR fallback.

This branch remains stacked on #6336 (Slice 6). The full eight-PR Workstream Board stack was synchronized bottom-up onto current `main`; this slice's original four commits and the review repair were replayed without semantic changes. Draft only; auto-merge is off.

### Testing

At exact published head `9adff6941569ed6353fb9b7cd02328f2dc55fa9b` on Blox workstation `larry-ws-workstream-stack` (ID `1885060`):

- Full Desktop unit suite: **5135/5135 passed**
- Desktop typecheck (`pnpm typecheck`): passed
- E2E build (`pnpm build:e2e`): passed (existing chunk-size/dynamic-import warnings only)
- Capture spec (`workstream-board-message-link.capture.spec.ts`): **2/2 passed** — mouse and keyboard
- Local publication guards: branch-skew and file-size checks passed against current `origin/main`

The repair from `46ce748b52fecffd8819bd79d1e53b4442ea32d5` was imported exactly: original and final stable patch ID are both `49b9f116069fe6f1d622078a3ac9826c74099f2f`.

### Artifacts

- Mouse recording (verified intact): [MP4](https://buzz.block.builderlab.xyz/media/1051923b0cd1f3106438bdb098e126937a7cd20f87edc594807698d52b9af3b1.mp4) — 67,131 bytes, full decode exit 0
- Keyboard recording (verified intact): [MP4](https://buzz.block.builderlab.xyz/media/b0ab38ec0ab7be3c28f5bf16560a844433f85d7270694a8e8a3f3d57a1575779.mp4) — 57,395 bytes, full decode exit 0

Both recordings show the seeded exact reply target in the thread panel and the available `Reply in thread to alice` composer. The mouse case demonstrates pointer activation; the keyboard case demonstrates focus plus Enter activation of the blocker button.

### Contract

`message: "buzz://message?channel=<uuid>&id=<64-hex>[&thread=<64-hex>]"`

No live Canvas mutation was made.
