### PR TITLE
fix(desktop): hydrate DM recipients before send

### DIFF
--- a/desktop/src/extensions/messages/dmRecipientHydration.test.mjs
+++ b/desktop/src/extensions/messages/dmRecipientHydration.test.mjs
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  dmRecipientPubkeysNeedHydration,
+  resolveHydratedMessageRecipientPubkeys,
+  resolveInboxReplyRecipientPubkeys,
+  resolveMessageRecipientPubkeys,
+} from "./dmRecipientHydration.ts";
+
+function channel(overrides = {}) {
+  return {
+    id: "dm-1",
+    name: "DM",
+    channelType: "dm",
+    visibility: "private",
+    description: "",
+    topic: null,
+    purpose: null,
+    memberCount: 2,
+    memberPubkeys: ["OWNER", "AGENT"],
+    participantPubkeys: ["owner", "agent"],
+    participants: [],
+    lastMessageAt: null,
+    archivedAt: null,
+    isMember: true,
+    ttlSeconds: null,
+    ttlDeadline: null,
+    ...overrides,
+  };
+}
+
+test("a restarted DM with empty participant arrays requires membership hydration", () => {
+  assert.equal(
+    dmRecipientPubkeysNeedHydration(
+      channel({ memberPubkeys: [], participantPubkeys: [] }),
+      "owner",
+    ),
+    true,
+  );
+});
+
+test("cached authoritative members repair a restarted DM without another relay read", async () => {
+  let loadCalls = 0;
+  const recipients = await resolveHydratedMessageRecipientPubkeys({
+    channel: channel({ memberPubkeys: [], participantPubkeys: [] }),
+    senderPubkey: "owner",
+    cachedMemberPubkeys: ["OWNER", "AGENT"],
+    loadDmMemberPubkeys: async () => {
+      loadCalls += 1;
+      return [];
+    },
+  });
+
+  assert.deepEqual(recipients, ["agent"]);
+  assert.equal(loadCalls, 0);
+});
+
+test("a complete DM keeps the local fast path", async () => {
+  let loadCalls = 0;
+  const recipients = await resolveHydratedMessageRecipientPubkeys({
+    channel: channel(),
+    senderPubkey: "owner",
+    loadDmMemberPubkeys: async () => {
+      loadCalls += 1;
+      return [];
+    },
+  });
+
+  assert.deepEqual(recipients, ["agent"]);
+  assert.equal(loadCalls, 0);
+});
+
+test("an incomplete restarted DM loads authoritative membership before sending", async () => {
+  let loadCalls = 0;
+  const recipients = await resolveHydratedMessageRecipientPubkeys({
+    channel: channel({ memberPubkeys: [], participantPubkeys: [] }),
+    senderPubkey: "owner",
+    loadDmMemberPubkeys: async () => {
+      loadCalls += 1;
+      return ["OWNER", "AGENT"];
+    },
+  });
+
+  assert.deepEqual(recipients, ["agent"]);
+  assert.equal(loadCalls, 1);
+});
+
+test("an incomplete group DM hydrates every missing recipient", async () => {
+  const recipients = await resolveHydratedMessageRecipientPubkeys({
+    channel: channel({
+      memberCount: 3,
+      memberPubkeys: ["owner", "agent"],
+      participantPubkeys: [],
+    }),
+    senderPubkey: "owner",
+    loadDmMemberPubkeys: async () => ["owner", "agent", "third"],
+  });
+
+  assert.deepEqual(recipients, ["agent", "third"]);
+});
+
+test("an unresolved DM fails instead of publishing an unreachable message", async () => {
+  await assert.rejects(
+    resolveHydratedMessageRecipientPubkeys({
+      channel: channel({ memberPubkeys: [], participantPubkeys: [] }),
+      senderPubkey: "owner",
+      loadDmMemberPubkeys: async () => ["owner"],
+    }),
+    /recipients are still loading/i,
+  );
+});
+
+test("stream messages never trigger DM membership loading", async () => {
+  let loadCalls = 0;
+  const recipients = await resolveHydratedMessageRecipientPubkeys({
+    channel: channel({ channelType: "stream" }),
+    senderPubkey: "owner",
+    explicitMentions: ["third"],
+    loadDmMemberPubkeys: async () => {
+      loadCalls += 1;
+      return [];
+    },
+  });
+
+  assert.deepEqual(recipients, ["third"]);
+  assert.equal(loadCalls, 0);
+});
+
+test("the send hook shares cached channel members before any relay fetch", async () => {
+  let fetchCalls = 0;
+  const queryClient = {
+    getQueryData: () => [{ pubkey: "OWNER" }, { pubkey: "AGENT" }],
+    fetchQuery: async () => {
+      fetchCalls += 1;
+      return [];
+    },
+  };
+
+  const recipients = await resolveMessageRecipientPubkeys({
+    channel: channel({ memberPubkeys: [], participantPubkeys: [] }),
+    senderPubkey: "owner",
+    queryClient,
+  });
+
+  assert.deepEqual(recipients, ["agent"]);
+  assert.equal(fetchCalls, 0);
+});
+
+test("the send hook forces an authoritative members query for incomplete cache state", async () => {
+  let fetchOptions;
+  const queryClient = {
+    getQueryData: () => undefined,
+    fetchQuery: async (options) => {
+      fetchOptions = options;
+      return [{ pubkey: "OWNER" }, { pubkey: "AGENT" }];
+    },
+  };
+
+  const recipients = await resolveMessageRecipientPubkeys({
+    channel: channel({ memberPubkeys: [], participantPubkeys: [] }),
+    senderPubkey: "owner",
+    queryClient,
+  });
+
+  assert.deepEqual(recipients, ["agent"]);
+  assert.deepEqual(fetchOptions.queryKey, ["channels", "dm-1", "members"]);
+  assert.equal(fetchOptions.staleTime, 0);
+});
+
+test("the inbox composer addresses every DM recipient through the shared send path", async () => {
+  let fetchCalls = 0;
+  const recipients = await resolveInboxReplyRecipientPubkeys({
+    channel: channel({ memberPubkeys: [], participantPubkeys: [] }),
+    channelId: "dm-1",
+    senderPubkey: "owner",
+    queryClient: {
+      getQueryData: () => [{ pubkey: "OWNER" }, { pubkey: "AGENT" }],
+      fetchQuery: async () => {
+        fetchCalls += 1;
+        return [];
+      },
+    },
+  });
+
+  assert.deepEqual(recipients, ["agent"]);
+  assert.equal(fetchCalls, 0);
+});
+
+test("the inbox composer refuses to publish before its channel snapshot is ready", async () => {
+  await assert.rejects(
+    resolveInboxReplyRecipientPubkeys({
+      channel: null,
+      channelId: "dm-1",
+      senderPubkey: "owner",
+      queryClient: {},
+    }),
+    /channel details are still loading/i,
+  );
+});
+
+test("the inbox composer refuses to publish before its sender identity is ready", async () => {
+  await assert.rejects(
+    resolveInboxReplyRecipientPubkeys({
+      channel: channel(),
+      channelId: "dm-1",
+      senderPubkey: null,
+      queryClient: {},
+    }),
+    /identity is still loading/i,
+  );
+});

