### PR TITLE
fix(desktop): normalize project README HTML safely

### DIFF
--- a/desktop/src/features/projects/lib/projectReadmeMarkdown.test.mjs
+++ b/desktop/src/features/projects/lib/projectReadmeMarkdown.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { normalizeReadmeMarkdown } from "./projectReadmeMarkdown.ts";
+
+test("normalizes the supported README HTML subset", () => {
+  assert.equal(
+    normalizeReadmeMarkdown(
+      '<h2>Hello &amp; welcome</h2><p><strong>Bold</strong><br><a href="https://example.com/a path">Docs</a></p>',
+    ),
+    "## Hello & welcome\n\n**Bold**\n[Docs](https://example.com/a%20path)",
+  );
+});
+
+test("renders unknown and entity-encoded HTML as inert text", () => {
+  const normalized = normalizeReadmeMarkdown(
+    "<p>&lt;script&gt;one()&lt;/script&gt;<scr<script>ipt>two()</scr<script>ipt></p>",
+  );
+
+  assert.doesNotMatch(normalized, /<script/i);
+  assert.match(normalized, /&lt;script&gt;one\(\)&lt;\/script&gt;/);
+  assert.match(normalized, /&lt;scr&lt;script&gt;ipt&gt;two\(\)/);
+});
+
+test("decodes only one entity layer", () => {
+  assert.equal(
+    normalizeReadmeMarkdown("&amp;lt;script&amp;gt;alert(1)"),
+    "&lt;script&gt;alert(1)",
+  );
+});
+
+test("drops unsafe link and image destinations without dropping labels", () => {
+  const normalized = normalizeReadmeMarkdown(
+    '<p><a href="java&#x73;cript:alert(1)">Open me</a><img alt="payload" src="data:text/html,boom"></p>',
+  );
+
+  assert.equal(normalized, "Open me");
+  assert.doesNotMatch(normalized, /javascript:|data:text\/html/i);
+});

