### PR TITLE
fix(desktop): bound live TTS sanitization

### DIFF
--- a/desktop/src/features/huddle/lib/ttsLiveMessageSanitizer.ts
+++ b/desktop/src/features/huddle/lib/ttsLiveMessageSanitizer.ts
@@ -1,0 +1,26 @@
+/**
+ * Remove empty multiline spoiler shells without a backtracking regular
+ * expression. The single forward scan is linear in the number of lines.
+ */
+export function removeEmptySpoilerBlocks(value: string): string {
+  const lines = value.split("\n");
+  const retained: string[] = [];
+  for (let index = 0; index < lines.length; ) {
+    if (lines[index]?.trim() === "||") {
+      let closingIndex = index + 1;
+      while (
+        closingIndex < lines.length &&
+        lines[closingIndex]?.trim() === ""
+      ) {
+        closingIndex += 1;
+      }
+      if (lines[closingIndex]?.trim() === "||") {
+        index = closingIndex + 1;
+        continue;
+      }
+    }
+    retained.push(lines[index] ?? "");
+    index += 1;
+  }
+  return retained.join("\n");
+}

--- a/desktop/src/features/huddle/lib/ttsLiveMessages.security.test.mjs
+++ b/desktop/src/features/huddle/lib/ttsLiveMessages.security.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { classifySpeakableAgentText } from "./ttsLiveMessages.ts";
+
+test("strips attachment spoiler shells in linear time", () => {
+  const channelId = "security-regression";
+  const url = "https://cdn.example/voice.png";
+  const blankLines = "\n".repeat(10_000);
+  const result = classifySpeakableAgentText(
+    {
+      id: "security-regression-event",
+      kind: 9,
+      pubkey: "agent",
+      content: `before\n||\n![image](${url})${blankLines}||\nafter`,
+      tags: [
+        ["h", channelId],
+        ["imeta", `url ${url}`, "m image/png"],
+      ],
+    },
+    new Set(["agent"]),
+    "human",
+    channelId,
+  );
+
+  assert.deepEqual(result, { text: "before\nafter", reason: null });
+});

--- a/desktop/src/features/huddle/lib/ttsLiveMessages.ts
+++ b/desktop/src/features/huddle/lib/ttsLiveMessages.ts
@@ -2,6 +2,7 @@ import {
   KIND_STREAM_MESSAGE,
   KIND_STREAM_MESSAGE_V2,
 } from "../../../shared/constants/kinds.ts";
+import { removeEmptySpoilerBlocks } from "./ttsLiveMessageSanitizer";
 
 export type LiveTtsEvent = {
   id: string;
@@ -46,10 +47,7 @@ function textWithoutAttachments(event: LiveTtsEvent): string {
       (line) => !Array.from(urls).some((url) => line.includes(`](${url})`)),
     )
     .join("\n");
-  return withoutMedia.replace(
-    /(^|\n)\s*\|\|\s*\n(?:\s*\n)*\s*\|\|\s*(?=\n|$)/gu,
-    "$1",
-  );
+  return removeEmptySpoilerBlocks(withoutMedia);
 }
 
 export function classifySpeakableAgentText(


### PR DESCRIPTION
## Summary

Move attachment/spoiler cleanup into a small linear scanner so adversarial delimiter runs cannot trigger pathological regular-expression backtracking during live TTS.

Behavior remains provider-neutral and preserves the existing spoken-message cleanup.

## Validation

- focused adversarial sanitizer test passes
- DCO sign-off included