### PR TITLE
fix(desktop): preserve bare-domain URL form in link preview href

### DIFF
--- a/desktop/src/shared/lib/linkPreview.test.mjs
+++ b/desktop/src/shared/lib/linkPreview.test.mjs
@@ -559,3 +559,34 @@ test("extractSupportedLinkPreviews finds generic links and preserves exclusions"
     ],
   );
 });
+
+test("parseSupportedLinkPreview preserves bare-domain URLs without trailing slash", () => {
+  // Bare-domain URLs like https://api.airtable.com must NOT get a trailing
+  // slash added. The relay's ingest validates that the canonical URL appears
+  // verbatim in the message body — a mismatched trailing slash causes
+  // "invalid link-preview canonical URL".
+  assert.equal(
+    parseSupportedLinkPreview("https://api.airtable.com")?.href,
+    "https://api.airtable.com",
+  );
+  assert.equal(
+    parseSupportedLinkPreview("https://example.com")?.href,
+    "https://example.com",
+  );
+});
+
+test("parseSupportedLinkPreview still strips fragments from bare-domain URLs", () => {
+  assert.equal(
+    parseSupportedLinkPreview("https://example.com#section")?.href,
+    "https://example.com",
+  );
+});
+
+test("extractSupportedLinkPreviews preserves bare-domain URL form for relay verbatim check", () => {
+  const previews = extractSupportedLinkPreviews(
+    "Request failed for https://api.airtable.com returned code 403",
+  );
+  assert.equal(previews.length, 1);
+  assert.equal(previews[0].href, "https://api.airtable.com");
+  assert.equal(previews[0].kind, "generic-link");
+});

--- a/desktop/src/shared/lib/linkPreview.ts
+++ b/desktop/src/shared/lib/linkPreview.ts
@@ -275,6 +275,7 @@ function createPreview(
   provider: SupportedLinkPreview["provider"],
   typeLabel: SupportedLinkPreview["typeLabel"],
   title: string,
+  sourceUrl?: string,
 ): SupportedLinkPreview {
   // Strip the `#fragment` from the preview identity. A fragment is a
   // client-only anchor into the page — the preview (and the signed snapshot's
@@ -282,11 +283,26 @@ function createPreview(
   // fragment-free snapshot-URL guard, so a link like `pull/3767#review-1`
   // would silently get no preview at all. The message body keeps the raw URL,
   // so click-through to the anchor is preserved.
-  const canonical = new URL(parsed.href);
-  canonical.hash = "";
+  //
+  // When `sourceUrl` is available (the original text the user typed), use it
+  // with string-based fragment stripping instead of round-tripping through
+  // `new URL().href`. The URL constructor normalizes bare-domain URLs by
+  // adding a trailing slash (e.g. `https://api.airtable.com` →
+  // `https://api.airtable.com/`), but the relay's ingest validates that the
+  // canonical URL appears *verbatim* in the message body — a mismatched
+  // trailing slash causes `invalid link-preview canonical URL`.
+  let href: string;
+  if (sourceUrl) {
+    const hashIndex = sourceUrl.indexOf("#");
+    href = hashIndex >= 0 ? sourceUrl.slice(0, hashIndex) : sourceUrl;
+  } else {
+    const canonical = new URL(parsed.href);
+    canonical.hash = "";
+    href = canonical.href;
+  }
   return {
     kind,
-    href: canonical.href,
+    href,
     provider,
     title,
     typeLabel,
@@ -393,7 +409,7 @@ function parseBuzzGitLink(
   };
 }
 
-function parseGithubLink(parsed: URL): SupportedLinkPreview | null {
+function parseGithubLink(parsed: URL, sourceUrl?: string): SupportedLinkPreview | null {
   if (normalizeHostname(parsed) !== "github.com") {
     return null;
   }
@@ -410,6 +426,7 @@ function parseGithubLink(parsed: URL): SupportedLinkPreview | null {
       "GitHub",
       "repo",
       repoLabel,
+      sourceUrl,
     );
   }
 
@@ -421,6 +438,7 @@ function parseGithubLink(parsed: URL): SupportedLinkPreview | null {
         "GitHub",
         "PR",
         `${repoLabel} #${number}`,
+        sourceUrl,
       );
     }
 
@@ -431,6 +449,7 @@ function parseGithubLink(parsed: URL): SupportedLinkPreview | null {
         "GitHub",
         "issue",
         `${repoLabel} #${number}`,
+        sourceUrl,
       );
     }
   }
@@ -438,7 +457,7 @@ function parseGithubLink(parsed: URL): SupportedLinkPreview | null {
   return null;
 }
 
