### PR TITLE
fix(desktop): isolate nested custom harness submits

### DIFF
--- a/desktop/src/features/settings/ui/CustomHarnessForm.tsx
+++ b/desktop/src/features/settings/ui/CustomHarnessForm.tsx
@@ -265,6 +265,10 @@ export function CustomHarnessForm({
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    // This form can be rendered in a dialog portal opened from the agent
+    // definition form. React events still bubble through the component tree
+    // across portals, so keep this save from submitting the outer form too.
+    e.stopPropagation();
     setError(null);
     // Mirror the backend comma-in-args rejection so the user gets an inline
     // error naming the offending argument before the round-trip.


### PR DESCRIPTION
## Summary

Custom harness forms can be rendered through a React portal while the owning agent-definition form remains in the React ancestor tree. Prevent the inner submit event from bubbling and triggering the outer agent save.

This is provider-neutral and changes only the nested form boundary.

## Validation

- Reviewed the exact nested form event sequence: prevent default, then stop propagation, before validation or mutation
- DCO sign-off included