### PR TITLE
fix(desktop): spawn agents with the workspace relay URL, not the canonical loopback form

### DIFF
--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -500,7 +500,21 @@ pub fn spawn_agent_child(
 
     // The caller supplies the explicit canonical pair relay. This is the only
     // relay this child may connect to, regardless of the record/workspace default.
-    let effective_relay_url = runtime_key.relay_url.clone();
+    // `normalize_relay_url` canonicalizes every loopback host to 127.0.0.1, and
+    // its own doc says the canonical form is "for identity, receipts, status and
+    // deduplication" while "connection code may retain the configured URL". The
+    // runtime key is that canonical form, so using it here handed agents
+    // ws://127.0.0.1:3000 while the desktop itself spoke to ws://localhost:3000.
+    // Relay tenants bind on the literal HTTP authority, so the agent landed in a
+    // different community, discovered 0 channels, and sat idle without an error.
+    // Identity stays canonical (runtime_key is untouched); the child connects
+    // with the workspace URL verbatim. Same invariant as the
+    // `loopback_ws_localhost_preserves_authority` test in src/relay.rs.
+    let effective_relay_url = {
+        use tauri::Manager as _;
+        let state = app.state::<crate::app_state::AppState>();
+        crate::relay::relay_ws_url_with_override(&state)
+    };
 
     // Augment PATH for DMG launches so child processes can find:
     //   - bundled CLI via ~/.local/bin symlink


### PR DESCRIPTION
## Problem

No managed agent can reply in local dev. Every agent starts cleanly, connects, resolves its owner and initialises its subprocess pool — then logs:

```
INFO  buzz_acp: discovered 0 channel(s)
WARN  buzz_acp: no channel subscriptions resolved — agent will sit idle
```

…and goes quiet. There is no error, and nothing appears in the relay log, so the failure is invisible unless you find the per-agent log file. Built-in agents (Fizz, Honey, Pollen) are affected too.

## Cause

`buzz_core::relay::normalize_relay_url` canonicalises **any loopback host to `127.0.0.1`**:

```rust
if loopback {
    url.set_host(Some("127.0.0.1"))?;
}
```

`ManagedAgentRuntimeKey::new` stores that canonical form, and `spawn_agent_child` used `runtime_key.relay_url` as the child's `BUZZ_RELAY_URL`. Meanwhile the desktop itself talks to `ws://localhost:3000`.

Relay tenants bind on the literal HTTP authority, and `scripts/seed-local-community.sh` creates **separate communities** for `localhost:3000` and `127.0.0.1:3000`. So the agent authenticates successfully into a *different, empty* community and finds none of the user's channels.

This contradicts two things already in the tree:

1. `normalize_relay_url`'s own doc — *"Connection code may retain the configured URL; this canonical form is for identity, receipts, status and deduplication."*
2. `desktop/src-tauri/src/relay.rs::loopback_ws_localhost_preserves_authority`, which pins exactly this invariant for the HTTP path:

> *"Tenant host-binding keys off the HTTP Host/authority. The desktop must not rewrite localhost to 127.0.0.1, or local dev HTTP calls target a different unmapped community than the WebSocket URL."*

The HTTP path was guarded; the agent-spawn path was not.

## Fix

Keep the runtime key canonical — runtime ids, log paths and dedup are unchanged — and hand the child the workspace relay URL verbatim.

## Verification

Same agent, same machine, before and after:

```
before:  discovered 0 channel(s) — agent will sit idle
after:   discovered 2 channel(s)
         subscribed to channel 1079b088-…
         subscribed to channel adafd400-…
```

A mention now round-trips end to end: relay `kind:9` events show the agent replying to its owner twice, 76s and 45s after each mention.

Reproduction on a clean checkout: `just setup`, `just dev`, onboard against the local relay, create an agent, add it to a channel, mention it. Before this change it never answers.