-function parseLinearIssue(parsed: URL): SupportedLinkPreview | null {
+function parseLinearIssue(parsed: URL, sourceUrl?: string): SupportedLinkPreview | null {
   if (normalizeHostname(parsed) !== "linear.app") {
     return null;
   }
@@ -459,10 +478,10 @@ function parseLinearIssue(parsed: URL): SupportedLinkPreview | null {
     return null;
   }
 
-  return createPreview("linear-issue", parsed, "Linear", "issue", issueId);
+  return createPreview("linear-issue", parsed, "Linear", "issue", issueId, sourceUrl);
 }
 
-function parseGoogleDriveLink(parsed: URL): SupportedLinkPreview | null {
+function parseGoogleDriveLink(parsed: URL, sourceUrl?: string): SupportedLinkPreview | null {
   if (normalizeHostname(parsed) !== "drive.google.com") {
     return null;
   }
@@ -479,6 +498,7 @@ function parseGoogleDriveLink(parsed: URL): SupportedLinkPreview | null {
       "Google Drive",
       "folder",
       "Drive folder",
+      sourceUrl,
     );
   }
 
@@ -492,13 +512,14 @@ function parseGoogleDriveLink(parsed: URL): SupportedLinkPreview | null {
       "Google Drive",
       "file",
       "Drive file",
+      sourceUrl,
     );
   }
 
   return null;
 }
 
-function parseGoogleDocsLink(parsed: URL): SupportedLinkPreview | null {
+function parseGoogleDocsLink(parsed: URL, sourceUrl?: string): SupportedLinkPreview | null {
   if (normalizeHostname(parsed) !== "docs.google.com") {
     return null;
   }
@@ -514,6 +535,7 @@ function parseGoogleDocsLink(parsed: URL): SupportedLinkPreview | null {
       "Google Docs",
       "document",
       "Document",
+      sourceUrl,
     );
   }
 
@@ -524,6 +546,7 @@ function parseGoogleDocsLink(parsed: URL): SupportedLinkPreview | null {
       "Google Sheets",
       "spreadsheet",
       "Spreadsheet",
+      sourceUrl,
     );
   }
 
@@ -534,6 +557,7 @@ function parseGoogleDocsLink(parsed: URL): SupportedLinkPreview | null {
       "Google Slides",
       "presentation",
       "Presentation",
+      sourceUrl,
     );
   }
 
@@ -563,12 +587,19 @@ export function parseSupportedLinkPreview(
     return null;
   }
 
+  // Preserve the original URL string for the preview href. The URL constructor
+  // normalizes bare-domain URLs by adding a trailing slash, but the relay
+  // validates that the canonical URL appears verbatim in the message body.
+  const sourceUrl = /^https?:\/\//i.test(candidate)
+    ? candidate
+    : `https://${candidate}`;
+
   const recognized =
     parseBuzzGitLink(parsed, activeRelayOrigin ?? null) ??
-    parseGithubLink(parsed) ??
-    parseLinearIssue(parsed) ??
-    parseGoogleDriveLink(parsed) ??
-    parseGoogleDocsLink(parsed);
+    parseGithubLink(parsed, sourceUrl) ??
+    parseLinearIssue(parsed, sourceUrl) ??
+    parseGoogleDriveLink(parsed, sourceUrl) ??
+    parseGoogleDocsLink(parsed, sourceUrl);
   if (recognized) return recognized;
   const hostname = normalizeHostname(parsed);
   if (
@@ -584,7 +615,7 @@ export function parseSupportedLinkPreview(
   }
 
   const provider = hostname;
-  return createPreview("generic-link", parsed, provider, "link", provider);
+  return createPreview("generic-link", parsed, provider, "link", provider, sourceUrl);
 }
 
 export function isSupportedLinkAutolinkLabel(


### PR DESCRIPTION
## Problem
    
    Messages containing a bare-domain HTTPS URL (e.g. https://api.airtable.com) fail to send with invalid link-preview canonical URL.
 Desktop normalizes the URL by adding a trailing slash via new URL().href (https://api.airtable.com → https://api.airtable.com/), but the relay's ingest validates that the canonical URL appears verbatim in the message body. The mismatched trailing slash causes the relay to reject the message.
    
    Fixes #6347
    
## Root cause
    
    createPreview() in linkPreview.ts round-trips the URL through new URL(parsed.href).href to strip fragments. JavaScript's URL constructor normalizes bare-domain URLs by adding a trailing slash — but the relay's event.content.contains(&parts[3]) check requires an exact substring match.
    
## Fix
    
    Thread the original URL string (what the user typed) through the preview builders and use string-based fragment stripping instead of URL normalization:
    
    - Add optional sourceUrl parameter to createPreview() and all internal parse functions
    - When sourceUrl is provided, strip #fragment with indexOf/slice instead of new URL().href
    - In parseSupportedLinkPreview(), compute sourceUrl from the original candidate text
    
    This preserves the exact URL form the user typed, matching what appears in the message body.
    
## Testing
    
    - Added 3 new tests covering bare-domain URL preservation, fragment stripping on bare domains, and the full extractSupportedLinkPreviews flow
    - All 40 existing + new tests pass
    - TypeScript compiles with 0 errors