### PR TITLE
elevate buzz-acp gate-7 dispatch logs to info level

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3727,13 +3727,13 @@ fn dispatch_pending(
             Some(a) => a,
             None => {
                 let pending = queue.pending_channels();
-                tracing::debug!(pending_channels = pending, "pool_exhausted");
+                tracing::info!(pending_channels = pending, "pool_exhausted");
                 queue.requeue_preserve_timestamps(batch);
                 queue.mark_complete(channel_id);
                 break;
             }
         };
-        tracing::debug!(agent = agent.index, channel = %channel_id, affinity_hit, "agent_claimed");
+        tracing::info!(agent = agent.index, channel = %channel_id, affinity_hit, "agent_claimed");
 
         let recoverable_batch = match ctx.dedup_mode {
             DedupMode::Queue => Some(batch.clone()),
@@ -3791,7 +3791,7 @@ fn dispatch_pending(
         dispatched_channels.push((channel_id, typing_scope));
         *last_activity = tokio::time::Instant::now();
     }
-    tracing::debug!(
+    tracing::info!(
         dispatched = dispatched_channels.len(),
         queue_depth = queue.pending_channels(),
         "dispatch_pending"


### PR DESCRIPTION
## Problem

Dispatch drops were invisible under `RUST_LOG=info`. All three gate-7 dispatch lifecycle events logged at `debug!`:
- `pool_exhausted` (lib.rs:3730)
- `agent_claimed` (lib.rs:3736)
- `dispatch_pending` summary (lib.rs:3794)

A filtered or silently-dropped dispatch left zero trace at the default level, forcing 15-60 min of blind diagnosis. Root-caused in RESEARCH/BUZZ_ACP_DISPATCH_GATES.md.

## Change
Promote all three to `info!` (single-file change, `crates/buzz-acp/src/lib.rs`) so queue/dispatch lifecycle is observable at the default level.

## Verification
- Change is a log-level swap only (`debug!` → `info!`); no logic touched.
- Originating thread: course-content, message 15278564aed4dd1a1fc8ed8238333059fef821b8aee213fc08194f95f58c8ba2