### PR TITLE
fix(cli): support viewable file attachments

### DIFF
--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -60,13 +60,26 @@ pub fn build_imeta_tag(d: &BlobDescriptor) -> Vec<String> {
     tag
 }
 
-/// MIME types accepted for upload.
-const ALLOWED_MIMES: &[&str] = &[
-    "image/jpeg",
-    "image/png",
-    "image/gif",
-    "image/webp",
-    "video/mp4",
+/// MIME types rejected by the generic attachment path.
+///
+/// Keep this in sync with `buzz_media::validation::BLOCKED_FILE_MIME_TYPES`.
+/// HTML is intentionally allowed: the relay stores it as a generic attachment
+/// and serves it with `Content-Disposition: attachment`, `nosniff`, and a
+/// restrictive CSP, so it cannot become same-origin active content.
+const BLOCKED_FILE_MIMES: &[&str] = &[
+    "application/xhtml+xml",
+    "image/svg+xml",
+    "application/javascript",
+    "text/javascript",
+    "application/x-msdownload",
+    "application/x-executable",
+    "application/vnd.microsoft.portable-executable",
+    "application/x-mach-binary",
+    "application/x-sharedlib",
+    "application/x-elf",
+    "application/x-msi",
+    "application/vnd.android.package-archive",
+    "application/x-apple-diskimage",
 ];
 
 /// Maximum file size for image uploads (50 MB).
@@ -74,6 +87,13 @@ const MAX_IMAGE_BYTES: u64 = 50 * 1024 * 1024;
 
 /// Maximum file size for video uploads (500 MB).
 const MAX_VIDEO_BYTES: u64 = 500 * 1024 * 1024;
+
+/// Maximum generic attachment size (50 MB), matching the relay default.
+const MAX_FILE_BYTES: u64 = 50 * 1024 * 1024;
+
+fn is_upload_mime_allowed(mime: &str) -> bool {
+    !BLOCKED_FILE_MIMES.contains(&mime)
+}
 
 /// Sign a NIP-98 HTTP auth event (kind:27235) and return the Authorization header value.
 ///
@@ -1113,15 +1133,17 @@ impl BuzzClient {
             .map(|t| t.mime_type().to_string())
             .unwrap_or_else(|| "application/octet-stream".to_string());
 
-        if !ALLOWED_MIMES.contains(&mime.as_str()) {
+        if !is_upload_mime_allowed(&mime) {
             return Err(CliError::Usage(format!("unsupported file type: {mime}")));
         }
 
         // 3. Size check
         let max = if mime.starts_with("video/") {
             MAX_VIDEO_BYTES
-        } else {
+        } else if mime.starts_with("image/") {
             MAX_IMAGE_BYTES
+        } else {
+            MAX_FILE_BYTES
         };
         if bytes.len() as u64 > max {
             return Err(CliError::Usage(format!(
@@ -2304,9 +2326,18 @@ mod retry_policy_tests {
 mod tests {
     use super::{
         advance_query_cursor, create_response_with_id_if_accepted, extract_relay_response_field,
-        BuzzClient,
+        is_upload_mime_allowed, BuzzClient,
     };
     use nostr::{EventBuilder, Keys, Kind, Tag};
+
+    #[test]
+    fn generic_uploads_allow_html_but_reject_active_or_executable_formats() {
+        assert!(is_upload_mime_allowed("text/html"));
+        assert!(is_upload_mime_allowed("application/pdf"));
+        assert!(!is_upload_mime_allowed("image/svg+xml"));
+        assert!(!is_upload_mime_allowed("application/javascript"));
+        assert!(!is_upload_mime_allowed("application/x-executable"));
+    }
 
     #[test]
     fn query_cursor_uses_last_events_composite_sort_key() {

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -610,7 +610,8 @@ pub async fn cmd_send_message(
         ));
     }
 
-    // Upload files and build imeta tags
+    // Upload files and build imeta tags. Images/video use embedded markdown;
+    // generic attachments use plain links so Desktop renders a file card.
     let mut media_tags: Vec<Vec<String>> = Vec::new();
     let mut media_content = String::new();
     for file_path in &p.files {
@@ -618,14 +619,32 @@ pub async fn cmd_send_message(
             .upload_file(file_path)
             .await
             .map_err(|e| CliError::Other(format!("upload failed for {file_path}: {e}")))?;
-        media_tags.push(crate::client::build_imeta_tag(&desc));
+        let filename = std::path::Path::new(file_path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("file");
+        let mut imeta = crate::client::build_imeta_tag(&desc);
+        imeta.push(format!("filename {filename}"));
+        media_tags.push(imeta);
         if desc.mime_type.starts_with("video/") {
             media_content.push_str("\n![video](");
-        } else {
+            media_content.push_str(&desc.url);
+            media_content.push(')');
+        } else if desc.mime_type.starts_with("image/") {
             media_content.push_str("\n![image](");
+            media_content.push_str(&desc.url);
+            media_content.push(')');
+        } else {
+            let escaped = filename
+                .replace('\\', "\\\\")
+                .replace('[', "\\[")
+                .replace(']', "\\]");
+            media_content.push_str("\n[");
+            media_content.push_str(&escaped);
+            media_content.push_str("](");
+            media_content.push_str(&desc.url);
+            media_content.push(')');
         }
-        media_content.push_str(&desc.url);
-        media_content.push(')');
     }
     let final_content = if media_content.is_empty() {
         p.content.clone()


### PR DESCRIPTION
## Summary

- allow safe generic files, including HTML decks and PDFs, through the CLI upload path
- keep executable and active formats such as SVG and JavaScript blocked
- attach filenames in NIP-92 metadata and render generic uploads as file links/cards instead of broken image embeds

This enables an agent to send a generated artifact in the same `buzz messages send --file ...` call that reports completion. The relay’s existing security boundary remains unchanged: HTML is served with `Content-Disposition: attachment`, `nosniff`, and a restrictive CSP rather than executed inline.

## Validation

- `git diff --check` passed
- added a regression test covering allowed HTML/PDF and blocked SVG/JavaScript/executable MIME types
- local Rust formatting/tests could not execute because the repository’s glibc Rustup binary is incompatible with this Alpine/musl runner (`makecontext`, `setcontext`, `gnu_get_libc_version` missing); GitHub CI is the authoritative run

Originating Buzz channel: `975d9e18-5232-4539-9281-b5d13a3df20c`.