--- a/desktop/src/extensions/messages/dmRecipientHydration.ts
+++ b/desktop/src/extensions/messages/dmRecipientHydration.ts
@@ -1,0 +1,210 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import { splitOutgoingTags } from "@/features/messages/lib/imetaMediaMarkdown";
+import { messageMentionPubkeys } from "@/features/messages/lib/messageMentionPubkeys";
+import { getChannelMembers, sendChannelMessage } from "@/shared/api/tauri";
+import type { Channel, ChannelMember } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+/**
+ * Whether a DM's locally available membership is too incomplete to address a
+ * message safely. Channel snapshots deliberately paint before relay
+ * revalidation, so a freshly reopened DM can temporarily have no participant
+ * arrays even though `memberCount` says another participant exists.
+ */
+export function dmRecipientPubkeysNeedHydration(
+  channel: Channel,
+  senderPubkey: string,
+  supplementalMemberPubkeys: readonly string[] = [],
+): boolean {
+  if (channel.channelType !== "dm") return false;
+
+  const sender = normalizePubkey(senderPubkey);
+  const knownRecipients = new Set(
+    [
+      ...channel.memberPubkeys,
+      ...channel.participantPubkeys,
+      ...supplementalMemberPubkeys,
+    ]
+      .map(normalizePubkey)
+      .filter((pubkey) => pubkey.length > 0 && pubkey !== sender),
+  );
+  const expectedRecipientCount = Math.max(1, channel.memberCount - 1);
+
+  return knownRecipients.size < expectedRecipientCount;
+}
+
+type ResolveMessageRecipientPubkeysInput = {
+  channel: Channel;
+  senderPubkey: string;
+  explicitMentions?: readonly string[];
+  cachedMemberPubkeys?: readonly string[];
+  loadDmMemberPubkeys: () => Promise<readonly string[]>;
+};
+
+/**
+ * Resolve message recipients without ever emitting an unaddressed DM.
+ *
+ * The normal path is entirely local. Only an incomplete DM snapshot falls
+ * back to the authoritative membership query; if that query still cannot
+ * identify every expected recipient, the send fails visibly instead of
+ * publishing a message that no recipient or hosted agent can receive.
+ */
+export async function resolveHydratedMessageRecipientPubkeys({
+  channel,
+  senderPubkey,
+  explicitMentions = [],
+  cachedMemberPubkeys = [],
+  loadDmMemberPubkeys,
+}: ResolveMessageRecipientPubkeysInput): Promise<string[]> {
+  if (channel.channelType !== "dm") {
+    return messageMentionPubkeys(channel, senderPubkey, explicitMentions);
+  }
+
+  let memberPubkeys = cachedMemberPubkeys;
+  if (
+    dmRecipientPubkeysNeedHydration(channel, senderPubkey, cachedMemberPubkeys)
+  ) {
+    memberPubkeys = await loadDmMemberPubkeys();
+  }
+
+  if (dmRecipientPubkeysNeedHydration(channel, senderPubkey, memberPubkeys)) {
+    throw new Error(
+      "Direct message recipients are still loading. Try sending again.",
+    );
+  }
+
+  return messageMentionPubkeys(channel, senderPubkey, [
+    ...explicitMentions,
+    ...memberPubkeys,
+  ]);
+}
+
+type ResolveMessageRecipientPubkeysForSendInput = {
+  channel: Channel;
+  senderPubkey: string;
+  explicitMentions?: readonly string[];
+  queryClient: QueryClient;
+};
+
+/**
+ * Stable send-path composition hook. It shares the channel-members query cache
+ * used by the channel UI, then forces a relay read only when that local state
+ * cannot address every expected DM recipient.
+ */
+export async function resolveMessageRecipientPubkeys({
+  channel,
+  senderPubkey,
+  explicitMentions,
+  queryClient,
+}: ResolveMessageRecipientPubkeysForSendInput): Promise<string[]> {
+  const membersKey = ["channels", channel.id, "members"] as const;
+  const cachedMemberPubkeys =
+    queryClient
+      .getQueryData<ChannelMember[]>(membersKey)
+      ?.map((member) => member.pubkey) ?? [];
+
+  return resolveHydratedMessageRecipientPubkeys({
+    channel,
+    senderPubkey,
+    explicitMentions,
+    cachedMemberPubkeys,
+    loadDmMemberPubkeys: async () =>
+      (
+        await queryClient.fetchQuery({
+          queryKey: membersKey,
+          queryFn: () => getChannelMembers(channel.id),
+          // This branch runs only after local membership proved incomplete;
+          // force an authoritative read even if an incomplete query was just
+          // populated.
+          staleTime: 0,
+        })
+      ).map((member) => member.pubkey),
+  });
+}
+
+type ResolveInboxReplyRecipientPubkeysInput = {
+  channel: Channel | null;
+  channelId: string;
+  senderPubkey: string | null | undefined;
+  explicitMentions?: readonly string[];
+  queryClient: QueryClient;
+};
+
+/**
+ * Resolve the recipients for the Home inbox composer through the same guarded
+ * path as the full channel composer.
+ *
+ * Home renders from feed state before its channel snapshot is necessarily
+ * available. Publishing in that gap would silently create an unaddressed DM,
+ * so fail visibly until both the channel and sender identity are authoritative.
+ */
+export async function resolveInboxReplyRecipientPubkeys({
+  channel,
+  channelId,
+  senderPubkey,
+  explicitMentions,
+  queryClient,
+}: ResolveInboxReplyRecipientPubkeysInput): Promise<string[]> {
+  if (!channel || channel.id !== channelId) {
+    throw new Error("Channel details are still loading. Try sending again.");
+  }
+
+  const sender = normalizePubkey(senderPubkey ?? "");
+  if (!sender) {
+    throw new Error("Your identity is still loading. Try sending again.");
+  }
+
+  return resolveMessageRecipientPubkeys({
+    channel,
+    senderPubkey: sender,
+    explicitMentions,
+    queryClient,
+  });
+}
+
+type SendInboxReplyInput = ResolveInboxReplyRecipientPubkeysInput & {
+  content: string;
+  mediaTags?: string[][];
+  mentionPubkeys: string[];
+  parentEventId: string | null;
+};
+
+/**
+ * Keep the Home inbox call site thin while applying the same tag splitting and
+ * guarded recipient resolution as the full composer.
+ */
+export async function sendInboxReply({
+  channel,
+  channelId,
+  senderPubkey,
+  content,
+  mediaTags,
+  mentionPubkeys,
+  parentEventId,
+  queryClient,
+}: SendInboxReplyInput) {
+  const {
+    mediaTags: imetaTags,
+    emojiTags,
+    mentionTags,
+  } = splitOutgoingTags(mediaTags);
+  const recipientPubkeys = await resolveInboxReplyRecipientPubkeys({
+    channel,
+    channelId,
+    senderPubkey,
+    explicitMentions: mentionPubkeys,
+    queryClient,
+  });
+  const result = await sendChannelMessage(
+    channelId,
+    content,
+    parentEventId,
+    imetaTags,
+    recipientPubkeys,
+    undefined,
+    emojiTags,
+    mentionTags,
+  );
+  return { emojiTags, imetaTags, mentionTags, result };
+}

