### PR TITLE
Add contextual references to Workstream Board discussions

### DIFF
--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -3785,6 +3785,24 @@ fn parse_dm_response(json: serde_json::Value, limit: u32) -> Option<Conversation
     })
 }
 
+fn json_board_references(obj: &serde_json::Value) -> Vec<buzz_sdk::BoardReference> {
+    let Some(raw_tags) = obj.get("tags").and_then(|value| value.as_array()) else {
+        return Vec::new();
+    };
+    let tags = raw_tags
+        .iter()
+        .filter_map(|value| {
+            let parts = value
+                .as_array()?
+                .iter()
+                .map(|part| part.as_str().map(str::to_string))
+                .collect::<Option<Vec<_>>>()?;
+            nostr::Tag::parse(parts).ok()
+        })
+        .collect::<Vec<_>>();
+    buzz_sdk::parse_board_references(&nostr::Tags::from_list(tags))
+}
+
 /// Extract a `ContextMessage` from a JSON message object.
 ///
 /// Works with both thread reply objects and channel message objects.
@@ -3819,6 +3837,7 @@ fn json_to_context_message(obj: &serde_json::Value) -> Option<ContextMessage> {
         pubkey: pubkey.to_string(),
         timestamp,
         content: content.to_string(),
+        board_references: json_board_references(obj),
     })
 }
 
@@ -5875,6 +5894,7 @@ mod tests {
                 pubkey: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".into(),
                 timestamp: "2026-03-25T05:51:25Z".into(),
                 content: "follow up".into(),
+                board_references: vec![],
             }],
             total: 1,
             truncated: false,
@@ -5951,6 +5971,7 @@ mod tests {
             pubkey: "author".into(),
             timestamp: "2026-08-09T00:00:00Z".into(),
             content: content.into(),
+            board_references: vec![],
         }
     }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -3800,7 +3800,16 @@ fn json_board_references(obj: &serde_json::Value) -> Vec<buzz_sdk::BoardReferenc
             nostr::Tag::parse(parts).ok()
         })
         .collect::<Vec<_>>();
-    buzz_sdk::parse_board_references(&nostr::Tags::from_list(tags))
+    let tags = nostr::Tags::from_list(tags);
+    let workstream_id = tags.iter().find_map(|tag| {
+        let values = tag.as_slice();
+        (values.first().map(String::as_str) == Some("h"))
+            .then(|| values.get(1))
+            .flatten()
+    });
+    workstream_id
+        .map(|id| buzz_sdk::parse_board_references_for_workstream(&tags, id))
+        .unwrap_or_default()
 }
 
 /// Extract a `ContextMessage` from a JSON message object.

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -5875,6 +5875,54 @@ mod tests {
     }
 
     #[test]
+    fn test_json_to_context_message_projects_only_strict_board_references() {
+        let workstream_id = "123e4567-e89b-12d3-a456-426614174000";
+        let valid = json!({
+            "kind": "workstream",
+            "identity": workstream_id,
+            "snapshot": { "label": "Checkout recovery" },
+            "placement": {
+                "workstreamId": workstream_id,
+                "workstreamLabel": "checkout-recovery",
+                "sectionId": "workstream",
+                "sectionLabel": "Workstream"
+            }
+        });
+        let mut unknown = valid.clone();
+        unknown["snapshot"]["extra"] = json!(true);
+        let mut controlled = valid.clone();
+        controlled["snapshot"]["label"] = json!("bad\u{0085}label");
+        let mut forged = valid.clone();
+        forged["identity"] = json!("123e4567-e89b-12d3-a456-426614174001");
+        let tag = |value: serde_json::Value| {
+            json!([
+                buzz_sdk::BOARD_REFERENCE_TAG,
+                buzz_sdk::BOARD_REFERENCE_VERSION,
+                serde_json::to_string(&value).unwrap()
+            ])
+        };
+        let obj = json!({
+            "pubkey": "abc",
+            "content": "hello",
+            "created_at": 1710518400,
+            "tags": [
+                ["h", workstream_id],
+                tag(unknown),
+                tag(controlled),
+                tag(forged),
+                tag(valid.clone())
+            ]
+        });
+
+        let msg = json_to_context_message(&obj).expect("message survives bad references");
+        assert_eq!(msg.board_references.len(), 1);
+        assert_eq!(
+            serde_json::to_value(&msg.board_references[0]).unwrap(),
+            valid
+        );
+    }
+
+    #[test]
     fn test_collect_prompt_pubkeys_includes_authors_mentions_and_context() {
         let keys = Keys::generate();
         let p_tag = Tag::parse([

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1029,6 +1029,8 @@ pub struct ContextMessage {
     pub pubkey: String,
     pub timestamp: String,
     pub content: String,
+    /// Validated, ordered Board references; raw reference tags are never projected.
+    pub board_references: Vec<buzz_sdk::BoardReference>,
 }
 
 /// Channel metadata for prompt formatting.
@@ -1107,6 +1109,17 @@ fn format_prompt_actor(pubkey: &str, profile_lookup: Option<&PromptProfileLookup
     }
 }
 
+/// Append a validated machine-readable projection associated with one message.
+fn append_board_references(output: &mut String, references: &[buzz_sdk::BoardReference]) {
+    if references.is_empty() {
+        return;
+    }
+    if let Ok(json) = serde_json::to_string(references) {
+        output.push_str("\nBoard references (validated JSON): ");
+        output.push_str(&json);
+    }
+}
+
 /// Format the per-event `[Event]` block for a single [`BatchEvent`].
 ///
 /// Includes: event_id, channel (name + UUID), kind, sender (hex + npub),
@@ -1152,10 +1165,20 @@ pub(crate) fn format_event_block(
     );
 
     // Always include tags — they carry structural information.
-    let tags_json: Vec<&[String]> = be.event.tags.iter().map(|t| t.as_slice()).collect();
+    let tags_json: Vec<&[String]> = be
+        .event
+        .tags
+        .iter()
+        .map(|t| t.as_slice())
+        .filter(|tag| tag.first().map(String::as_str) != Some(buzz_sdk::BOARD_REFERENCE_TAG))
+        .collect();
     if let Ok(tags_str) = serde_json::to_string(&tags_json) {
         block.push_str(&format!("\nTags: {tags_str}"));
     }
+    append_board_references(
+        &mut block,
+        &buzz_sdk::parse_board_references(&be.event.tags),
+    );
 
     // Parsed structural fields.
     let thread = parse_thread_tags(&be.event);
@@ -1440,6 +1463,7 @@ fn format_conversation_context(
             msg.timestamp,
             msg.content,
         ));
+        append_board_references(&mut s, &msg.board_references);
     }
     s
 }
@@ -2744,6 +2768,7 @@ mod tests {
                 event_id: String::new(),
                 pubkey: "npub1test".into(),
                 content: "prior message".into(),
+                board_references: vec![],
                 timestamp: "2024-01-01T00:00:00Z".into(),
             }],
             total: 1,
@@ -3362,12 +3387,14 @@ mod tests {
                     pubkey: "npub1xyz".into(),
                     timestamp: "2026-03-15T16:30:00Z".into(),
                     content: "Let's refactor auth".into(),
+                    board_references: vec![],
                 },
                 ContextMessage {
                     event_id: String::new(),
                     pubkey: "npub1def".into(),
                     timestamp: "2026-03-15T16:35:00Z".into(),
                     content: "yes go ahead".into(),
+                    board_references: vec![],
                 },
             ],
             total: 5,
@@ -3412,6 +3439,7 @@ mod tests {
                 pubkey: "npub1abc".into(),
                 timestamp: "2026-03-15T16:00:00Z".into(),
                 content: "Can you deploy?".into(),
+                board_references: vec![],
             }],
             total: 1,
             truncated: false,
@@ -3458,6 +3486,7 @@ mod tests {
                 pubkey: author_hex.clone(),
                 timestamp: "2026-03-25T05:51:25Z".into(),
                 content: "follow up".into(),
+                board_references: vec![],
             }],
             total: 1,
             truncated: false,
