### PR TITLE
Restrict Canvas revisions to channel managers

### DIFF
--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -468,6 +468,73 @@ pub(crate) fn extract_channel_id(event: &Event) -> Option<Uuid> {
     None
 }
 
+const MAX_CANVAS_CONTENT_BYTES: usize = 64 * 1024;
+
+/// Validate the immutable wire-level invariants for a Canvas event.
+///
+/// Canvas is a single-channel, human-approved Markdown document. Keeping this
+/// validation at ingest prevents malformed or unexpectedly large revisions
+/// from reaching storage or fan-out, regardless of which client submitted it.
+fn validate_canvas_event(event: &Event) -> Result<(), IngestError> {
+    if event.content.trim().is_empty() {
+        return Err(IngestError::Rejected(
+            "invalid: Canvas content must not be blank".to_string(),
+        ));
+    }
+    if event.content.len() > MAX_CANVAS_CONTENT_BYTES {
+        return Err(IngestError::Rejected(format!(
+            "invalid: Canvas content exceeds maximum size of {MAX_CANVAS_CONTENT_BYTES} bytes (got {})",
+            event.content.len()
+        )));
+    }
+
+    let channel_tags: Vec<&str> = event
+        .tags
+        .iter()
+        .filter_map(|tag| {
+            let parts = tag.as_slice();
+            (parts.len() >= 2 && parts[0] == "h").then_some(parts[1].as_str())
+        })
+        .collect();
+    if channel_tags.len() != 1 {
+        return Err(IngestError::Rejected(
+            "invalid: Canvas events must include exactly one h tag".to_string(),
+        ));
+    }
+    Uuid::parse_str(channel_tags[0]).map_err(|_| {
+        IngestError::Rejected("invalid: Canvas h tag must contain a channel UUID".to_string())
+    })?;
+
+    Ok(())
+}
+
+fn authorize_canvas_role(role: Option<&str>) -> Result<(), IngestError> {
+    if matches!(role, Some("owner" | "admin")) {
+        return Ok(());
+    }
+    Err(IngestError::AuthFailed(
+        "restricted: only channel owners or admins may update the Canvas".to_string(),
+    ))
+}
+
+async fn authorize_canvas_write(
+    tenant: &TenantContext,
+    state: &AppState,
+    channel_id: Uuid,
+    author_pubkey: &[u8],
+) -> Result<(), IngestError> {
+    let role = state
+        .db
+        .get_member_role(tenant.community(), channel_id, author_pubkey)
+        .await
+        .map_err(|error| {
+            IngestError::Internal(format!(
+                "error: internal error checking Canvas author role: {error}"
+            ))
+        })?;
+    authorize_canvas_role(role.as_deref())
+}
+
 /// Result of resolving a reaction's target channel.
 pub(crate) enum ReactionChannelResult {
     Channel(Uuid),
@@ -2234,6 +2301,10 @@ async fn ingest_event_inner(
         extract_channel_id(&event)
     };
 
+    if kind_u32 == KIND_CANVAS {
+        validate_canvas_event(&event)?;
+    }
+
     if is_global_only_kind(kind_u32) {
         channel_id = None;
     }
@@ -2330,6 +2401,15 @@ async fn ingest_event_inner(
             );
             auth_result.map_err(IngestError::Rejected)?;
         }
+    }
+
+    if kind_u32 == KIND_CANVAS {
+        let ch_id = channel_id.ok_or_else(|| {
+            IngestError::Rejected(
+                "invalid: Canvas events must include exactly one h tag".to_string(),
+            )
+        })?;
+        authorize_canvas_write(tenant, state, ch_id, &pubkey_bytes).await?;
     }
 
     // Handled directly — these mutate relay_members and do NOT get stored.
@@ -3392,6 +3472,75 @@ mod tests {
                 requires_h_channel_scope(kind),
                 "kind {kind} should require h"
             );
