### PR TITLE
feat(desktop): discover platform-managed providers

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1059,6 +1059,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "buzz-azure-storage"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "object_store",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "buzz-core"
 version = "0.1.0"
 dependencies = [
@@ -1180,6 +1192,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "blurhash",
+ "buzz-azure-storage",
  "buzz-core",
  "bytes",
  "chrono",
@@ -4557,6 +4570,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6859,6 +6881,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354792e39fa5f0009e47623cf8b15b099bf9a652fa55c6f817fe28ac84fea50"
+dependencies = [
+ "async-trait",
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "httparse",
+ "humantime",
+ "hyper",
+ "itertools 0.15.0",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml 0.41.0",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7878,7 +7938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -7898,7 +7958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck 0.5.0",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -7917,7 +7977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7930,7 +7990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -8087,6 +8147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -8297,7 +8358,7 @@ dependencies = [
  "compact_str 0.9.1",
  "critical-section",
  "hashbrown 0.17.1",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "palette",
@@ -8362,7 +8423,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -8401,7 +8462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
 ]
 
@@ -11079,7 +11140,7 @@ dependencies = [
  "esaxx-rs",
  "fancy-regex 0.14.0",
  "getrandom 0.3.4",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -11814,7 +11875,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width 0.2.2",
 ]
@@ -13385,7 +13446,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.4.3",
  "heapify",
- "itertools",
+ "itertools 0.14.0",
  "lazy_static",
  "lz4_flex",
  "more-asserts",
@@ -13415,7 +13476,7 @@ dependencies = [
  "chrono",
  "gearhash",
  "http",
- "itertools",
+ "itertools 0.14.0",
  "lazy_static",
  "more-asserts",
  "rand 0.10.2",

--- a/desktop/src-tauri/src/managed_agents/backend.rs
+++ b/desktop/src-tauri/src/managed_agents/backend.rs
@@ -4,6 +4,9 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::Duration;
 
+#[path = "provider_platform.rs"]
+mod provider_platform;
+
 const STDERR_CAP: usize = 65536;
 /// Provider responses should be small JSON objects. Cap stdout to prevent a
 /// buggy or malicious provider from OOM-ing the desktop process.
@@ -481,6 +484,7 @@ fn stage_provider(
     std::fs::set_permissions(&staged_path, permissions)
         .map_err(|error| format!("failed to protect staged provider: {error}"))?;
     drop(staged);
+    provider_platform::verify_provider_platform_signature(&staged_path)?;
 
     #[cfg(windows)]
     let execution_guard = {
@@ -570,17 +574,7 @@ pub fn validate_provider_config(config: &serde_json::Value) -> Result<(), String
 /// Windows leaves the executable/script extension, which is not part of the
 /// provider id.
 fn provider_id_from_filename(name: &str) -> Option<&str> {
-    let raw = name.strip_prefix("buzz-backend-")?;
-    let id = [".exe", ".bat", ".cmd"]
-        .into_iter()
-        .find_map(|extension| {
-            raw.get(raw.len().saturating_sub(extension.len())..)
-                .filter(|suffix| suffix.eq_ignore_ascii_case(extension))
-                .map(|_| &raw[..raw.len() - extension.len()])
-        })
-        .unwrap_or(raw);
-
-    (!id.is_empty()).then_some(id)
+    provider_platform::provider_id_from_filename(name)
 }
 
 /// Enumerate PATH for buzz-backend-* executables. Returns (id, path) pairs.
@@ -617,6 +611,8 @@ pub fn discover_provider_candidates() -> Vec<(String, PathBuf)> {
             dirs.push(local_bin);
         }
     }
+
+    provider_platform::augment_provider_search_dirs(&mut dirs);
 
     for dir in dirs {
         let Ok(entries) = std::fs::read_dir(&dir) else {

--- a/desktop/src-tauri/src/managed_agents/provider_platform.rs
+++ b/desktop/src-tauri/src/managed_agents/provider_platform.rs
@@ -1,0 +1,144 @@
+// Platform-specific provider discovery and signature policy.
+#[cfg(any(windows, test))]
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+/// Derive a provider ID from a staged or installed provider filename.
+pub(super) fn provider_id_from_filename(name: &str) -> Option<&str> {
+    let raw = name.strip_prefix("buzz-backend-")?;
+    let id = [".exe", ".bat", ".cmd"]
+        .into_iter()
+        .find_map(|extension| {
+            raw.get(raw.len().saturating_sub(extension.len())..)
+                .filter(|suffix| suffix.eq_ignore_ascii_case(extension))
+                .map(|_| &raw[..raw.len() - extension.len()])
+        })
+        .unwrap_or(raw);
+
+    (!id.is_empty()).then_some(id)
+}
+
+/// Add stable platform-owned provider locations ahead of inherited PATH.
+pub(super) fn augment_provider_search_dirs(dirs: &mut Vec<PathBuf>) {
+    #[cfg(windows)]
+    if let Some(provider_dir) = windows_user_provider_dir(std::env::var_os("LOCALAPPDATA")) {
+        if !dirs.contains(&provider_dir) {
+            dirs.insert(0, provider_dir);
+        }
+    }
+
+    #[cfg(not(windows))]
+    let _ = dirs;
+}
+
+#[cfg(any(windows, test))]
+fn windows_user_provider_dir(local_app_data: Option<OsString>) -> Option<PathBuf> {
+    local_app_data
+        .map(PathBuf::from)
+        .map(|base| base.join("Buzz").join("providers"))
+}
+
+/// Enforce the build-pinned Windows signer policy for immutable staged bytes.
+#[cfg(windows)]
+pub(super) fn verify_provider_platform_signature(binary: &Path) -> Result<(), String> {
+    let configured = option_env!("BUZZ_TRUSTED_PROVIDER_SIGNER_SUBJECTS").unwrap_or("");
+    if configured.split(';').map(str::trim).all(str::is_empty) {
+        return Ok(());
+    }
+    let system_root = std::env::var_os("SystemRoot")
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            "Windows system root is unavailable for provider verification".to_string()
+        })?;
+    let powershell = system_root
+        .join("System32")
+        .join("WindowsPowerShell")
+        .join("v1.0")
+        .join("powershell.exe");
+    let script = r#"$signature = Get-AuthenticodeSignature -LiteralPath $env:BUZZ_PROVIDER_SIGNATURE_TARGET; if ($signature.Status -ne 'Valid' -or $null -eq $signature.SignerCertificate) { exit 41 }; [Console]::Out.Write($signature.SignerCertificate.Subject)"#;
+    let output = std::process::Command::new(powershell)
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            script,
+        ])
+        .env("BUZZ_PROVIDER_SIGNATURE_TARGET", binary)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .map_err(|error| format!("provider signature verification failed to run: {error}"))?;
+    if !output.status.success() {
+        return Err("provider has no valid trusted Authenticode signature".to_string());
+    }
+    let subject = String::from_utf8(output.stdout)
+        .map_err(|_| "provider signer subject is not valid UTF-8".to_string())?;
+    if !signer_subject_allowed(configured, subject.trim()) {
+        return Err("provider Authenticode signer is not approved by this Buzz build".to_string());
+    }
+    Ok(())
+}
+
+/// Non-Windows builds have no platform signature policy.
+#[cfg(not(windows))]
+pub(super) fn verify_provider_platform_signature(_binary: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(any(windows, test))]
+fn signer_subject_allowed(configured: &str, actual: &str) -> bool {
+    configured
+        .split(';')
+        .map(str::trim)
+        .filter(|candidate| !candidate.is_empty())
+        .any(|candidate| candidate.eq_ignore_ascii_case(actual))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_platform_provider_filenames() {
+        assert_eq!(
+            provider_id_from_filename("buzz-backend-kubernetes"),
+            Some("kubernetes")
+        );
+        assert_eq!(
+            provider_id_from_filename("buzz-backend-kubernetes.EXE"),
+            Some("kubernetes")
+        );
+        assert_eq!(
+            provider_id_from_filename("buzz-backend-claude-code.cmd"),
+            Some("claude-code")
+        );
+        assert_eq!(provider_id_from_filename("buzz-backend-"), None);
+        assert_eq!(provider_id_from_filename("other"), None);
+    }
+
+    #[test]
+    fn builds_the_windows_user_provider_directory() {
+        assert_eq!(
+            windows_user_provider_dir(Some(OsString::from("C:\\Users\\Ross\\AppData\\Local"))),
+            Some(
+                PathBuf::from("C:\\Users\\Ross\\AppData\\Local")
+                    .join("Buzz")
+                    .join("providers")
+            )
+        );
+        assert_eq!(windows_user_provider_dir(None), None);
+    }
+
+    #[test]
+    fn signer_allowlist_is_trimmed_and_case_insensitive() {
+        assert!(signer_subject_allowed(
+            "CN=Example Publisher; CN=Other Signer ",
+            "cn=example publisher"
+        ));
+        assert!(!signer_subject_allowed(
+            "CN=Example Publisher; CN=Other Signer",
+            "CN=Unknown"
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- discover managed-provider executables from a stable per-user Windows directory ahead of inherited PATH
- derive provider IDs consistently from executable/script filenames
- stage provider bytes before use
- support an optional build-pinned Authenticode subject allowlist; builds without a policy retain current behavior

The implementation is provider-neutral and contains no vendor IDs or endpoints.

## Validation

- cargo fmt --check
- 3 exact provider-platform Rust tests pass
- DCO sign-off included