@@ -3672,6 +3701,7 @@ mod tests {
                 pubkey: "npub1xyz".into(),
                 timestamp: "2026-03-15T16:30:00Z".into(),
                 content: "Should I deploy?".into(),
+                board_references: vec![],
             }],
             total: 1,
             truncated: false,

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1175,10 +1175,21 @@ pub(crate) fn format_event_block(
     if let Ok(tags_str) = serde_json::to_string(&tags_json) {
         block.push_str(&format!("\nTags: {tags_str}"));
     }
-    append_board_references(
-        &mut block,
-        &buzz_sdk::parse_board_references(&be.event.tags),
-    );
+    let board_references = be
+        .event
+        .tags
+        .iter()
+        .find_map(|tag| {
+            let values = tag.as_slice();
+            (values.first().map(String::as_str) == Some("h"))
+                .then(|| values.get(1))
+                .flatten()
+        })
+        .map(|workstream_id| {
+            buzz_sdk::parse_board_references_for_workstream(&be.event.tags, workstream_id)
+        })
+        .unwrap_or_default();
+    append_board_references(&mut block, &board_references);
 
     // Parsed structural fields.
     let thread = parse_thread_tags(&be.event);

--- a/crates/buzz-sdk/src/board_references.rs
+++ b/crates/buzz-sdk/src/board_references.rs
@@ -1,0 +1,280 @@
+//! Typed, bounded references attached to Board discussion messages.
+
+use nostr::Tag;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// Event tag name carrying a Board reference.
+pub const BOARD_REFERENCE_TAG: &str = "buzz:board-ref";
+/// Current wire version.
+pub const BOARD_REFERENCE_VERSION: &str = "1";
+/// Maximum references accepted on one message.
+pub const MAX_BOARD_REFERENCES: usize = 32;
+const MAX_PAYLOAD_BYTES: usize = 4096;
+const MAX_LABEL_BYTES: usize = 160;
+const MAX_ID_BYTES: usize = 512;
+
+/// As-sent placement used when a live object no longer exists.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BoardPlacement {
+    /// Canonical workstream channel UUID.
+    pub workstream_id: String,
+    /// Least-privilege workstream display label.
+    pub workstream_label: String,
+    /// Stable Board section identifier.
+    pub section_id: String,
+    /// As-sent section display label.
+    pub section_label: String,
+}
+
+/// Immutable semantic snapshot safe to show after live data disappears.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BoardSnapshot {
+    /// Primary display label.
+    pub label: String,
+    /// Optional secondary state/relationship annotation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// Canonical thread destination bound to a blocker.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BoardThreadDestination {
+    /// Destination channel UUID.
+    pub channel_id: String,
+    /// Exact target message ID.
+    pub message_id: String,
+    /// Thread root ID when the target is in a thread.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_root_id: Option<String>,
+}
+
+/// Supported Board domain terms. `kind` is the discriminant on the wire.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum BoardReference {
+    /// A workstream card.
+    Workstream {
+        /// Canonical channel UUID.
+        identity: String,
+        /// As-sent display data.
+        snapshot: BoardSnapshot,
+        /// As-sent Board placement.
+        placement: BoardPlacement,
+    },
+    /// A Buzz or GitHub pull request.
+    PullRequest {
+        /// Canonical provider-qualified identity.
+        identity: String,
+        /// As-sent display data.
+        snapshot: BoardSnapshot,
+        /// As-sent Board placement.
+        placement: BoardPlacement,
+    },
+    /// An agent identity.
+    Agent {
+        /// Canonical lowercase hex pubkey.
+        identity: String,
+        /// As-sent display data.
+        snapshot: BoardSnapshot,
+        /// As-sent Board placement.
+        placement: BoardPlacement,
+    },
+    /// A stable agent-team identity.
+    AgentGroup {
+        /// Canonical team identity.
+        identity: String,
+        /// As-sent display data.
+        snapshot: BoardSnapshot,
+        /// As-sent Board placement.
+        placement: BoardPlacement,
+    },
+    /// A blocker bound to an exact conversation destination.
+    ThreadBlocker {
+        /// Stable manual wait key or canonical PR-derived wait identity.
+        identity: String,
+        /// Exact conversation destination.
+        destination: BoardThreadDestination,
+        /// As-sent display data.
+        snapshot: BoardSnapshot,
+        /// As-sent Board placement.
+        placement: BoardPlacement,
+    },
+}
+
+impl BoardReference {
+    fn identity(&self) -> &str {
+        match self {
+            Self::Workstream { identity, .. }
+            | Self::PullRequest { identity, .. }
+            | Self::Agent { identity, .. }
+            | Self::AgentGroup { identity, .. }
+            | Self::ThreadBlocker { identity, .. } => identity,
+        }
+    }
+
+    fn snapshot(&self) -> &BoardSnapshot {
+        match self {
+            Self::Workstream { snapshot, .. }
+            | Self::PullRequest { snapshot, .. }
+            | Self::Agent { snapshot, .. }
+            | Self::AgentGroup { snapshot, .. }
+            | Self::ThreadBlocker { snapshot, .. } => snapshot,
+        }
+    }
+
+    fn placement(&self) -> &BoardPlacement {
+        match self {
+            Self::Workstream { placement, .. }
+            | Self::PullRequest { placement, .. }
+            | Self::Agent { placement, .. }
+            | Self::AgentGroup { placement, .. }
+            | Self::ThreadBlocker { placement, .. } => placement,
+        }
+    }
+
+    fn validate(&self) -> bool {
+        let placement = self.placement();
+        let snapshot = self.snapshot();
+        valid_id(self.identity())
+            && valid_uuid(&placement.workstream_id)
+            && valid_label(&placement.workstream_label)
+            && valid_id(&placement.section_id)
+            && valid_label(&placement.section_label)
+            && valid_label(&snapshot.label)
+            && snapshot.detail.as_deref().is_none_or(valid_label)
+            && match self {
+                Self::Agent { identity, .. } => valid_hex64(identity),
+                Self::ThreadBlocker { destination, .. } => {
+                    valid_uuid(&destination.channel_id)
+                        && valid_hex64(&destination.message_id)
+                        && destination
+                            .thread_root_id
+                            .as_deref()
+                            .is_none_or(valid_hex64)
+                }
+                _ => true,
+            }
+    }
+}
+
+fn valid_label(value: &str) -> bool {
+    !value.trim().is_empty()
+        && value.len() <= MAX_LABEL_BYTES
+        && !value.chars().any(char::is_control)
+}
+
+fn valid_id(value: &str) -> bool {
+    !value.trim().is_empty() && value.len() <= MAX_ID_BYTES && !value.chars().any(char::is_control)
+}
+
+fn valid_hex64(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
+fn valid_uuid(value: &str) -> bool {
+    uuid::Uuid::parse_str(value).is_ok() && value == value.to_ascii_lowercase()
+}
+
+/// Build validated ordered event tags. Invalid input rejects the whole send.
+pub fn build_board_reference_tags(
+    references: &[BoardReference],
+) -> Result<Vec<Tag>, crate::SdkError> {
+    if references.len() > MAX_BOARD_REFERENCES {
+        return Err(crate::SdkError::InvalidInput(format!(
+            "too many Board references (max {MAX_BOARD_REFERENCES})"
+        )));
+    }
+    let mut identities = HashSet::new();
+    references
+        .iter()
+        .map(|reference| {
+            if !reference.validate() || !identities.insert(reference.identity().to_string()) {
+                return Err(crate::SdkError::InvalidInput(
+                    "invalid or duplicate Board reference".into(),
+                ));
+            }
+            let payload = serde_json::to_string(reference)
+                .map_err(|error| crate::SdkError::InvalidInput(error.to_string()))?;
+            if payload.len() > MAX_PAYLOAD_BYTES {
+                return Err(crate::SdkError::InvalidInput(
+                    "Board reference payload too large".into(),
+                ));
+            }
+            Tag::parse([
+                BOARD_REFERENCE_TAG,
+                BOARD_REFERENCE_VERSION,
+                payload.as_str(),
+            ])
+            .map_err(|error| crate::SdkError::InvalidTag(error.to_string()))
+        })
+        .collect()
+}
+
+/// Parse valid references in persisted order. Bad entries fail closed individually.
+pub fn parse_board_references(tags: &nostr::Tags) -> Vec<BoardReference> {
+    let mut identities = HashSet::new();
+    tags.iter()
+        .filter_map(|tag| {
+            let values = tag.as_slice();
+            if values.len() != 3
+                || values[0] != BOARD_REFERENCE_TAG
+                || values[1] != BOARD_REFERENCE_VERSION
+                || values[2].len() > MAX_PAYLOAD_BYTES
+            {
+                return None;
+            }
+            let reference: BoardReference = serde_json::from_str(&values[2]).ok()?;
+            (reference.validate() && identities.insert(reference.identity().to_string()))
+                .then_some(reference)
+        })
+        .take(MAX_BOARD_REFERENCES)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr::Tags;
+
+    fn reference(identity: &str) -> BoardReference {
+        BoardReference::Workstream {
+            identity: identity.into(),
+            snapshot: BoardSnapshot {
+                label: "Checkout recovery".into(),
+                detail: Some("Active".into()),
+            },
+            placement: BoardPlacement {
+                workstream_id: "123e4567-e89b-12d3-a456-426614174000".into(),
+                workstream_label: "checkout-recovery".into(),
+                section_id: "workstream".into(),
+                section_label: "Workstream".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn round_trip_preserves_order() {
+        let tags = build_board_reference_tags(&[reference("one"), reference("two")]).unwrap();
+        let parsed = parse_board_references(&Tags::from_list(tags));
+        assert_eq!(parsed, vec![reference("one"), reference("two")]);
+    }
+
+    #[test]
+    fn malformed_unknown_and_duplicate_entries_fail_closed() {
+        let mut tags = build_board_reference_tags(&[reference("one")]).unwrap();
+        tags.push(Tag::parse([BOARD_REFERENCE_TAG, "99", "{}"]).unwrap());
+        tags.push(Tag::parse([BOARD_REFERENCE_TAG, BOARD_REFERENCE_VERSION, "not-json"]).unwrap());
+        tags.extend(build_board_reference_tags(&[reference("one"), reference("two")]).unwrap());
+        assert_eq!(
+            parse_board_references(&Tags::from_list(tags)),
+            vec![reference("one"), reference("two")]
+        );
+    }
+}

--- a/crates/buzz-sdk/src/board_references.rs
+++ b/crates/buzz-sdk/src/board_references.rs
@@ -106,13 +106,16 @@ pub enum BoardReference {
 }
 
 impl BoardReference {
-    fn dedup_key(&self) -> (&'static str, String) {
+    fn dedup_key(&self) -> (String, &'static str, String) {
+        let workstream_id = self.placement().workstream_id.clone();
         match self {
-            Self::Workstream { identity, .. } => ("workstream", identity.clone()),
-            Self::PullRequest { identity, .. } => ("pull-request", identity.clone()),
-            Self::Agent { identity, .. } => ("agent", identity.clone()),
-            Self::AgentGroup { identity, .. } => ("agent-group", identity.clone()),
-            Self::ThreadBlocker { identity, .. } => ("thread-blocker", identity.clone()),
+            Self::Workstream { identity, .. } => (workstream_id, "workstream", identity.clone()),
+            Self::PullRequest { identity, .. } => (workstream_id, "pull-request", identity.clone()),
+            Self::Agent { identity, .. } => (workstream_id, "agent", identity.clone()),
+            Self::AgentGroup { identity, .. } => (workstream_id, "agent-group", identity.clone()),
+            Self::ThreadBlocker { identity, .. } => {
+                (workstream_id, "thread-blocker", identity.clone())
+            }
         }
     }
 
@@ -157,6 +160,7 @@ impl BoardReference {
             && valid_label(&snapshot.label)
             && snapshot.detail.as_deref().is_none_or(valid_label)
             && match self {
+                Self::Workstream { identity, .. } => identity == &placement.workstream_id,
                 Self::Agent { identity, .. } => valid_hex64(identity),
                 Self::ThreadBlocker { destination, .. } => {
                     valid_uuid(&destination.channel_id)
@@ -263,15 +267,15 @@ mod tests {
     use super::*;
     use nostr::Tags;
 
-    fn reference(identity: &str) -> BoardReference {
+    fn reference(workstream_id: &str) -> BoardReference {
         BoardReference::Workstream {
-            identity: identity.into(),
+            identity: workstream_id.into(),
             snapshot: BoardSnapshot {
                 label: "Checkout recovery".into(),
                 detail: Some("Active".into()),
             },
             placement: BoardPlacement {
-                workstream_id: "123e4567-e89b-12d3-a456-426614174000".into(),
+                workstream_id: workstream_id.into(),
                 workstream_label: "checkout-recovery".into(),
                 section_id: "workstream".into(),
                 section_label: "Workstream".into(),
@@ -281,29 +285,102 @@ mod tests {
 
     #[test]
     fn round_trip_preserves_order() {
-        let tags = build_board_reference_tags(&[reference("one"), reference("two")]).unwrap();
+        let tags = build_board_reference_tags(&[
+            reference("123e4567-e89b-12d3-a456-426614174000"),
+            reference("123e4567-e89b-12d3-a456-426614174001"),
+        ])
+        .unwrap();
         let parsed = parse_board_references(&Tags::from_list(tags));
-        assert_eq!(parsed, vec![reference("one"), reference("two")]);
+        assert_eq!(
+            parsed,
+            vec![
+                reference("123e4567-e89b-12d3-a456-426614174000"),
+                reference("123e4567-e89b-12d3-a456-426614174001")
+            ]
+        );
     }
 
     #[test]
     fn malformed_unknown_and_duplicate_entries_fail_closed() {
-        let mut tags = build_board_reference_tags(&[reference("one")]).unwrap();
+        let mut tags =
+            build_board_reference_tags(&[reference("123e4567-e89b-12d3-a456-426614174000")])
+                .unwrap();
         tags.push(Tag::parse([BOARD_REFERENCE_TAG, "99", "{}"]).unwrap());
         tags.push(Tag::parse([BOARD_REFERENCE_TAG, BOARD_REFERENCE_VERSION, "not-json"]).unwrap());
-        tags.extend(build_board_reference_tags(&[reference("one"), reference("two")]).unwrap());
+        tags.extend(
+            build_board_reference_tags(&[
+                reference("123e4567-e89b-12d3-a456-426614174000"),
+                reference("123e4567-e89b-12d3-a456-426614174001"),
+            ])
+            .unwrap(),
+        );
         assert_eq!(
             parse_board_references(&Tags::from_list(tags)),
-            vec![reference("one"), reference("two")]
+            vec![
+                reference("123e4567-e89b-12d3-a456-426614174000"),
+                reference("123e4567-e89b-12d3-a456-426614174001")
+            ]
         );
     }
     #[test]
-    fn cross_workstream_references_fail_closed() {
-        let allowed = reference("allowed");
-        let mut other = reference("other");
-        if let BoardReference::Workstream { placement, .. } = &mut other {
-            placement.workstream_id = "123e4567-e89b-12d3-a456-426614174001".into();
+    fn strict_unknown_controls_and_forged_workstream_binding_fail_closed() {
+        let valid = reference("123e4567-e89b-12d3-a456-426614174000");
+        let payload = serde_json::to_value(&valid).unwrap();
+        let mut invalid = Vec::new();
+        for path in ["top", "snapshot", "placement"] {
+            let mut value = payload.clone();
+            let target = match path {
+                "top" => value.as_object_mut().unwrap(),
+                "snapshot" => value.get_mut("snapshot").unwrap().as_object_mut().unwrap(),
+                _ => value.get_mut("placement").unwrap().as_object_mut().unwrap(),
+            };
+            target.insert("extra".into(), serde_json::json!(true));
+            invalid.push(value);
         }
+        let mut controlled = payload.clone();
+        controlled["snapshot"]["label"] = serde_json::json!("bad\u{0085}label");
+        invalid.push(controlled);
+        let mut forged = payload;
+        forged["identity"] = serde_json::json!("123e4567-e89b-12d3-a456-426614174001");
+        invalid.push(forged);
+
+        let mut tags = invalid
+            .into_iter()
+            .map(|value| {
+                Tag::parse([
+                    BOARD_REFERENCE_TAG,
+                    BOARD_REFERENCE_VERSION,
+                    serde_json::to_string(&value).unwrap().as_str(),
+                ])
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
+        tags.extend(build_board_reference_tags(&[valid.clone()]).unwrap());
+        assert_eq!(parse_board_references(&Tags::from_list(tags)), vec![valid]);
+    }
+
+    #[test]
+    fn dedup_key_is_scoped_to_workstream_placement() {
+        let first = reference("123e4567-e89b-12d3-a456-426614174000");
+        let mut second = first.clone();
+        if let BoardReference::Workstream {
+            identity,
+            placement,
+            ..
+        } = &mut second
+        {
+            *identity = "123e4567-e89b-12d3-a456-426614174001".into();
+            placement.workstream_id = identity.clone();
+        }
+        let tags =
+            Tags::from_list(build_board_reference_tags(&[first.clone(), second.clone()]).unwrap());
+        assert_eq!(parse_board_references(&tags), vec![first, second]);
+    }
+
+    #[test]
+    fn cross_workstream_references_fail_closed() {
+        let allowed = reference("123e4567-e89b-12d3-a456-426614174000");
+        let other = reference("123e4567-e89b-12d3-a456-426614174001");
         let tags = Tags::from_list(build_board_reference_tags(&[allowed.clone(), other]).unwrap());
         assert_eq!(
             parse_board_references_for_workstream(&tags, "123e4567-e89b-12d3-a456-426614174000"),

--- a/crates/buzz-sdk/src/board_references.rs
+++ b/crates/buzz-sdk/src/board_references.rs
@@ -106,6 +106,16 @@ pub enum BoardReference {
 }
 
 impl BoardReference {
+    fn dedup_key(&self) -> (&'static str, String) {
+        match self {
+            Self::Workstream { identity, .. } => ("workstream", identity.clone()),
+            Self::PullRequest { identity, .. } => ("pull-request", identity.clone()),
+            Self::Agent { identity, .. } => ("agent", identity.clone()),
+            Self::AgentGroup { identity, .. } => ("agent-group", identity.clone()),
+            Self::ThreadBlocker { identity, .. } => ("thread-blocker", identity.clone()),
+        }
+    }
+
     fn identity(&self) -> &str {
         match self {
             Self::Workstream { identity, .. }
@@ -195,7 +205,7 @@ pub fn build_board_reference_tags(
     references
         .iter()
         .map(|reference| {
-            if !reference.validate() || !identities.insert(reference.identity().to_string()) {
+            if !reference.validate() || !identities.insert(reference.dedup_key()) {
                 return Err(crate::SdkError::InvalidInput(
                     "invalid or duplicate Board reference".into(),
                 ));
@@ -231,10 +241,20 @@ pub fn parse_board_references(tags: &nostr::Tags) -> Vec<BoardReference> {
                 return None;
             }
             let reference: BoardReference = serde_json::from_str(&values[2]).ok()?;
-            (reference.validate() && identities.insert(reference.identity().to_string()))
-                .then_some(reference)
+            (reference.validate() && identities.insert(reference.dedup_key())).then_some(reference)
         })
         .take(MAX_BOARD_REFERENCES)
+        .collect()
+}
+
+/// Parse references authorized for one current Board workstream.
+pub fn parse_board_references_for_workstream(
+    tags: &nostr::Tags,
+    workstream_id: &str,
+) -> Vec<BoardReference> {
+    parse_board_references(tags)
+        .into_iter()
+        .filter(|reference| reference.placement().workstream_id == workstream_id)
         .collect()
 }
 
@@ -275,6 +295,19 @@ mod tests {
         assert_eq!(
             parse_board_references(&Tags::from_list(tags)),
             vec![reference("one"), reference("two")]
+        );
+    }
+    #[test]
+    fn cross_workstream_references_fail_closed() {
+        let allowed = reference("allowed");
+        let mut other = reference("other");
+        if let BoardReference::Workstream { placement, .. } = &mut other {
+            placement.workstream_id = "123e4567-e89b-12d3-a456-426614174001".into();
+        }
+        let tags = Tags::from_list(build_board_reference_tags(&[allowed.clone(), other]).unwrap());
+        assert_eq!(
+            parse_board_references_for_workstream(&tags, "123e4567-e89b-12d3-a456-426614174000"),
+            vec![allowed]
         );
     }
 }

--- a/crates/buzz-sdk/src/board_references.rs
+++ b/crates/buzz-sdk/src/board_references.rs
@@ -355,7 +355,7 @@ mod tests {
                 .unwrap()
             })
             .collect::<Vec<_>>();
-        tags.extend(build_board_reference_tags(&[valid.clone()]).unwrap());
+        tags.extend(build_board_reference_tags(std::slice::from_ref(&valid)).unwrap());
         assert_eq!(parse_board_references(&Tags::from_list(tags)), vec![valid]);
     }
 

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -229,6 +229,28 @@ pub fn build_message(
     broadcast: bool,
     media_tags: &[Vec<String>],
 ) -> Result<EventBuilder, SdkError> {
+    build_message_with_board_references(
+        channel_id,
+        content,
+        thread_ref,
+        mentions,
+        broadcast,
+        media_tags,
+        &[],
+    )
+}
+
+/// Build a stream message carrying validated, ordered Board references.
+#[allow(clippy::too_many_arguments)]
+pub fn build_message_with_board_references(
+    channel_id: Uuid,
+    content: &str,
+    thread_ref: Option<&ThreadRef>,
+    mentions: &[&str],
+    broadcast: bool,
+    media_tags: &[Vec<String>],
+    board_references: &[crate::BoardReference],
+) -> Result<EventBuilder, SdkError> {
     check_content(content, 64 * 1024)?;
     let mut tags = vec![tag(&["h", &channel_id.to_string()])?];
     if let Some(tr) = thread_ref {
@@ -239,6 +261,7 @@ pub fn build_message(
         tags.push(tag(&["broadcast", "1"])?);
     }
     imeta_tags(media_tags, &mut tags)?;
+    tags.extend(crate::build_board_reference_tags(board_references)?);
     Ok(EventBuilder::new(Kind::Custom(9), content)
         .tags(tags)
         .allow_self_tagging())

--- a/crates/buzz-sdk/src/lib.rs
+++ b/crates/buzz-sdk/src/lib.rs
@@ -12,10 +12,12 @@
 //! The caller signs with their own keys: `builder.sign_with_keys(&keys)?`.
 //! No keys are held here. No network calls are made.
 
+pub mod board_references;
 pub mod builders;
 pub mod mentions;
 pub mod nip_oa;
 
+pub use board_references::*;
 pub use builders::*;
 
 /// Re-export kind constants so consumers don't need buzz-core directly.

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
         "**/navigation.spec.ts",
         "**/channels.spec.ts",
         "**/workstream-board-message-link.capture.spec.ts",
+        "**/workstream-board-context-references.capture.spec.ts",
         "**/channel-shared-header-backdrop.spec.ts",
         "**/channel-composer-overflow.spec.ts",
         "**/badge.spec.ts",

--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -448,6 +448,7 @@ pub async fn send_channel_message(
     mention_tags: Option<Vec<Vec<String>>>,
     link_preview_tags: Option<Vec<Vec<String>>>,
     sent_from_thread_tag: Option<Vec<String>>,
+    board_references: Option<Vec<buzz_sdk_pkg::BoardReference>>,
     mention_pubkeys: Option<Vec<String>>,
     kind: Option<u32>,
     expected_relay_url: Option<String>,
@@ -462,6 +463,7 @@ pub async fn send_channel_message(
     let emoji = emoji_tags.unwrap_or_default();
     let mention_refs_only = mention_tags.unwrap_or_default();
     let link_previews = link_preview_tags.unwrap_or_default();
+    let board_references = board_references.unwrap_or_default();
     // Resolve the relay AND the signing identity once and use them for every
     // read and the submission. Callers that captured a tenant scope before an
     // await (Projects agent sends) pass `expected_relay_url` and
@@ -531,6 +533,8 @@ pub async fn send_channel_message(
                 &link_previews,
                 sent_from_thread_tag.as_deref(),
                 &relay_base,
+                &[],
+                &board_references,
             )?
         }
     };
@@ -693,6 +697,7 @@ fn build_managed_agent_channel_message(
     thread_ref: Option<&events::ThreadRef>,
     mention_pubkeys: &[String],
     client_tags: &[Vec<String>],
+    board_references: &[buzz_sdk_pkg::BoardReference],
 ) -> Result<nostr::EventBuilder, String> {
     let mention_refs: Vec<&str> = mention_pubkeys.iter().map(String::as_str).collect();
     events::build_message_with_client_tags(
@@ -707,6 +712,7 @@ fn build_managed_agent_channel_message(
         None,
         &crate::relay::relay_api_base_url(),
         client_tags,
+        board_references,
     )
 }
 
@@ -721,6 +727,7 @@ pub async fn send_managed_agent_channel_message(
     mention_pubkeys: Option<Vec<String>>,
     parent_event_id: Option<String>,
     additional_markers: Option<Vec<String>>,
+    board_references: Option<Vec<buzz_sdk_pkg::BoardReference>>,
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<SendChannelMessageResponse, String> {
@@ -813,6 +820,7 @@ pub async fn send_managed_agent_channel_message(
         thread_ref.as_ref(),
         &mentions,
         &client_tags,
+        &board_references.unwrap_or_default(),
     )?;
     // Same contract as `send_channel_message`: `created_at` is the signed
     // event's, not a post-publication clock read.

--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -522,7 +522,7 @@ pub async fn send_channel_message(
                 }
                 None => None,
             };
-            events::build_message(
+            events::build_message_with_client_tags(
                 channel_uuid,
                 content.trim(),
                 thread_ref.as_ref(),

--- a/desktop/src-tauri/src/commands/messages_tests.rs
+++ b/desktop/src-tauri/src/commands/messages_tests.rs
@@ -41,6 +41,7 @@ fn managed_agent_message_builder_adds_mentions_and_client_marker() {
         None,
         std::slice::from_ref(&pubkey),
         &[vec!["client".to_string(), "welcome-v1".to_string()]],
+        &[],
     )
     .expect("message should build")
     .sign_with_keys(&Keys::generate())
@@ -64,6 +65,7 @@ fn managed_agent_message_builder_can_carry_multiple_client_markers() {
             vec!["client".to_string(), "opener-v1".to_string()],
             vec!["client".to_string(), "closer-v1".to_string()],
         ],
+        &[],
     )
     .expect("message should build")
     .sign_with_keys(&Keys::generate())
@@ -80,6 +82,7 @@ fn managed_agent_message_builder_rejects_invalid_mentions() {
         "Welcome!",
         None,
         &["not-a-pubkey".to_string()],
+        &[],
         &[],
     )
     .expect_err("invalid mentions should fail");

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -273,6 +273,7 @@ pub fn build_message(
         sent_from_thread_tag,
         relay_base,
         &[],
+        &[],
     )
 }
 
@@ -294,6 +295,7 @@ pub fn build_message_with_client_tags(
     sent_from_thread_tag: Option<&[String]>,
     relay_base: &str,
     client_tags: &[Vec<String>],
+    board_references: &[buzz_sdk_pkg::BoardReference],
 ) -> Result<EventBuilder, String> {
     if sent_from_thread_tag.is_some() && thread_ref.is_some() {
         return Err("sent-from-thread provenance requires a top-level message".into());
@@ -310,6 +312,9 @@ pub fn build_message_with_client_tags(
     crate::link_preview_tags::append(link_preview_tags, relay_base, &mut tags)?;
     append_sent_from_thread_tag(sent_from_thread_tag, &mut tags)?;
     append_client_tags(client_tags, &mut tags)?;
+    tags.extend(
+        buzz_sdk_pkg::build_board_reference_tags(board_references).map_err(|e| e.to_string())?,
+    );
     Ok(EventBuilder::new(Kind::Custom(9), content).tags(tags))
 }
 

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -41,6 +41,10 @@ import { relayClient, setVisibleChannel } from "@/shared/api/relayClient";
 import { customEmojiQueryKey } from "@/features/custom-emoji/hooks";
 import { channelsQueryKey } from "@/features/channels/hooks";
 import { reactionEmojiUrl } from "@/shared/api/customEmoji";
+import {
+  boardReferenceTags,
+  type BoardReference,
+} from "@/features/workstream-board/lib/boardReferences";
 import type { CustomEmoji } from "@/shared/lib/remarkCustomEmoji";
 import {
   addReaction,
@@ -95,6 +99,7 @@ export function createOptimisticMessage(
   mediaTags: string[][] = [],
   sentFromThreadRootId: string | null = null,
   sentFromThreadRootExcerpt: string | null = null,
+  boardReferences: readonly BoardReference[] = [],
 ): RelayEvent {
   const localKey = `optimistic-${crypto.randomUUID()}`;
   const tags: string[][] = [];
@@ -123,6 +128,7 @@ export function createOptimisticMessage(
   for (const tag of mediaTags) {
     tags.push(tag);
   }
+  for (const tag of boardReferenceTags(boardReferences)) tags.push(tag);
   if (sentFromThreadRootId) {
     tags.push(
       buildSentFromThreadTag(sentFromThreadRootId, sentFromThreadRootExcerpt),
@@ -454,6 +460,7 @@ export function useSendMessageMutation(
       sentFromThreadRootId?: string | null;
       sentFromThreadRootExcerpt?: string | null;
       transport?: "auto" | "http";
+      boardReferences?: BoardReference[];
     },
     MessageQueryContext | undefined
   >({
@@ -468,6 +475,7 @@ export function useSendMessageMutation(
       sentFromThreadRootId,
       sentFromThreadRootExcerpt,
       transport = "auto",
+      boardReferences = [],
     }) => {
       // Prefer a channel captured by the caller at compose time. Otherwise,
       // resolve a captured id from the shared channel cache so navigation
@@ -532,7 +540,8 @@ export function useSendMessageMutation(
         parentEventId ||
         imetaTags.length > 0 ||
         emojiTags.length > 0 ||
-        linkPreviewTags.length > 0
+        linkPreviewTags.length > 0 ||
+        boardReferences.length > 0
       ) {
         const cachedMessages =
           queryClient.getQueryData<RelayEvent[]>(
@@ -549,6 +558,9 @@ export function useSendMessageMutation(
           mentionTags,
           linkPreviewTags,
           sentFromThreadTag,
+          undefined,
+          undefined,
+          boardReferences,
         );
 
         // Build tags matching relay-emitted shape: h, author p, mention ps, reply es, imeta, emoji.
@@ -587,6 +599,7 @@ export function useSendMessageMutation(
             ...emojiTags,
             ...mentionTags,
             ...linkPreviewTags,
+            ...boardReferenceTags(boardReferences),
             ...(sentFromThreadTag ? [sentFromThreadTag] : []),
           ],
           content: content.trim(),
@@ -610,6 +623,7 @@ export function useSendMessageMutation(
       mediaTags,
       sentFromThreadRootId,
       sentFromThreadRootExcerpt,
+      boardReferences = [],
     }) => {
       // Mirror mutationFn's target resolution so the optimistic message lands
       // in the cache for the same channel as the real send. A caller-supplied
@@ -647,6 +661,7 @@ export function useSendMessageMutation(
         mediaTags ?? [],
         sentFromThreadRootId ?? null,
         sentFromThreadRootExcerpt ?? null,
+        boardReferences,
       );
 
       const nextWindow = mergeLiveChannelWindowEvent(

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -894,7 +894,10 @@ export const MessageRow = React.memo(
                 {headerNode}
                 <div className={bodyContainerClass} data-testid="message-body">
                   {messageBodyNode}
-                  <BoardReferenceSet tags={message.tags} />
+                  <BoardReferenceSet
+                    channelId={channelId}
+                    tags={message.tags}
+                  />
                 </div>
               </div>
             </>
@@ -905,7 +908,10 @@ export const MessageRow = React.memo(
                 {headerNode}
                 <div className={bodyContainerClass} data-testid="message-body">
                   {messageBodyNode}
-                  <BoardReferenceSet tags={message.tags} />
+                  <BoardReferenceSet
+                    channelId={channelId}
+                    tags={message.tags}
+                  />
                 </div>
               </div>
             </>

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -59,6 +59,8 @@ import { SentFromThreadLine } from "./SentFromThreadLine";
 import { WaveMessageAttachment } from "./WaveMessageAttachment";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
+import { BoardReferenceSet } from "@/features/workstream-board/ui/BoardReferenceSet";
+
 const DiffMessage = React.lazy(() => import("./DiffMessage"));
 const DiffMessageExpanded = React.lazy(() => import("./DiffMessageExpanded"));
 
@@ -892,6 +894,7 @@ export const MessageRow = React.memo(
                 {headerNode}
                 <div className={bodyContainerClass} data-testid="message-body">
                   {messageBodyNode}
+                  <BoardReferenceSet tags={message.tags} />
                 </div>
               </div>
             </>
@@ -902,6 +905,7 @@ export const MessageRow = React.memo(
                 {headerNode}
                 <div className={bodyContainerClass} data-testid="message-body">
                   {messageBodyNode}
+                  <BoardReferenceSet tags={message.tags} />
                 </div>
               </div>
             </>

--- a/desktop/src/features/workstream-board/lib/boardReferences.test.mjs
+++ b/desktop/src/features/workstream-board/lib/boardReferences.test.mjs
@@ -20,7 +20,7 @@ const ref = (kind, identity, workstreamId = WS) => ({
   },
 });
 test("ordered mixed references round trip while malformed and cross-workstream entries fail closed", () => {
-  const valid = [ref("workstream", "one"), ref("pull-request", "one")];
+  const valid = [ref("workstream", WS), ref("pull-request", "one")];
   const tags = [
     ...boardReferenceTags(valid),
     ["buzz:board-ref", "99", "{}"],
@@ -31,9 +31,9 @@ test("ordered mixed references round trip while malformed and cross-workstream e
 });
 test("resolution distinguishes same identity across kinds and removed objects", () => {
   const refs = [
-    ref("workstream", "same"),
     ref("pull-request", "same"),
-    ref("agent-group", "gone"),
+    ref("agent-group", "same"),
+    ref("pull-request", "gone"),
   ];
   const live = new Map([
     [boardReferenceKey(refs[0]), refs[0]],
@@ -46,4 +46,43 @@ test("resolution distinguishes same identity across kinds and removed objects", 
     resolveBoardReferences(refs, live).map(({ state }) => state),
     ["live", "changed", "historical"],
   );
+});
+
+test("strict decoding rejects unknown fields and Unicode controls per reference", () => {
+  const valid = ref("workstream", WS);
+  const malformed = [
+    { ...valid, extra: true },
+    { ...valid, snapshot: { ...valid.snapshot, extra: true } },
+    { ...valid, placement: { ...valid.placement, extra: true } },
+    { ...valid, snapshot: { label: "bad\u0085label" } },
+  ];
+  const tags = malformed.map((value) => [
+    "buzz:board-ref",
+    "1",
+    JSON.stringify(value),
+  ]);
+  assert.deepEqual(
+    parseBoardReferences([...tags, ...boardReferenceTags([valid])]),
+    [valid],
+  );
+});
+
+test("workstream identity is canonically bound to placement", () => {
+  const forged = ref("workstream", OTHER);
+  forged.placement.workstreamId = WS;
+  const tag = ["buzz:board-ref", "1", JSON.stringify(forged)];
+  assert.deepEqual(parseBoardReferences([tag], WS), []);
+});
+
+test("same reusable identity is scoped to its recorded workstream", () => {
+  const inA = ref("agent", "6".repeat(64), WS);
+  const inB = ref("agent", "6".repeat(64), OTHER);
+  const live = new Map([
+    [boardReferenceKey(inA), inA],
+    [boardReferenceKey(inB), inB],
+  ]);
+  assert.notEqual(boardReferenceKey(inA), boardReferenceKey(inB));
+  assert.equal(resolveBoardReferences([inA], live)[0].state, "live");
+  live.delete(boardReferenceKey(inA));
+  assert.equal(resolveBoardReferences([inA], live)[0].state, "historical");
 });

--- a/desktop/src/features/workstream-board/lib/boardReferences.test.mjs
+++ b/desktop/src/features/workstream-board/lib/boardReferences.test.mjs
@@ -67,6 +67,56 @@ test("strict decoding rejects unknown fields and Unicode controls per reference"
   );
 });
 
+test("strict decoding enforces Rust-compatible UTF-8 byte limits without hiding the message", () => {
+  const valid = ref("pull-request", "valid");
+  const exact160Bytes = "é".repeat(80);
+  const exact512Bytes = "é".repeat(256);
+  const over160Bytes = "é".repeat(100);
+  const over512Bytes = "é".repeat(300);
+  const malformed = [
+    { ...valid, snapshot: { ...valid.snapshot, label: over160Bytes } },
+    { ...valid, snapshot: { ...valid.snapshot, detail: over160Bytes } },
+    {
+      ...valid,
+      placement: { ...valid.placement, workstreamLabel: over160Bytes },
+    },
+    { ...valid, placement: { ...valid.placement, sectionLabel: over160Bytes } },
+    { ...valid, identity: over512Bytes },
+    { ...valid, placement: { ...valid.placement, sectionId: over512Bytes } },
+  ];
+  const exactBoundary = {
+    ...valid,
+    identity: exact512Bytes,
+    snapshot: { label: exact160Bytes, detail: exact160Bytes },
+    placement: {
+      ...valid.placement,
+      workstreamLabel: exact160Bytes,
+      sectionId: exact512Bytes,
+      sectionLabel: exact160Bytes,
+    },
+  };
+  assert.equal(Buffer.byteLength(exact160Bytes, "utf8"), 160);
+  assert.equal(Buffer.byteLength(exact512Bytes, "utf8"), 512);
+  assert.ok(over160Bytes.length < 160);
+  assert.ok(Buffer.byteLength(over160Bytes, "utf8") > 160);
+  assert.ok(over512Bytes.length < 512);
+  assert.ok(Buffer.byteLength(over512Bytes, "utf8") > 512);
+
+  const malformedTags = malformed.map((value) => [
+    "buzz:board-ref",
+    "1",
+    JSON.stringify(value),
+  ]);
+  assert.deepEqual(
+    parseBoardReferences([
+      ...malformedTags,
+      ["client-only", "message remains usable"],
+      ...boardReferenceTags([exactBoundary, valid]),
+    ]),
+    [exactBoundary, valid],
+  );
+});
+
 test("workstream identity is canonically bound to placement", () => {
   const forged = ref("workstream", OTHER);
   forged.placement.workstreamId = WS;

--- a/desktop/src/features/workstream-board/lib/boardReferences.test.mjs
+++ b/desktop/src/features/workstream-board/lib/boardReferences.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  boardReferenceKey,
+  boardReferenceTags,
+  parseBoardReferences,
+  resolveBoardReferences,
+} from "./boardReferences.ts";
+const WS = "123e4567-e89b-12d3-a456-426614174000";
+const OTHER = "123e4567-e89b-12d3-a456-426614174001";
+const ref = (kind, identity, workstreamId = WS) => ({
+  kind,
+  identity,
+  snapshot: { label: identity },
+  placement: {
+    workstreamId,
+    workstreamLabel: "Checkout",
+    sectionId: "workstream",
+    sectionLabel: "Workstream",
+  },
+});
+test("ordered mixed references round trip while malformed and cross-workstream entries fail closed", () => {
+  const valid = [ref("workstream", "one"), ref("pull-request", "one")];
+  const tags = [
+    ...boardReferenceTags(valid),
+    ["buzz:board-ref", "99", "{}"],
+    ["buzz:board-ref", "1", "bad"],
+    ...boardReferenceTags([ref("agent-group", "other", OTHER)]),
+  ];
+  assert.deepEqual(parseBoardReferences(tags, WS), valid);
+});
+test("resolution distinguishes same identity across kinds and removed objects", () => {
+  const refs = [
+    ref("workstream", "same"),
+    ref("pull-request", "same"),
+    ref("agent-group", "gone"),
+  ];
+  const live = new Map([
+    [boardReferenceKey(refs[0]), refs[0]],
+    [
+      boardReferenceKey(refs[1]),
+      { ...refs[1], snapshot: { label: "changed" } },
+    ],
+  ]);
+  assert.deepEqual(
+    resolveBoardReferences(refs, live).map(({ state }) => state),
+    ["live", "changed", "historical"],
+  );
+});

--- a/desktop/src/features/workstream-board/lib/boardReferences.ts
+++ b/desktop/src/features/workstream-board/lib/boardReferences.ts
@@ -1,0 +1,157 @@
+export const BOARD_REFERENCE_TAG = "buzz:board-ref";
+export const BOARD_REFERENCE_VERSION = "1";
+export const MAX_BOARD_REFERENCES = 32;
+
+export type BoardPlacement = {
+  workstreamId: string;
+  workstreamLabel: string;
+  sectionId: string;
+  sectionLabel: string;
+};
+export type BoardSnapshot = { label: string; detail?: string };
+type Common = {
+  identity: string;
+  snapshot: BoardSnapshot;
+  placement: BoardPlacement;
+};
+export type BoardReference =
+  | (Common & { kind: "workstream" })
+  | (Common & { kind: "pull-request" })
+  | (Common & { kind: "agent" })
+  | (Common & { kind: "agent-group" })
+  | (Common & {
+      kind: "thread-blocker";
+      destination: {
+        channelId: string;
+        messageId: string;
+        threadRootId?: string;
+      };
+    });
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const HEX = /^[0-9a-f]{64}$/;
+const KINDS = new Set([
+  "workstream",
+  "pull-request",
+  "agent",
+  "agent-group",
+  "thread-blocker",
+]);
+const safe = (value: unknown, max = 160): value is string =>
+  typeof value === "string" &&
+  value.trim().length > 0 &&
+  value.length <= max &&
+  ![...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code < 32 || code === 127;
+  });
+
+export function isBoardReference(value: unknown): value is BoardReference {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const v = value as Record<string, unknown>;
+  if (
+    typeof v.kind !== "string" ||
+    !KINDS.has(v.kind) ||
+    !safe(v.identity, 512) ||
+    !v.snapshot ||
+    typeof v.snapshot !== "object" ||
+    Array.isArray(v.snapshot) ||
+    !safe((v.snapshot as Record<string, unknown>).label) ||
+    ((v.snapshot as Record<string, unknown>).detail !== undefined &&
+      !safe((v.snapshot as Record<string, unknown>).detail))
+  )
+    return false;
+  const p = v.placement as Record<string, unknown> | undefined;
+  if (
+    !p ||
+    !safe(p.workstreamId, 36) ||
+    !UUID.test(p.workstreamId) ||
+    !safe(p.workstreamLabel) ||
+    !safe(p.sectionId, 512) ||
+    !safe(p.sectionLabel)
+  )
+    return false;
+  if (v.kind === "agent" && !HEX.test(v.identity)) return false;
+  if (v.kind === "thread-blocker") {
+    const d = v.destination as Record<string, unknown> | undefined;
+    if (
+      !d ||
+      !safe(d.channelId, 36) ||
+      !UUID.test(d.channelId) ||
+      !safe(d.messageId, 64) ||
+      !HEX.test(d.messageId) ||
+      (d.threadRootId !== undefined &&
+        (!safe(d.threadRootId, 64) || !HEX.test(d.threadRootId)))
+    )
+      return false;
+  }
+  return true;
+}
+
+export function boardReferenceTags(
+  references: readonly BoardReference[],
+): string[][] {
+  if (references.length > MAX_BOARD_REFERENCES)
+    throw new Error(`Select at most ${MAX_BOARD_REFERENCES} references.`);
+  const seen = new Set<string>();
+  return references.map((reference) => {
+    if (!isBoardReference(reference) || seen.has(reference.identity))
+      throw new Error("Invalid or duplicate Board reference.");
+    seen.add(reference.identity);
+    const payload = JSON.stringify(reference);
+    if (new TextEncoder().encode(payload).length > 4096)
+      throw new Error("Board reference is too large.");
+    return [BOARD_REFERENCE_TAG, BOARD_REFERENCE_VERSION, payload];
+  });
+}
+
+export function parseBoardReferences(
+  tags: readonly (readonly string[])[] | undefined,
+): BoardReference[] {
+  const result: BoardReference[] = [];
+  const seen = new Set<string>();
+  for (const tag of tags ?? []) {
+    if (result.length >= MAX_BOARD_REFERENCES) break;
+    if (
+      tag.length !== 3 ||
+      tag[0] !== BOARD_REFERENCE_TAG ||
+      tag[1] !== BOARD_REFERENCE_VERSION ||
+      new TextEncoder().encode(tag[2]).length > 4096
+    )
+      continue;
+    try {
+      const value: unknown = JSON.parse(tag[2]);
+      if (isBoardReference(value) && !seen.has(value.identity)) {
+        seen.add(value.identity);
+        result.push(value);
+      }
+    } catch {
+      /* malformed references do not break the message */
+    }
+  }
+  return result;
+}
+
+export type BoardReferenceResolution = {
+  reference: BoardReference;
+  state: "live" | "changed" | "historical";
+};
+export function resolveBoardReferences(
+  references: readonly BoardReference[],
+  live: ReadonlyMap<string, BoardReference>,
+): BoardReferenceResolution[] {
+  return references.map((reference) => {
+    const current = live.get(reference.identity);
+    return {
+      reference,
+      state: !current
+        ? "historical"
+        : JSON.stringify(current.snapshot) ===
+              JSON.stringify(reference.snapshot) &&
+            JSON.stringify(current.placement) ===
+              JSON.stringify(reference.placement)
+          ? "live"
+          : "changed",
+    };
+  });
+}

--- a/desktop/src/features/workstream-board/lib/boardReferences.ts
+++ b/desktop/src/features/workstream-board/lib/boardReferences.ts
@@ -95,9 +95,9 @@ export function boardReferenceTags(
     throw new Error(`Select at most ${MAX_BOARD_REFERENCES} references.`);
   const seen = new Set<string>();
   return references.map((reference) => {
-    if (!isBoardReference(reference) || seen.has(reference.identity))
+    if (!isBoardReference(reference) || seen.has(boardReferenceKey(reference)))
       throw new Error("Invalid or duplicate Board reference.");
-    seen.add(reference.identity);
+    seen.add(boardReferenceKey(reference));
     const payload = JSON.stringify(reference);
     if (new TextEncoder().encode(payload).length > 4096)
       throw new Error("Board reference is too large.");
@@ -107,6 +107,7 @@ export function boardReferenceTags(
 
 export function parseBoardReferences(
   tags: readonly (readonly string[])[] | undefined,
+  workstreamId?: string,
 ): BoardReference[] {
   const result: BoardReference[] = [];
   const seen = new Set<string>();
@@ -121,8 +122,12 @@ export function parseBoardReferences(
       continue;
     try {
       const value: unknown = JSON.parse(tag[2]);
-      if (isBoardReference(value) && !seen.has(value.identity)) {
-        seen.add(value.identity);
+      if (
+        isBoardReference(value) &&
+        (!workstreamId || value.placement.workstreamId === workstreamId) &&
+        !seen.has(boardReferenceKey(value))
+      ) {
+        seen.add(boardReferenceKey(value));
         result.push(value);
       }
     } catch {
@@ -141,7 +146,7 @@ export function resolveBoardReferences(
   live: ReadonlyMap<string, BoardReference>,
 ): BoardReferenceResolution[] {
   return references.map((reference) => {
-    const current = live.get(reference.identity);
+    const current = live.get(boardReferenceKey(reference));
     return {
       reference,
       state: !current

--- a/desktop/src/features/workstream-board/lib/boardReferences.ts
+++ b/desktop/src/features/workstream-board/lib/boardReferences.ts
@@ -37,33 +37,56 @@ const KINDS = new Set([
   "agent-group",
   "thread-blocker",
 ]);
+const CONTROL_CHARACTER = /\p{Cc}/u;
 const safe = (value: unknown, max = 160): value is string =>
   typeof value === "string" &&
   value.trim().length > 0 &&
   value.length <= max &&
-  ![...value].some((character) => {
-    const code = character.charCodeAt(0);
-    return code < 32 || code === 127;
-  });
+  !CONTROL_CHARACTER.test(value);
+
+const hasExactKeys = (
+  value: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[] = [],
+): boolean => {
+  const allowed = new Set([...required, ...optional]);
+  return (
+    required.every((key) => Object.hasOwn(value, key)) &&
+    Object.keys(value).every((key) => allowed.has(key))
+  );
+};
 
 export function isBoardReference(value: unknown): value is BoardReference {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const v = value as Record<string, unknown>;
+  if (typeof v.kind !== "string" || !KINDS.has(v.kind)) return false;
+  const topLevelKeys =
+    v.kind === "thread-blocker"
+      ? ["kind", "identity", "destination", "snapshot", "placement"]
+      : ["kind", "identity", "snapshot", "placement"];
+  if (!hasExactKeys(v, topLevelKeys) || !safe(v.identity, 512)) return false;
   if (
-    typeof v.kind !== "string" ||
-    !KINDS.has(v.kind) ||
-    !safe(v.identity, 512) ||
     !v.snapshot ||
     typeof v.snapshot !== "object" ||
-    Array.isArray(v.snapshot) ||
-    !safe((v.snapshot as Record<string, unknown>).label) ||
-    ((v.snapshot as Record<string, unknown>).detail !== undefined &&
-      !safe((v.snapshot as Record<string, unknown>).detail))
+    Array.isArray(v.snapshot)
+  )
+    return false;
+  const snapshot = v.snapshot as Record<string, unknown>;
+  if (
+    !hasExactKeys(snapshot, ["label"], ["detail"]) ||
+    !safe(snapshot.label) ||
+    (snapshot.detail !== undefined && !safe(snapshot.detail))
   )
     return false;
   const p = v.placement as Record<string, unknown> | undefined;
   if (
     !p ||
+    !hasExactKeys(p, [
+      "workstreamId",
+      "workstreamLabel",
+      "sectionId",
+      "sectionLabel",
+    ]) ||
     !safe(p.workstreamId, 36) ||
     !UUID.test(p.workstreamId) ||
     !safe(p.workstreamLabel) ||
@@ -71,11 +94,13 @@ export function isBoardReference(value: unknown): value is BoardReference {
     !safe(p.sectionLabel)
   )
     return false;
+  if (v.kind === "workstream" && v.identity !== p.workstreamId) return false;
   if (v.kind === "agent" && !HEX.test(v.identity)) return false;
   if (v.kind === "thread-blocker") {
     const d = v.destination as Record<string, unknown> | undefined;
     if (
       !d ||
+      !hasExactKeys(d, ["channelId", "messageId"], ["threadRootId"]) ||
       !safe(d.channelId, 36) ||
       !UUID.test(d.channelId) ||
       !safe(d.messageId, 64) ||
@@ -162,7 +187,7 @@ export function resolveBoardReferences(
 }
 
 export function boardReferenceKey(
-  reference: Pick<BoardReference, "kind" | "identity">,
+  reference: Pick<BoardReference, "kind" | "identity" | "placement">,
 ): string {
-  return `${reference.kind}:${reference.identity}`;
+  return `${reference.placement.workstreamId}:${reference.kind}:${reference.identity}`;
 }

--- a/desktop/src/features/workstream-board/lib/boardReferences.ts
+++ b/desktop/src/features/workstream-board/lib/boardReferences.ts
@@ -41,7 +41,7 @@ const CONTROL_CHARACTER = /\p{Cc}/u;
 const safe = (value: unknown, max = 160): value is string =>
   typeof value === "string" &&
   value.trim().length > 0 &&
-  value.length <= max &&
+  new TextEncoder().encode(value).byteLength <= max &&
   !CONTROL_CHARACTER.test(value);
 
 const hasExactKeys = (

--- a/desktop/src/features/workstream-board/lib/boardReferences.ts
+++ b/desktop/src/features/workstream-board/lib/boardReferences.ts
@@ -155,3 +155,9 @@ export function resolveBoardReferences(
     };
   });
 }
+
+export function boardReferenceKey(
+  reference: Pick<BoardReference, "kind" | "identity">,
+): string {
+  return `${reference.kind}:${reference.identity}`;
+}

--- a/desktop/src/features/workstream-board/ui/BoardReferenceItems.tsx
+++ b/desktop/src/features/workstream-board/ui/BoardReferenceItems.tsx
@@ -1,0 +1,37 @@
+import type { BoardReference } from "@/features/workstream-board/lib/boardReferences";
+import { boardReferenceKey } from "@/features/workstream-board/lib/boardReferences";
+import { cn } from "@/shared/lib/cn";
+
+export function BoardReferenceItems({
+  references,
+  onRemove,
+}: {
+  references: readonly BoardReference[];
+  onRemove?: (reference: BoardReference) => void;
+}) {
+  return (
+    <ol className="flex flex-wrap gap-1.5" data-testid="board-reference-items">
+      {references.map((reference, index) => (
+        <li
+          className="inline-flex items-center gap-1 rounded-full border bg-background px-2 py-1 text-3xs"
+          data-reference-key={boardReferenceKey(reference)}
+          key={boardReferenceKey(reference)}
+        >
+          <span>
+            {index + 1}. {reference.kind}: {reference.snapshot.label}
+          </span>
+          {onRemove ? (
+            <button
+              aria-label={`Remove ${reference.snapshot.label}`}
+              className={cn("font-semibold underline")}
+              onClick={() => onRemove(reference)}
+              type="button"
+            >
+              Remove
+            </button>
+          ) : null}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/desktop/src/features/workstream-board/ui/BoardReferenceSet.tsx
+++ b/desktop/src/features/workstream-board/ui/BoardReferenceSet.tsx
@@ -1,0 +1,37 @@
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { parseBoardReferences } from "@/features/workstream-board/lib/boardReferences";
+
+export const BOARD_REPLAY_STORAGE_KEY = "buzz:board-replay:v1";
+
+export function BoardReferenceSet({
+  tags,
+}: {
+  tags?: readonly (readonly string[])[];
+}) {
+  const references = parseBoardReferences(tags);
+  const { goWorkstreams } = useAppNavigation();
+  if (references.length === 0) return null;
+  return (
+    <button
+      className="mt-2 flex w-full flex-wrap gap-1.5 rounded-lg border bg-muted/40 p-2 text-left"
+      data-testid="message-board-references"
+      onClick={() => {
+        sessionStorage.setItem(
+          BOARD_REPLAY_STORAGE_KEY,
+          JSON.stringify(references),
+        );
+        void goWorkstreams();
+      }}
+      type="button"
+    >
+      {references.map((reference, index) => (
+        <span
+          className="rounded-full border bg-background px-2 py-1 text-3xs"
+          key={`${reference.kind}:${reference.identity}`}
+        >
+          {index + 1}. {reference.kind}: {reference.snapshot.label}
+        </span>
+      ))}
+    </button>
+  );
+}

--- a/desktop/src/features/workstream-board/ui/BoardReferenceSet.tsx
+++ b/desktop/src/features/workstream-board/ui/BoardReferenceSet.tsx
@@ -1,5 +1,6 @@
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { parseBoardReferences } from "@/features/workstream-board/lib/boardReferences";
+import { BoardReferenceItems } from "@/features/workstream-board/ui/BoardReferenceItems";
 
 export const BOARD_REPLAY_STORAGE_KEY = "buzz:board-replay:v1";
 
@@ -26,14 +27,7 @@ export function BoardReferenceSet({
       }}
       type="button"
     >
-      {references.map((reference, index) => (
-        <span
-          className="rounded-full border bg-background px-2 py-1 text-3xs"
-          key={`${reference.kind}:${reference.identity}`}
-        >
-          {index + 1}. {reference.kind}: {reference.snapshot.label}
-        </span>
-      ))}
+      <BoardReferenceItems references={references} />
     </button>
   );
 }

--- a/desktop/src/features/workstream-board/ui/BoardReferenceSet.tsx
+++ b/desktop/src/features/workstream-board/ui/BoardReferenceSet.tsx
@@ -4,11 +4,13 @@ import { parseBoardReferences } from "@/features/workstream-board/lib/boardRefer
 export const BOARD_REPLAY_STORAGE_KEY = "buzz:board-replay:v1";
 
 export function BoardReferenceSet({
+  channelId,
   tags,
 }: {
+  channelId?: string | null;
   tags?: readonly (readonly string[])[];
 }) {
-  const references = parseBoardReferences(tags);
+  const references = parseBoardReferences(tags, channelId ?? undefined);
   const { goWorkstreams } = useAppNavigation();
   if (references.length === 0) return null;
   return (

--- a/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
@@ -62,6 +62,7 @@ export function WorkstreamBoardScreen() {
   >([]);
   const [replayFocusIndex, setReplayFocusIndex] = React.useState(0);
   const startReplay = React.useCallback((references: BoardReference[]) => {
+    setDiscussionMode(true);
     setReplayFocusIndex(0);
     setReplayReferences(references);
   }, []);

--- a/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
@@ -22,8 +22,10 @@ import {
 } from "@/features/workstream-board/lib/workstreamWaits";
 import { WorkstreamCard } from "@/features/workstream-board/ui/WorkstreamCard";
 import { BOARD_REPLAY_STORAGE_KEY } from "@/features/workstream-board/ui/BoardReferenceSet";
+import { BoardReferenceItems } from "@/features/workstream-board/ui/BoardReferenceItems";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import { Button } from "@/shared/ui/button";
+import { cn } from "@/shared/lib/cn";
 import { PageHeader } from "@/shared/ui/PageHeader";
 
 const WORKSTREAM_CARD_GRID_CLASS =
@@ -59,16 +61,26 @@ export function WorkstreamBoardScreen() {
     BoardReference[]
   >([]);
   const [replayFocusIndex, setReplayFocusIndex] = React.useState(0);
+  const startReplay = React.useCallback((references: BoardReference[]) => {
+    setReplayFocusIndex(0);
+    setReplayReferences(references);
+  }, []);
   React.useEffect(() => {
     if (!discussionMode && replayReferences.length === 0) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         if (replayReferences.length > 0) setReplayReferences([]);
         else if (
-          selectedReferences.length === 0 ||
-          window.confirm("Discard the unsent reference tray?")
-        )
+          (selectedReferences.length === 0 && draft.length === 0) ||
+          window.confirm(
+            "Discard the unsent discussion draft and reference tray?",
+          )
+        ) {
           setDiscussionMode(false);
+          setSelectedReferences([]);
+          setDiscussionChannelId(null);
+          setDraft("");
+        }
       } else if (
         replayReferences.length > 0 &&
         (event.key === "ArrowRight" || event.key === "]")
@@ -90,7 +102,7 @@ export function WorkstreamBoardScreen() {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [discussionMode, replayReferences, selectedReferences.length]);
+  }, [discussionMode, draft, replayReferences, selectedReferences.length]);
   const [liveReferencesByChannel, setLiveReferencesByChannel] = React.useState<
     ReadonlyMap<string, readonly BoardReference[]>
   >(() => new Map());
@@ -101,7 +113,7 @@ export function WorkstreamBoardScreen() {
     try {
       const parsed: unknown = JSON.parse(stored);
       if (Array.isArray(parsed)) {
-        setReplayReferences(
+        startReplay(
           parsed.flatMap((value) => {
             const references = parseBoardReferences([
               ["buzz:board-ref", "1", JSON.stringify(value)],
@@ -113,7 +125,7 @@ export function WorkstreamBoardScreen() {
     } catch {
       // Malformed cross-route replay state fails closed.
     }
-  }, []);
+  }, [startReplay]);
   const workstreamChannels = filterWorkstreamChannels(channelsQuery.data ?? []);
   const discussionChannel =
     workstreamChannels.find((channel) => channel.id === discussionChannelId) ??
@@ -131,6 +143,9 @@ export function WorkstreamBoardScreen() {
     () => new Set(replayReferences.map(boardReferenceKey)),
     [replayReferences],
   );
+  const replayFocusedKey = replayReferences[replayFocusIndex]
+    ? boardReferenceKey(replayReferences[replayFocusIndex])
+    : undefined;
   const liveReferences = React.useMemo(
     () =>
       new Map(
@@ -139,6 +154,21 @@ export function WorkstreamBoardScreen() {
           .map((reference) => [boardReferenceKey(reference), reference]),
       ),
     [liveReferencesByChannel],
+  );
+  const resolvedReplayReferences = React.useMemo(
+    () => resolveBoardReferences(replayReferences, liveReferences),
+    [liveReferences, replayReferences],
+  );
+  const replayReferenceStates = React.useMemo(
+    () =>
+      new Map(
+        resolvedReplayReferences.flatMap((item) =>
+          item.state === "historical"
+            ? []
+            : [[boardReferenceKey(item.reference), item.state] as const],
+        ),
+      ),
+    [resolvedReplayReferences],
   );
   const onReferencesChange = React.useCallback(
     (channelId: string, references: readonly BoardReference[]) => {
@@ -242,14 +272,17 @@ export function WorkstreamBoardScreen() {
               onClick={() => {
                 if (
                   discussionMode &&
-                  selectedReferences.length > 0 &&
-                  !window.confirm("Discard the unsent reference tray?")
+                  (selectedReferences.length > 0 || draft.length > 0) &&
+                  !window.confirm(
+                    "Discard the unsent discussion draft and reference tray?",
+                  )
                 )
                   return;
                 setDiscussionMode(!discussionMode);
                 setSelectedReferences([]);
                 setReplayReferences([]);
                 setDiscussionChannelId(null);
+                setDraft("");
               }}
               variant={discussionMode ? "secondary" : "default"}
             >
@@ -270,25 +303,10 @@ export function WorkstreamBoardScreen() {
               <p className="text-sm font-semibold">
                 Reference tray ({selectedReferences.length})
               </p>
-              <ol className="space-y-1">
-                {selectedReferences.map((reference, index) => (
-                  <li
-                    className="flex items-center gap-2 text-xs"
-                    key={boardReferenceKey(reference)}
-                  >
-                    <span>
-                      {index + 1}. {reference.kind}: {reference.snapshot.label}
-                    </span>
-                    <button
-                      className="underline"
-                      onClick={() => toggleReference(reference)}
-                      type="button"
-                    >
-                      Remove
-                    </button>
-                  </li>
-                ))}
-              </ol>
+              <BoardReferenceItems
+                onRemove={toggleReference}
+                references={selectedReferences}
+              />
               <textarea
                 aria-label="Discussion message"
                 className="min-h-20 w-full rounded-md border bg-background p-2 text-sm"
@@ -329,15 +347,11 @@ export function WorkstreamBoardScreen() {
                         <button
                           className="block w-full rounded-md border bg-background p-2 text-left text-xs"
                           key={event.id}
-                          onClick={() => setReplayReferences(refs)}
+                          onClick={() => startReplay(refs)}
                           type="button"
                         >
                           <span className="block">{event.content}</span>
-                          <span className="text-muted-foreground">
-                            {refs
-                              .map((reference) => reference.snapshot.label)
-                              .join(" · ")}
-                          </span>
+                          <BoardReferenceItems references={refs} />
                         </button>
                       );
                     })}
@@ -349,9 +363,15 @@ export function WorkstreamBoardScreen() {
               )}
               {replayReferences.length > 0
                 ? (() => {
-                    const resolved = resolveBoardReferences(
-                      replayReferences,
-                      liveReferences,
+                    const resolved = resolvedReplayReferences;
+                    const fallbackHistorical = resolved.filter(
+                      (item) =>
+                        item.state === "historical" &&
+                        !workstreamChannels.some(
+                          (channel) =>
+                            channel.id ===
+                            item.reference.placement.workstreamId,
+                        ),
                     );
                     return (
                       <div className="text-xs">
@@ -403,20 +423,30 @@ export function WorkstreamBoardScreen() {
                             Next
                           </button>
                         </span>
-                        {resolved.some(
-                          (item) => item.state === "historical",
-                        ) ? (
+                        {fallbackHistorical.length > 0 ? (
                           <div className="mt-2 rounded-md border border-dashed p-2">
                             <strong>Historical references</strong>
-                            {resolved
-                              .filter((item) => item.state === "historical")
-                              .map((item) => (
-                                <p key={boardReferenceKey(item.reference)}>
+                            {fallbackHistorical.map((item) => {
+                              const key = boardReferenceKey(item.reference);
+                              const current = replayFocusedKey === key;
+                              return (
+                                <p
+                                  aria-current={current ? "true" : undefined}
+                                  className={cn(
+                                    "rounded px-1",
+                                    current &&
+                                      "font-bold outline outline-2 outline-offset-2",
+                                  )}
+                                  data-testid="historical-reference-placeholder"
+                                  key={key}
+                                >
                                   {item.reference.snapshot.label} · formerly{" "}
                                   {item.reference.placement.workstreamLabel} /{" "}
                                   {item.reference.placement.sectionLabel}
+                                  {current ? " · Current" : ""}
                                 </p>
-                              ))}
+                              );
+                            })}
                           </div>
                         ) : null}
                       </div>
@@ -457,6 +487,15 @@ export function WorkstreamBoardScreen() {
                     onReferencesChange(channel.id, references)
                   }
                   replayReferenceKeys={replayKeys}
+                  replayFocusedReferenceKey={replayFocusedKey}
+                  replayReferenceStates={replayReferenceStates}
+                  historicalReplayReferences={resolvedReplayReferences
+                    .filter(
+                      (item) =>
+                        item.state === "historical" &&
+                        item.reference.placement.workstreamId === channel.id,
+                    )
+                    .map((item) => item.reference)}
                   selectedReferenceKeys={selectedKeys}
                   currentOwnerPubkey={identityQuery.data?.pubkey}
                   key={channel.id}

--- a/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
@@ -3,6 +3,16 @@ import * as React from "react";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { useActiveAgentTurnsByChannel } from "@/features/agents/activeAgentTurnsStore";
 import { useChannelsQuery } from "@/features/channels/hooks";
+import {
+  useChannelMessagesQuery,
+  useSendMessageMutation,
+} from "@/features/messages/hooks";
+import {
+  parseBoardReferences,
+  boardReferenceKey,
+  resolveBoardReferences,
+  type BoardReference,
+} from "@/features/workstream-board/lib/boardReferences";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { filterWorkstreamChannels } from "@/features/workstream-board/lib/discoverWorkstreamChannels";
 import { getActiveWorkstreamTurns } from "@/features/workstream-board/lib/activeWorkstreamTurns";
@@ -11,6 +21,7 @@ import {
   type WorkstreamWait,
 } from "@/features/workstream-board/lib/workstreamWaits";
 import { WorkstreamCard } from "@/features/workstream-board/ui/WorkstreamCard";
+import { BOARD_REPLAY_STORAGE_KEY } from "@/features/workstream-board/ui/BoardReferenceSet";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import { Button } from "@/shared/ui/button";
 import { PageHeader } from "@/shared/ui/PageHeader";
@@ -36,7 +47,95 @@ export function WorkstreamBoardScreen() {
   const { goChannel } = useAppNavigation();
   const identityQuery = useIdentityQuery();
   const channelsQuery = useChannelsQuery();
+  const [discussionMode, setDiscussionMode] = React.useState(false);
+  const [selectedReferences, setSelectedReferences] = React.useState<
+    BoardReference[]
+  >([]);
+  const [discussionChannelId, setDiscussionChannelId] = React.useState<
+    string | null
+  >(null);
+  const [draft, setDraft] = React.useState("");
+  const [replayReferences, setReplayReferences] = React.useState<
+    BoardReference[]
+  >([]);
+  const [liveReferencesByChannel, setLiveReferencesByChannel] = React.useState<
+    ReadonlyMap<string, readonly BoardReference[]>
+  >(() => new Map());
+  React.useEffect(() => {
+    const stored = sessionStorage.getItem(BOARD_REPLAY_STORAGE_KEY);
+    if (!stored) return;
+    sessionStorage.removeItem(BOARD_REPLAY_STORAGE_KEY);
+    try {
+      const parsed: unknown = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        setReplayReferences(
+          parsed.flatMap((value) => {
+            const references = parseBoardReferences([
+              ["buzz:board-ref", "1", JSON.stringify(value)],
+            ]);
+            return references;
+          }),
+        );
+      }
+    } catch {
+      // Malformed cross-route replay state fails closed.
+    }
+  }, []);
   const workstreamChannels = filterWorkstreamChannels(channelsQuery.data ?? []);
+  const discussionChannel =
+    workstreamChannels.find((channel) => channel.id === discussionChannelId) ??
+    null;
+  const discussionMessages = useChannelMessagesQuery(discussionChannel);
+  const sendMessage = useSendMessageMutation(
+    discussionChannel,
+    identityQuery.data,
+  );
+  const selectedKeys = React.useMemo(
+    () => new Set(selectedReferences.map(boardReferenceKey)),
+    [selectedReferences],
+  );
+  const replayKeys = React.useMemo(
+    () => new Set(replayReferences.map(boardReferenceKey)),
+    [replayReferences],
+  );
+  const liveReferences = React.useMemo(
+    () =>
+      new Map(
+        [...liveReferencesByChannel.values()]
+          .flat()
+          .map((reference) => [reference.identity, reference]),
+      ),
+    [liveReferencesByChannel],
+  );
+  const onReferencesChange = React.useCallback(
+    (channelId: string, references: readonly BoardReference[]) => {
+      setLiveReferencesByChannel((current) => {
+        const previous = current.get(channelId);
+        if (JSON.stringify(previous) === JSON.stringify(references))
+          return current;
+        const next = new Map(current);
+        next.set(channelId, references);
+        return next;
+      });
+    },
+    [],
+  );
+  const toggleReference = React.useCallback((reference: BoardReference) => {
+    setDiscussionChannelId(
+      (current) => current ?? reference.placement.workstreamId,
+    );
+    setSelectedReferences((current) => {
+      if (
+        current.length > 0 &&
+        current[0].placement.workstreamId !== reference.placement.workstreamId
+      )
+        return current;
+      const key = boardReferenceKey(reference);
+      return current.some((item) => boardReferenceKey(item) === key)
+        ? current.filter((item) => boardReferenceKey(item) !== key)
+        : [...current, reference];
+    });
+  }, []);
   const activeTurnsByChannel = useActiveAgentTurnsByChannel();
   const activeWorkstreamTurns = React.useMemo(
     () => getActiveWorkstreamTurns(workstreamChannels, activeTurnsByChannel),
@@ -105,6 +204,162 @@ export function WorkstreamBoardScreen() {
             description="Live canvases for active workstream channels."
             title="Workstream Board"
           />
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              onClick={() => {
+                if (
+                  discussionMode &&
+                  selectedReferences.length > 0 &&
+                  !window.confirm("Discard the unsent reference tray?")
+                )
+                  return;
+                setDiscussionMode(!discussionMode);
+                setSelectedReferences([]);
+                setReplayReferences([]);
+                setDiscussionChannelId(null);
+              }}
+              variant={discussionMode ? "secondary" : "default"}
+            >
+              {discussionMode ? "Exit discussion" : "Discuss Board"}
+            </Button>
+            {replayReferences.length > 0 ? (
+              <Button onClick={() => setReplayReferences([])} variant="outline">
+                End replay
+              </Button>
+            ) : null}
+          </div>
+          {discussionMode ? (
+            <section
+              aria-label="Board discussion"
+              className="space-y-3 rounded-xl border bg-muted/30 p-4"
+              data-testid="board-discussion"
+            >
+              <p className="text-sm font-semibold">
+                Reference tray ({selectedReferences.length})
+              </p>
+              <ol className="space-y-1">
+                {selectedReferences.map((reference, index) => (
+                  <li
+                    className="flex items-center gap-2 text-xs"
+                    key={boardReferenceKey(reference)}
+                  >
+                    <span>
+                      {index + 1}. {reference.kind}: {reference.snapshot.label}
+                    </span>
+                    <button
+                      className="underline"
+                      onClick={() => toggleReference(reference)}
+                      type="button"
+                    >
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ol>
+              <textarea
+                aria-label="Discussion message"
+                className="min-h-20 w-full rounded-md border bg-background p-2 text-sm"
+                onChange={(event) => setDraft(event.target.value)}
+                placeholder="Discuss these Board references…"
+                value={draft}
+              />
+              <Button
+                disabled={
+                  !discussionChannel ||
+                  (!draft.trim() && selectedReferences.length === 0) ||
+                  sendMessage.isPending
+                }
+                onClick={async () => {
+                  if (!discussionChannel) return;
+                  await sendMessage.mutateAsync({
+                    content: draft || "Board references",
+                    boardReferences: selectedReferences,
+                  });
+                  setDraft("");
+                  setSelectedReferences([]);
+                }}
+              >
+                Send
+              </Button>
+              {discussionChannel ? (
+                <div className="space-y-2 border-t pt-3">
+                  <p className="text-xs font-semibold">
+                    #{discussionChannel.name} messages
+                  </p>
+                  {(discussionMessages.data ?? [])
+                    .filter(
+                      (event) => parseBoardReferences(event.tags).length > 0,
+                    )
+                    .map((event) => {
+                      const refs = parseBoardReferences(event.tags);
+                      return (
+                        <button
+                          className="block w-full rounded-md border bg-background p-2 text-left text-xs"
+                          key={event.id}
+                          onClick={() => setReplayReferences(refs)}
+                          type="button"
+                        >
+                          <span className="block">{event.content}</span>
+                          <span className="text-muted-foreground">
+                            {refs
+                              .map((reference) => reference.snapshot.label)
+                              .join(" · ")}
+                          </span>
+                        </button>
+                      );
+                    })}
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Select an object in one workstream to choose the discussion.
+                </p>
+              )}
+              {replayReferences.length > 0
+                ? (() => {
+                    const resolved = resolveBoardReferences(
+                      replayReferences,
+                      liveReferences,
+                    );
+                    return (
+                      <div className="text-xs">
+                        <strong>Replay:</strong>{" "}
+                        {
+                          resolved.filter((item) => item.state === "live")
+                            .length
+                        }{" "}
+                        live ·{" "}
+                        {
+                          resolved.filter((item) => item.state === "changed")
+                            .length
+                        }{" "}
+                        changed ·{" "}
+                        {
+                          resolved.filter((item) => item.state === "historical")
+                            .length
+                        }{" "}
+                        historical
+                        {resolved.some(
+                          (item) => item.state === "historical",
+                        ) ? (
+                          <div className="mt-2 rounded-md border border-dashed p-2">
+                            <strong>Historical references</strong>
+                            {resolved
+                              .filter((item) => item.state === "historical")
+                              .map((item) => (
+                                <p key={boardReferenceKey(item.reference)}>
+                                  {item.reference.snapshot.label} · formerly{" "}
+                                  {item.reference.placement.workstreamLabel} /{" "}
+                                  {item.reference.placement.sectionLabel}
+                                </p>
+                              ))}
+                          </div>
+                        ) : null}
+                      </div>
+                    );
+                  })()
+                : null}
+            </section>
+          ) : null}
           {channelsQuery.isLoading ? (
             <p className="text-sm text-muted-foreground">
               Loading workstreams…
@@ -131,6 +386,13 @@ export function WorkstreamBoardScreen() {
                 <WorkstreamCard
                   activeWorking={activeTurnsByChannelId.get(channel.id)}
                   channel={channel}
+                  discussionMode={discussionMode}
+                  onToggleReference={toggleReference}
+                  onReferencesChange={(references) =>
+                    onReferencesChange(channel.id, references)
+                  }
+                  replayReferenceKeys={replayKeys}
+                  selectedReferenceKeys={selectedKeys}
                   currentOwnerPubkey={identityQuery.data?.pubkey}
                   key={channel.id}
                   onSelect={(channelId) => void goChannel(channelId)}

--- a/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
@@ -53,9 +53,8 @@ export function WorkstreamBoardScreen() {
   const [selectedReferences, setSelectedReferences] = React.useState<
     BoardReference[]
   >([]);
-  const [discussionChannelId, setDiscussionChannelId] = React.useState<
-    string | null
-  >(null);
+  const discussionChannelId =
+    selectedReferences[0]?.placement.workstreamId ?? null;
   const [draft, setDraft] = React.useState("");
   const [replayReferences, setReplayReferences] = React.useState<
     BoardReference[]
@@ -79,7 +78,6 @@ export function WorkstreamBoardScreen() {
         ) {
           setDiscussionMode(false);
           setSelectedReferences([]);
-          setDiscussionChannelId(null);
           setDraft("");
         }
       } else if (
@@ -185,9 +183,6 @@ export function WorkstreamBoardScreen() {
     [],
   );
   const toggleReference = React.useCallback((reference: BoardReference) => {
-    setDiscussionChannelId(
-      (current) => current ?? reference.placement.workstreamId,
-    );
     setSelectedReferences((current) => {
       if (
         current.length > 0 &&
@@ -282,7 +277,6 @@ export function WorkstreamBoardScreen() {
                 setDiscussionMode(!discussionMode);
                 setSelectedReferences([]);
                 setReplayReferences([]);
-                setDiscussionChannelId(null);
                 setDraft("");
               }}
               variant={discussionMode ? "secondary" : "default"}

--- a/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
@@ -340,10 +340,15 @@ export function WorkstreamBoardScreen() {
                   </p>
                   {(discussionMessages.data ?? [])
                     .filter(
-                      (event) => parseBoardReferences(event.tags).length > 0,
+                      (event) =>
+                        parseBoardReferences(event.tags, discussionChannel.id)
+                          .length > 0,
                     )
                     .map((event) => {
-                      const refs = parseBoardReferences(event.tags);
+                      const refs = parseBoardReferences(
+                        event.tags,
+                        discussionChannel.id,
+                      );
                       return (
                         <button
                           className="block w-full rounded-md border bg-background p-2 text-left text-xs"

--- a/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamBoardScreen.tsx
@@ -58,6 +58,39 @@ export function WorkstreamBoardScreen() {
   const [replayReferences, setReplayReferences] = React.useState<
     BoardReference[]
   >([]);
+  const [replayFocusIndex, setReplayFocusIndex] = React.useState(0);
+  React.useEffect(() => {
+    if (!discussionMode && replayReferences.length === 0) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        if (replayReferences.length > 0) setReplayReferences([]);
+        else if (
+          selectedReferences.length === 0 ||
+          window.confirm("Discard the unsent reference tray?")
+        )
+          setDiscussionMode(false);
+      } else if (
+        replayReferences.length > 0 &&
+        (event.key === "ArrowRight" || event.key === "]")
+      ) {
+        event.preventDefault();
+        setReplayFocusIndex(
+          (current) => (current + 1) % replayReferences.length,
+        );
+      } else if (
+        replayReferences.length > 0 &&
+        (event.key === "ArrowLeft" || event.key === "[")
+      ) {
+        event.preventDefault();
+        setReplayFocusIndex(
+          (current) =>
+            (current - 1 + replayReferences.length) % replayReferences.length,
+        );
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [discussionMode, replayReferences, selectedReferences.length]);
   const [liveReferencesByChannel, setLiveReferencesByChannel] = React.useState<
     ReadonlyMap<string, readonly BoardReference[]>
   >(() => new Map());
@@ -103,7 +136,7 @@ export function WorkstreamBoardScreen() {
       new Map(
         [...liveReferencesByChannel.values()]
           .flat()
-          .map((reference) => [reference.identity, reference]),
+          .map((reference) => [boardReferenceKey(reference), reference]),
       ),
     [liveReferencesByChannel],
   );
@@ -322,7 +355,10 @@ export function WorkstreamBoardScreen() {
                     );
                     return (
                       <div className="text-xs">
-                        <strong>Replay:</strong>{" "}
+                        <strong>
+                          Replay {replayFocusIndex + 1}/
+                          {replayReferences.length}:
+                        </strong>{" "}
                         {
                           resolved.filter((item) => item.state === "live")
                             .length
@@ -338,6 +374,35 @@ export function WorkstreamBoardScreen() {
                             .length
                         }{" "}
                         historical
+                        <span className="ml-2 inline-flex gap-1">
+                          <button
+                            aria-label="Previous reference"
+                            className="underline"
+                            onClick={() =>
+                              setReplayFocusIndex(
+                                (current) =>
+                                  (current - 1 + replayReferences.length) %
+                                  replayReferences.length,
+                              )
+                            }
+                            type="button"
+                          >
+                            Previous
+                          </button>
+                          <button
+                            aria-label="Next reference"
+                            className="underline"
+                            onClick={() =>
+                              setReplayFocusIndex(
+                                (current) =>
+                                  (current + 1) % replayReferences.length,
+                              )
+                            }
+                            type="button"
+                          >
+                            Next
+                          </button>
+                        </span>
                         {resolved.some(
                           (item) => item.state === "historical",
                         ) ? (

--- a/desktop/src/features/workstream-board/ui/WorkstreamCard.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamCard.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import { Hash } from "lucide-react";
+import type { BoardReference } from "@/features/workstream-board/lib/boardReferences";
+import { boardReferenceKey } from "@/features/workstream-board/lib/boardReferences";
 
 import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
 import {
@@ -12,6 +14,7 @@ import {
   useWorkstreamPullRequestStatuses,
 } from "@/features/workstream-board/lib/workstreamPullRequestStatus";
 import {
+  parseWorkstreamWaitMessageLink,
   waitsForCard,
   type WorkstreamWait,
 } from "@/features/workstream-board/lib/workstreamWaits";
@@ -34,15 +37,25 @@ type WorkstreamCardProps = {
     createdAt: string | null | undefined,
   ) => void;
   onSelect: (channelId: string) => void;
+  discussionMode?: boolean;
+  selectedReferenceKeys?: ReadonlySet<string>;
+  replayReferenceKeys?: ReadonlySet<string>;
+  onToggleReference?: (reference: BoardReference) => void;
+  onReferencesChange?: (references: readonly BoardReference[]) => void;
 };
 
 export function WorkstreamCard({
   activeWorking,
   channel,
+  discussionMode = false,
   currentOwnerPubkey,
   onSelect,
   onWaitsChange,
+  onToggleReference,
+  onReferencesChange,
   profiles,
+  replayReferenceKeys,
+  selectedReferenceKeys,
 }: WorkstreamCardProps) {
   const canvasQuery = useCanvasQuery(channel.id);
   const detailsQuery = useChannelDetailsQuery(channel.id);
@@ -87,18 +100,102 @@ export function WorkstreamCard({
       normalizePubkey(wait.actor.pubkey) ===
         normalizePubkey(currentOwnerPubkey),
   );
+  const discussionReferences = React.useMemo<BoardReference[]>(() => {
+    if (viewModel.status !== "ready") return [];
+    const placement = {
+      workstreamId: channel.id,
+      workstreamLabel: channel.name,
+      sectionId: "workstream",
+      sectionLabel: "Workstream",
+    };
+    const result: BoardReference[] = [
+      {
+        kind: "workstream",
+        identity: channel.id,
+        snapshot: { label: channel.name, detail: viewModel.card.synopsis },
+        placement,
+      },
+    ];
+    for (const reference of references) {
+      result.push({
+        kind: "pull-request",
+        identity: reference.identity,
+        snapshot: { label: reference.rawUrl },
+        placement: {
+          ...placement,
+          sectionId: "pull-requests",
+          sectionLabel: "Pull requests",
+        },
+      });
+    }
+    for (const assignee of viewModel.card.assignees) {
+      const identity = normalizePubkey(assignee.pubkey);
+      if (/^[0-9a-f]{64}$/.test(identity))
+        result.push({
+          kind: "agent",
+          identity,
+          snapshot: { label: assignee.name },
+          placement: {
+            ...placement,
+            sectionId: "agents",
+            sectionLabel: "Agents",
+          },
+        });
+    }
+    result.push({
+      kind: "agent-group",
+      identity: `orchestrator:${normalizePubkey(viewModel.card.orchestrator.pubkey)}`,
+      snapshot: {
+        label: `${viewModel.card.orchestrator.name}'s team`,
+        detail: "Orchestrator group",
+      },
+      placement: { ...placement, sectionId: "agents", sectionLabel: "Agents" },
+    });
+    for (const wait of waits) {
+      const destination = parseWorkstreamWaitMessageLink(wait.message);
+      if (!destination) continue;
+      result.push({
+        kind: "thread-blocker",
+        identity: wait.key,
+        destination: {
+          channelId: destination.channelId,
+          messageId: destination.messageId,
+          ...(destination.threadRootId
+            ? { threadRootId: destination.threadRootId }
+            : {}),
+        },
+        snapshot: { label: wait.reason, detail: wait.actor.name },
+        placement: {
+          ...placement,
+          sectionId: "blockers",
+          sectionLabel: "Blockers",
+        },
+      });
+    }
+    return result;
+  }, [channel.id, channel.name, references, viewModel, waits]);
+  React.useEffect(() => {
+    onReferencesChange?.(discussionReferences);
+  }, [discussionReferences, onReferencesChange]);
 
   return (
     <div
       className={cn(
         "group relative w-full self-start overflow-hidden rounded-2xl border border-border/70 bg-muted/50 p-5 text-left text-foreground shadow-xs transition-all hover:-translate-y-0.5 hover:border-border hover:bg-muted/65 hover:shadow-md",
         waitingOnPrincipal && "border-t-4 border-t-amber-400/70",
+        discussionReferences.some((reference) =>
+          replayReferenceKeys?.has(boardReferenceKey(reference)),
+        ) && "ring-2 ring-primary ring-offset-2 ring-offset-background",
       )}
       data-testid={`workstream-card-${channel.id}`}
     >
       <button
         className="absolute inset-0 z-0 rounded-2xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-        onClick={() => onSelect(channel.id)}
+        onClick={() =>
+          discussionMode
+            ? onToggleReference?.(discussionReferences[0])
+            : onSelect(channel.id)
+        }
         type="button"
       >
         <span className="sr-only">Open #{channel.name}</span>
@@ -111,12 +208,50 @@ export function WorkstreamCard({
       <div className="pointer-events-none relative z-10 flex flex-col">
         <button
           className="pointer-events-auto flex max-w-[calc(100%-4rem)] items-center gap-1.5 text-xs font-semibold text-muted-foreground hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-          onClick={() => onSelect(channel.id)}
+          onClick={() =>
+            discussionMode
+              ? onToggleReference?.(discussionReferences[0])
+              : onSelect(channel.id)
+          }
           type="button"
         >
           <Hash className="h-3.5 w-3.5 shrink-0" />
           <span className="truncate">{channel.name}</span>
         </button>
+        {discussionMode ? (
+          <div
+            className="pointer-events-auto mt-3 flex flex-wrap gap-1.5"
+            data-testid={`board-reference-options-${channel.id}`}
+          >
+            {discussionReferences.map((reference) => {
+              const key = boardReferenceKey(reference);
+              const selected = selectedReferenceKeys?.has(key) ?? false;
+              const replayed = replayReferenceKeys?.has(key) ?? false;
+              return (
+                <button
+                  aria-pressed={selected}
+                  className={cn(
+                    "rounded-full border px-2 py-1 text-3xs",
+                    selected && "border-primary bg-primary/15",
+                    replayed && "ring-2 ring-primary",
+                  )}
+                  key={key}
+                  onClick={() => onToggleReference?.(reference)}
+                  type="button"
+                >
+                  {reference.kind}: {reference.snapshot.label}
+                </button>
+              );
+            })}
+            <button
+              className="rounded-full border px-2 py-1 text-3xs font-semibold"
+              onClick={() => onSelect(channel.id)}
+              type="button"
+            >
+              Open
+            </button>
+          </div>
+        ) : null}
         {viewModel.status === "ready" ? (
           <>
             <p className="mt-3 line-clamp-3 text-sm leading-relaxed text-foreground">

--- a/desktop/src/features/workstream-board/ui/WorkstreamCard.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamCard.tsx
@@ -40,6 +40,9 @@ type WorkstreamCardProps = {
   discussionMode?: boolean;
   selectedReferenceKeys?: ReadonlySet<string>;
   replayReferenceKeys?: ReadonlySet<string>;
+  replayFocusedReferenceKey?: string;
+  replayReferenceStates?: ReadonlyMap<string, "live" | "changed">;
+  historicalReplayReferences?: readonly BoardReference[];
   onToggleReference?: (reference: BoardReference) => void;
   onReferencesChange?: (references: readonly BoardReference[]) => void;
 };
@@ -55,6 +58,9 @@ export function WorkstreamCard({
   onReferencesChange,
   profiles,
   replayReferenceKeys,
+  replayFocusedReferenceKey,
+  replayReferenceStates,
+  historicalReplayReferences = [],
   selectedReferenceKeys,
 }: WorkstreamCardProps) {
   const canvasQuery = useCanvasQuery(channel.id);
@@ -178,14 +184,25 @@ export function WorkstreamCard({
     onReferencesChange?.(discussionReferences);
   }, [discussionReferences, onReferencesChange]);
 
+  const workstreamReference = discussionReferences[0];
+  const workstreamReferenceKey = workstreamReference
+    ? boardReferenceKey(workstreamReference)
+    : undefined;
+  const workstreamIsCurrent =
+    workstreamReferenceKey !== undefined &&
+    replayFocusedReferenceKey === workstreamReferenceKey;
+
   return (
     <div
+      aria-current={workstreamIsCurrent ? "true" : undefined}
       className={cn(
         "group relative w-full self-start overflow-hidden rounded-2xl border border-border/70 bg-muted/50 p-5 text-left text-foreground shadow-xs transition-all hover:-translate-y-0.5 hover:border-border hover:bg-muted/65 hover:shadow-md",
         waitingOnPrincipal && "border-t-4 border-t-amber-400/70",
         discussionReferences.some((reference) =>
           replayReferenceKeys?.has(boardReferenceKey(reference)),
-        ) && "ring-2 ring-primary ring-offset-2 ring-offset-background",
+        ) && "border-dashed border-2",
+        workstreamIsCurrent &&
+          "ring-2 ring-primary ring-offset-2 ring-offset-background",
       )}
       data-testid={`workstream-card-${channel.id}`}
     >
@@ -193,7 +210,7 @@ export function WorkstreamCard({
         className="absolute inset-0 z-0 rounded-2xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
         onClick={() =>
           discussionMode
-            ? onToggleReference?.(discussionReferences[0])
+            ? workstreamReference && onToggleReference?.(workstreamReference)
             : onSelect(channel.id)
         }
         type="button"
@@ -210,7 +227,7 @@ export function WorkstreamCard({
           className="pointer-events-auto flex max-w-[calc(100%-4rem)] items-center gap-1.5 text-xs font-semibold text-muted-foreground hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
           onClick={() =>
             discussionMode
-              ? onToggleReference?.(discussionReferences[0])
+              ? workstreamReference && onToggleReference?.(workstreamReference)
               : onSelect(channel.id)
           }
           type="button"
@@ -227,20 +244,47 @@ export function WorkstreamCard({
               const key = boardReferenceKey(reference);
               const selected = selectedReferenceKeys?.has(key) ?? false;
               const replayed = replayReferenceKeys?.has(key) ?? false;
+              const replayState = replayReferenceStates?.get(key);
+              const current =
+                reference.kind !== "workstream" &&
+                replayFocusedReferenceKey === key;
               return (
                 <button
                   aria-pressed={selected}
                   className={cn(
                     "rounded-full border px-2 py-1 text-3xs",
                     selected && "border-primary bg-primary/15",
-                    replayed && "ring-2 ring-primary",
+                    replayed && "border-dashed font-semibold",
+                    current && "ring-2 ring-primary ring-offset-2",
                   )}
+                  aria-current={current ? "true" : undefined}
                   key={key}
                   onClick={() => onToggleReference?.(reference)}
                   type="button"
                 >
                   {reference.kind}: {reference.snapshot.label}
+                  {replayed ? ` · Referenced · ${replayState}` : ""}
+                  {current ? " · Current" : ""}
                 </button>
+              );
+            })}
+            {historicalReplayReferences.map((reference) => {
+              const key = boardReferenceKey(reference);
+              const current = replayFocusedReferenceKey === key;
+              return (
+                <div
+                  aria-current={current ? "true" : undefined}
+                  className={cn(
+                    "rounded-md border border-dashed px-2 py-1 text-3xs font-semibold",
+                    current && "ring-2 ring-primary ring-offset-2",
+                  )}
+                  data-testid="historical-reference-placeholder"
+                  key={key}
+                >
+                  Historical {reference.placement.sectionLabel}:{" "}
+                  {reference.snapshot.label}
+                  {current ? " · Current" : ""}
+                </div>
               );
             })}
             <button

--- a/desktop/src/features/workstream-board/ui/WorkstreamCard.tsx
+++ b/desktop/src/features/workstream-board/ui/WorkstreamCard.tsx
@@ -235,6 +235,14 @@ export function WorkstreamCard({
           <Hash className="h-3.5 w-3.5 shrink-0" />
           <span className="truncate">{channel.name}</span>
         </button>
+        {workstreamIsCurrent ? (
+          <span
+            className="mt-2 w-fit rounded-full border border-foreground/60 px-2 py-1 text-3xs font-bold uppercase tracking-wider"
+            data-testid="current-workstream-reference"
+          >
+            Current reference
+          </span>
+        ) : null}
         {discussionMode ? (
           <div
             className="pointer-events-auto mt-3 flex flex-wrap gap-1.5"

--- a/desktop/src/shared/api/tauriManagedAgentMessages.ts
+++ b/desktop/src/shared/api/tauriManagedAgentMessages.ts
@@ -1,5 +1,6 @@
 import type { SendChannelMessageResult } from "@/shared/api/types";
 import { invokeTauri } from "@/shared/api/tauri";
+import type { BoardReference } from "@/features/workstream-board/lib/boardReferences";
 
 type RawSendChannelMessageResult = {
   event_id: string;
@@ -18,6 +19,7 @@ export async function sendManagedAgentChannelMessage(input: {
   mentionPubkeys?: string[];
   parentEventId?: string;
   additionalMarkers?: string[];
+  boardReferences?: BoardReference[];
 }): Promise<SendChannelMessageResult> {
   const response = await invokeTauri<RawSendChannelMessageResult>(
     "send_managed_agent_channel_message",
@@ -30,6 +32,7 @@ export async function sendManagedAgentChannelMessage(input: {
       mentionPubkeys: input.mentionPubkeys ?? null,
       parentEventId: input.parentEventId ?? null,
       additionalMarkers: input.additionalMarkers ?? null,
+      boardReferences: input.boardReferences ?? null,
     },
   );
 

--- a/desktop/src/shared/api/tauriMessages.ts
+++ b/desktop/src/shared/api/tauriMessages.ts
@@ -1,5 +1,6 @@
 import { invokeTauri } from "@/shared/api/tauri";
 import type { RawSendChannelMessageResult } from "@/shared/api/tauriMessageTypes";
+import type { BoardReference } from "@/features/workstream-board/lib/boardReferences";
 import type { SendChannelMessageResult } from "@/shared/api/types";
 
 export async function sendChannelMessage(
@@ -15,6 +16,7 @@ export async function sendChannelMessage(
   sentFromThreadTag?: string[],
   expectedRelayUrl?: string,
   expectedSignerPubkey?: string,
+  boardReferences?: BoardReference[],
 ): Promise<SendChannelMessageResult> {
   const response = await invokeTauri<RawSendChannelMessageResult>(
     "send_channel_message",
@@ -27,6 +29,7 @@ export async function sendChannelMessage(
       mentionTags: mentionTags ?? null,
       linkPreviewTags,
       sentFromThreadTag: sentFromThreadTag ?? null,
+      boardReferences: boardReferences ?? null,
       mentionPubkeys: mentionPubkeys ?? null,
       kind: kind ?? null,
       // Tenant scope captured by the caller before its first await; the

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -6904,6 +6904,7 @@ async function handleOpenDm(
     pubkeys: string[];
     expectedRelayUrl?: string | null;
     expectedSignerPubkey?: string | null;
+    boardReferences?: Array<Record<string, unknown>> | null;
   },
   config: E2eConfig | undefined,
 ) {
@@ -9591,6 +9592,7 @@ async function handleSendChannelMessage(
     suppressLinkPreviews?: boolean;
     expectedRelayUrl?: string | null;
     expectedSignerPubkey?: string | null;
+    boardReferences?: Array<Record<string, unknown>> | null;
   },
   config: E2eConfig | undefined,
 ): Promise<RawSendChannelMessageResponse> {
@@ -9666,6 +9668,11 @@ async function handleSendChannelMessage(
     ...linkPreviewTags,
     ...(args.sentFromThreadTag ? [args.sentFromThreadTag] : []),
     ...(args.suppressLinkPreviews ? [["link-preview", "none"]] : []),
+    ...(args.boardReferences ?? []).map((reference) => [
+      "buzz:board-ref",
+      "1",
+      JSON.stringify(reference),
+    ]),
   ];
   const identity = getIdentity(config);
   if (!identity) {
@@ -9796,6 +9803,7 @@ async function handleSendManagedAgentChannelMessage(
     mentionPubkeys?: string[] | null;
     parentEventId?: string | null;
     additionalMarkers?: string[] | null;
+    boardReferences?: Array<Record<string, unknown>> | null;
   },
   _config: E2eConfig | undefined,
 ): Promise<RawSendChannelMessageResponse> {
@@ -9832,6 +9840,9 @@ async function handleSendManagedAgentChannelMessage(
         args.mentionPubkeys ?? undefined,
         agent.pubkey,
       );
+  for (const reference of args.boardReferences ?? []) {
+    tags.push(["buzz:board-ref", "1", JSON.stringify(reference)]);
+  }
   for (const clientMarker of [marker, ...(args.additionalMarkers ?? [])]) {
     if (clientMarker?.trim()) tags.push(["client", clientMarker.trim()]);
   }

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -349,6 +349,7 @@ type E2eConfig = {
     canvasReadError?: string;
     /** Optional deterministic Workstream Board blocker/thread fixture. */
     workstreamBoardFixture?: MockWorkstreamBoardFixture;
+    workstreamBoardFixtures?: MockWorkstreamBoardFixture[];
     /** Delay (ms) for `apply_workspace` so e2e tests can observe the
      *  community-switch gate. 0/undefined = instant. */
     applyCommunityDelayMs?: number;
@@ -3086,11 +3087,19 @@ const mockChannels: MockChannel[] = [
   }),
 ];
 
-function ensureMockWorkstreamBoardFixture(config?: E2eConfig | null) {
-  const fixture = config?.mock?.workstreamBoardFixture;
-  if (!fixture) return;
+function getMockWorkstreamBoardFixtures(config?: E2eConfig | null) {
+  return [
+    ...(config?.mock?.workstreamBoardFixture
+      ? [config.mock.workstreamBoardFixture]
+      : []),
+    ...(config?.mock?.workstreamBoardFixtures ?? []),
+  ];
+}
 
-  if (!mockChannels.some((channel) => channel.id === fixture.channelId)) {
+function ensureMockWorkstreamBoardFixture(config?: E2eConfig | null) {
+  for (const fixture of getMockWorkstreamBoardFixtures(config)) {
+    if (mockChannels.some((channel) => channel.id === fixture.channelId))
+      continue;
     mockChannels.push(
       createMockChannel({
         id: fixture.channelId,
@@ -3115,9 +3124,8 @@ function ensureMockWorkstreamBoardFixture(config?: E2eConfig | null) {
         members: [createMockMember(MOCK_IDENTITY_PUBKEY, "owner", 10)],
       }),
     );
+    getMockMessageStore(fixture.channelId);
   }
-
-  getMockMessageStore(fixture.channelId);
 }
 
 const mockMessages = new Map<string, RelayEvent[]>();
@@ -4372,8 +4380,10 @@ function getMockMessageStore(channelId: string): RelayEvent[] {
     return existing;
   }
 
-  const fixture = getConfig()?.mock?.workstreamBoardFixture;
-  if (fixture?.channelId === channelId) {
+  const fixture = getMockWorkstreamBoardFixtures(getConfig()).find(
+    (candidate) => candidate.channelId === channelId,
+  );
+  if (fixture) {
     const seeded: RelayEvent[] = [
       {
         id: fixture.rootEventId,
@@ -13803,8 +13813,10 @@ export function maybeInstallE2eTauriMocks() {
           throw new Error(canvasReadError);
         }
         const channelId = (payload as { channelId?: string }).channelId;
-        const fixture = activeConfig?.mock?.workstreamBoardFixture;
-        if (fixture && fixture.channelId === channelId) {
+        const fixture = getMockWorkstreamBoardFixtures(activeConfig).find(
+          (candidate) => candidate.channelId === channelId,
+        );
+        if (fixture) {
           return {
             content: fixture.canvas,
             event_id: "slice7-workstream-fixture-canvas",

--- a/desktop/tests/e2e/workstream-board-context-references.capture.spec.ts
+++ b/desktop/tests/e2e/workstream-board-context-references.capture.spec.ts
@@ -5,6 +5,7 @@ import { installMockBridge } from "../helpers/bridge";
 test.use({ video: "on" });
 
 const CHANNEL_ID = "7b4d3d2e-3c15-4e88-9a11-1c0f7d2b6e55";
+const OTHER_CHANNEL_ID = "da7ab52e-a378-4888-8291-1a11d0ab8068";
 const ROOT_EVENT_ID = "c3".repeat(32);
 const TARGET_EVENT_ID = "d4".repeat(32);
 const AGENT_PUBKEY = "6".repeat(64);
@@ -31,7 +32,7 @@ ${JSON.stringify({
 \`\`\``;
 
 type BoardReference = {
-  kind: "thread-blocker";
+  kind: "workstream" | "thread-blocker";
   identity: string;
   snapshot: { label: string; detail?: string };
   placement: {
@@ -40,7 +41,7 @@ type BoardReference = {
     sectionId: string;
     sectionLabel: string;
   };
-  destination: {
+  destination?: {
     channelId: string;
     messageId: string;
     threadRootId?: string;
@@ -110,6 +111,9 @@ test("human and orchestrator references replay live and removed Board context", 
   const card = page.getByTestId(`workstream-card-${CHANNEL_ID}`);
   await expect(card).toHaveAttribute("aria-current", "true");
   await expect(card).toHaveClass(/border-dashed/);
+  await expect(card.getByTestId("current-workstream-reference")).toHaveText(
+    "Current reference",
+  );
   await expect(
     options.getByRole("button", { name: /workstream:/ }),
   ).toContainText("Referenced");
@@ -127,6 +131,45 @@ test("human and orchestrator references replay live and removed Board context", 
   });
   await page.waitForTimeout(1_500);
 
+  const crossWorkstreamReference: BoardReference = {
+    kind: "thread-blocker",
+    identity: "cross-workstream-forgery",
+    snapshot: { label: "Other workstream blocker" },
+    placement: {
+      workstreamId: OTHER_CHANNEL_ID,
+      workstreamLabel: "other-workstream",
+      sectionId: "blockers",
+      sectionLabel: "Blockers",
+    },
+    destination: {
+      channelId: OTHER_CHANNEL_ID,
+      messageId: TARGET_EVENT_ID,
+      threadRootId: ROOT_EVENT_ID,
+    },
+  };
+  await invoke(page, "send_managed_agent_channel_message", {
+    agentPubkey: AGENT_PUBKEY,
+    channelId: CHANNEL_ID,
+    content: "Forged cross-workstream Board history entry",
+    marker: "board-context-cross-workstream",
+    boardReferences: [crossWorkstreamReference],
+  });
+  await page.waitForTimeout(500);
+  await expect(page.getByTestId("board-discussion")).not.toContainText(
+    "Forged cross-workstream Board history entry",
+  );
+
+  const orchestratorWorkstreamReference: BoardReference = {
+    kind: "workstream",
+    identity: CHANNEL_ID,
+    snapshot: { label: "loganj-ws-board-context" },
+    placement: {
+      workstreamId: CHANNEL_ID,
+      workstreamLabel: "loganj-ws-board-context",
+      sectionId: "workstream",
+      sectionLabel: "Workstream",
+    },
+  };
   const removedReference: BoardReference = {
     kind: "thread-blocker",
     identity: "removed-deployment-gate",
@@ -152,7 +195,7 @@ test("human and orchestrator references replay live and removed Board context", 
     content:
       "Orchestrator: this points to the approval removed after state advanced.",
     marker: "board-context-orchestrator",
-    boardReferences: [removedReference],
+    boardReferences: [orchestratorWorkstreamReference, removedReference],
   });
 
   // Open the workstream conversation, where the orchestrator-authored live
@@ -171,14 +214,19 @@ test("human and orchestrator references replay live and removed Board context", 
   await expect(page).toHaveURL(/\/workstreams$/);
   await expect(page.getByTestId("workstream-board-view")).toBeVisible();
   await expect(page.getByTestId("board-discussion")).toContainText(
-    "Replay 1/1: 0 live · 0 changed · 1 historical",
+    "Replay 1/2: 0 live · 1 changed · 1 historical",
   );
   const historical = page.getByTestId("historical-reference-placeholder");
   await expect(historical).toBeVisible();
   await expect(historical).toContainText(
-    "Historical Blockers: Removed deployment approval · Current",
+    "Historical Blockers: Removed deployment approval",
   );
-  await expect(historical).toHaveAttribute("aria-current", "true");
+  await expect(historical).not.toHaveAttribute("aria-current");
+  await expect(
+    page
+      .getByTestId(`workstream-card-${CHANNEL_ID}`)
+      .getByTestId("current-workstream-reference"),
+  ).toHaveText("Current reference");
   await page.screenshot({
     path: testInfo.outputPath("orchestrator-removed-replay.png"),
     fullPage: true,
@@ -196,4 +244,42 @@ test("human and orchestrator references replay live and removed Board context", 
   await page.keyboard.press("Escape");
   await expect(draft).toHaveValue("Keep this unsent draft");
   await page.waitForTimeout(1_500);
+});
+
+test("unavailable workstream cards cannot mutate the discussion tray", async ({
+  page,
+}) => {
+  const pageErrors: Error[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error));
+  await installMockBridge(page, {
+    canvasReadError: "Canvas unavailable",
+    workstreamBoardFixture: {
+      channelId: CHANNEL_ID,
+      channelName: "loganj-ws-board-context",
+      canvas: CANVAS,
+      rootEventId: ROOT_EVENT_ID,
+      targetEventId: TARGET_EVENT_ID,
+    },
+  });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.getByTestId("open-workstream-board-view").click();
+  const board = page.getByTestId("workstream-board-view");
+  await expect(board).toBeVisible();
+  const card = page.getByTestId(`workstream-card-${CHANNEL_ID}`);
+  await expect(card).toContainText("Card details unavailable");
+  await board.getByRole("button", { name: "Discuss Board" }).click();
+
+  await card
+    .getByRole("button", { name: /Open #loganj-ws-board-context/ })
+    .click();
+
+  await expect(page.getByText("Reference tray (0)")).toBeVisible();
+  const unavailableOptions = page.getByTestId(
+    `board-reference-options-${CHANNEL_ID}`,
+  );
+  await expect(unavailableOptions.getByRole("button")).toHaveCount(1);
+  await expect(
+    unavailableOptions.getByRole("button", { name: "Open", exact: true }),
+  ).toBeVisible();
+  expect(pageErrors).toEqual([]);
 });

--- a/desktop/tests/e2e/workstream-board-context-references.capture.spec.ts
+++ b/desktop/tests/e2e/workstream-board-context-references.capture.spec.ts
@@ -1,0 +1,174 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+test.use({ video: "on" });
+
+const CHANNEL_ID = "7b4d3d2e-3c15-4e88-9a11-1c0f7d2b6e55";
+const ROOT_EVENT_ID = "c3".repeat(32);
+const TARGET_EVENT_ID = "d4".repeat(32);
+const AGENT_PUBKEY = "6".repeat(64);
+const MESSAGE_LINK = `buzz://message?channel=${CHANNEL_ID}&id=${TARGET_EVENT_ID}&thread=${ROOT_EVENT_ID}`;
+const CANVAS = `# Board context references demo
+
+\`\`\`buzz-workstream-card
+${JSON.stringify({
+  version: 1,
+  synopsis: "Discuss immutable Board context with humans and orchestrators.",
+  orchestrator: { pubkey: AGENT_PUBKEY, name: "Board Orchestrator" },
+  assignees: [{ pubkey: "7".repeat(64), name: "Field Agent" }],
+  pullRequests: ["https://github.com/block/buzz/pull/6357"],
+  waitingOn: [
+    {
+      key: "decision-thread",
+      actor: { kind: "person", name: "Logan", pubkey: "8".repeat(64) },
+      reason: "Decide the rollout in the cited thread",
+      since: "2026-08-19T21:00:00.000Z",
+      message: MESSAGE_LINK,
+    },
+  ],
+})}
+\`\`\``;
+
+type BoardReference = {
+  kind: "thread-blocker";
+  identity: string;
+  snapshot: { label: string; detail?: string };
+  placement: {
+    workstreamId: string;
+    workstreamLabel: string;
+    sectionId: string;
+    sectionLabel: string;
+  };
+  destination: {
+    channelId: string;
+    messageId: string;
+    threadRootId?: string;
+  };
+};
+
+async function invoke(
+  page: Page,
+  command: string,
+  payload: Record<string, unknown>,
+) {
+  return page.evaluate(
+    async ({ command: target, payload: args }) => {
+      const fn = window.__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
+      if (!fn) throw new Error("Mock invoke bridge is unavailable.");
+      return fn(target, args);
+    },
+    { command, payload },
+  );
+}
+
+test("human and orchestrator references replay live and removed Board context", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(90_000);
+  await installMockBridge(page, {
+    workstreamBoardFixture: {
+      channelId: CHANNEL_ID,
+      channelName: "loganj-ws-board-context",
+      canvas: CANVAS,
+      rootEventId: ROOT_EVENT_ID,
+      targetEventId: TARGET_EVENT_ID,
+    },
+    managedAgents: [
+      {
+        pubkey: AGENT_PUBKEY,
+        name: "Board Orchestrator",
+        channelIds: [CHANNEL_ID],
+      },
+    ],
+  });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("app-sidebar")).toBeVisible();
+  await page.getByTestId("open-workstream-board-view").click();
+  const board = page.getByTestId("workstream-board-view");
+  await expect(board).toBeVisible();
+  await board.getByRole("button", { name: "Discuss Board" }).click();
+
+  const options = page.getByTestId(`board-reference-options-${CHANNEL_ID}`);
+  await expect(options).toBeVisible();
+  await options.getByRole("button", { name: /workstream:/ }).click();
+  await options.getByRole("button", { name: /thread-blocker:/ }).click();
+  await expect(page.getByText("Reference tray (2)")).toBeVisible();
+  await page
+    .getByLabel("Discussion message")
+    .fill("Human: use this workstream and blocker context.");
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+
+  const humanMessage = page.getByRole("button", {
+    name: /Human: use this workstream and blocker context\./,
+  });
+  await expect(humanMessage).toBeVisible();
+  await humanMessage.click();
+  await expect(page.getByTestId("board-discussion")).toContainText(
+    "Replay 1/2: 2 live",
+  );
+  await expect(page.getByTestId(`workstream-card-${CHANNEL_ID}`)).toHaveClass(
+    /ring-2/,
+  );
+  await page.screenshot({
+    path: testInfo.outputPath("human-live-replay.png"),
+    fullPage: true,
+  });
+  await page.waitForTimeout(1_500);
+
+  const removedReference: BoardReference = {
+    kind: "thread-blocker",
+    identity: "removed-deployment-gate",
+    snapshot: {
+      label: "Removed deployment approval",
+      detail: "Release captain",
+    },
+    placement: {
+      workstreamId: CHANNEL_ID,
+      workstreamLabel: "loganj-ws-board-context",
+      sectionId: "blockers",
+      sectionLabel: "Blockers",
+    },
+    destination: {
+      channelId: CHANNEL_ID,
+      messageId: TARGET_EVENT_ID,
+      threadRootId: ROOT_EVENT_ID,
+    },
+  };
+  await invoke(page, "send_managed_agent_channel_message", {
+    agentPubkey: AGENT_PUBKEY,
+    channelId: CHANNEL_ID,
+    content:
+      "Orchestrator: this points to the approval removed after state advanced.",
+    marker: "board-context-orchestrator",
+    boardReferences: [removedReference],
+  });
+
+  // Open the workstream conversation, where the orchestrator-authored live
+  // event renders its machine-readable reference chip. Clicking the chip
+  // carries immutable replay state back to the Board.
+  await options.getByRole("button", { name: "Open", exact: true }).click();
+  await expect(page).toHaveURL(new RegExp(`/channels/${CHANNEL_ID}`));
+  const orchestratorRow = page.getByText(
+    "Orchestrator: this points to the approval removed after state advanced.",
+  );
+  await expect(orchestratorRow).toBeVisible();
+  const orchestratorMessage = orchestratorRow.locator(
+    "xpath=ancestor::*[@data-testid='message-row']",
+  );
+  await orchestratorMessage.getByTestId("message-board-references").click();
+  await expect(page).toHaveURL(/\/workstreams$/);
+  await expect(page.getByTestId("workstream-board-view")).toBeVisible();
+  await expect(page.getByTestId("board-discussion")).toContainText(
+    "Replay 1/1: 0 live · 0 changed · 1 historical",
+  );
+  await expect(page.getByText("Historical references")).toBeVisible();
+  await expect(
+    page.getByText(/Removed deployment approval · formerly/),
+  ).toContainText("loganj-ws-board-context / Blockers");
+  await page.screenshot({
+    path: testInfo.outputPath("orchestrator-removed-replay.png"),
+    fullPage: true,
+  });
+  await page.waitForTimeout(2_500);
+});

--- a/desktop/tests/e2e/workstream-board-context-references.capture.spec.ts
+++ b/desktop/tests/e2e/workstream-board-context-references.capture.spec.ts
@@ -107,9 +107,20 @@ test("human and orchestrator references replay live and removed Board context", 
   await expect(page.getByTestId("board-discussion")).toContainText(
     "Replay 1/2: 2 live",
   );
-  await expect(page.getByTestId(`workstream-card-${CHANNEL_ID}`)).toHaveClass(
-    /ring-2/,
-  );
+  const card = page.getByTestId(`workstream-card-${CHANNEL_ID}`);
+  await expect(card).toHaveAttribute("aria-current", "true");
+  await expect(card).toHaveClass(/border-dashed/);
+  await expect(
+    options.getByRole("button", { name: /workstream:/ }),
+  ).toContainText("Referenced");
+  await page.getByRole("button", { name: "Next reference" }).click();
+  const currentBlocker = options.getByRole("button", {
+    name: /thread-blocker:/,
+  });
+  await expect(currentBlocker).toHaveAttribute("aria-current", "true");
+  await expect(currentBlocker).toContainText("Current");
+  await page.keyboard.press("ArrowLeft");
+  await expect(card).toHaveAttribute("aria-current", "true");
   await page.screenshot({
     path: testInfo.outputPath("human-live-replay.png"),
     fullPage: true,
@@ -162,13 +173,27 @@ test("human and orchestrator references replay live and removed Board context", 
   await expect(page.getByTestId("board-discussion")).toContainText(
     "Replay 1/1: 0 live · 0 changed · 1 historical",
   );
-  await expect(page.getByText("Historical references")).toBeVisible();
-  await expect(
-    page.getByText(/Removed deployment approval · formerly/),
-  ).toContainText("loganj-ws-board-context / Blockers");
+  const historical = page.getByTestId("historical-reference-placeholder");
+  await expect(historical).toBeVisible();
+  await expect(historical).toContainText(
+    "Historical Blockers: Removed deployment approval · Current",
+  );
+  await expect(historical).toHaveAttribute("aria-current", "true");
   await page.screenshot({
     path: testInfo.outputPath("orchestrator-removed-replay.png"),
     fullPage: true,
   });
-  await page.waitForTimeout(2_500);
+  await page.waitForTimeout(1_500);
+
+  // Draft text alone is unsent state. Cancelling either exit path preserves it.
+  await page.keyboard.press("Escape");
+  const draft = page.getByLabel("Discussion message");
+  await draft.fill("Keep this unsent draft");
+  page.once("dialog", async (dialog) => dialog.dismiss());
+  await board.getByRole("button", { name: "Exit discussion" }).click();
+  await expect(draft).toHaveValue("Keep this unsent draft");
+  page.once("dialog", async (dialog) => dialog.dismiss());
+  await page.keyboard.press("Escape");
+  await expect(draft).toHaveValue("Keep this unsent draft");
+  await page.waitForTimeout(1_500);
 });

--- a/desktop/tests/e2e/workstream-board-context-references.capture.spec.ts
+++ b/desktop/tests/e2e/workstream-board-context-references.capture.spec.ts
@@ -100,11 +100,17 @@ test("human and orchestrator references replay live and removed Board context", 
     .fill("Human: use this workstream and blocker context.");
   await page.getByRole("button", { name: "Send", exact: true }).click();
 
-  const humanMessage = page.getByRole("button", {
-    name: /Human: use this workstream and blocker context\./,
-  });
+  await options.getByRole("button", { name: "Open", exact: true }).click();
+  await expect(page).toHaveURL(new RegExp(`/channels/${CHANNEL_ID}`));
+  const humanMessage = page.getByText(
+    "Human: use this workstream and blocker context.",
+  );
   await expect(humanMessage).toBeVisible();
-  await humanMessage.click();
+  await humanMessage
+    .locator("xpath=ancestor::*[@data-testid='message-row']")
+    .getByTestId("message-board-references")
+    .click();
+  await expect(page).toHaveURL(/\/workstreams$/);
   await expect(page.getByTestId("board-discussion")).toContainText(
     "Replay 1/2: 2 live",
   );
@@ -282,4 +288,75 @@ test("unavailable workstream cards cannot mutate the discussion tray", async ({
     unavailableOptions.getByRole("button", { name: "Open", exact: true }),
   ).toBeVisible();
   expect(pageErrors).toEqual([]);
+});
+
+test("emptying the tray lets the next workstream become the send destination", async ({
+  page,
+}) => {
+  const channelBId = "4da24e0a-e0b5-4baf-bf3a-9ef26fe88c0d";
+  const channelBName = "loganj-ws-board-context-b";
+  await installMockBridge(page, {
+    workstreamBoardFixtures: [
+      {
+        channelId: CHANNEL_ID,
+        channelName: "loganj-ws-board-context",
+        canvas: CANVAS,
+        rootEventId: ROOT_EVENT_ID,
+        targetEventId: TARGET_EVENT_ID,
+      },
+      {
+        channelId: channelBId,
+        channelName: channelBName,
+        canvas: CANVAS.replaceAll(CHANNEL_ID, channelBId).replaceAll(
+          "loganj-ws-board-context",
+          channelBName,
+        ),
+        rootEventId: "e5".repeat(32),
+        targetEventId: "f6".repeat(32),
+      },
+    ],
+  });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.getByTestId("open-workstream-board-view").click();
+  const board = page.getByTestId("workstream-board-view");
+  await expect(board).toBeVisible();
+  await board.getByRole("button", { name: "Discuss Board" }).click();
+
+  const channelAOptions = page.getByTestId(
+    `board-reference-options-${CHANNEL_ID}`,
+  );
+  await channelAOptions.getByRole("button", { name: /workstream:/ }).click();
+  await expect(page.getByText("Reference tray (1)")).toBeVisible();
+  await page
+    .getByRole("button", { name: "Remove loganj-ws-board-context" })
+    .click();
+  await expect(page.getByText("Reference tray (0)")).toBeVisible();
+  await expect(
+    page.getByText(
+      "Select an object in one workstream to choose the discussion.",
+    ),
+  ).toBeVisible();
+
+  const channelBOptions = page.getByTestId(
+    `board-reference-options-${channelBId}`,
+  );
+  await channelBOptions.getByRole("button", { name: /workstream:/ }).click();
+  await page
+    .getByLabel("Discussion message")
+    .fill("Send only through workstream B.");
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+  const sends = await page.evaluate(() =>
+    (window.__BUZZ_E2E_COMMAND_PAYLOADS__ ?? []).filter(
+      (entry) => entry.command === "send_channel_message",
+    ),
+  );
+  expect(sends).toHaveLength(1);
+  expect(sends[0]?.payload).toMatchObject({
+    channelId: channelBId,
+    boardReferences: [
+      {
+        placement: { workstreamId: channelBId },
+      },
+    ],
+  });
 });

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -287,6 +287,13 @@ type MockBridgeOptions = {
     rootEventId: string;
     targetEventId: string;
   };
+  workstreamBoardFixtures?: Array<{
+    channelId: string;
+    channelName: string;
+    canvas: string;
+    rootEventId: string;
+    targetEventId: string;
+  }>;
   /** Delay (ms) for `apply_workspace`; see e2eBridge mock config. */
   applyCommunityDelayMs?: number;
   /** Reject `clear_pending_navigation_deep_links` with this message. */


### PR DESCRIPTION
🤖 Larry

## Summary

People and agents need to discuss specific objects on the Workstream Board without losing what they meant when the Board later changes. This adds an ordered reference tray to Board discussions: references travel with the message through the represented workstream, and reopening that message restores the referenced context.

Replayed references show whether each object is still **live**, has **changed** since it was sent, or is now **historical**. Removed or unavailable objects remain visible as non-interactive placeholders rather than disappearing or redirecting to unrelated state.

This PR is stacked on #6357.

### Details

- Human-authored and orchestrator-authored messages use the same typed, self-describing reference format and validation rules across Desktop, the Rust SDK, and ACP agent context.
- Malformed, oversized, cross-workstream, or otherwise unauthorized reference data fails closed while the surrounding message remains usable. Raw transport tags are not exposed to agents.
- Discussion mode supports ordered multi-object selection within one workstream, message replay, keyboard stepping between references, and confirmation before discarding an unsent draft or tray.
- The current replay target has a visible non-color marker. Unavailable cards cannot mutate the tray.
- The send destination is derived from the resulting non-empty tray. Removing the final reference clears the destination, so selecting a reference from another workstream sends only through that new workstream.

### Related issue

- Stacked on #6357

### Testing

Verified at exact published head `5316a93d4230c4ee59233e937e3c9c1842ad5c31`:

- Desktop unit suite: **5,141/5,141 passed** across 75 suites
- Desktop check and typecheck: passed
- Checked-in Workstream Board context-reference smoke spec: **3/3 passed**, covering persisted replay, live/changed/historical rendering, draft preservation, unavailable-card guarding, and the empty-tray A → B destination transition
- Rust `buzz-sdk`: **267/267 passed**, including documentation tests
- Rust `buzz-acp`: **803/803 passed**, plus **9/9** lifecycle tests and documentation tests
- Branch-skew and file-size publication gates: passed

The repository-wide smoke command enumerated 1,085 tests but did not complete within the 10-minute command window, so it is not counted as passing evidence. The complete checked-in smoke spec affected by this change passed 3/3.
