### PR TITLE
fix(desktop): clarify add agents channel action

### DIFF
--- a/desktop/src/features/channels/ui/useChannelIntro.tsx
+++ b/desktop/src/features/channels/ui/useChannelIntro.tsx
@@ -91,9 +91,9 @@ export function useChannelIntro({
     if (!activeChannel.archivedAt && activeChannel.isMember) {
       if (onAddAgent) {
         actions.push({
-          description: "Add an agent here.",
+          description: "Choose agents to add to this channel.",
           icon: <Bot aria-hidden className="h-6 w-6" />,
-          label: "Create agent",
+          label: "Add agents",
           onClick: onAddAgent,
           testId: "channel-intro-action-create-agent",
         });

--- a/desktop/src/features/channels/ui/useChannelIntro.tsx
+++ b/desktop/src/features/channels/ui/useChannelIntro.tsx
@@ -91,7 +91,7 @@ export function useChannelIntro({
     if (!activeChannel.archivedAt && activeChannel.isMember) {
       if (onAddAgent) {
         actions.push({
-          description: "Choose agents to add to this channel.",
+          description: "Bring them in.",
           icon: <Bot aria-hidden className="h-6 w-6" />,
           label: "Add agents",
           onClick: onAddAgent,

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1752,7 +1752,7 @@ test("empty channel shows intro actions", async ({ page }) => {
     addAgentsAction.getByText("Add agents", { exact: true }),
   ).toBeVisible();
   await expect(
-    addAgentsAction.getByText("Choose agents to add to this channel.", {
+    addAgentsAction.getByText("Bring them in.", {
       exact: true,
     }),
   ).toBeVisible();

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1746,8 +1746,15 @@ test("empty channel shows intro actions", async ({ page }) => {
   await expect(
     page.getByTestId("channel-intro-action-create-channel"),
   ).toHaveCount(0);
+  const addAgentsAction = page.getByTestId("channel-intro-action-create-agent");
+  await expect(addAgentsAction).toBeVisible();
   await expect(
-    page.getByTestId("channel-intro-action-create-agent"),
+    addAgentsAction.getByText("Add agents", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    addAgentsAction.getByText("Choose agents to add to this channel.", {
+      exact: true,
+    }),
   ).toBeVisible();
   await expect(
     page.getByTestId("channel-intro-action-add-people"),
@@ -1767,7 +1774,7 @@ test("empty channel shows intro actions", async ({ page }) => {
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("members-sidebar")).not.toBeVisible();
 
-  await page.getByTestId("channel-intro-action-create-agent").click();
+  await addAgentsAction.click();
   await expect(page.getByRole("heading", { name: "Add agents" })).toBeVisible();
 
   await page.keyboard.press("Escape");

--- a/desktop/tests/e2e/tooltip-semantics.spec.ts
+++ b/desktop/tests/e2e/tooltip-semantics.spec.ts
@@ -142,7 +142,7 @@ for (const theme of THEMES) {
     await expect(row).toBeVisible();
     await expectMutedSupportingText(
       row.getByRole("button", { name: "Open channel general" }),
-      /Public channel · Active \d+[mhdw] ago/,
+      /Public channel · Active (just now|\d+[mhdw] ago)/,
     );
     await page.mouse.move(0, 0);
     await expectMutedSupportingText(


### PR DESCRIPTION
"Create agent" button takes you to a UI to **invite** your existing agents to a channel. Rewording the button to make this clear.

Before
<img width="481" height="251" alt="Screenshot 2026-08-21 at 1 58 40 pm" src="https://github.com/user-attachments/assets/1b64f722-62b8-46fa-a6c4-dafcf2bdfaa7" />


After
(Sorry about different elements being in hover state in the screenshots)
<img width="481" height="313" alt="Screenshot 2026-08-21 at 1 58 16 pm" src="https://github.com/user-attachments/assets/f68a9c9b-2276-4ef5-ace8-c4017977b1e8" />
## Summary

- Clarify that the empty-channel intro action adds existing agents to the channel.
- Assert the exact action title and description in the existing E2E coverage while preserving the separate Welcome create-agent flow.

### Related issue

None found.

### Testing

- `../node_modules/.bin/biome check src/features/channels/ui/useChannelIntro.tsx tests/e2e/channels.spec.ts` passed.
- `./node_modules/.bin/tsc && ./node_modules/.bin/vite build --mode e2e` passed.
- The isolated Playwright smoke case `empty channel shows intro actions` passed (1/1) after installing the repo-pinned Chromium.
- `env -u BUZZ_AGENT_PROVIDER just ci` passed.
- Screenshots not captured; this is a copy-only UI change.
