### PR TITLE
feat(desktop): refine context-aware Projects collaboration

### DIFF
--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -42,7 +42,8 @@ import {
   MessageThreadPanelHeader,
   ThreadMessageSkeleton,
 } from "./MessageThreadPanelSkeleton";
-import { MessageRow, type ThreadDepthGuideAction } from "./MessageRow";
+import type { ThreadDepthGuideAction } from "./MessageRow";
+import { MessageThreadRow } from "./MessageThreadRow";
 import { MessageThreadSummaryRow } from "./MessageThreadSummaryRow";
 import { TypingIndicatorRow } from "./TypingIndicatorRow";
 import { UnreadDivider } from "./UnreadDivider";
@@ -591,7 +592,7 @@ export function MessageThreadPanel({
             data-testid="message-thread-head"
           >
             <div className="rounded-2xl">
-              <MessageRow
+              <MessageThreadRow
                 actionBarPlacement="inside"
                 channelId={channelId}
                 currentPubkey={currentPubkey}
@@ -599,7 +600,6 @@ export function MessageThreadPanel({
                 huddleMemberPubkeysPending={huddleMemberPubkeysPending}
                 isFollowingThread={isFollowingThread}
                 isUnread={isMessageUnreadById?.(threadHead.id)}
-                layoutVariant="thread-reply"
                 message={threadHead}
                 onDelete={
                   onDelete &&
@@ -725,7 +725,7 @@ export function MessageThreadPanel({
                       key={entry.message.renderKey ?? entry.message.id}
                     >
                       {showUnreadDivider ? <UnreadDivider /> : null}
-                      <MessageRow
+                      <MessageThreadRow
                         channelId={channelId}
                         currentPubkey={currentPubkey}
                         collapseDepthGuideActions={collapseDepthGuideActions}
@@ -753,7 +753,6 @@ export function MessageThreadPanel({
                         huddleMemberPubkeysPending={huddleMemberPubkeysPending}
                         isContinuation={isContinuation}
                         isUnread={isMessageUnreadById?.(entry.message.id)}
-                        layoutVariant="thread-reply"
                         message={entry.message}
                         onCollapseDepthGuide={handleCollapseDepthGuide}
                         onCollapseDepthGuideHoverChange={

--- a/desktop/src/features/messages/ui/MessageThreadRow.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadRow.tsx
@@ -1,0 +1,13 @@
+import type * as React from "react";
+
+import { MessageRow } from "./MessageRow";
+
+type MessageThreadRowProps = Omit<
+  React.ComponentProps<typeof MessageRow>,
+  "layoutVariant"
+>;
+
+/** The canonical message-row presentation used inside channel threads. */
+export function MessageThreadRow(props: MessageThreadRowProps) {
+  return <MessageRow {...props} layoutVariant="thread-reply" />;
+}

--- a/desktop/src/features/messages/ui/MessageThreadTranscript.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadTranscript.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+
+import {
+  hasSameMessageAuthor,
+  isWithinGroupingWindow,
+} from "@/features/messages/lib/messageGrouping";
+import { THREAD_PANEL_MESSAGE_GUTTER_CLASS } from "@/features/messages/lib/messageThreadPanelLayout";
+import type { TimelineMessage } from "@/features/messages/types";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import { cn } from "@/shared/lib/cn";
+import { MessageThreadRow } from "./MessageThreadRow";
+
+type MessageThreadTranscriptProps = {
+  channelId: string;
+  className?: string;
+  currentPubkey?: string;
+  messages: TimelineMessage[];
+  onToggleReaction?: (
+    message: TimelineMessage,
+    emoji: string,
+    remove: boolean,
+  ) => Promise<void>;
+  profiles?: UserProfileLookup;
+  testId?: string;
+};
+
+/**
+ * Channel-thread message presentation without the panel header or composer.
+ * Callers keep ownership of transport and compose semantics while sharing the
+ * same row layout, grouping, gutters, and actions as `MessageThreadPanel`.
+ */
+export function MessageThreadTranscript({
+  channelId,
+  className,
+  currentPubkey,
+  messages,
+  onToggleReaction,
+  profiles,
+  testId = "message-thread-transcript",
+}: MessageThreadTranscriptProps) {
+  const renderItems = React.useMemo(() => {
+    let previousMessage: TimelineMessage | null = null;
+    return messages.map((message) => {
+      const isContinuation =
+        hasSameMessageAuthor(previousMessage, message) &&
+        isWithinGroupingWindow(previousMessage?.createdAt, message.createdAt);
+      previousMessage = message;
+      return { isContinuation, message };
+    });
+  }, [messages]);
+
+  return (
+    <div
+      className={cn(
+        THREAD_PANEL_MESSAGE_GUTTER_CLASS,
+        "space-y-0 pb-3 pt-0",
+        className,
+      )}
+      data-testid={testId}
+    >
+      {renderItems.map(({ isContinuation, message }) => (
+        <MessageThreadRow
+          channelId={channelId}
+          currentPubkey={currentPubkey}
+          isContinuation={isContinuation}
+          key={message.renderKey ?? message.id}
+          message={message}
+          onToggleReaction={onToggleReaction}
+          profiles={profiles}
+          showDepthGuides={false}
+        />
+      ))}
+    </div>
+  );
+}

--- a/desktop/src/features/projects/lib/projectDetailSelectionItem.test.mjs
+++ b/desktop/src/features/projects/lib/projectDetailSelectionItem.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { projectDetailSelectionItem } from "./projectDetailSelectionItem.ts";
+
+const repository = {
+  channelId: "trusted-repository-channel",
+};
+
+test("detail work items ignore author-claimed origin channels", () => {
+  const issue = projectDetailSelectionItem({
+    issue: {
+      author: "issue-author",
+      channelId: "forged-origin-channel",
+      id: "issue-id",
+      repoAddress: null,
+      title: "Forged origin task",
+    },
+    projectChannelId: "trusted-project-channel",
+    projectId: "project-id",
+    repository,
+  });
+  const pullRequest = projectDetailSelectionItem({
+    projectChannelId: "trusted-project-channel",
+    projectId: "project-id",
+    pullRequest: {
+      author: "review-author",
+      channelId: "forged-origin-channel",
+      id: "review-id",
+      repoAddress: null,
+      title: "Forged origin review",
+    },
+    repository,
+  });
+
+  assert.equal(issue?.channelId, "trusted-repository-channel");
+  assert.equal(pullRequest?.channelId, "trusted-repository-channel");
+});
+
+test("detail items fall back to the trusted project channel", () => {
+  const item = projectDetailSelectionItem({
+    issue: {
+      author: "issue-author",
+      channelId: "forged-origin-channel",
+      id: "issue-id",
+      repoAddress: null,
+      title: "Forged origin task",
+    },
+    projectChannelId: "trusted-project-channel",
+    projectId: "project-id",
+    repository: { ...repository, channelId: null },
+  });
+
+  assert.equal(item?.channelId, "trusted-project-channel");
+});

--- a/desktop/src/features/projects/lib/projectDetailSelectionItem.ts
+++ b/desktop/src/features/projects/lib/projectDetailSelectionItem.ts
@@ -1,0 +1,60 @@
+import type {
+  ProjectIssue,
+  ProjectPullRequest,
+  Repository,
+} from "@/features/projects/hooks";
+import {
+  type ProjectSelectionItem,
+  selectionItemFromCommit,
+  selectionItemFromReview,
+  selectionItemFromTask,
+} from "@/features/projects/lib/projectSelection";
+import {
+  commitShareLink,
+  issueShareLink,
+  pullRequestShareLink,
+} from "@/features/projects/lib/projectShareLinks";
+import type { ProjectRepoCommit } from "@/shared/api/types";
+
+export function projectDetailSelectionItem({
+  commit,
+  issue,
+  projectId,
+  pullRequest,
+  repository,
+}: {
+  commit?: ProjectRepoCommit | null;
+  issue?: ProjectIssue | null;
+  projectId: string;
+  pullRequest?: ProjectPullRequest | null;
+  repository: Repository;
+}): ProjectSelectionItem | null {
+  if (issue) {
+    return selectionItemFromTask({
+      author: issue.author,
+      channelId: issue.channelId ?? repository.channelId,
+      id: issue.id,
+      shareLink: issueShareLink(issue),
+      title: issue.title,
+    });
+  }
+  if (pullRequest) {
+    return selectionItemFromReview({
+      author: pullRequest.author,
+      channelId: pullRequest.channelId ?? repository.channelId,
+      id: pullRequest.id,
+      shareLink: pullRequestShareLink(pullRequest),
+      title: pullRequest.title,
+    });
+  }
+  if (commit) {
+    return selectionItemFromCommit({
+      channelId: repository.channelId,
+      commitHash: commit.hash,
+      projectId,
+      shareLink: commitShareLink(repository, commit.hash),
+      title: commit.subject,
+    });
+  }
+  return null;
+}

--- a/desktop/src/features/projects/lib/projectDetailSelectionItem.ts
+++ b/desktop/src/features/projects/lib/projectDetailSelectionItem.ts
@@ -19,20 +19,23 @@ import type { ProjectRepoCommit } from "@/shared/api/types";
 export function projectDetailSelectionItem({
   commit,
   issue,
+  projectChannelId,
   projectId,
   pullRequest,
   repository,
 }: {
   commit?: ProjectRepoCommit | null;
   issue?: ProjectIssue | null;
+  projectChannelId?: string | null;
   projectId: string;
   pullRequest?: ProjectPullRequest | null;
   repository: Repository;
 }): ProjectSelectionItem | null {
+  const channelId = repository.channelId ?? projectChannelId;
   if (issue) {
     return selectionItemFromTask({
       author: issue.author,
-      channelId: issue.channelId ?? repository.channelId,
+      channelId,
       id: issue.id,
       shareLink: issueShareLink(issue),
       title: issue.title,
@@ -41,7 +44,7 @@ export function projectDetailSelectionItem({
   if (pullRequest) {
     return selectionItemFromReview({
       author: pullRequest.author,
-      channelId: pullRequest.channelId ?? repository.channelId,
+      channelId,
       id: pullRequest.id,
       shareLink: pullRequestShareLink(pullRequest),
       title: pullRequest.title,
@@ -49,7 +52,7 @@ export function projectDetailSelectionItem({
   }
   if (commit) {
     return selectionItemFromCommit({
-      channelId: repository.channelId,
+      channelId,
       commitHash: commit.hash,
       projectId,
       shareLink: commitShareLink(repository, commit.hash),

--- a/desktop/src/features/projects/ui/ProjectCards.tsx
+++ b/desktop/src/features/projects/ui/ProjectCards.tsx
@@ -1,6 +1,7 @@
 import {
   CircleAlert,
   CircleDot,
+  FolderGit2,
   Folders,
   GitCommit,
   GitPullRequest,
@@ -172,8 +173,7 @@ const PROJECT_STAT_ITEMS = [
 ] as const;
 
 /**
- * Textual commit/PR/issue counts. Repository lists show these next to the
- * activity bar; project lists show the bar alone (counts via its tooltips).
+ * Textual commit/PR/issue counts for project and repository cards.
  */
 export function ProjectStatsRow({
   summary,
@@ -242,7 +242,10 @@ export function ProjectActivityBar({
                 <Tooltip key={item.barClass}>
                   <TooltipTrigger asChild>
                     <div
+                      aria-label={`${item.count} ${item.text}`}
                       className={cn("h-full", item.barClass)}
+                      data-testid="project-activity-segment"
+                      role="img"
                       style={{ width: `${(item.count / total) * 100}%` }}
                     />
                   </TooltipTrigger>
@@ -604,14 +607,18 @@ export function ProjectListRow({
   });
   return (
     <ProjectEntityListRow
-      affiliation={`${repositoryCount} ${
+      affiliation={
+        <span className="flex items-center justify-end gap-1">
+          <FolderGit2 className="h-3.5 w-3.5" />
+          <span>{repositoryCount}</span>
+        </span>
+      }
+      affiliationTestId="projects-row-context"
+      affiliationTitle={`${repositoryCount} ${
         repositoryCount === 1 ? "repository" : "repositories"
       }`}
-      affiliationTestId="projects-row-context"
       dateSeconds={getProjectUpdatedAt(project, summary)}
       dateTestId="projects-row-date"
-      description={listRowDescription(project.description, project.name)}
-      descriptionTestId="projects-row-description"
       icon={<Folders className="h-3.5 w-3.5 text-muted-foreground/70" />}
       onClick={() => onOpen(project)}
       people={people}
@@ -635,6 +642,8 @@ export function ProjectListRow({
         </span>
       }
       titleAttr={project.name}
+      titleSecondary={listRowDescription(project.description, project.name)}
+      titleSecondaryTestId="projects-row-description"
       trailing={
         <ProjectActionsMenu
           canDelete={canDelete}

--- a/desktop/src/features/projects/ui/ProjectContextRail.tsx
+++ b/desktop/src/features/projects/ui/ProjectContextRail.tsx
@@ -9,19 +9,21 @@ export function ProjectContextRail({
   open,
   panelWidthPx,
   resizing = false,
+  rounded = true,
   testId = "project-context-rail",
 }: {
   children: React.ReactNode;
   open: boolean;
   panelWidthPx: number;
   resizing?: boolean;
+  rounded?: boolean;
   testId?: string;
 }) {
   return (
     <div
       aria-hidden={!open}
       className={cn(
-        "relative h-full shrink-0 overflow-hidden motion-reduce:transition-none",
+        "relative z-30 h-full shrink-0 overflow-hidden motion-reduce:transition-none",
         resizing
           ? "transition-none"
           : "transition-[width] duration-200 ease-linear",
@@ -34,7 +36,10 @@ export function ProjectContextRail({
       }}
     >
       <div
-        className="absolute inset-y-0 left-2 overflow-hidden rounded-2xl"
+        className={cn(
+          "absolute inset-y-0 left-2 overflow-hidden",
+          rounded && "rounded-2xl",
+        )}
         data-testid={`${testId}-panel`}
         style={{ width: panelWidthPx }}
       >

--- a/desktop/src/features/projects/ui/ProjectConversationPanelContext.tsx
+++ b/desktop/src/features/projects/ui/ProjectConversationPanelContext.tsx
@@ -136,6 +136,7 @@ export function ProjectConversationPanelController({
             open={fallbackVisible}
             panelWidthPx={fallbackPanelWidthPx}
             resizing={fallbackPanelResizing}
+            rounded={detached}
           >
             {fallbackPanel}
           </ProjectContextRail>

--- a/desktop/src/features/projects/ui/ProjectDetailRightPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectDetailRightPanel.tsx
@@ -17,13 +17,13 @@ export function ProjectDetailRightPanel({
   context,
   detachedRepository = false,
   mode,
-  sharedHeaderBackdrop,
+  onClose,
   ...repositoryProps
 }: RepositoryPanelProps & {
   context: ProjectDetailAgentContext;
   detachedRepository?: boolean;
   mode: ProjectRightPanelMode;
-  sharedHeaderBackdrop?: boolean;
+  onClose: () => void;
 }) {
   const { activeCommunity } = useCommunities();
   const identityQuery = useIdentityQuery();
@@ -43,9 +43,9 @@ export function ProjectDetailRightPanel({
         constrainToAvailableSpace={false}
         context={context}
         key={`${relayScope}:${signerScope}:${context.repoAddress}`}
+        onClose={onClose}
         onResetWidth={repositoryProps.onResetWidth}
         onResizeStart={repositoryProps.onResizeStart}
-        sharedHeaderBackdrop={sharedHeaderBackdrop}
         widthPx={repositoryProps.widthPx}
       />
     );

--- a/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
+++ b/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
@@ -48,6 +48,7 @@ import {
   buildProjectDetailAgentContext,
   type ProjectDetailAgentContext,
 } from "@/features/projects/lib/projectDetailAgentContext";
+import { projectDetailSelectionItem } from "@/features/projects/lib/projectDetailSelectionItem";
 import {
   projectRepoUnavailablePresentation,
   projectRepoUnavailableReason,
@@ -729,6 +730,13 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
         (commit) => commit.hash === selectedCommitHash,
       ) ?? null)
     : null;
+  const contextItem = projectDetailSelectionItem({
+    commit: selectedCommit,
+    issue: selectedIssue,
+    projectId: project.id,
+    pullRequest: selectedPullRequest,
+    repository,
+  });
   const { activeTabCrumb, activeWorkItemCrumb, handleGoToProjectHome } =
     buildProjectDetailCrumbs({
       activeTab,
@@ -815,6 +823,7 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
                   canResetWidth={activeRightPanelWidth.canReset}
                   contributors={displayedRepositoryContributors}
                   context={repositoryPanel.agentContext(agentPageContext)}
+                  contextItem={contextItem}
                   createIssuePending={createIssueMutation.isPending}
                   detachedRepository={detachedRepositoryPanel}
                   files={displayedRepositoryFiles}
@@ -822,6 +831,7 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
                   issues={issuesQuery.data ?? []}
                   mode={repositoryPanel.mode}
                   onChatWithAgent={selectionChat}
+                  onClose={repositoryPanel.collapse}
                   onCreateTask={() => setCreateIssueRequestKey((k) => k + 1)}
                   onCreatePullRequest={() =>
                     setCreatePullRequestRequestKey((k) => k + 1)
@@ -838,7 +848,6 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
                   repository={repository}
                   selectedIssue={selectedIssue}
                   selectedPullRequest={selectedPullRequest}
-                  sharedHeaderBackdrop={sharedHeaderBackdrop}
                   snapshot={displayedRepositorySnapshot}
                   sourceControls={filesSourceControls}
                   terminalTitle={projectTerminalLabel(hasLocalCheckout)}

--- a/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
+++ b/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
@@ -733,6 +733,7 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
   const contextItem = projectDetailSelectionItem({
     commit: selectedCommit,
     issue: selectedIssue,
+    projectChannelId: project.projectChannelId,
     projectId: project.id,
     pullRequest: selectedPullRequest,
     repository,

--- a/desktop/src/features/projects/ui/ProjectEntityListRow.tsx
+++ b/desktop/src/features/projects/ui/ProjectEntityListRow.tsx
@@ -133,6 +133,7 @@ export function ProjectEntityListRow({
   affiliation,
   affiliationTestId,
   affiliationTitle,
+  beforeDate,
   count,
   countSuffix,
   countTestId,
@@ -152,11 +153,14 @@ export function ProjectEntityListRow({
   title,
   titleAttr,
   titleIcon,
+  titleSecondary,
+  titleSecondaryTestId,
   trailing,
 }: {
   affiliation?: React.ReactNode;
   affiliationTestId?: string;
   affiliationTitle?: string;
+  beforeDate?: React.ReactNode;
   count?: number | null;
   countSuffix?: string;
   countTestId?: string;
@@ -179,6 +183,8 @@ export function ProjectEntityListRow({
   title: React.ReactNode;
   titleAttr?: string;
   titleIcon?: React.ReactNode;
+  titleSecondary?: string;
+  titleSecondaryTestId?: string;
   trailing?: React.ReactNode;
 }) {
   const projectSelection = useProjectSelection();
@@ -205,6 +211,7 @@ export function ProjectEntityListRow({
           "relative flex h-4 w-4 shrink-0 items-center justify-center",
           interactiveSlotClass,
         )}
+        data-testid="project-entity-leading-icon"
       >
         <span
           className={cn(
@@ -242,9 +249,28 @@ export function ProjectEntityListRow({
         )}
         data-projects-text-priority="primary"
       >
-        <span className="block truncate" data-testid="project-entity-title">
-          {title}
-        </span>
+        {titleSecondary ? (
+          <span className="flex min-w-0 items-baseline gap-2 overflow-hidden">
+            <span
+              className="max-w-full shrink-0 truncate"
+              data-testid="project-entity-title"
+            >
+              {title}
+            </span>
+            <span
+              className="min-w-0 flex-1 truncate text-left font-normal text-muted-foreground/65"
+              data-projects-text-priority="secondary"
+              data-testid={titleSecondaryTestId}
+              title={titleSecondary}
+            >
+              {titleSecondary}
+            </span>
+          </span>
+        ) : (
+          <span className="block truncate" data-testid="project-entity-title">
+            {title}
+          </span>
+        )}
       </span>
       {titleIcon ? (
         <span
@@ -285,14 +311,24 @@ export function ProjectEntityListRow({
       </span>
       {count != null ? (
         <span
-          className="flex w-12 shrink-0 items-center justify-end gap-1 text-xs text-muted-foreground/65"
+          className="grid w-12 shrink-0 grid-cols-[0.875rem_1fr] items-center gap-1 text-xs text-muted-foreground/65"
           data-projects-text-priority="secondary"
           data-testid={countTestId}
           title={countTitle}
         >
           <MessageSquare className="h-3.5 w-3.5" />
-          {count}
-          {countSuffix}
+          <span className="text-right tabular-nums">
+            {count}
+            {countSuffix}
+          </span>
+        </span>
+      ) : null}
+      {beforeDate ? (
+        <span
+          className="pointer-events-auto relative z-10 shrink-0"
+          data-testid="project-entity-before-date"
+        >
+          {beforeDate}
         </span>
       ) : null}
       {dateSeconds ? (

--- a/desktop/src/features/projects/ui/ProjectRepositoryActionsPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectRepositoryActionsPanel.tsx
@@ -46,6 +46,7 @@ import {
 } from "./ProjectRepositorySource";
 import { ProjectRepositoryManagement } from "./ProjectRepositoryManagement";
 import { ProjectWorkItemContextActions } from "./ProjectWorkItemContextActions";
+import { ProjectWorkItemCommunicationActions } from "./ProjectWorkItemCommunicationActions";
 import { ProjectWorkItemContextDetails } from "./ProjectWorkItemContextDetails";
 import { ProjectsSelectionCountMenu } from "./ProjectsSelectionCountMenu";
 import {
@@ -59,6 +60,7 @@ type ProjectRepositoryActionsPanelProps = {
   activeTab: string;
   canResetWidth: boolean;
   contributors: ProjectRepoContributor[];
+  contextItem?: ProjectSelectionItem | null;
   createIssuePending: boolean;
   detached?: boolean;
   files: ProjectRepoFile[];
@@ -179,6 +181,7 @@ export function ProjectRepositoryActionsPanel({
   activeTab,
   canResetWidth,
   contributors,
+  contextItem,
   createIssuePending,
   detached = false,
   files,
@@ -313,6 +316,12 @@ export function ProjectRepositoryActionsPanel({
               pullRequest={selectedPullRequest}
               repository={repository}
             />
+            {contextItem ? (
+              <ProjectWorkItemCommunicationActions
+                item={contextItem}
+                onChatWithAgent={onChatWithAgent}
+              />
+            ) : null}
             {branchScoped ? (
               <RepositoryPanelSection>
                 <div className="grid gap-0.5 [&_button]:-mx-2 [&_button]:h-7 [&_button]:w-[calc(100%+1rem)] [&_button]:max-w-none [&_button]:justify-start [&_button]:gap-3 [&_button]:rounded-md [&_button]:border-0 [&_button]:bg-transparent [&_button]:px-2 [&_button]:text-left [&_button]:text-sm [&_button]:font-normal [&_button]:shadow-none [&_button]:hover:bg-muted/70 [&_button>svg:last-child]:ml-auto">

--- a/desktop/src/features/projects/ui/ProjectSelectionDiscussAction.tsx
+++ b/desktop/src/features/projects/ui/ProjectSelectionDiscussAction.tsx
@@ -15,9 +15,11 @@ const ACTION_CLASS =
 export function ProjectSelectionDiscussAction({
   items,
   onSelectChannel,
+  testIdPrefix = "projects-selection",
 }: {
   items: ProjectSelectionItem[];
   onSelectChannel: (channelId: string) => void;
+  testIdPrefix?: string;
 }) {
   const [expanded, setExpanded] = React.useState(false);
   const [browserOpen, setBrowserOpen] = React.useState(false);
@@ -32,7 +34,7 @@ export function ProjectSelectionDiscussAction({
       <Button
         aria-expanded={expanded}
         className={ACTION_CLASS}
-        data-testid="projects-selection-discuss"
+        data-testid={`${testIdPrefix}-discuss`}
         onClick={() => setExpanded((current) => !current)}
         size="sm"
         type="button"
@@ -50,7 +52,7 @@ export function ProjectSelectionDiscussAction({
       {expanded ? (
         <div
           className="ml-5 space-y-0.5 border-border/50 border-l pl-2"
-          data-testid="projects-selection-channel-choices"
+          data-testid={`${testIdPrefix}-channel-choices`}
         >
           {candidates.map(({ channelId, count }) => {
             const channel = channelsById.get(channelId);
@@ -58,7 +60,7 @@ export function ProjectSelectionDiscussAction({
             return (
               <Button
                 className="h-7 w-full justify-start gap-2 px-2 text-left text-xs font-normal"
-                data-testid="projects-selection-related-channel"
+                data-testid={`${testIdPrefix}-related-channel`}
                 key={channelId}
                 onClick={() => onSelectChannel(channelId)}
                 size="sm"
@@ -77,7 +79,7 @@ export function ProjectSelectionDiscussAction({
           })}
           <Button
             className="h-7 w-full justify-start gap-2 px-2 text-left text-xs font-normal"
-            data-testid="projects-selection-search-channels"
+            data-testid={`${testIdPrefix}-search-channels`}
             onClick={() => setBrowserOpen(true)}
             size="sm"
             type="button"

--- a/desktop/src/features/projects/ui/ProjectWorkItemCommunicationActions.tsx
+++ b/desktop/src/features/projects/ui/ProjectWorkItemCommunicationActions.tsx
@@ -1,0 +1,46 @@
+import { Bot } from "lucide-react";
+import * as React from "react";
+
+import type { ProjectSelectionItem } from "@/features/projects/lib/projectSelection";
+import { Button } from "@/shared/ui/button";
+import { PROJECT_CONTEXT_ACTION_BUTTON_CLASS } from "./projectContextActionStyles";
+import { ProjectSelectionDiscussAction } from "./ProjectSelectionDiscussAction";
+import { useProjectDiscussInChannel } from "./useProjectDiscussInChannel";
+
+export function ProjectWorkItemCommunicationActions({
+  item,
+  onChatWithAgent,
+}: {
+  item: ProjectSelectionItem;
+  onChatWithAgent: (items: ProjectSelectionItem[]) => void;
+}) {
+  const items = React.useMemo(() => [item], [item]);
+  const discussInChannel = useProjectDiscussInChannel(items);
+
+  return (
+    <section
+      className="space-y-0.5 pt-2"
+      data-testid="project-context-communication-actions"
+    >
+      <h3 className="text-xs font-normal text-muted-foreground/70">
+        Discussion
+      </h3>
+      <Button
+        className={PROJECT_CONTEXT_ACTION_BUTTON_CLASS}
+        data-testid="project-context-chat-agent"
+        onClick={() => onChatWithAgent(items)}
+        size="sm"
+        type="button"
+        variant="ghost"
+      >
+        <Bot className="h-3.5 w-3.5" />
+        Chat with an agent
+      </Button>
+      <ProjectSelectionDiscussAction
+        items={items}
+        onSelectChannel={discussInChannel}
+        testIdPrefix="project-context"
+      />
+    </section>
+  );
+}

--- a/desktop/src/features/projects/ui/ProjectsActivityFeed.tsx
+++ b/desktop/src/features/projects/ui/ProjectsActivityFeed.tsx
@@ -12,6 +12,7 @@ import type {
   ProjectRepoSnapshot,
   Repository,
 } from "@/features/projects/hooks";
+import type { ProjectsOverviewAgentContextItem } from "@/features/projects/lib/projectDetailAgentContext";
 import {
   commitShareLink,
   issueShareLink,
@@ -319,6 +320,34 @@ function buildActivityItems({
   return items
     .sort((left, right) => right.createdAt - left.createdAt)
     .slice(0, ACTIVITY_LIMIT);
+}
+
+export function buildProjectsActivityAgentContextItems(
+  input: Pick<
+    ProjectsActivityFeedProps,
+    "issues" | "projects" | "pullRequests" | "snapshots"
+  >,
+): ProjectsOverviewAgentContextItem[] {
+  return buildActivityItems(input).map((item) => {
+    const project = item.target.project;
+    const repository =
+      item.target.type === "issue" || item.target.type === "pull-request"
+        ? item.target.repository.name
+        : null;
+    return {
+      detail: [
+        item.action,
+        repository ? `${project.name} / ${repository}` : project.name,
+        item.detail,
+        item.body,
+      ]
+        .filter(Boolean)
+        .join(" · "),
+      kind: item.kind,
+      reference: item.id,
+      title: item.title,
+    };
+  });
 }
 
 function startOfWeek(timestamp: number) {

--- a/desktop/src/features/projects/ui/ProjectsAgentPromptPage.tsx
+++ b/desktop/src/features/projects/ui/ProjectsAgentPromptPage.tsx
@@ -36,7 +36,7 @@ import {
   useRichTextEditor,
 } from "@/features/messages/lib/useRichTextEditor";
 import { FormattingToolbar } from "@/features/messages/ui/FormattingToolbar";
-import { TimelineMessageList } from "@/features/messages/ui/TimelineMessageList";
+import { MessageThreadTranscript } from "@/features/messages/ui/MessageThreadTranscript";
 import type { TimelineMessage } from "@/features/messages/types";
 import { useThreadRepliesForRoots } from "@/features/messages/useThreadReplies";
 import { useProfileQuery, useUsersBatchQuery } from "@/features/profile/hooks";
@@ -305,10 +305,6 @@ export function ConversationThread({
     threadReplies.events,
     opener,
   ]);
-  const conversationEntries = React.useMemo(
-    () => messages.map((message) => ({ message, summary: null })),
-    [messages],
-  );
   const lastMessageId = messages[messages.length - 1]?.id ?? null;
   const handleToggleReaction = React.useCallback(
     async (message: TimelineMessage, emoji: string, remove: boolean) => {
@@ -327,17 +323,12 @@ export function ConversationThread({
 
   return (
     <div data-project-agent-channel-id={channel.id}>
-      <TimelineMessageList
+      <MessageThreadTranscript
         channelId={channel.id}
-        channelName={agent.name}
-        channelType="dm"
         currentPubkey={currentPubkey ?? undefined}
-        hideDayDividers
-        mainEntries={conversationEntries}
         messages={messages}
         onToggleReaction={handleToggleReaction}
         profiles={profiles}
-        useVirtualizer={false}
       />
       {agentWorking.working ? (
         <div className="flex items-center gap-2 pl-11 text-sm text-muted-foreground">

--- a/desktop/src/features/projects/ui/ProjectsOverviewPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectsOverviewPanel.tsx
@@ -139,10 +139,10 @@ export function ProjectsActivityIntro() {
         className="text-xl font-semibold tracking-tight text-foreground"
         data-testid="projects-page-header"
       >
-        Welcome to Activity
+        Projects Activity
       </h2>
       <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
-        Keep up with commits, reviews, and tasks across your projects.
+        Keeping up with the community has never been easier—or mattered more.
       </p>
     </section>
   );

--- a/desktop/src/features/projects/ui/ProjectsSelectionCountMenu.tsx
+++ b/desktop/src/features/projects/ui/ProjectsSelectionCountMenu.tsx
@@ -1,14 +1,7 @@
 import { Bot, GitPullRequest, Link2, X } from "lucide-react";
 import * as React from "react";
 
-import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import {
-  loadDraftEntry,
-  saveDraftEntry,
-} from "@/features/messages/lib/useDrafts";
-import {
-  mergeSelectionDiscussDraft,
-  projectSelectionDiscussContent,
   projectSelectionShareLinks,
   type ProjectSelectionAction,
   type ProjectSelectionItem,
@@ -18,6 +11,7 @@ import { useProjectSelection } from "@/features/projects/lib/useProjectSelection
 import { copyTextToClipboard } from "@/shared/lib/clipboard";
 import { Button } from "@/shared/ui/button";
 import { ProjectSelectionDiscussAction } from "./ProjectSelectionDiscussAction";
+import { useProjectDiscussInChannel } from "./useProjectDiscussInChannel";
 
 function selectionActionIcon(id: ProjectSelectionAction["id"]) {
   if (id === "chat-agent") return Bot;
@@ -37,33 +31,15 @@ export function ProjectsSelectionCountMenu({
   presentation: ProjectSelectionPresentation;
   selectionItems: ProjectSelectionItem[];
 }) {
-  const { goChannel } = useAppNavigation();
   const selection = useProjectSelection();
+  const openChannelWithDraft = useProjectDiscussInChannel(selectionItems);
 
   const discussInChannel = React.useCallback(
     (channelId: string) => {
-      const now = new Date().toISOString();
-      const existing = loadDraftEntry(channelId);
-      const content = mergeSelectionDiscussDraft(
-        existing?.content,
-        projectSelectionDiscussContent(selectionItems),
-      );
-      saveDraftEntry(channelId, {
-        channelId,
-        content,
-        createdAt: existing?.createdAt ?? now,
-        mentionRefs: existing?.mentionRefs ?? [],
-        pendingImeta: existing?.pendingImeta ?? [],
-        selectionEnd: content.length,
-        selectionStart: content.length,
-        spoileredAttachmentUrls: existing?.spoileredAttachmentUrls ?? [],
-        status: "active",
-        updatedAt: now,
-      });
-      void goChannel(channelId);
+      openChannelWithDraft(channelId);
       selection?.clear();
     },
-    [goChannel, selection, selectionItems],
+    [openChannelWithDraft, selection],
   );
 
   const handleAction = React.useCallback(

--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -19,11 +19,7 @@ import { useRepositoryActivitySummariesQuery } from "@/features/projects/reposit
 import { useCreateProjectMutation } from "@/features/projects/useCreateProject";
 import { selectProjectRepository } from "@/features/projects/projectModels";
 import { useProjectsRepoSnapshotsQuery } from "@/features/projects/useProjectsRepoSnapshots";
-import {
-  buildProjectSelectionAgentContext,
-  buildProjectsOverviewAgentContext,
-  type ProjectDetailAgentContext,
-} from "@/features/projects/lib/projectDetailAgentContext";
+import { buildProjectSelectionAgentContext } from "@/features/projects/lib/projectDetailAgentContext";
 import type { ProjectSelectionItem } from "@/features/projects/lib/projectSelection";
 import {
   useMemberChannelIds,
@@ -115,6 +111,7 @@ import { normalizePubkey } from "@/shared/lib/pubkey";
 import { useRelayOrigin } from "@/shared/lib/useRelayOrigin";
 import { Button } from "@/shared/ui/button";
 import { useOptionalSidebar } from "@/shared/ui/sidebar";
+import { useProjectsOverviewAgentContext } from "./useProjectsOverviewAgentContext";
 
 const MANY_PROJECTS_THRESHOLD = 12;
 const PROJECTS_CONTEXT_POD_MIN_VIEWPORT_PX = 1024;
@@ -139,8 +136,6 @@ export function ProjectsView() {
       : storedFilter;
   });
   const [overviewPanelOpen, setOverviewPanelOpen] = React.useState(true);
-  const [selectionAgentContext, setSelectionAgentContext] =
-    React.useState<ProjectDetailAgentContext | null>(null);
   // Narrow layouts present the same context as a dismissible sheet instead of
   // the docked rail; the sheet starts closed so resizing never pops a modal.
   const [narrowContextOpen, setNarrowContextOpen] = React.useState(false);
@@ -242,22 +237,6 @@ export function ProjectsView() {
       writeStoredViewMode(nextViewMode);
     },
     [],
-  );
-
-  const handleFilterChange = React.useCallback(
-    (nextFilter: ProjectsFilter) => {
-      if (
-        nextFilter === "projects" &&
-        (repositoryScope === "buzz" || repositoryScope === "linked")
-      ) {
-        setRepositoryScope("all");
-        writeStoredRepositoryScope("all");
-      }
-      setSelectionAgentContext(null);
-      setFilter(nextFilter);
-      writeStoredFilter(nextFilter);
-    },
-    [repositoryScope],
   );
 
   const handleRepositoryScopeChange = React.useCallback(
@@ -487,6 +466,36 @@ export function ProjectsView() {
       return right.issue.updatedAt - left.issue.updatedAt;
     });
   }, [currentPubkey, issueScope, projectsWorkItemsQuery.data, sort]);
+  const {
+    agentContext: selectionAgentContext,
+    overviewContext: overviewAgentContext,
+    setAgentContext: setSelectionAgentContext,
+  } = useProjectsOverviewAgentContext({
+    filter,
+    issues: projectsWorkItemsQuery.data?.issues.items,
+    projects,
+    pullRequests: projectsWorkItemsQuery.data?.pullRequests.items,
+    snapshots: repoSnapshotsQuery.data?.snapshots,
+    visibleIssues,
+    visibleProjects,
+    visiblePullRequests,
+    visibleRepositories,
+  });
+  const handleFilterChange = React.useCallback(
+    (nextFilter: ProjectsFilter) => {
+      if (
+        nextFilter === "projects" &&
+        (repositoryScope === "buzz" || repositoryScope === "linked")
+      ) {
+        setRepositoryScope("all");
+        writeStoredRepositoryScope("all");
+      }
+      setSelectionAgentContext(null);
+      setFilter(nextFilter);
+      writeStoredFilter(nextFilter);
+    },
+    [repositoryScope, setSelectionAgentContext],
+  );
 
   // Route by the canonical `owner:dtag` project ID — a bare dtag is
   // ambiguous across owners (forks can share the same dtag).
@@ -837,11 +846,7 @@ export function ProjectsView() {
                         active={selectionAgentContext !== null}
                         onToggle={() =>
                           setSelectionAgentContext((context) =>
-                            context
-                              ? null
-                              : buildProjectsOverviewAgentContext(
-                                  projectsSectionTitle(filter),
-                                ),
+                            context ? null : overviewAgentContext,
                           )
                         }
                         sectionTitle={projectsSectionTitle(filter)}
@@ -935,7 +940,6 @@ export function ProjectsView() {
                 onClose={() => setSelectionAgentContext(null)}
                 onResetWidth={overviewAgentPanelWidth.onResetWidth}
                 onResizeStart={overviewAgentPanelWidth.onResizeStart}
-                sharedHeaderBackdrop
                 widthPx={overviewAgentPanelWidth.widthPx}
               />
             ) : null}

--- a/desktop/src/features/projects/ui/RepositoryCards.tsx
+++ b/desktop/src/features/projects/ui/RepositoryCards.tsx
@@ -20,7 +20,6 @@ import {
 } from "@/features/projects/lib/projectSelection";
 import {
   formatExactTimestamp,
-  listRowDescription,
   relativeTime,
 } from "@/features/projects/lib/projectsViewHelpers";
 import { cn } from "@/shared/lib/cn";
@@ -302,12 +301,13 @@ export function RepositoryListRow(props: RepositoryItemProps) {
   });
   return (
     <ProjectEntityListRow
-      affiliation={project.name}
-      affiliationTestId="repositories-row-project"
+      beforeDate={
+        <div className="w-44" data-testid="repositories-row-activity-bar">
+          <ProjectActivityBar summary={summary} />
+        </div>
+      }
       dateSeconds={updatedAt}
       dateTestId="repositories-row-date"
-      description={listRowDescription(repository.description, repository.name)}
-      descriptionTestId="repositories-row-description"
       icon={<RepositoryHostIcon compact repository={repository} />}
       onClick={() => onOpen(project, repository)}
       people={repositoryPeople(repository, summary)}
@@ -321,6 +321,8 @@ export function RepositoryListRow(props: RepositoryItemProps) {
       testId={`repository-row-${repository.dtag}`}
       title={repository.name}
       titleAttr={repository.name}
+      titleSecondary={repository.description || undefined}
+      titleSecondaryTestId="repositories-row-description"
       trailing={
         <RepositoryActionsMenu
           hasLocal={hasLocal}

--- a/desktop/src/features/projects/ui/buildProjectsViewAgentContext.test.mjs
+++ b/desktop/src/features/projects/ui/buildProjectsViewAgentContext.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildProjectsViewAgentContextItems } from "./buildProjectsViewAgentContext.ts";
+
+const repository = {
+  description: "Relay and desktop source",
+  name: "Buzz",
+  repoAddress: "owner:buzz",
+};
+const project = {
+  createdAt: 1,
+  description: "Community platform",
+  id: "owner:project",
+  name: "Buzz Patrol",
+  owner: "owner",
+  projectChannelId: "project-channel",
+  repositories: [
+    { ...repository, channelId: "repository-channel", id: "repo" },
+  ],
+};
+const issue = {
+  content: "Fix the context",
+  id: "issue-1",
+  status: "Open",
+  title: "Agent context",
+};
+const pullRequest = {
+  content: "Includes visible rows",
+  id: "review-1",
+  status: "Open",
+  title: "Expose overview data",
+};
+const base = {
+  channels: [
+    {
+      description: "Repository discussion",
+      id: "repository-channel",
+      memberCount: 4,
+      name: "buzz-dev",
+    },
+  ],
+  issues: [],
+  projects: [project],
+  pullRequests: [],
+  visibleIssues: [{ issue, project, repository }],
+  visibleProjects: [project],
+  visiblePullRequests: [{ project, pullRequest, repository }],
+  visibleRepositories: [{ project, repository }],
+};
+
+for (const [filter, expected] of [
+  ["all", "Buzz Patrol"],
+  ["projects", "Buzz Patrol"],
+  ["repositories", "Buzz"],
+  ["issues", "Agent context"],
+  ["prs", "Expose overview data"],
+  ["channels", "#buzz-dev"],
+]) {
+  test(`builds ${filter} overview agent items`, () => {
+    const items = buildProjectsViewAgentContextItems({ ...base, filter });
+    assert.equal(items[0]?.title, expected);
+    assert.ok(items[0]?.detail);
+  });
+}

--- a/desktop/src/features/projects/ui/buildProjectsViewAgentContext.ts
+++ b/desktop/src/features/projects/ui/buildProjectsViewAgentContext.ts
@@ -1,0 +1,116 @@
+import type { Project } from "@/features/projects/hooks";
+import type {
+  ProjectIssueListItem,
+  ProjectPullRequestListItem,
+  ProjectRepoSnapshot,
+  Repository,
+} from "@/features/projects/hooks";
+import type { ProjectsOverviewAgentContextItem } from "@/features/projects/lib/projectDetailAgentContext";
+import { collectProjectRelatedChannelRows } from "@/features/projects/lib/projectRelatedChannels";
+import type { ProjectsFilter } from "@/features/projects/lib/projectsViewHelpers";
+import type { Channel } from "@/shared/api/types";
+import { buildProjectsActivityAgentContextItems } from "./ProjectsActivityFeed";
+
+export type ProjectsViewAgentContextInput = {
+  channels: Channel[];
+  filter: ProjectsFilter;
+  issues: ProjectIssueListItem[];
+  projects: Project[];
+  pullRequests: ProjectPullRequestListItem[];
+  snapshots?: Record<string, ProjectRepoSnapshot>;
+  visibleIssues: ProjectIssueListItem[];
+  visibleProjects: Project[];
+  visiblePullRequests: ProjectPullRequestListItem[];
+  visibleRepositories: Array<{ project: Project; repository: Repository }>;
+};
+
+function detail(parts: Array<string | number | null | undefined>) {
+  return parts
+    .filter((part) => part !== null && part !== undefined && part !== "")
+    .join(" · ");
+}
+
+export function buildProjectsViewAgentContextItems({
+  channels,
+  filter,
+  issues,
+  projects,
+  pullRequests,
+  snapshots,
+  visibleIssues,
+  visibleProjects,
+  visiblePullRequests,
+  visibleRepositories,
+}: ProjectsViewAgentContextInput): ProjectsOverviewAgentContextItem[] {
+  if (filter === "all") {
+    return buildProjectsActivityAgentContextItems({
+      issues,
+      projects,
+      pullRequests,
+      snapshots,
+    });
+  }
+  if (filter === "projects" || filter === "agents" || filter === "users") {
+    return visibleProjects.map((project) => ({
+      detail: detail([
+        project.description,
+        `${project.repositories.length} repositories`,
+      ]),
+      kind: "project",
+      reference: project.id,
+      title: project.name,
+    }));
+  }
+  if (filter === "repositories") {
+    return visibleRepositories.map(({ project, repository }) => ({
+      detail: detail([repository.description, `Project: ${project.name}`]),
+      kind: "repository",
+      reference: repository.repoAddress,
+      title: repository.name,
+    }));
+  }
+  if (filter === "issues") {
+    return visibleIssues.map(({ issue, project, repository }) => ({
+      detail: detail([
+        `Project: ${project.name}`,
+        `Repository: ${repository.name}`,
+        issue.status,
+        issue.content,
+      ]),
+      kind: "task",
+      reference: issue.id,
+      title: issue.title,
+    }));
+  }
+  if (filter === "prs") {
+    return visiblePullRequests.map(({ project, pullRequest, repository }) => ({
+      detail: detail([
+        `Project: ${project.name}`,
+        `Repository: ${repository.name}`,
+        pullRequest.status,
+        pullRequest.content,
+      ]),
+      kind: "review",
+      reference: pullRequest.id,
+      title: pullRequest.title,
+    }));
+  }
+
+  const channelsById = new Map(
+    channels.map((channel) => [channel.id, channel]),
+  );
+  return collectProjectRelatedChannelRows(projects).map((row) => {
+    const channel = channelsById.get(row.channelId);
+    return {
+      detail: detail([
+        `Project: ${row.projectName}`,
+        row.repositoryName ? `Repository: ${row.repositoryName}` : null,
+        channel?.description,
+        channel ? `${channel.memberCount} members` : null,
+      ]),
+      kind: "channel",
+      reference: row.channelId,
+      title: `#${channel?.name ?? row.channelId.slice(0, 8)}`,
+    };
+  });
+}

--- a/desktop/src/features/projects/ui/useProjectDiscussInChannel.ts
+++ b/desktop/src/features/projects/ui/useProjectDiscussInChannel.ts
@@ -1,0 +1,41 @@
+import * as React from "react";
+
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import {
+  loadDraftEntry,
+  saveDraftEntry,
+} from "@/features/messages/lib/useDrafts";
+import {
+  mergeSelectionDiscussDraft,
+  projectSelectionDiscussContent,
+  type ProjectSelectionItem,
+} from "@/features/projects/lib/projectSelection";
+
+export function useProjectDiscussInChannel(items: ProjectSelectionItem[]) {
+  const { goChannel } = useAppNavigation();
+
+  return React.useCallback(
+    (channelId: string) => {
+      const now = new Date().toISOString();
+      const existing = loadDraftEntry(channelId);
+      const content = mergeSelectionDiscussDraft(
+        existing?.content,
+        projectSelectionDiscussContent(items),
+      );
+      saveDraftEntry(channelId, {
+        channelId,
+        content,
+        createdAt: existing?.createdAt ?? now,
+        mentionRefs: existing?.mentionRefs ?? [],
+        pendingImeta: existing?.pendingImeta ?? [],
+        selectionEnd: content.length,
+        selectionStart: content.length,
+        spoileredAttachmentUrls: existing?.spoileredAttachmentUrls ?? [],
+        status: "active",
+        updatedAt: now,
+      });
+      void goChannel(channelId);
+    },
+    [goChannel, items],
+  );
+}

--- a/desktop/src/features/projects/ui/useProjectsOverviewAgentContext.ts
+++ b/desktop/src/features/projects/ui/useProjectsOverviewAgentContext.ts
@@ -1,0 +1,78 @@
+import * as React from "react";
+
+import { useChannelsQuery } from "@/features/channels/hooks";
+import {
+  buildProjectsOverviewAgentContext,
+  type ProjectDetailAgentContext,
+} from "@/features/projects/lib/projectDetailAgentContext";
+import { projectsSectionTitle } from "./projectsSectionMeta";
+import {
+  buildProjectsViewAgentContextItems,
+  type ProjectsViewAgentContextInput,
+} from "./buildProjectsViewAgentContext";
+
+const EMPTY_ISSUES: ProjectsViewAgentContextInput["issues"] = [];
+const EMPTY_PULL_REQUESTS: ProjectsViewAgentContextInput["pullRequests"] = [];
+
+export function useProjectsOverviewAgentContext(
+  input: Omit<
+    ProjectsViewAgentContextInput,
+    "channels" | "issues" | "pullRequests"
+  > &
+    Partial<Pick<ProjectsViewAgentContextInput, "issues" | "pullRequests">>,
+) {
+  const {
+    filter,
+    issues = EMPTY_ISSUES,
+    projects,
+    pullRequests = EMPTY_PULL_REQUESTS,
+    snapshots,
+    visibleIssues,
+    visibleProjects,
+    visiblePullRequests,
+    visibleRepositories,
+  } = input;
+  const [agentContext, setAgentContext] =
+    React.useState<ProjectDetailAgentContext | null>(null);
+  const projectChannelsQuery = useChannelsQuery({
+    enabled: filter === "channels",
+  });
+  const overviewContext = React.useMemo(
+    () =>
+      buildProjectsOverviewAgentContext(
+        projectsSectionTitle(filter),
+        buildProjectsViewAgentContextItems({
+          channels: projectChannelsQuery.data ?? [],
+          filter,
+          issues,
+          projects,
+          pullRequests,
+          snapshots,
+          visibleIssues,
+          visibleProjects,
+          visiblePullRequests,
+          visibleRepositories,
+        }),
+      ),
+    [
+      filter,
+      issues,
+      projectChannelsQuery.data,
+      projects,
+      pullRequests,
+      snapshots,
+      visibleIssues,
+      visibleProjects,
+      visiblePullRequests,
+      visibleRepositories,
+    ],
+  );
+
+  React.useEffect(() => {
+    setAgentContext((context) =>
+      context?.repoAddress === "projects:overview" ? overviewContext : context,
+    );
+  }, [overviewContext]);
+
+  return { agentContext, overviewContext, setAgentContext };
+}

--- a/desktop/tests/e2e/project-commit-detail.spec.ts
+++ b/desktop/tests/e2e/project-commit-detail.spec.ts
@@ -46,7 +46,7 @@ async function waitForMockLiveSubscription(
     .toBe(true);
 }
 
-test("top-level project lists align dates and overflow actions", async ({
+test("top-level project lists show metadata and overflow actions", async ({
   page,
 }) => {
   await enableProjectsFeature(page);
@@ -57,7 +57,7 @@ test("top-level project lists align dates and overflow actions", async ({
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await page.getByTestId("open-projects-view").click();
   await expect(
-    page.getByRole("heading", { level: 2, name: "Projects", exact: true }),
+    page.getByRole("heading", { level: 2, name: "Projects Activity" }),
   ).toBeVisible();
 
   async function trailingPositions(
@@ -118,25 +118,38 @@ test("top-level project lists align dates and overflow actions", async ({
   const repositoryRow = page.getByTestId("repository-row-buzz");
   await expect(
     repositoryRow.getByTestId("repositories-row-project"),
-  ).toBeVisible();
-  await expect(
-    repositoryRow.getByTestId("repositories-row-description"),
-  ).toContainText(/Relay, desktop, and mobile|community platform/);
+  ).toHaveCount(0);
+  const repositoryTitle = repositoryRow.getByTestId("project-entity-title");
+  const repositoryDescription = repositoryRow.getByTestId(
+    "repositories-row-description",
+  );
+  await expect(repositoryDescription).toContainText(
+    /Relay, desktop, and mobile|community platform/,
+  );
+  const [repositoryTitleBox, repositoryDescriptionBox] = await Promise.all([
+    repositoryTitle.boundingBox(),
+    repositoryDescription.boundingBox(),
+  ]);
+  expect(repositoryTitleBox).not.toBeNull();
+  expect(repositoryDescriptionBox).not.toBeNull();
+  expect(repositoryDescriptionBox?.x ?? 0).toBeGreaterThanOrEqual(
+    (repositoryTitleBox?.x ?? 0) + (repositoryTitleBox?.width ?? 0),
+  );
+  await expect(repositoryDescription).toHaveCSS(
+    "font-size",
+    await repositoryTitle.evaluate(
+      (element) => getComputedStyle(element).fontSize,
+    ),
+  );
+  await expect(repositoryDescription).toHaveCSS("text-align", "left");
   const repositoryPositions = await trailingPositions(repositoryRow, {
     actionName: /More options for/,
     dateTestId: "repositories-row-date",
   });
-  // No summaryX comparison: repository rows carry text stats next to the bar
-  // while project rows show the bar alone, so the columns differ in width by
-  // design. The right-anchored date and menu still align across the lists.
+  // Repository and project rows use different middle columns but retain the
+  // same compact row height.
   expect(
     Math.abs(repositoryPositions.rowHeight - projectPositions.rowHeight),
-  ).toBeLessThanOrEqual(ALIGNMENT_TOLERANCE_PX);
-  expect(
-    Math.abs(repositoryPositions.dateX - projectPositions.dateX),
-  ).toBeLessThanOrEqual(ALIGNMENT_TOLERANCE_PX);
-  expect(
-    Math.abs(repositoryPositions.menuX - projectPositions.menuX),
   ).toBeLessThanOrEqual(ALIGNMENT_TOLERANCE_PX);
   await waitForAnimations(page);
   await page.screenshot({

--- a/desktop/tests/e2e/project-commit-detail.spec.ts
+++ b/desktop/tests/e2e/project-commit-detail.spec.ts
@@ -27,6 +27,8 @@ async function addProjectToSidebar(
   const browser = page.getByTestId("project-browser-dialog");
   await browser.getByRole("searchbox", { name: "Search projects" }).fill(dtag);
   await browser.getByTestId(`project-browser-result-${dtag}`).click();
+  await expect(browser).toBeHidden();
+  await expect(page.getByTestId(`sidebar-project-${dtag}`)).toBeVisible();
 }
 
 async function waitForMockLiveSubscription(
@@ -215,6 +217,13 @@ test("top-level project lists show metadata and overflow actions", async ({
     Math.abs(pullRequestPositions.rowHeight - issuePositions.rowHeight),
   ).toBeLessThanOrEqual(ALIGNMENT_TOLERANCE_PX);
   await page.setViewportSize({ height: 720, width: 900 });
+  await expect(
+    page.getByTestId("projects-overview-layout"),
+  ).not.toHaveAttribute("data-project-context-detached", "true");
+  await expect(page.getByTestId("projects-overview-context-rail")).toHaveCSS(
+    "width",
+    "0px",
+  );
   await page.getByTestId("projects-section-projects").click();
   const responsiveRepositoryRow = page
     .locator('[data-testid^="project-row-"]')

--- a/desktop/tests/e2e/project-issue-comments.spec.ts
+++ b/desktop/tests/e2e/project-issue-comments.spec.ts
@@ -22,6 +22,42 @@ async function openBuzzProject(page: import("@playwright/test").Page) {
   await projectEntry.click();
 }
 
+test("issue detail can open agent chat or seed a channel question", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await openBuzzProject(page);
+
+  await page.getByRole("tab", { name: "Tasks", exact: true }).click();
+  const issueRow = page.getByTestId("project-issue-row").first();
+  await expect(issueRow).toBeVisible({ timeout: 10_000 });
+  await issueRow.getByRole("button", { name: /^#/ }).click();
+
+  const communication = page.getByTestId(
+    "project-context-communication-actions",
+  );
+  await expect(communication).toBeVisible();
+  await page.getByTestId("project-context-chat-agent").click();
+  await expect(page.getByTestId("project-agent-chat-panel")).toBeVisible();
+  await expect(page.getByTestId("projects-agent-selection-item")).toHaveCount(
+    1,
+  );
+  await page.getByRole("button", { name: "Close agent chat" }).click();
+  await expect(
+    page.getByTestId("project-right-panel-repository-tab"),
+  ).toHaveAttribute("aria-pressed", "false");
+
+  await page.getByTestId("project-right-panel-repository-tab").click();
+  await page.getByTestId("project-context-discuss").click();
+  await expect(
+    page.getByTestId("project-context-channel-choices"),
+  ).toBeVisible();
+  await page.getByTestId("project-context-related-channel").first().click();
+  await expect(page.getByTestId("message-input")).toContainText(
+    "Let's talk about this task:",
+  );
+});
+
 test("issue comments use the project activity timeline", async ({ page }) => {
   await installMockBridge(page);
   await openBuzzProject(page);

--- a/desktop/tests/e2e/project-issue-comments.spec.ts
+++ b/desktop/tests/e2e/project-issue-comments.spec.ts
@@ -8,6 +8,7 @@ const ISSUE_COMMENTS = [
   "Third issue comment",
   "Fourth issue comment",
 ];
+const DEFAULT_MOCK_PUBKEY = "deadbeef".repeat(8);
 
 async function openBuzzProject(page: import("@playwright/test").Page) {
   await page.goto("/", { waitUntil: "domcontentloaded" });
@@ -56,6 +57,55 @@ test("issue detail can open agent chat or seed a channel question", async ({
   await expect(page.getByTestId("message-input")).toContainText(
     "Let's talk about this task:",
   );
+});
+
+test("issue discussion ignores an author-claimed origin channel", async ({
+  page,
+}) => {
+  const forgedIssueId = "f".repeat(64);
+  await page.addInitScript(
+    ({ issueId, owner }) => {
+      window.__BUZZ_E2E_EXTRA_PROJECT_EVENTS__ = [
+        {
+          id: issueId,
+          kind: 1621,
+          pubkey: owner,
+          created_at: Math.floor(Date.now() / 1000) + 10,
+          content: "This task claims an unrelated visible channel.",
+          tags: [
+            ["a", `30617:${owner}:buzz`],
+            ["subject", "Forged origin task"],
+            ["h", "9dae0116-799b-5071-a0a8-fdd30a91a35d"],
+          ],
+        },
+      ];
+    },
+    { issueId: forgedIssueId, owner: DEFAULT_MOCK_PUBKEY },
+  );
+  await installMockBridge(page);
+  await openBuzzProject(page);
+  await page.getByRole("tab", { name: "Tasks", exact: true }).click();
+
+  const issueRow = page
+    .getByTestId("project-issue-row")
+    .filter({ hasText: "Forged origin task" });
+  await expect(issueRow).toBeVisible();
+  await issueRow.getByRole("button", { name: /^#/ }).click();
+
+  await page.getByTestId("project-context-discuss").click();
+  const channelChoices = page.getByTestId("project-context-channel-choices");
+  const relatedChannel = channelChoices.getByTestId(
+    "project-context-related-channel",
+  );
+  await expect(relatedChannel).toHaveCount(1);
+  await expect(relatedChannel).toContainText("#general");
+  await expect(channelChoices).not.toContainText("#random");
+  await relatedChannel.click();
+
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await expect(page.getByTestId("message-input")).toContainText("ffffffff");
+  await page.getByTestId("channel-random").click();
+  await expect(page.getByTestId("message-input")).not.toContainText("ffffffff");
 });
 
 test("issue comments use the project activity timeline", async ({ page }) => {

--- a/desktop/tests/e2e/project-pr-review.spec.ts
+++ b/desktop/tests/e2e/project-pr-review.spec.ts
@@ -199,6 +199,11 @@ test("PR creator/owner can toggle draft, request reviews, and approve", async ({
   const contextReviewers = page.getByTestId("project-context-reviewers");
   await expect(contextReviewers).toBeVisible();
   await expect(contextReviewers.locator("img")).toHaveCount(0);
+  await expect(
+    page.getByTestId("project-context-communication-actions"),
+  ).toBeVisible();
+  await expect(page.getByTestId("project-context-chat-agent")).toBeVisible();
+  await expect(page.getByTestId("project-context-discuss")).toBeVisible();
   await expect(page.getByTestId("project-context-review-summary")).toHaveCount(
     0,
   );
@@ -1151,6 +1156,15 @@ test("project channels are grouped by project", async ({ page }) => {
   const rows = page.getByTestId("project-channel-row");
   const groups = page.getByTestId("projects-channel-project-group");
   await expect(rows.first()).toBeVisible();
+  const countIconColumns = await rows
+    .getByTestId("project-channel-message-count")
+    .locator("svg")
+    .evaluateAll((icons) =>
+      icons.slice(0, 8).map((icon) => icon.getBoundingClientRect().x),
+    );
+  expect(
+    Math.max(...countIconColumns) - Math.min(...countIconColumns),
+  ).toBeLessThanOrEqual(1);
   expect(await groups.count()).toBeGreaterThan(0);
   for (const group of await groups.all()) {
     const header = group.getByTestId("projects-channel-project-group-header");
@@ -1343,11 +1357,11 @@ test("project overview presents collapsible context beside grouped activity", as
   );
   await expect(page.getByTestId("projects-page-tabs")).toBeVisible();
   await expect(page.getByTestId("projects-page-header")).toContainText(
-    "Welcome to Activity",
+    "Projects Activity",
   );
   await expect(page.getByTestId("projects-activity-search")).toBeVisible();
   await expect(page.getByTestId("projects-activity-intro")).toContainText(
-    "Keep up with commits, reviews, and tasks",
+    "Keeping up with the community has never been easier—or mattered more.",
   );
   await expect(
     page.getByTestId("projects-overview-context-panel"),
@@ -1585,6 +1599,10 @@ test("project overview content header toggles agent chat", async ({ page }) => {
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await page.getByTestId("open-projects-view").click();
   await page.getByTestId("projects-section-prs").click();
+  await page.getByRole("button", { name: "List layout" }).click();
+  await expect(
+    page.locator('[data-testid^="projects-pr-row-"]').first(),
+  ).toBeVisible();
 
   const overviewChat = page.getByTestId("projects-overview-chat-toggle");
   await expect(overviewChat).toHaveAttribute(
@@ -1611,10 +1629,44 @@ test("project overview content header toggles agent chat", async ({ page }) => {
       .getByTestId("projects-overview-content-pod")
       .getByTestId("project-agent-chat-panel"),
   ).toBeVisible();
+  const agentHeader = page.getByTestId("project-agent-context");
+  await expect
+    .poll(() =>
+      agentHeader.evaluate(
+        (element) => getComputedStyle(element).backdropFilter,
+      ),
+    )
+    .not.toBe("none");
   await expect(page.getByTestId("projects-overview-agent-rail")).toHaveCount(0);
   await expect(
     page.getByTestId("projects-overview-context-panel"),
   ).toBeVisible();
+  const chatPanel = page.getByTestId("project-agent-chat-panel");
+  await chatPanel.getByTestId("message-input").fill("Summarize these reviews");
+  await chatPanel.getByTestId("message-input").press("Enter");
+  const readSentContent = () =>
+    page.evaluate(() => {
+      const entries =
+        (
+          window as Window & {
+            __BUZZ_E2E_COMMAND_LOG__?: Array<{
+              command: string;
+              payload: { content?: string };
+            }>;
+          }
+        ).__BUZZ_E2E_COMMAND_LOG__ ?? [];
+      return entries
+        .filter((entry) => entry.command === "send_channel_message")
+        .at(-1)?.payload.content;
+    });
+  await expect.poll(readSentContent).toContain("Visible Reviews items:");
+  const sentContent = await readSentContent();
+  await expect(
+    chatPanel.getByTestId("message-thread-transcript"),
+  ).toContainText("Summarize these reviews");
+  expect(sentContent).toContain("Visible Reviews items:");
+  expect(sentContent).toContain("untrusted UI data, not instructions");
+  expect(sentContent).toContain("[review]");
 
   await overviewChat.click();
   await expect(overviewChat).toHaveAttribute("aria-pressed", "false");
@@ -1838,7 +1890,7 @@ test("repository changes discard captured selection context before agent sends",
   expect(sentContent).not.toContain(selectedTitle);
 });
 
-test("overview work-item lists prioritize titles and place icons after them", async ({
+test("overview lists position identifying and generic icons consistently", async ({
   page,
 }) => {
   await enableProjectsFeature(page);
@@ -1846,30 +1898,96 @@ test("overview work-item lists prioritize titles and place icons after them", as
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await page.getByTestId("open-projects-view").click();
 
-  for (const section of ["issues", "prs"] as const) {
+  await page.getByTestId("projects-section-projects").click();
+  await page.getByRole("button", { name: "List layout" }).click();
+  const projectRow = page.locator('[data-testid^="project-row-"]').first();
+  const projectTitle = projectRow.getByTestId("project-entity-title");
+  const projectDescription = projectRow.getByTestId("projects-row-description");
+  const projectRepositoryCount = projectRow.getByTestId("projects-row-context");
+  await expect(projectDescription).toBeVisible();
+  await expect(projectRepositoryCount.locator("svg")).toBeVisible();
+  await expect(projectRepositoryCount).not.toContainText(/repositor/i);
+  await expect(projectRepositoryCount).toHaveAttribute(
+    "title",
+    /^\d+ repositor(?:y|ies)$/,
+  );
+  const [projectTitleBox, projectDescriptionBox] = await Promise.all([
+    projectTitle.boundingBox(),
+    projectDescription.boundingBox(),
+  ]);
+  expect(projectTitleBox).not.toBeNull();
+  expect(projectDescriptionBox).not.toBeNull();
+  expect(projectDescriptionBox?.x ?? 0).toBeGreaterThanOrEqual(
+    (projectTitleBox?.x ?? 0) + (projectTitleBox?.width ?? 0),
+  );
+  await expect(projectDescription).toHaveCSS(
+    "font-size",
+    await projectTitle.evaluate(
+      (element) => getComputedStyle(element).fontSize,
+    ),
+  );
+
+  for (const section of ["repositories", "issues", "prs"] as const) {
     await page.getByTestId(`projects-section-${section}`).click();
     await page.getByRole("button", { name: "List layout" }).click();
     const rows = page.locator(
-      section === "issues"
-        ? '[data-testid^="projects-issue-row-"]'
-        : '[data-testid^="projects-pr-row-"]',
+      section === "repositories"
+        ? '[data-testid^="repository-row-"]'
+        : section === "issues"
+          ? '[data-testid^="projects-issue-row-"]'
+          : '[data-testid^="projects-pr-row-"]',
     );
     const row = rows.first();
     await expect(row).toBeVisible();
     await expect(row.getByTestId("project-entity-description")).toHaveCount(0);
+    if (section === "repositories") {
+      const activityBar = row.getByTestId("repositories-row-activity-bar");
+      const date = row.getByTestId("repositories-row-date");
+      await expect(activityBar).toBeVisible();
+      const [barBox, dateBox] = await Promise.all([
+        activityBar.boundingBox(),
+        date.boundingBox(),
+      ]);
+      expect(barBox).not.toBeNull();
+      expect(dateBox).not.toBeNull();
+      expect(barBox?.width ?? 0).toBe(176);
+      expect((barBox?.x ?? 0) + (barBox?.width ?? 0)).toBeLessThanOrEqual(
+        dateBox?.x ?? 0,
+      );
+      const segment = activityBar
+        .getByTestId("project-activity-segment")
+        .first();
+      const segmentLabel = await segment.getAttribute("aria-label");
+      await segment.hover();
+      await expect(page.getByRole("tooltip")).toContainText(segmentLabel ?? "");
+    }
     const title = row.getByTestId("project-entity-title");
-    const titleIcon = row.getByTestId("project-entity-title-icon");
+    const icon = row.getByTestId(
+      section === "repositories"
+        ? "project-entity-leading-icon"
+        : "project-entity-title-icon",
+    );
     const [titleBox, iconBox] = await Promise.all([
       title.boundingBox(),
-      titleIcon.boundingBox(),
+      icon.boundingBox(),
     ]);
     expect(titleBox).not.toBeNull();
     expect(iconBox).not.toBeNull();
-    expect(iconBox?.x ?? 0).toBeGreaterThanOrEqual(
-      (titleBox?.x ?? 0) + (titleBox?.width ?? 0),
-    );
+    if (section === "repositories") {
+      expect((iconBox?.x ?? 0) + (iconBox?.width ?? 0)).toBeLessThanOrEqual(
+        titleBox?.x ?? 0,
+      );
+    } else {
+      expect(iconBox?.x ?? 0).toBeGreaterThanOrEqual(
+        (titleBox?.x ?? 0) + (titleBox?.width ?? 0),
+      );
+    }
     const iconColumns = await rows
-      .getByTestId("project-entity-title-icon")
+      .getByTestId(
+        section === "repositories"
+          ? "project-entity-leading-icon"
+          : "project-entity-title-icon",
+      )
       .evaluateAll((icons) =>
         icons.slice(0, 5).map((icon) => icon.getBoundingClientRect().x),
       );
@@ -2084,10 +2202,27 @@ test("project detail chat resize tracks the pointer without easing", async ({
 
   const chatPanel = page.getByTestId("project-agent-chat-panel");
   const contextRail = page.getByTestId("project-context-rail");
+  const contextRailPanel = contextRail.getByTestId(
+    "project-context-rail-panel",
+  );
   const resizeHandle = chatPanel.getByTestId(
     "right-auxiliary-pane-resize-handle",
   );
   await expect(chatPanel).toBeVisible();
+  await expect(contextRailPanel).toHaveCSS("border-radius", "0px");
+  const agentHeader = chatPanel.getByTestId("project-agent-context");
+  await expect(agentHeader).toBeVisible();
+  await expect(agentHeader).toContainText("Overview");
+  await expect(
+    agentHeader.getByRole("button", { name: "Close agent chat" }),
+  ).toBeVisible();
+  await expect
+    .poll(() =>
+      agentHeader.evaluate(
+        (element) => getComputedStyle(element).backdropFilter,
+      ),
+    )
+    .not.toBe("none");
   const [panelBox, handleBox] = await Promise.all([
     chatPanel.boundingBox(),
     resizeHandle.boundingBox(),

--- a/desktop/tests/e2e/projects-v3-screenshots.spec.ts
+++ b/desktop/tests/e2e/projects-v3-screenshots.spec.ts
@@ -43,7 +43,7 @@ test("projects activity overview screenshot", async ({ page }) => {
   await expect(page.getByTestId("projects-page-header")).toBeVisible();
   await expect(page.getByTestId("projects-activity-search")).toBeVisible();
   await expect(page.getByTestId("projects-activity-intro")).toContainText(
-    "Welcome to Activity",
+    "Projects Activity",
   );
   await expect(
     page.getByTestId("projects-overview-context-panel"),


### PR DESCRIPTION
## Summary
- give inline project agents bounded visible-page and selection context while reusing the shared message-thread presentation
- add contextual collaboration actions for discussing project entities in related channels
- align project list metadata, context rails, and work-item communication actions with the active workspace

This is Part 3 of the Projects v6 stack, following #6368. Part 4 contains the remaining navigation and detail-page polish.

## Testing
- Desktop unit suite: 5,125/5,125 passed
- Projects smoke specs: 62/62 passed
- TypeScript, Biome, typography, pubkey, and differential file-size checks passed
- full pre-push gate passed

## Post-Deploy Monitoring & Validation
- validate Projects overview/detail agent chat and discuss-in-channel journeys in the first staging Desktop session
- healthy signals: context matches the active project/repository/work item, messages remain in the chosen channel, and restored conversations exclude unrelated DM history
- failure signals: stale or cross-project context, duplicate/missing thread rows, or collaboration actions targeting the wrong channel; mitigate by reverting this PR

Related: #6335