+        }
+    }
+
+    fn canvas_event(content: impl Into<String>, tags: Vec<nostr::Tag>) -> Event {
+        EventBuilder::new(Kind::Custom(KIND_CANVAS as u16), content.into())
+            .tags(tags)
+            .sign_with_keys(&nostr::Keys::generate())
+            .expect("sign Canvas event")
+    }
+
+    #[test]
+    fn canvas_validation_accepts_one_channel_and_nonblank_content() {
+        let channel = Uuid::new_v4().to_string();
+        let event = canvas_event(
+            "# Business Canvas\n\nApproved context",
+            vec![nostr::Tag::parse(["h", &channel]).expect("h tag")],
+        );
+        assert!(validate_canvas_event(&event).is_ok());
+    }
+
+    #[test]
+    fn canvas_validation_rejects_blank_oversize_and_malformed_scope() {
+        let channel = Uuid::new_v4().to_string();
+        let other_channel = Uuid::new_v4().to_string();
+        let one_h = vec![nostr::Tag::parse(["h", &channel]).expect("h tag")];
+
+        assert!(matches!(
+            validate_canvas_event(&canvas_event("  \n", one_h.clone())),
+            Err(IngestError::Rejected(message)) if message.contains("must not be blank")
+        ));
+        assert!(matches!(
+            validate_canvas_event(&canvas_event(
+                "x".repeat(MAX_CANVAS_CONTENT_BYTES + 1),
+                one_h
+            )),
+            Err(IngestError::Rejected(message)) if message.contains("exceeds maximum size")
+        ));
+        assert!(matches!(
+            validate_canvas_event(&canvas_event("content", Vec::new())),
+            Err(IngestError::Rejected(message)) if message.contains("exactly one h tag")
+        ));
+        assert!(matches!(
+            validate_canvas_event(&canvas_event(
+                "content",
+                vec![
+                    nostr::Tag::parse(["h", &channel]).expect("first h tag"),
+                    nostr::Tag::parse(["h", &other_channel]).expect("second h tag"),
+                ]
+            )),
+            Err(IngestError::Rejected(message)) if message.contains("exactly one h tag")
+        ));
+        assert!(matches!(
+            validate_canvas_event(&canvas_event(
+                "content",
+                vec![nostr::Tag::parse(["h", "not-a-uuid"]).expect("invalid h tag")]
+            )),
+            Err(IngestError::Rejected(message)) if message.contains("channel UUID")
+        ));
+    }
+
+    #[test]
+    fn canvas_authorization_allows_only_channel_managers() {
+        assert!(authorize_canvas_role(Some("owner")).is_ok());
+        assert!(authorize_canvas_role(Some("admin")).is_ok());
+        for role in [Some("member"), Some("bot"), Some("guest"), None] {
+            assert!(matches!(
+                authorize_canvas_role(role),
+                Err(IngestError::AuthFailed(message)) if message.contains("owners or admins")
+            ));
         }
     }
 

--- a/crates/buzz-test-client/tests/e2e_relay.rs
+++ b/crates/buzz-test-client/tests/e2e_relay.rs
@@ -2345,6 +2345,231 @@ async fn add_member_with_role_ws(
     (ok.accepted, ok.message)
 }
 
