### PR TITLE
fix(desktop): keep active room agents mentionable

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -201,7 +201,7 @@ test("shouldHideAgentFromMentions: hides non-member non-invocable agents", () =>
   );
 });
 
-test("shouldHideAgentFromMentions: hides member agents with an explicit not-invocable directory entry (Fizz)", () => {
+test("shouldHideAgentFromMentions: keeps active room members mentionable when directory policy is not invocable", () => {
   assert.equal(
     shouldHideAgentFromMentions({
       isAgent: true,
@@ -210,7 +210,7 @@ test("shouldHideAgentFromMentions: hides member agents with an explicit not-invo
       mentionableAgentPubkeys: new Set(),
       directoryAgentPubkeys: new Set([PUB_A]),
     }),
-    true,
+    false,
   );
 });
 
@@ -227,19 +227,19 @@ test("shouldHideAgentFromMentions: shows member agents with unknown invocability
   );
 });
 
-test("shouldHideAgentFromMentions: normalizes the pubkey before lookup", () => {
+test("shouldHideAgentFromMentions: normalizes invocable pubkeys before lookup", () => {
   const mixedCase = "Ab".repeat(32);
   const normalized = mixedCase.toLowerCase();
 
   assert.equal(
     shouldHideAgentFromMentions({
       isAgent: true,
-      isMember: true,
+      isMember: false,
       pubkey: mixedCase,
-      mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set([normalized]),
+      mentionableAgentPubkeys: new Set([normalized]),
+      directoryAgentPubkeys: new Set(),
     }),
-    true,
+    false,
   );
 });
 

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -69,7 +69,6 @@ export function shouldHideAgentFromMentions({
   isMember,
   pubkey,
   mentionableAgentPubkeys,
-  directoryAgentPubkeys,
 }: {
   isAgent: boolean;
   isMember: boolean;
@@ -83,18 +82,10 @@ export function shouldHideAgentFromMentions({
   if (mentionableAgentPubkeys.has(normalized)) return false;
   // Non-member, non-invocable => hide (preserves prior behavior).
   if (!isMember) return true;
-  // Member (Option B): hide only when we have an explicit not-invocable
-  // signal — a relay directory (kind:10100) entry that excludes us.
-  // Unknown invocability (not in directory) => show.
-  //
-  // NOTE: this assumes `directoryAgentPubkeys` and `mentionableAgentPubkeys`
-  // share the same source query (`relayAgentsQuery.data`), so directory
-  // presence without membership in `mentionableAgentPubkeys` is a real
-  // explicit-exclusion signal. If a future change sources the directory set
-  // from a different query, an agent that's directory-present but whose
-  // mentionability is still loading could be hidden prematurely — keep the
-  // two sets derived from the same query.
-  return directoryAgentPubkeys.has(normalized);
+  // Active room membership is sufficient for composer discovery. The relay
+  // still enforces invocation policy when the message is sent; hiding a live
+  // room member here forces users to type the same agent name repeatedly.
+  return false;
 }
 
 type AgentAutocompleteCandidate = {


### PR DESCRIPTION
## Summary
<!-- What does this change and why? -->

### Related issue
<!-- Fixes #1234, or N/A. Before opening: search existing issues/PRs for duplicates — link the closest one, or say "none found". -->

### Testing
<!-- How was this verified? UI change? Include before/after screenshots (or a short recording). -->