--- a/desktop/src/features/home/ui/HomeView.tsx
+++ b/desktop/src/features/home/ui/HomeView.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
 import { RefreshCcw } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { useAppShell } from "@/app/AppShellContext";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { sendInboxReply } from "@/extensions/messages/dmRecipientHydration";
 import { useKnownAgentPubkeys } from "@/features/agents/useKnownAgentPubkeys";
 import { useChannelsQuery, useOpenDmMutation } from "@/features/channels/hooks";
 import { RightAuxiliaryPane } from "@/features/channels/ui/RightAuxiliaryPane";
@@ -54,13 +56,12 @@ import {
 import { collectMessageMentionPubkeys } from "@/features/messages/lib/formatTimelineMessages";
 import { formatTime } from "@/features/messages/lib/dateFormatters";
 import { DeleteMessageConfirmDialog } from "@/features/messages/ui/DeleteMessageConfirmDialog";
-import { splitOutgoingTags } from "@/features/messages/lib/imetaMediaMarkdown";
 import { getThreadReference } from "@/features/messages/lib/threading";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { useRelaySelfQuery } from "@/features/moderation/hooks";
 import { resolveUserLabel } from "@/features/profile/lib/identity";
 import { useRemindLater } from "@/features/reminders/ui/RemindMeLaterProvider";
-import { deleteMessage, sendChannelMessage } from "@/shared/api/tauri";
+import { deleteMessage } from "@/shared/api/tauri";
 import type { Channel, HomeFeedResponse } from "@/shared/api/types";
 import { KIND_REACTION } from "@/shared/constants/kinds";
 import { topChromeInset } from "@/shared/layout/chromeLayout";
@@ -104,6 +105,7 @@ export function HomeView({
   onOpenContext,
   onRefresh,
 }: HomeViewProps) {
+  const queryClient = useQueryClient();
   const relaySelfPubkey = useRelaySelfQuery().data;
   const [homeInboxRef, homeInboxWidthPx] = useElementWidth<HTMLDivElement>();
   const isNarrowHomeViewport =
@@ -844,21 +846,17 @@ export function HomeView({
                 const itemToReply = selectedItem;
                 setIsSendingReply(true);
                 try {
-                  const {
-                    mediaTags: imetaTags,
-                    emojiTags,
-                    mentionTags,
-                  } = splitOutgoingTags(mediaTags);
-                  const result = await sendChannelMessage(
-                    channelId,
-                    content,
-                    parentEventId,
-                    imetaTags,
-                    mentionPubkeys,
-                    undefined,
-                    emojiTags,
-                    mentionTags,
-                  );
+                  const { emojiTags, imetaTags, mentionTags, result } =
+                    await sendInboxReply({
+                      channel: selectedChannel,
+                      channelId,
+                      senderPubkey: currentPubkey ?? relaySelfPubkey,
+                      content,
+                      mediaTags,
+                      mentionPubkeys,
+                      parentEventId,
+                      queryClient,
+                    });
                   const authorPubkey = currentPubkey ?? itemToReply.item.pubkey;
                   const reply: InboxReply = {
                     authorLabel: currentPubkey

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -31,7 +31,7 @@ import {
 
 export { mergeMessages, mergeTimelineCacheMessages };
 import { splitOutgoingTags } from "@/features/messages/lib/imetaMediaMarkdown";
-import { messageMentionPubkeys } from "@/features/messages/lib/messageMentionPubkeys";
+import { resolveMessageRecipientPubkeys } from "@/extensions/messages/dmRecipientHydration";
 import { buildSentFromThreadTag } from "@/features/messages/lib/sentFromThread";
 import {
   clearTimeoutState,
@@ -505,11 +505,12 @@ export function useSendMessageMutation(
         mentionTags,
         linkPreviewTags,
       } = splitOutgoingTags(mediaTags);
-      const recipientPubkeys = messageMentionPubkeys(
-        effectiveChannel,
-        identity.pubkey,
-        mentionPubkeys,
-      );
+      const recipientPubkeys = await resolveMessageRecipientPubkeys({
+        channel: effectiveChannel,
+        senderPubkey: identity.pubkey,
+        explicitMentions: mentionPubkeys,
+        queryClient,
+      });
       if (sentFromThreadRootId && parentEventId) {
         throw new Error(
           "A thread message can only be sent as a top-level message.",


### PR DESCRIPTION
## Summary

Persisted DM snapshots can render before participant arrays are authoritative. Hydrate recipient membership through one shared, fail-closed send path before publishing so restarted one-to-one and group DMs retain every required recipient tag.

The cache is used only when its membership is authoritative; unresolved DMs do not publish unreachable events.

## Validation

- 12 focused recipient-hydration tests pass
- covers restart-empty pairs, group DMs, cached/authoritative membership, inbox routing, and fail-closed behavior
- DCO sign-off included