+async fn send_canvas_event_ws(
+    client: &mut BuzzTestClient,
+    content: &str,
+    tags: Vec<Tag>,
+    signer: &Keys,
+) -> (bool, String) {
+    let event = EventBuilder::new(Kind::Custom(40_100), content)
+        .tags(tags)
+        .sign_with_keys(signer)
+        .expect("sign Canvas event");
+    let ok = client.send_event(event).await.expect("send Canvas event");
+    (ok.accepted, ok.message)
+}
+
+/// Submit a well-formed, channel-scoped Canvas revision over WebSocket.
+async fn set_canvas_ws(
+    client: &mut BuzzTestClient,
+    channel_id: &str,
+    content: &str,
+    signer: &Keys,
+) -> (bool, String) {
+    send_canvas_event_ws(
+        client,
+        content,
+        vec![Tag::parse(["h", channel_id]).expect("Canvas h tag")],
+        signer,
+    )
+    .await
+}
+
+async fn query_canvas_events(client: &mut BuzzTestClient, channel_id: &str) -> Vec<nostr::Event> {
+    let sid = sub_id("canvas");
+    let filter = Filter::new()
+        .kind(Kind::Custom(40_100))
+        .custom_tag(
+            SingleLetterTag::lowercase(Alphabet::H),
+            channel_id.to_string(),
+        )
+        .limit(20);
+    client
+        .subscribe(&sid, vec![filter])
+        .await
+        .expect("subscribe to Canvas events");
+    client
+        .collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("collect Canvas events")
+}
+
+/// Canvas is human-approved channel context. Owners/admins may revise it;
+/// bots, members, outsiders, cross-channel authors, and malformed events fail
+/// closed and never replace the stored revision.
+#[tokio::test]
+#[ignore]
+async fn test_canvas_writes_require_channel_owner_or_admin() {
+    let url = relay_url();
+    let owner_keys = Keys::generate();
+    let admin_keys = Keys::generate();
+    let member_keys = Keys::generate();
+    let bot_keys = Keys::generate();
+    let outsider_keys = Keys::generate();
+    let other_owner_keys = Keys::generate();
+
+    let mut owner_client = BuzzTestClient::connect(&url, &owner_keys)
+        .await
+        .expect("connect as owner");
+    let channel_id = create_private_channel_ws(&mut owner_client, &owner_keys).await;
+
+    for (keys, role) in [(&admin_keys, "admin"), (&bot_keys, "bot")] {
+        let (accepted, message) = add_member_with_role_ws(
+            &mut owner_client,
+            &channel_id,
+            &keys.public_key().to_hex(),
+            role,
+            &owner_keys,
+        )
+        .await;
+        assert!(accepted, "owner should add {role}: {message}");
+    }
+    let (accepted, message) = add_member_ws(
+        &mut owner_client,
+        &channel_id,
+        &member_keys.public_key().to_hex(),
+        &owner_keys,
+    )
+    .await;
+    assert!(accepted, "owner should add member: {message}");
+
+    let (accepted, message) = set_canvas_ws(
+        &mut owner_client,
+        &channel_id,
+        "# Approved owner Canvas",
+        &owner_keys,
+    )
+    .await;
+    assert!(accepted, "owner Canvas should be accepted: {message}");
+
+    let mut admin_client = BuzzTestClient::connect(&url, &admin_keys)
+        .await
+        .expect("connect as admin");
+    let (accepted, message) = set_canvas_ws(
+        &mut admin_client,
+        &channel_id,
+        "# Approved admin Canvas",
+        &admin_keys,
+    )
+    .await;
+    assert!(accepted, "admin Canvas should be accepted: {message}");
+
+    let mut member_client = BuzzTestClient::connect(&url, &member_keys)
+        .await
+        .expect("connect as member");
+    let (accepted, message) = set_canvas_ws(
+        &mut member_client,
+        &channel_id,
+        "# Unapproved member Canvas",
+        &member_keys,
+    )
+    .await;
+    assert!(!accepted, "member Canvas must be rejected");
+    assert!(
+        message.contains("owners or admins"),
+        "member rejection should name the authority boundary: {message}"
+    );
+
+    let mut bot_client = BuzzTestClient::connect(&url, &bot_keys)
+        .await
+        .expect("connect as bot");
+    let (accepted, _) = set_canvas_ws(
+        &mut bot_client,
+        &channel_id,
+        "# Unapproved bot Canvas",
+        &bot_keys,
+    )
+    .await;
+    assert!(!accepted, "bot Canvas must be rejected");
+
+    let mut outsider_client = BuzzTestClient::connect(&url, &outsider_keys)
+        .await
+        .expect("connect as outsider");
+    let (accepted, _) = set_canvas_ws(
+        &mut outsider_client,
+        &channel_id,
+        "# Unapproved outsider Canvas",
+        &outsider_keys,
+    )
+    .await;
+    assert!(!accepted, "nonmember Canvas must be rejected");
+
+    let mut other_owner_client = BuzzTestClient::connect(&url, &other_owner_keys)
+        .await
+        .expect("connect as other owner");
+    let other_channel_id =
+        create_private_channel_ws(&mut other_owner_client, &other_owner_keys).await;
+    let (accepted, _) = set_canvas_ws(
+        &mut member_client,
+        &other_channel_id,
+        "# Cross-channel Canvas",
+        &member_keys,
+    )
+    .await;
+    assert!(!accepted, "cross-channel Canvas must be rejected");
+
+    for (content, tags) in [
+        (
+            "   \n".to_string(),
+            vec![Tag::parse(["h", &channel_id]).expect("blank h tag")],
+        ),
+        (
+            "x".repeat(64 * 1024 + 1),
+            vec![Tag::parse(["h", &channel_id]).expect("oversize h tag")],
+        ),
+        ("# Missing scope".to_string(), Vec::new()),
+        (
+            "# Multiple scopes".to_string(),
+            vec![
+                Tag::parse(["h", &channel_id]).expect("first h tag"),
+                Tag::parse(["h", &other_channel_id]).expect("second h tag"),
+            ],
+        ),
+    ] {
+        let (accepted, _) =
+            send_canvas_event_ws(&mut owner_client, &content, tags, &owner_keys).await;
+        assert!(!accepted, "malformed Canvas must be rejected");
+    }
+
+    let stored = query_canvas_events(&mut owner_client, &channel_id).await;
+    let stored_contents: Vec<&str> = stored.iter().map(|event| event.content.as_str()).collect();
+    assert!(stored_contents.contains(&"# Approved owner Canvas"));
+    assert!(stored_contents.contains(&"# Approved admin Canvas"));
+    for rejected in [
+        "# Unapproved member Canvas",
+        "# Unapproved bot Canvas",
+        "# Unapproved outsider Canvas",
+        "# Cross-channel Canvas",
+        "# Missing scope",
+        "# Multiple scopes",
+    ] {
+        assert!(
+            !stored_contents.contains(&rejected),
+            "rejected revision reached storage: {rejected}"
+        );
+    }
+    let other_stored = query_canvas_events(&mut other_owner_client, &other_channel_id).await;
+    assert!(
+        other_stored
+            .iter()
+            .all(|event| event.content != "# Cross-channel Canvas"),
+        "cross-channel revision reached storage"
+    );
+
+    owner_client.disconnect().await.expect("disconnect owner");
+    admin_client.disconnect().await.expect("disconnect admin");
+    member_client.disconnect().await.expect("disconnect member");
+    bot_client.disconnect().await.expect("disconnect bot");
+    outsider_client
+        .disconnect()
+        .await
+        .expect("disconnect outsider");
+    other_owner_client
+        .disconnect()
+        .await
+        .expect("disconnect other owner");
+}
+
 /// Any active member can add any ordinary role to a private channel.
 #[tokio::test]
 #[ignore]


### PR DESCRIPTION
## Summary

- restrict kind 40100 Canvas ingestion to the current channel owner or an admin
- require nonblank Markdown content no larger than 64 KiB and exactly one valid h channel tag
- keep the existing kind 40100 wire interface unchanged
- fail closed before storage so rejected revisions cannot replace visible Canvas state
- add relay unit tests and ignored WebSocket E2E coverage for owner, admin, member, bot, outsider, cross-channel, and malformed events

## Why

This supports human-approved customer Business Canvas governance: agents may propose revisions in-channel, while only a channel manager publishes durable context.

## Product contract decision

This intentionally narrows the current generic Canvas contract described in VISION.md, where channel membership is the write gate. Please review that product-level change explicitly. No schema migration is required.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p buzz-relay canvas_`
- `cargo clippy -p buzz-relay -p buzz-test-client --tests -- -D warnings`
- `cargo test -p buzz-test-client --test e2e_relay --no-run`
- `git diff --check`

The hosted relay still needs its normal post-merge release and deployment path before this boundary is enforced in production.
