### PR TITLE
fix(desktop): register a community field clear as a real change

### DIFF
--- a/desktop/src/features/communities/resolveCommunityUpdateResult.test.mjs
+++ b/desktop/src/features/communities/resolveCommunityUpdateResult.test.mjs
@@ -105,3 +105,53 @@ test("resolveCommunityUpdateResult_same_relay_url_is_not_duplicate_of_self", () 
   });
   assert.deepEqual(result, { kind: "unchanged" });
 });
+
+// ---------------------------------------------------------------------------
+// Clearing an optional field to `undefined` (repos_dir / token save bug)
+// ---------------------------------------------------------------------------
+
+test("resolveCommunityUpdateResult_clearing_reposDir_alone_is_registered_as_updated", () => {
+  // Clearing an existing reposDir sends { reposDir: undefined } as the only
+  // key. Regression guard: this must not be treated as "field omitted."
+  const communitiesWithReposDir = [
+    { ...COMMUNITIES[0], reposDir: "/Users/sheldrone/code" },
+    COMMUNITIES[1],
+  ];
+  const result = resolveCommunityUpdateResult(
+    communitiesWithReposDir,
+    "ws-1",
+    "ws-1",
+    { reposDir: undefined },
+  );
+  assert.deepEqual(result, { kind: "updated", requiresReinit: true });
+});
+
+test("resolveCommunityUpdateResult_clearing_token_alone_is_registered_as_updated", () => {
+  const communitiesWithToken = [
+    { ...COMMUNITIES[0], token: "buzz_existing" },
+    COMMUNITIES[1],
+  ];
+  const result = resolveCommunityUpdateResult(
+    communitiesWithToken,
+    "ws-1",
+    "ws-1",
+    { token: undefined },
+  );
+  assert.deepEqual(result, { kind: "updated", requiresReinit: true });
+});
+
+test("resolveCommunityUpdateResult_omitting_reposDir_key_entirely_is_unchanged", () => {
+  // The other side of the fix: a field genuinely not present in `updates`
+  // (not even as `undefined`) must still be a no-op, same as before.
+  const communitiesWithReposDir = [
+    { ...COMMUNITIES[0], reposDir: "/Users/sheldrone/code" },
+    COMMUNITIES[1],
+  ];
+  const result = resolveCommunityUpdateResult(
+    communitiesWithReposDir,
+    "ws-1",
+    "ws-1",
+    { name: "Community A" },
+  );
+  assert.deepEqual(result, { kind: "unchanged" });
+});

--- a/desktop/src/features/communities/useCommunities.tsx
+++ b/desktop/src/features/communities/useCommunities.tsx
@@ -56,12 +56,21 @@ export function resolveCommunityUpdateResult(
     return { kind: "duplicate-relay" };
   }
 
+  // `token` and `reposDir` are optional fields cleared by sending `undefined`
+  // — that is a real, intentional value, not "field omitted." Gating on
+  // `!== undefined` (as the other fields below do) would treat a clear as no
+  // change and silently drop it, so these two check key presence instead.
+  const tokenChanged =
+    Object.hasOwn(updates, "token") && updates.token !== current.token;
+  const reposDirChanged =
+    Object.hasOwn(updates, "reposDir") && updates.reposDir !== current.reposDir;
+
   const hasChange =
     (updates.name !== undefined && updates.name !== current.name) ||
     (updates.relayUrl !== undefined && updates.relayUrl !== current.relayUrl) ||
-    (updates.token !== undefined && updates.token !== current.token) ||
+    tokenChanged ||
     (updates.pubkey !== undefined && updates.pubkey !== current.pubkey) ||
-    (updates.reposDir !== undefined && updates.reposDir !== current.reposDir);
+    reposDirChanged;
 
   if (!hasChange) return { kind: "unchanged" };
 
@@ -70,9 +79,8 @@ export function resolveCommunityUpdateResult(
     isActive &&
     ((updates.relayUrl !== undefined &&
       updates.relayUrl !== current.relayUrl) ||
-      (updates.token !== undefined && updates.token !== current.token) ||
-      (updates.reposDir !== undefined &&
-        updates.reposDir !== current.reposDir));
+      tokenChanged ||
+      reposDirChanged);
 
   return { kind: "updated", requiresReinit: backendFieldsChanged };
 }


### PR DESCRIPTION
## Summary

`resolveCommunityUpdateResult` (`desktop/src/features/communities/useCommunities.tsx`) gates whether a community edit persists on a `hasChange` check. For the two optional, clearable fields (`token`, `reposDir`), that check was `updates.<field> !== undefined`.

Clearing either field to empty always produces exactly `undefined` (the dialog's `expandTilde("")` / `token.trim() || undefined` both resolve an empty input to `undefined`, matching `Partial<Community>`'s existing "clear this field" convention). So a save whose *only* change was clearing `reposDir` or `token` was classified `unchanged` and silently dropped — the field looked cleared in the dialog, then reverted to the old value the next time it was opened, with no error and no indication anything went wrong.

Live repro: set a community's Repos Directory to a path, clear the field, Save Changes, reopen — the old value is back.

## Fix

Check key presence (`Object.hasOwn(updates, "token" | "reposDir")`) instead of value for these two fields, so an explicit clear-to-`undefined` registers as a real change, the same as any other edit. `name`/`relayUrl`/`pubkey` are unaffected — they're never intentionally cleared through this path.

## Test plan

- [x] Added 3 regression tests to `resolveCommunityUpdateResult.test.mjs`: clearing `reposDir` alone registers as `updated`/`requiresReinit: true`; clearing `token` alone does the same; omitting the key entirely (genuinely untouched) still correctly resolves to `unchanged`.
- [x] `node --import ./test-loader.mjs --experimental-strip-types --test src/features/communities/resolveCommunityUpdateResult.test.mjs` — 12/12 pass.
- [x] Full desktop suite (`pnpm test`) — 5,102/5,102 pass, no regressions.
- [x] `tsc --noEmit` clean.
- [x] Confirmed via `git show` that the bug is present in both the `desktop-v0.5.16` and `desktop-v0.5.17` tags, not a recent regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)