--- a/desktop/src/features/projects/lib/projectReadmeMarkdown.ts
+++ b/desktop/src/features/projects/lib/projectReadmeMarkdown.ts
@@ -1,0 +1,122 @@
+const NAMED_HTML_ENTITIES: Record<string, string> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  quot: '"',
+};
+
+/** Decode exactly one HTML-entity layer so replacements are never re-decoded. */
+function decodeHtmlEntitiesOnce(value: string): string {
+  return value.replace(
+    /&(?:#(\d+)|#x([\da-f]+)|([a-z]+));/gi,
+    (
+      match,
+      decimal: string | undefined,
+      hex: string | undefined,
+      named: string | undefined,
+    ) => {
+      if (named) {
+        return NAMED_HTML_ENTITIES[named.toLowerCase()] ?? match;
+      }
+
+      const codePoint = Number.parseInt(
+        decimal ?? hex ?? "",
+        decimal ? 10 : 16,
+      );
+      if (
+        !Number.isInteger(codePoint) ||
+        codePoint < 0 ||
+        codePoint > 0x10ffff ||
+        (codePoint >= 0xd800 && codePoint <= 0xdfff)
+      ) {
+        return match;
+      }
+      return String.fromCodePoint(codePoint);
+    },
+  );
+}
+
+function markdownDestination(value: string, image: boolean): string | null {
+  const trimmed = value.trim();
+  const containsControlCharacter = Array.from(trimmed).some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 0x1f || codePoint === 0x7f;
+  });
+  if (!trimmed || containsControlCharacter) {
+    return null;
+  }
+
+  const scheme = /^([a-z][a-z\d+.-]*):/i.exec(trimmed)?.[1]?.toLowerCase();
+  const allowedSchemes = image
+    ? new Set(["http", "https"])
+    : new Set(["buzz", "http", "https", "mailto"]);
+  if (scheme && !allowedSchemes.has(scheme)) {
+    return null;
+  }
+
+  return trimmed
+    .replace(/\\/g, "%5C")
+    .replace(/ /g, "%20")
+    .replace(/\(/g, "%28")
+    .replace(/\)/g, "%29");
+}
+
+function escapeMarkdownLabel(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]");
+}
+
+/**
+ * Convert the small inline-HTML subset commonly used by README files.
+ * Anything outside the allowlist is rendered as inert text, never removed by
+ * a regex that could expose a second tag after replacement.
+ */
+function convertDecodedInlineHtml(value: string): string {
+  return value
+    .replace(/<br\s*\/?\s*>/gi, "\n")
+    .replace(/<img\b([^>]*)>/gi, (_match: string, attrs: string) => {
+      const rawSource = attrs.match(/\bsrc=["']([^"']+)["']/i)?.[1];
+      const source = rawSource ? markdownDestination(rawSource, true) : null;
+      const alt = escapeMarkdownLabel(
+        attrs.match(/\balt=["']([^"']*)["']/i)?.[1] ?? "",
+      );
+      return source ? `![${alt}](${source})` : "";
+    })
+    .replace(
+      /<a\b[^>]*\bhref=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi,
+      (_match: string, rawHref: string, label: string) => {
+        const renderedLabel = escapeMarkdownLabel(
+          convertDecodedInlineHtml(label).trim(),
+        );
+        const href = markdownDestination(rawHref, false);
+        return href ? `[${renderedLabel}](${href})` : renderedLabel;
+      },
+    )
+    .replace(/<(strong|b)\b[^>]*>([\s\S]*?)<\/\1>/gi, "**$2**")
+    .replace(/<(em|i)\b[^>]*>([\s\S]*?)<\/\1>/gi, "*$2*")
+    .replace(/<code\b[^>]*>([\s\S]*?)<\/code>/gi, "`$1`")
+    .replace(/<sub\b[^>]*>([\s\S]*?)<\/sub>/gi, "$1")
+    .replace(/<span\b[^>]*>([\s\S]*?)<\/span>/gi, "$1")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+export function normalizeReadmeMarkdown(content: string): string {
+  const decoded = decodeHtmlEntitiesOnce(content);
+  const blockNormalized = decoded
+    .replace(
+      /<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi,
+      (_match, depth: string, value: string) =>
+        `${"#".repeat(Number(depth))} ${value}\n\n`,
+    )
+    .replace(/<p\b[^>]*>([\s\S]*?)<\/p>/gi, "$1\n\n")
+    .replace(/<div\b[^>]*>([\s\S]*?)<\/div>/gi, "$1\n\n")
+    .replace(/<center\b[^>]*>([\s\S]*?)<\/center>/gi, "$1\n\n");
+
+  return convertDecodedInlineHtml(blockNormalized)
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/desktop/src/features/projects/ui/ProjectReadmePanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectReadmePanel.tsx
@@ -9,6 +9,7 @@ import {
 import type { ProjectRepoFile } from "@/features/projects/hooks";
 import { projectExternalRefUrl } from "@/features/projects/lib/projectExternalUrl";
 import type { ProjectRepoUnavailableReason } from "@/features/projects/lib/projectRepoAvailability";
+import { normalizeReadmeMarkdown } from "@/features/projects/lib/projectReadmeMarkdown";
 import { formatLastChangedAt } from "@/features/projects/lib/projectsViewHelpers";
 import { Button } from "@/shared/ui/button";
 import { BuzzLoadingState } from "@/shared/ui/BuzzLoadingState";
@@ -35,59 +36,6 @@ export function findReadmeFile(files: ProjectRepoFile[]) {
   return readmes.find((file) => !file.path.includes("/")) ?? readmes[0] ?? null;
 }
 
-function decodeHtmlEntities(value: string) {
-  return value
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'");
-}
-
-function htmlInlineToMarkdown(value: string): string {
-  return decodeHtmlEntities(value)
-    .replace(/<br\s*\/?\s*>/gi, "\n")
-    .replace(/<img\b([^>]*)>/gi, (_match: string, attrs: string) => {
-      const src = attrs.match(/\bsrc=["']([^"']+)["']/i)?.[1];
-      const alt = attrs.match(/\balt=["']([^"']*)["']/i)?.[1] ?? "";
-      return src ? `![${alt}](${src})` : "";
-    })
-    .replace(
-      /<a\b[^>]*\bhref=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi,
-      (_match: string, href: string, label: string) =>
-        `[${htmlInlineToMarkdown(label).trim()}](${href})`,
-    )
-    .replace(/<(strong|b)\b[^>]*>([\s\S]*?)<\/\1>/gi, "**$2**")
-    .replace(/<(em|i)\b[^>]*>([\s\S]*?)<\/\1>/gi, "*$2*")
-    .replace(/<code\b[^>]*>([\s\S]*?)<\/code>/gi, "`$1`")
-    .replace(/<sub\b[^>]*>([\s\S]*?)<\/sub>/gi, "$1")
-    .replace(/<span\b[^>]*>([\s\S]*?)<\/span>/gi, "$1")
-    .replace(/<[^>]+>/g, "")
-    .trim();
-}
-
-function normalizeReadmeMarkdown(content: string) {
-  return content
-    .replace(
-      /<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi,
-      (_match, depth: string, value: string) =>
-        `${"#".repeat(Number(depth))} ${htmlInlineToMarkdown(value)}\n\n`,
-    )
-    .replace(
-      /<p\b[^>]*>([\s\S]*?)<\/p>/gi,
-      (_match, value: string) => `${htmlInlineToMarkdown(value)}\n\n`,
-    )
-    .replace(
-      /<div\b[^>]*>([\s\S]*?)<\/div>/gi,
-      (_match, value: string) => `${htmlInlineToMarkdown(value)}\n\n`,
-    )
-    .replace(
-      /<center\b[^>]*>([\s\S]*?)<\/center>/gi,
-      (_match, value: string) => `${htmlInlineToMarkdown(value)}\n\n`,
-    )
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
 
 export function ReadmePanel({
   accessChannelId,

--- a/desktop/src/features/projects/ui/ProjectReadmePanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectReadmePanel.tsx
@@ -36,7 +36,6 @@ export function findReadmeFile(files: ProjectRepoFile[]) {
   return readmes.find((file) => !file.path.includes("/")) ?? readmes[0] ?? null;
 }
 
-
 export function ReadmePanel({
   accessChannelId,
   file,


### PR DESCRIPTION
## Summary

Extract README normalization into a bounded, provider-neutral helper. Supported HTML is converted to Markdown, unknown/entity-encoded markup remains inert text, and unsafe link/image destinations are dropped without losing their labels.

## Validation

- 4 focused normalization/security tests pass
- DCO sign-off included