### PR TITLE
feat(desktop): render provider-owned agent configuration

### DIFF
--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -36,7 +36,6 @@ import {
   BLOCK_BUILD_HIDDEN_PROVIDER_IDS,
   buildPersonaRuntimeDropdownOptions,
   CUSTOM_PROVIDER_DROPDOWN_VALUE,
-  computeLocalModeGate,
   formatRuntimeOptionLabel,
   getDefaultPersonaRuntime,
   getPersonaModelOptions,
@@ -76,12 +75,12 @@ import {
   type AgentAiConfigurationMode,
 } from "./AgentAiConfigurationMode";
 import {
-  agentAiConfigurationModeSatisfied,
   agentAiConfigurationPairForMode,
   initialAgentAiConfigurationMode,
 } from "./agentAiConfigurationPolicy";
 import { useProviderApiKeyFieldState } from "./providerApiKeyFieldState";
 import { buildRuntimeModelProviderPayload } from "./agentDefinitionSubmitPayload";
+import { useAgentDefinitionExecutionReadiness } from "./useAgentDefinitionExecutionReadiness";
 import { AgentDefinitionDialogFooter } from "./AgentDefinitionDialogFooter";
 import { AgentDefinitionDialogShell } from "./AgentDefinitionDialogShell";
 import { AddCustomHarnessDialog } from "./AddCustomHarnessDialog";
@@ -329,9 +328,9 @@ export function AgentDefinitionDialog({
   }
 
   async function handleSubmit() {
-    // D1: the same localModeSatisfied gate as canSubmit prevents form-submit
-    // (Enter) from bypassing a missing credential.
-    if (!initialValues || !localModeSatisfied || !canSubmit) return;
+    // Use the same readiness policy as canSubmit so Enter cannot bypass an
+    // execution-config validation failure.
+    if (!initialValues || !executionReadinessSatisfied || !canSubmit) return;
 
     const {
       runtime: runtimeForSubmit,
@@ -426,36 +425,25 @@ export function AgentDefinitionDialog({
     setModel(nextPair.model);
   }
   const { data: bakedEnvKeys } = useBakedBuildEnvKeysQuery({ enabled: open });
-  const localModeGate = React.useMemo(
-    () =>
-      computeLocalModeGate({
-        bakedEnvKeys,
-        envVars,
-        globalEnvVars: globalConfig.env_vars,
-        globalProvider: inheritedProviderDefault.value,
-        globalModel: inheritedModelDefault.value,
-        isProviderMode: false,
-        model,
-        provider: trimmedProvider,
-        runtimeId: runtime,
-        runtimeFileConfig,
-      }),
-    [
+  const { executionReadinessSatisfied, localModeGate } =
+    useAgentDefinitionExecutionReadiness({
+      aiConfigurationMode,
       bakedEnvKeys,
       envVars,
-      globalConfig.env_vars,
-      inheritedModelDefault.value,
-      inheritedProviderDefault.value,
+      globalEnvVars: globalConfig.env_vars,
+      globalModel: inheritedModelDefault.value,
+      globalProvider: inheritedProviderDefault.value,
+      initialValues,
+      isRuntimeAutoSeeded: isRuntimeAutoSeededRef.current,
       model,
-      trimmedProvider,
-      runtime,
+      provider: trimmedProvider,
+      runtimeCanChooseLlmProvider,
       runtimeFileConfig,
-    ],
-  );
+      runtimeId: runtime,
+    });
   // requiredEnvKeys: the gate already handles baked-, global-, and file-
   // satisfied keys so no further filtering is needed.
   const { requiredEnvKeys } = localModeGate;
-  const localModeSatisfied = localModeGate.satisfied;
   // Effective provider: agent value → global fallback → file fallback.
   // Mirrors the chain inside computeLocalModeGate so model-option scoping and
   // model requiredness are consistent with the readiness gate.
@@ -484,11 +472,6 @@ export function AgentDefinitionDialog({
   const modelFieldVisible =
     runtime.trim().length > 0 || blankRuntimeModelProviderEditable;
   const isExplicitModelRequired = aiConfigurationMode === "custom";
-  const customAiPairSatisfied = agentAiConfigurationModeSatisfied(
-    aiConfigurationMode,
-    { provider, model },
-    runtimeCanChooseLlmProvider,
-  );
   const selectedRuntimeIsAvailable =
     runtime.trim().length === 0 ||
     selectedRuntime?.availability === "available";
@@ -502,10 +485,10 @@ export function AgentDefinitionDialog({
     // Crash-loop guard, create AND edit: an empty allowlist would crash
     // every instance minted from this definition at startup.
     personaBehaviorDraftValid(behaviorDraft) &&
-    // D1: localModeSatisfied covers both missingNormalizedFields AND
-    // missingEnvKeys — credential env keys now block submit, not just display.
-    localModeSatisfied &&
-    customAiPairSatisfied &&
+    // Creates and execution-config edits must be ready. Existing definitions
+    // may save unrelated profile/behavior changes while preserving a stale or
+    // remotely-owned execution configuration.
+    executionReadinessSatisfied &&
     !isAvatarUploadPending;
 
   // Merge global env as the base layer so credential keys satisfied via global

--- a/desktop/src/features/agents/ui/ProviderConfigFields.test.mjs
+++ b/desktop/src/features/agents/ui/ProviderConfigFields.test.mjs
@@ -2,6 +2,12 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { coerceConfigValues } from "./ProviderConfigFields.tsx";
+import { providerSchemaUsesExtendedPresentation } from "./ProviderConfigSchemaFields.tsx";
+import {
+  providerConfigFieldVisible,
+  providerConfigOptions,
+  reconcileProviderConfig,
+} from "./providerConfigSchema.ts";
 
 const schema = {
   properties: {
@@ -26,6 +32,151 @@ describe("coerceConfigValues", () => {
     assert.deepEqual(
       coerceConfigValues({ inactivity_seconds: "not-a-number" }, schema),
       { inactivity_seconds: "not-a-number" },
+    );
+  });
+});
+
+describe("providerConfigOptions", () => {
+  it("renders simple enum values without provider-specific logic", () => {
+    assert.deepEqual(providerConfigOptions({ enum: ["codex", "claude"] }), [
+      { label: "codex", value: "codex" },
+      { label: "claude", value: "claude" },
+    ]);
+  });
+
+  it("uses oneOf titles as bounded option labels", () => {
+    assert.deepEqual(
+      providerConfigOptions({
+        oneOf: [
+          { const: "auto", title: "Automatic" },
+          { const: "opus", title: "Claude Opus" },
+        ],
+      }),
+      [
+        { label: "Automatic", value: "auto" },
+        { label: "Claude Opus", value: "opus" },
+      ],
+    );
+  });
+
+  it("provides a bounded boolean choice", () => {
+    assert.deepEqual(providerConfigOptions({ type: "boolean" }), [
+      { label: "Yes", value: "true" },
+      { label: "No", value: "false" },
+    ]);
+  });
+
+  it("uses provider-owned labels for enum values", () => {
+    assert.deepEqual(
+      providerConfigOptions({
+        enum: ["codex", "claude-code"],
+        "x-enum-labels": {
+          codex: "Codex CLI",
+          "claude-code": "Claude Code",
+        },
+      }),
+      [
+        { label: "Codex CLI", value: "codex" },
+        { label: "Claude Code", value: "claude-code" },
+      ],
+    );
+  });
+
+  it("resolves and filters dependent provider-owned options", () => {
+    const property = {
+      "x-options-by-field": {
+        field: "harness",
+        options: {
+          codex: [
+            { value: "gpt", label: "GPT", selector_kind: "version" },
+            { value: "stable", label: "Stable", selector_kind: "track" },
+          ],
+        },
+      },
+      "x-option-filter": {
+        field: "model_mode",
+        option_property: "selector_kind",
+      },
+    };
+    assert.deepEqual(
+      providerConfigOptions(property, {
+        harness: "codex",
+        model_mode: "track",
+      }),
+      [{ value: "stable", label: "Stable", selector_kind: "track" }],
+    );
+  });
+
+  it("hides fields when their bounded option set is empty", () => {
+    const property = {
+      "x-hide-when-no-options": true,
+      "x-options-by-fields": {
+        fields: ["harness", "model_selector"],
+        options: { "codex|": [{ value: "auto", label: "Automatic" }] },
+      },
+    };
+    assert.equal(
+      providerConfigFieldVisible(property, {
+        harness: "claude-code",
+        model_selector: "",
+      }),
+      false,
+    );
+  });
+
+  it("clears a dependent value that is invalid for the new selection", () => {
+    const entries = [
+      ["harness", { enum: ["codex", "claude-code"] }],
+      [
+        "model",
+        {
+          default: "auto",
+          "x-options-by-field": {
+            field: "harness",
+            options: {
+              codex: [{ value: "gpt", label: "GPT" }],
+              "claude-code": [{ value: "opus", label: "Opus" }],
+            },
+          },
+        },
+      ],
+    ];
+    assert.deepEqual(
+      reconcileProviderConfig(
+        entries,
+        { harness: "codex", model: "gpt" },
+        "harness",
+        "claude-code",
+      ),
+      { harness: "claude-code", model: "" },
+    );
+  });
+});
+
+describe("providerSchemaUsesExtendedPresentation", () => {
+  it("leaves upstream string-only schemas on the upstream renderer", () => {
+    assert.equal(
+      providerSchemaUsesExtendedPresentation({
+        properties: { label: { type: "string", default: "" } },
+      }),
+      false,
+    );
+  });
+
+  it("routes bounded and dependent schemas through the generic extension", () => {
+    assert.equal(
+      providerSchemaUsesExtendedPresentation({
+        properties: { harness: { enum: ["codex", "claude-code"] } },
+      }),
+      true,
+    );
+    assert.equal(
+      providerSchemaUsesExtendedPresentation({
+        properties: {
+          model: { "x-visible-when": { field: "harness", equals: "codex" } },
+        },
+      }),
+      true,
     );
   });
 });

--- a/desktop/src/features/agents/ui/ProviderConfigFields.tsx
+++ b/desktop/src/features/agents/ui/ProviderConfigFields.tsx
@@ -1,4 +1,8 @@
 import { Input } from "@/shared/ui/input";
+import {
+  ProviderConfigSchemaFields,
+  providerSchemaUsesExtendedPresentation,
+} from "./ProviderConfigSchemaFields";
 
 /// Coerce string config values to their schema-declared types (number, boolean).
 /// Providers receive JSON — sending "3" instead of 3 for an integer field breaks
@@ -48,6 +52,16 @@ export function ProviderConfigFields({
 
   if (entries.length === 0) {
     return null;
+  }
+
+  if (providerSchemaUsesExtendedPresentation(schema)) {
+    return (
+      <ProviderConfigSchemaFields
+        config={config}
+        onChange={onChange}
+        schema={schema}
+      />
+    );
   }
 
   return (

--- a/desktop/src/features/agents/ui/ProviderConfigSchemaFields.tsx
+++ b/desktop/src/features/agents/ui/ProviderConfigSchemaFields.tsx
@@ -1,0 +1,129 @@
+import { Input } from "@/shared/ui/input";
+import { PersonaDropdownField } from "./PersonaDropdownField";
+import {
+  providerConfigDefault,
+  providerConfigEntries,
+  providerConfigFieldVisible,
+  providerConfigOptions,
+  reconcileProviderConfig,
+} from "./providerConfigSchema";
+
+/** Whether a schema needs the provider-owned extended field presentation. */
+export function providerSchemaUsesExtendedPresentation(
+  schema: Record<string, unknown>,
+): boolean {
+  return providerConfigEntries(schema).some(([, property]) => {
+    const type = property.type;
+    return (
+      type === "integer" ||
+      type === "number" ||
+      type === "boolean" ||
+      property.readOnly === true ||
+      Array.isArray(property.enum) ||
+      Array.isArray(property.oneOf) ||
+      Object.keys(property).some((key) => key.startsWith("x-"))
+    );
+  });
+}
+
+/** Render provider-owned JSON-schema extensions without provider-specific IDs. */
+export function ProviderConfigSchemaFields({
+  schema,
+  config,
+  onChange,
+}: {
+  schema: Record<string, unknown>;
+  config: Record<string, string>;
+  onChange: (config: Record<string, string>) => void;
+}) {
+  const entries = providerConfigEntries(schema);
+  const required = new Set<string>(
+    Array.isArray(schema.required)
+      ? schema.required.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : [],
+  );
+
+  if (entries.length === 0) return null;
+
+  const updateConfig = (key: string, value: string) => {
+    onChange(reconcileProviderConfig(entries, config, key, value));
+  };
+
+  return (
+    <div className="space-y-3">
+      {entries.map(([key, property]) => {
+        if (!providerConfigFieldVisible(property, config)) return null;
+        const options = providerConfigOptions(property, config);
+        const value = config[key] ?? providerConfigDefault(property);
+
+        return (
+          <div key={key} className="space-y-1.5">
+            <label
+              className="text-sm font-medium"
+              htmlFor={`provider-cfg-${key}`}
+            >
+              {typeof property.title === "string" ? property.title : key}
+              {required.has(key) ? (
+                <span className="ml-1 text-destructive">*</span>
+              ) : null}
+            </label>
+            {property.readOnly === true ? (
+              <p
+                className="rounded-xl border bg-muted/40 px-3 py-2 text-sm text-muted-foreground"
+                id={`provider-cfg-${key}`}
+              >
+                {value}
+              </p>
+            ) : options ? (
+              <PersonaDropdownField
+                id={`provider-cfg-${key}`}
+                onValueChange={(nextValue) => updateConfig(key, nextValue)}
+                options={options}
+                placeholder={`Choose ${
+                  typeof property.title === "string"
+                    ? property.title.toLowerCase()
+                    : key
+                }`}
+                value={value}
+              />
+            ) : (
+              <Input
+                id={`provider-cfg-${key}`}
+                max={
+                  typeof property.maximum === "number"
+                    ? property.maximum
+                    : undefined
+                }
+                min={
+                  typeof property.minimum === "number"
+                    ? property.minimum
+                    : undefined
+                }
+                onChange={(event) => updateConfig(key, event.target.value)}
+                placeholder={
+                  typeof property.description === "string"
+                    ? property.description
+                    : ""
+                }
+                step={property.type === "integer" ? 1 : undefined}
+                type={
+                  property.type === "integer" || property.type === "number"
+                    ? "number"
+                    : "text"
+                }
+                value={value}
+              />
+            )}
+            {typeof property.description === "string" ? (
+              <p className="text-xs text-muted-foreground">
+                {property.description}
+              </p>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/desktop/src/features/agents/ui/agentDefinitionExecutionReadiness.test.mjs
+++ b/desktop/src/features/agents/ui/agentDefinitionExecutionReadiness.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  definitionEditPreservesExecutionConfiguration,
+  definitionExecutionReadinessSatisfied,
+} from "./agentDefinitionExecutionReadiness.ts";
+
+const HOSTED_DEFINITION = {
+  runtime: "buzz-agent",
+  model: null,
+  provider: null,
+  envVars: {},
+};
+
+test("unchanged hosted definition can save profile edits without local defaults", () => {
+  const preservesExecutionConfiguration =
+    definitionEditPreservesExecutionConfiguration({
+      initial: HOSTED_DEFINITION,
+      runtime: "buzz-agent",
+      model: "",
+      provider: "",
+      envVars: {},
+      isRuntimeAutoSeeded: false,
+    });
+
+  assert.equal(preservesExecutionConfiguration, true);
+  assert.equal(
+    definitionExecutionReadinessSatisfied({
+      isEditMode: true,
+      preservesExecutionConfiguration,
+      localModeSatisfied: false,
+      customAiPairSatisfied: true,
+    }),
+    true,
+    "name/instructions edits must not require irrelevant local provider defaults",
+  );
+});
+
+test("changing an execution field restores the readiness gate", () => {
+  const cases = [
+    { runtime: "codex", model: "", provider: "", envVars: {} },
+    {
+      runtime: "buzz-agent",
+      model: "claude-opus-4-1",
+      provider: "anthropic",
+      envVars: {},
+    },
+    {
+      runtime: "buzz-agent",
+      model: "",
+      provider: "",
+      envVars: { ANTHROPIC_API_KEY: "changed" },
+    },
+  ];
+
+  for (const next of cases) {
+    const preservesExecutionConfiguration =
+      definitionEditPreservesExecutionConfiguration({
+        initial: HOSTED_DEFINITION,
+        ...next,
+        isRuntimeAutoSeeded: false,
+      });
+    assert.equal(preservesExecutionConfiguration, false);
+    assert.equal(
+      definitionExecutionReadinessSatisfied({
+        isEditMode: true,
+        preservesExecutionConfiguration,
+        localModeSatisfied: false,
+        customAiPairSatisfied: false,
+      }),
+      false,
+    );
+  }
+});
+
+test("create mode never bypasses execution readiness", () => {
+  assert.equal(
+    definitionExecutionReadinessSatisfied({
+      isEditMode: false,
+      preservesExecutionConfiguration: true,
+      localModeSatisfied: false,
+      customAiPairSatisfied: true,
+    }),
+    false,
+  );
+});
+
+test("ready create and execution edits remain submit-ready", () => {
+  assert.equal(
+    definitionExecutionReadinessSatisfied({
+      isEditMode: false,
+      preservesExecutionConfiguration: false,
+      localModeSatisfied: true,
+      customAiPairSatisfied: true,
+    }),
+    true,
+  );
+  assert.equal(
+    definitionExecutionReadinessSatisfied({
+      isEditMode: true,
+      preservesExecutionConfiguration: false,
+      localModeSatisfied: true,
+      customAiPairSatisfied: true,
+    }),
+    true,
+  );
+});
+
+test("auto-seeded runtime remains unchanged when submit omits it", () => {
+  assert.equal(
+    definitionEditPreservesExecutionConfiguration({
+      initial: { runtime: null, model: null, provider: null, envVars: {} },
+      runtime: "buzz-agent",
+      model: "",
+      provider: "",
+      envVars: {},
+      isRuntimeAutoSeeded: true,
+    }),
+    true,
+  );
+});

--- a/desktop/src/features/agents/ui/agentDefinitionExecutionReadiness.ts
+++ b/desktop/src/features/agents/ui/agentDefinitionExecutionReadiness.ts
@@ -1,0 +1,89 @@
+import { buildRuntimeModelProviderPayload } from "./agentDefinitionSubmitPayload";
+
+type DefinitionExecutionConfiguration = {
+  runtime?: string | null;
+  model?: string | null;
+  provider?: string | null;
+  envVars?: Record<string, string> | null;
+};
+
+/**
+ * Existing definitions may carry an execution configuration that is no longer
+ * ready on this machine (for example, a remote provider owns execution while
+ * the local provider/model defaults are unset). Editing profile fields must
+ * not force that unrelated configuration through today's local readiness
+ * gate. Once any execution field changes, the normal readiness rules apply.
+ */
+export function definitionEditPreservesExecutionConfiguration({
+  initial,
+  runtime,
+  model,
+  provider,
+  envVars,
+  isRuntimeAutoSeeded,
+}: {
+  initial: DefinitionExecutionConfiguration;
+  runtime: string;
+  model: string;
+  provider: string;
+  envVars: Record<string, string>;
+  isRuntimeAutoSeeded: boolean;
+}): boolean {
+  const initialRuntime = normalizeOptionalString(initial.runtime);
+  const initialModel = normalizeOptionalString(initial.model);
+  const initialProvider = normalizeOptionalString(initial.provider);
+  const next = buildRuntimeModelProviderPayload({
+    runtime,
+    model,
+    provider,
+    isEditMode: true,
+    isAutoSeeded: isRuntimeAutoSeeded,
+    initialPreviousRuntime: initialRuntime,
+    initialModel: initial.model,
+    initialProvider: initial.provider,
+    initialModelProviderEditableWithoutRuntime:
+      initialRuntime.length === 0 &&
+      (initialModel.length > 0 || initialProvider.length > 0),
+  });
+
+  return (
+    normalizeOptionalString(next.runtime) === initialRuntime &&
+    normalizeOptionalString(next.model) === initialModel &&
+    normalizeOptionalString(next.provider) === initialProvider &&
+    stringRecordsEqual(envVars, initial.envVars ?? {})
+  );
+}
+
+/**
+ * Readiness is mandatory for creates and execution-config edits. An existing
+ * definition may still save profile/behavior changes when its execution
+ * configuration's normalized submit projection is unchanged.
+ */
+export function definitionExecutionReadinessSatisfied({
+  isEditMode,
+  preservesExecutionConfiguration,
+  localModeSatisfied,
+  customAiPairSatisfied,
+}: {
+  isEditMode: boolean;
+  preservesExecutionConfiguration: boolean;
+  localModeSatisfied: boolean;
+  customAiPairSatisfied: boolean;
+}): boolean {
+  if (isEditMode && preservesExecutionConfiguration) return true;
+  return localModeSatisfied && customAiPairSatisfied;
+}
+
+function normalizeOptionalString(value: string | null | undefined): string {
+  return value?.trim() ?? "";
+}
+
+function stringRecordsEqual(
+  a: Readonly<Record<string, string>>,
+  b: Readonly<Record<string, string>>,
+): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => key in b && a[key] === b[key]);
+}

--- a/desktop/src/features/agents/ui/providerConfigSchema.ts
+++ b/desktop/src/features/agents/ui/providerConfigSchema.ts
@@ -1,0 +1,226 @@
+/** A provider-owned JSON-schema property supported by the generic renderer. */
+export type ProviderConfigProperty = Record<string, unknown>;
+
+/** A normalized provider configuration option. */
+export type ProviderConfigOption = {
+  label: string;
+  value: string;
+  [key: string]: unknown;
+};
+
+/** Return provider configuration properties in schema declaration order. */
+export function providerConfigEntries(
+  schema: Record<string, unknown>,
+): [string, ProviderConfigProperty][] {
+  const properties = schema.properties;
+  if (
+    !properties ||
+    typeof properties !== "object" ||
+    Array.isArray(properties)
+  ) {
+    return [];
+  }
+  return Object.entries(properties) as [string, ProviderConfigProperty][];
+}
+
+/** Return a schema property's scalar default as a form value. */
+export function providerConfigDefault(
+  property: ProviderConfigProperty,
+): string {
+  return typeof property.default === "string" ||
+    typeof property.default === "number" ||
+    typeof property.default === "boolean"
+    ? String(property.default)
+    : "";
+}
+
+/** Whether a property is visible for the current provider-owned configuration. */
+export function providerConfigFieldVisible(
+  property: ProviderConfigProperty,
+  config: Record<string, string>,
+): boolean {
+  if (
+    property["x-hide-when-no-options"] === true &&
+    providerConfigOptions(property, config)?.length === 0
+  ) {
+    return false;
+  }
+  const condition = property["x-visible-when"];
+  if (!condition || typeof condition !== "object" || Array.isArray(condition)) {
+    return true;
+  }
+  const record = condition as Record<string, unknown>;
+  if (typeof record.field !== "string") return true;
+  const selected = config[record.field] ?? "";
+  if (typeof record.equals === "string") return selected === record.equals;
+  if (typeof record.not === "string") return selected !== record.not;
+  return true;
+}
+
+/** Resolve a property's provider-owned bounded options for the current config. */
+export function providerConfigOptions(
+  property: ProviderConfigProperty,
+  config: Record<string, string> = {},
+): ProviderConfigOption[] | null {
+  const multipleDependencies = property["x-options-by-fields"];
+  if (
+    multipleDependencies &&
+    typeof multipleDependencies === "object" &&
+    !Array.isArray(multipleDependencies)
+  ) {
+    const source = multipleDependencies as Record<string, unknown>;
+    const fields = Array.isArray(source.fields)
+      ? source.fields.filter(
+          (field): field is string => typeof field === "string",
+        )
+      : [];
+    const optionMap =
+      source.options &&
+      typeof source.options === "object" &&
+      !Array.isArray(source.options)
+        ? (source.options as Record<string, unknown>)
+        : null;
+    if (fields.length === 0 || fields.length > 4 || !optionMap) return [];
+    const selected =
+      optionMap[fields.map((field) => config[field] ?? "").join("|")];
+    return Array.isArray(selected)
+      ? selected.filter(isProviderConfigOption)
+      : [];
+  }
+
+  const dependency = property["x-options-by-field"];
+  if (
+    dependency &&
+    typeof dependency === "object" &&
+    !Array.isArray(dependency)
+  ) {
+    const source = dependency as Record<string, unknown>;
+    const field = typeof source.field === "string" ? source.field : null;
+    const optionMap =
+      source.options &&
+      typeof source.options === "object" &&
+      !Array.isArray(source.options)
+        ? (source.options as Record<string, unknown>)
+        : null;
+    const selected = field ? optionMap?.[config[field] ?? ""] : null;
+    let options = Array.isArray(selected)
+      ? selected.filter(isProviderConfigOption)
+      : [];
+    const filter = property["x-option-filter"];
+    if (filter && typeof filter === "object" && !Array.isArray(filter)) {
+      const record = filter as Record<string, unknown>;
+      if (
+        typeof record.field === "string" &&
+        typeof record.option_property === "string" &&
+        config[record.field]
+      ) {
+        options = options.filter(
+          (option) =>
+            option[record.option_property as string] ===
+            config[record.field as string],
+        );
+      }
+    }
+    return options;
+  }
+
+  if (Array.isArray(property.enum)) {
+    const labels =
+      property["x-enum-labels"] &&
+      typeof property["x-enum-labels"] === "object" &&
+      !Array.isArray(property["x-enum-labels"])
+        ? (property["x-enum-labels"] as Record<string, unknown>)
+        : {};
+    return property.enum
+      .filter((value): value is string | number =>
+        ["string", "number"].includes(typeof value),
+      )
+      .map((value) => {
+        const serialized = String(value);
+        return {
+          label:
+            typeof labels[serialized] === "string"
+              ? (labels[serialized] as string)
+              : serialized,
+          value: serialized,
+        };
+      });
+  }
+
+  if (Array.isArray(property.oneOf)) {
+    const options = property.oneOf.flatMap((entry) => {
+      if (!entry || typeof entry !== "object") return [];
+      const option = entry as Record<string, unknown>;
+      if (
+        typeof option.const !== "string" &&
+        typeof option.const !== "number"
+      ) {
+        return [];
+      }
+      return [
+        {
+          label:
+            typeof option.title === "string"
+              ? option.title
+              : String(option.const),
+          value: String(option.const),
+        },
+      ];
+    });
+    return options.length > 0 ? options : null;
+  }
+
+  if (property.type === "boolean") {
+    return [
+      { label: "Yes", value: "true" },
+      { label: "No", value: "false" },
+    ];
+  }
+
+  return null;
+}
+
+/**
+ * Reconcile dependent schema values after one field changes.
+ *
+ * Hidden values return to their scalar default. Visible bounded values that no
+ * longer exist return to a still-valid default or to an empty value.
+ */
+export function reconcileProviderConfig(
+  entries: [string, ProviderConfigProperty][],
+  config: Record<string, string>,
+  key: string,
+  value: string,
+): Record<string, string> {
+  const next = { ...config, [key]: value };
+  for (const [dependentKey, dependentProperty] of entries) {
+    if (!providerConfigFieldVisible(dependentProperty, next)) {
+      next[dependentKey] = providerConfigDefault(dependentProperty);
+      continue;
+    }
+    const options = providerConfigOptions(dependentProperty, next);
+    if (
+      options &&
+      next[dependentKey] &&
+      !options.some((option) => option.value === next[dependentKey])
+    ) {
+      const defaultValue = providerConfigDefault(dependentProperty);
+      next[dependentKey] = options.some(
+        (option) => option.value === defaultValue,
+      )
+        ? defaultValue
+        : "";
+    }
+  }
+  return next;
+}
+
+function isProviderConfigOption(value: unknown): value is ProviderConfigOption {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as ProviderConfigOption).value === "string" &&
+    typeof (value as ProviderConfigOption).label === "string"
+  );
+}

--- a/desktop/src/features/agents/ui/useAgentDefinitionExecutionReadiness.ts
+++ b/desktop/src/features/agents/ui/useAgentDefinitionExecutionReadiness.ts
@@ -1,0 +1,96 @@
+import * as React from "react";
+
+import type {
+  CreatePersonaInput,
+  UpdatePersonaInput,
+} from "@/shared/api/types";
+import { computeLocalModeGate } from "./agentConfigOptions";
+import {
+  agentAiConfigurationModeSatisfied,
+  type AgentAiConfigurationMode,
+} from "./agentAiConfigurationPolicy";
+import {
+  definitionEditPreservesExecutionConfiguration,
+  definitionExecutionReadinessSatisfied,
+} from "./agentDefinitionExecutionReadiness";
+
+type LocalModeGateInput = Parameters<typeof computeLocalModeGate>[0];
+
+export function useAgentDefinitionExecutionReadiness({
+  aiConfigurationMode,
+  initialValues,
+  isRuntimeAutoSeeded,
+  runtimeCanChooseLlmProvider,
+  ...localModeInput
+}: Omit<LocalModeGateInput, "isProviderMode"> & {
+  aiConfigurationMode: AgentAiConfigurationMode;
+  initialValues: CreatePersonaInput | UpdatePersonaInput | null;
+  isRuntimeAutoSeeded: boolean;
+  runtimeCanChooseLlmProvider: boolean;
+}) {
+  const {
+    bakedEnvKeys,
+    envVars,
+    globalEnvVars,
+    globalModel,
+    globalProvider,
+    model,
+    provider,
+    runtimeFileConfig,
+    runtimeId,
+  } = localModeInput;
+  const localModeGate = React.useMemo(
+    () =>
+      computeLocalModeGate({
+        bakedEnvKeys,
+        envVars,
+        globalEnvVars,
+        globalModel,
+        globalProvider,
+        isProviderMode: false,
+        model,
+        provider,
+        runtimeFileConfig,
+        runtimeId,
+      }),
+    [
+      bakedEnvKeys,
+      envVars,
+      globalEnvVars,
+      globalModel,
+      globalProvider,
+      model,
+      provider,
+      runtimeFileConfig,
+      runtimeId,
+    ],
+  );
+  const customAiPairSatisfied = agentAiConfigurationModeSatisfied(
+    aiConfigurationMode,
+    { provider, model },
+    runtimeCanChooseLlmProvider,
+  );
+  const isEditMode = Boolean(initialValues && "id" in initialValues);
+  const preservesExecutionConfiguration = Boolean(
+    initialValues &&
+      "id" in initialValues &&
+      definitionEditPreservesExecutionConfiguration({
+        initial: initialValues,
+        runtime: runtimeId,
+        model: aiConfigurationMode === "defaults" ? "" : model,
+        provider: aiConfigurationMode === "defaults" ? "" : provider,
+        envVars,
+        isRuntimeAutoSeeded,
+      }),
+  );
+
+  return {
+    localModeGate,
+    executionReadinessSatisfied: definitionExecutionReadinessSatisfied({
+      isEditMode,
+      preservesExecutionConfiguration,
+      localModeSatisfied: localModeGate.satisfied,
+      customAiPairSatisfied,
+    }),
+  };
+}

--- a/desktop/tests/e2e/global-agent-config-screenshots.spec.ts
+++ b/desktop/tests/e2e/global-agent-config-screenshots.spec.ts
@@ -882,16 +882,12 @@ test.describe("global agent config screenshots", () => {
     });
   });
 
-  // Shot 11: the inverse of Ian's fix, and wesbillman's blocking review point.
-  // A runtime-LESS legacy/builtin definition (no runtime, but a saved model)
-  // still EXPOSES the provider picker via blankRuntimeModelProviderEditable, so
-  // an empty provider must keep Save DISABLED. The gate must key off the field's
-  // visibility (runtimeCanChooseLlmProvider), not the raw runtime capability —
-  // otherwise Save persists `provider: undefined` despite the visible picker.
-  // A global provider/model default keeps localMode satisfied, so the ONLY thing
-  // that can block Save here is the Customize-pair provider gate (step 7), which
-  // is exactly what this regression pins.
-  test("11-edit-runtime-less-provider-required-save-blocked", async ({
+  // Shot 11: a legacy runtime-less definition can still save non-execution
+  // metadata while its existing execution projection remains unchanged. The
+  // provider picker stays visible so the incomplete legacy configuration is
+  // clear. Focused readiness tests separately pin that changing an execution
+  // field restores the gate and that create mode is always gated.
+  test("11-edit-runtime-less-unchanged-execution-save-enabled", async ({
     page,
   }) => {
     const PERSONA_ID = "persona-runtime-less-edit-e2e";
@@ -921,8 +917,9 @@ test.describe("global agent config screenshots", () => {
           id: PERSONA_ID,
           displayName: "Legacy Editor",
           systemPrompt: "You are the runtime-less edit-mode e2e persona.",
-          // Runtime-less definition with a saved model and NO provider — the
-          // picker is editable-without-runtime, so the provider stays required.
+          // Runtime-less definition with a saved model and NO provider. The
+          // picker remains visible, while unchanged-edit readiness allows
+          // non-execution metadata to be saved.
           runtime: null,
           model: "claude-opus-4-5",
           provider: null,
@@ -958,11 +955,13 @@ test.describe("global agent config screenshots", () => {
     await expect(page.locator("#persona-llm-provider")).toBeVisible({
       timeout: 10_000,
     });
-    // … so the empty provider must block Save …
-    await expect(page.getByTestId("persona-dialog-submit")).toBeDisabled({
+    // … but an unchanged legacy execution projection does not block metadata
+    // edits such as profile, instructions, access, or behavior (Rule 14).
+    await expect(page.getByTestId("persona-dialog-submit")).toBeEnabled({
       timeout: 10_000,
     });
-    // Disabled-state guidance belongs with the fields, not in the modal footer.
+    // No footer-level blocked-state guidance should appear for this saveable
+    // unchanged edit.
     await expect(page.getByTestId("persona-dialog-submit-reason")).toHaveCount(
       0,
     );
@@ -971,7 +970,7 @@ test.describe("global agent config screenshots", () => {
 
     const dialog = page.getByRole("dialog");
     await dialog.screenshot({
-      path: `${SHOTS}/11-edit-runtime-less-provider-required-save-blocked.png`,
+      path: `${SHOTS}/11-edit-runtime-less-unchanged-execution-save-enabled.png`,
     });
   });
 


### PR DESCRIPTION
## Summary

- render bounded provider-owned schema fields without provider IDs in React
- support enums, titled oneOf options, conditional visibility, dependent option filtering, and reconciliation
- use one execution-readiness policy for create/edit and allow unrelated edits to preserve unchanged remotely-owned execution configuration
- keep existing simple string schemas on the existing renderer

## Validation

- 16 focused Node tests pass with the desktop TypeScript loader
- includes create/edit readiness and provider-schema reconciliation coverage
- DCO sign-off included

This is vendor-neutral; concrete hosted providers remain external and are described only by the existing provider protocol.