### PR TITLE
feat(acp): make hosted turns durable and observable

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -13,6 +13,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, ChildStdin, ChildStdout};
 use tokio_util::codec::{FramedRead, LinesCodec, LinesCodecError};
 
+use crate::local_publication::{LocalPublicationIntent, LocalPublicationPublisher};
 use crate::observer::{ObserverContext, ObserverHandle};
 use crate::usage::{
     PromptResponseUsage, StandardAdapterKind, StandardUsageTracker, TurnUsage, UsageTracker,
@@ -21,6 +22,12 @@ use crate::usage::{
 /// Maximum allowed size of a single NDJSON line from the agent's stdout.
 /// Lines exceeding this limit are rejected to prevent OOM from rogue agents.
 const MAX_LINE_SIZE: usize = 10_000_000; // 10 MB
+
+fn is_local_publication_update(msg: &serde_json::Value) -> bool {
+    msg.pointer("/params/update/sessionUpdate")
+        .and_then(|value| value.as_str())
+        == Some("buzz_local_publication")
+}
 
 /// An MCP server configuration passed to `session/new`.
 ///
@@ -210,6 +217,14 @@ pub struct AcpClient {
     steer_rx: Option<tokio::sync::mpsc::Receiver<crate::pool::SteerRequest>>,
     /// Usage tracker for goose/buzz-agent's cumulative notification format.
     goose_usage: UsageTracker,
+    /// Optional, explicitly enabled publisher for the local ACP extension.
+    /// It holds the Buzz signer in this parent process; the child only emits
+    /// validated publication intents and never receives private key material.
+    local_publication_publisher: Option<LocalPublicationPublisher>,
+    /// Structured Buzz envelope attached to the next `session/prompt` as a
+    /// namespaced ACP extension. Custom agents can consume this instead of
+    /// parsing the human-readable prompt; legacy agents ignore it.
+    buzz_prompt_metadata: Option<serde_json::Value>,
     /// Per-turn prompt-response usage and Claude's optional cumulative cost.
     standard_usage: StandardUsageTracker,
     /// Known adapter identity for prompt-response usage mapping.
@@ -561,9 +576,25 @@ impl AcpClient {
             steering_supported: false,
             steer_rx: None,
             goose_usage: UsageTracker::default(),
+            local_publication_publisher: None,
+            buzz_prompt_metadata: None,
             standard_usage: StandardUsageTracker::default(),
             standard_adapter,
         })
+    }
+
+    /// Install (or clear) the local publication boundary for this
+    /// process. Production enables it explicitly with
+    /// `BUZZ_ACP_LOCAL_PUBLICATION_ENABLED=true`.
+    pub(crate) fn set_local_publication_publisher(
+        &mut self,
+        publisher: Option<LocalPublicationPublisher>,
+    ) {
+        self.local_publication_publisher = publisher;
+    }
+
+    pub(crate) fn set_buzz_prompt_metadata(&mut self, metadata: Option<serde_json::Value>) {
+        self.buzz_prompt_metadata = metadata;
     }
 
     /// Attach a local observer feed to this ACP client.
@@ -597,6 +628,36 @@ impl AcpClient {
                 payload,
             );
         }
+    }
+
+    /// The publication extension carries user-authored output to a strictly
+    /// local signer. Keep that body out of debug wire logs and observer frames;
+    /// correlation identifiers and byte length remain observable.
+    fn observe_acp_read(&self, msg: &serde_json::Value) {
+        if is_local_publication_update(msg) {
+            let mut redacted = msg.clone();
+            if let Some(update) = redacted.pointer_mut("/params/update") {
+                let content_bytes = update
+                    .get("content")
+                    .and_then(|value| value.as_str())
+                    .map(str::len)
+                    .unwrap_or(0);
+                update["content"] = serde_json::json!("[redacted local publication content]");
+                update["contentBytes"] = serde_json::json!(content_bytes);
+            }
+            tracing::debug!(
+                target: "acp::wire",
+                "received redacted buzz_local_publication update"
+            );
+            self.observe("acp_read", redacted);
+            return;
+        }
+        tracing::debug!(
+            target: "acp::wire",
+            "← {}",
+            serde_json::to_string(msg).unwrap_or_default()
+        );
+        self.observe("acp_read", msg.clone());
     }
 
     /// Send the `initialize` request and return the agent's response result value.
@@ -781,7 +842,8 @@ impl AcpClient {
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
-        let params = build_prompt_params(session_id, prompt_blocks);
+        let params =
+            build_prompt_params(session_id, prompt_blocks, self.buzz_prompt_metadata.take());
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
 
@@ -1214,9 +1276,6 @@ impl AcpClient {
                 continue;
             }
 
-            // Only log and reset idle after we have a valid non-empty line.
-            tracing::debug!(target: "acp::wire", "← {trimmed}");
-
             let msg: serde_json::Value = match serde_json::from_str(trimmed) {
                 Ok(v) => v,
                 Err(e) => {
@@ -1234,7 +1293,7 @@ impl AcpClient {
                     continue;
                 }
             };
-            self.observe("acp_read", msg.clone());
+            self.observe_acp_read(&msg);
 
             // Check if this is a response to our expected request (has matching id
             // AND no `method` field — a `method` field means it's an agent-initiated
@@ -1538,8 +1597,6 @@ impl AcpClient {
                         continue;
                     }
 
-                    tracing::debug!(target: "acp::wire", "← {trimmed}");
-
                     let msg: serde_json::Value = match serde_json::from_str(trimmed) {
                         Ok(v) => v,
                         Err(e) => {
@@ -1557,7 +1614,7 @@ impl AcpClient {
                             continue;
                         }
                     };
-                    self.observe("acp_read", msg.clone());
+                    self.observe_acp_read(&msg);
 
                     let activity_now = Instant::now();
                     idle_deadline = activity_now + idle_timeout;
@@ -1753,6 +1810,24 @@ impl AcpClient {
             .unwrap_or("unknown");
 
         match update_type {
+            "buzz_local_publication" => {
+                let Some(publisher) = &self.local_publication_publisher else {
+                    tracing::warn!(
+                        target: "buzz::local_publication",
+                        "discarded local publication update because the publisher is disabled"
+                    );
+                    return false;
+                };
+                match serde_json::from_value::<LocalPublicationIntent>(update.clone()) {
+                    Ok(intent) => publisher.enqueue(intent),
+                    Err(error) => tracing::warn!(
+                        target: "buzz::local_publication",
+                        error = %error,
+                        "discarded malformed local publication update"
+                    ),
+                }
+                false
+            }
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
                     tracing::info!(target: "acp::stream", "{text}");
@@ -2041,15 +2116,23 @@ impl AcpClient {
 }
 
 /// Build `session/prompt` params from one or more text content blocks.
-fn build_prompt_params(session_id: &str, prompt_blocks: &[&str]) -> serde_json::Value {
+fn build_prompt_params(
+    session_id: &str,
+    prompt_blocks: &[&str],
+    buzz_metadata: Option<serde_json::Value>,
+) -> serde_json::Value {
     let blocks: Vec<serde_json::Value> = prompt_blocks
         .iter()
         .map(|text| serde_json::json!({ "type": "text", "text": text }))
         .collect();
-    serde_json::json!({
+    let mut params = serde_json::json!({
         "sessionId": session_id,
         "prompt": blocks,
-    })
+    });
+    if let Some(metadata) = buzz_metadata {
+        params["_meta"] = serde_json::json!({ "buzz": metadata });
+    }
+    params
 }
 
 /// Build `_goose/unstable/session/steer` params from one or more text
@@ -2585,6 +2668,7 @@ mod tests {
                 "/goal ship it",
                 "[Buzz event: @mention]\nContent: @Eva /goal ship it",
             ],
+            None,
         );
         let prompt = params["prompt"].as_array().unwrap();
         assert_eq!(prompt.len(), 2);

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4,6 +4,7 @@ mod acp;
 mod config;
 mod engram_fetch;
 mod filter;
+mod local_publication;
 mod observer;
 mod pool;
 mod pool_lifecycle;
@@ -2385,6 +2386,7 @@ async fn tokio_main() -> Result<()> {
         Panic(tokio::task::JoinError),
         SteerAck(SteerAckEvent),
         Wake(u32, Result<AgentPool, String>),
+        QueueRetryReady,
     }
 
     loop {
@@ -2517,6 +2519,17 @@ async fn tokio_main() -> Result<()> {
             }
         }
 
+        // A failed batch may be the only work on an otherwise quiet relay.
+        // Snapshot its exact deadline before splitting the pool borrow so the
+        // select loop can wake and redispatch it without external traffic.
+        let queue_retry_deadline = if pool_ready {
+            queue
+                .next_retry_deadline()
+                .map(tokio::time::Instant::from_std)
+        } else {
+            None
+        };
+
         // Borrow result_rx and join_set simultaneously via split-borrow helper.
         let pool_event: Option<PoolEvent> = {
             let (result_rx, join_set) = pool.rx_and_join_set();
@@ -2548,6 +2561,12 @@ async fn tokio_main() -> Result<()> {
                 Some((attempt, result)) = wake_rx.recv(), if config.lazy_pool && !pool_ready => {
                     Some(PoolEvent::Wake(attempt, result))
                 }
+                _ = async {
+                    match queue_retry_deadline {
+                        Some(deadline) => tokio::time::sleep_until(deadline).await,
+                        None => std::future::pending().await,
+                    }
+                } => Some(PoolEvent::QueueRetryReady),
                 // Gated on pending work: with an empty queue there is nothing
                 // for the retry to dispatch, and a past `retry_at` would
                 // otherwise complete instantly on every iteration (busy spin).
@@ -2762,13 +2781,17 @@ async fn tokio_main() -> Result<()> {
                                 // contain "!shutdown" from a non-owner.
                             }
 
-                            // Mirrors !shutdown: kind:9, content "!cancel", from
-                            // owner, mentions THIS agent. Must be BEFORE
-                            // queue.push() — the event content is moved by push.
+                            // Mirrors !shutdown: kind:9, content "!cancel",
+                            // mentions THIS agent. Must be BEFORE queue.push()
+                            // — the event content is moved by push.
                             //
                             // Mode-independent: !cancel fires regardless of
                             // --multiple-event-handling. It is explicit user
-                            // intent, not an automatic policy decision.
+                            // intent, not an automatic policy decision. Owners
+                            // retain channel-wide cancellation authority here.
+                            // Other authorized members are handled after the
+                            // inbound author gate and may cancel only a turn
+                            // triggered by their own event.
                             let is_cancel = is_owner_control_command(
                                 &buzz_event.event,
                                 kind_u32,
@@ -2792,7 +2815,8 @@ async fn tokio_main() -> Result<()> {
                                         continue; // consume event — do NOT push to queue
                                     }
                                 }
-                                // Not from owner — fall through to normal prompt handling.
+                                // Non-owner control commands continue through
+                                // the author gate, then are consumed below.
                             }
 
                             // Mirrors !shutdown / !cancel: kind:9, content
@@ -2877,6 +2901,24 @@ async fn tokio_main() -> Result<()> {
                                     );
                                     continue;
                                 }
+                            }
+
+                            if is_cancel {
+                                let author = buzz_event.event.pubkey.to_hex();
+                                let fired = signal_in_flight_task_for_author(
+                                    &mut pool,
+                                    buzz_event.channel_id,
+                                    &author,
+                                    ControlSignal::Cancel,
+                                );
+                                if !fired {
+                                    tracing::warn!(
+                                        channel_id = %buzz_event.channel_id,
+                                        author = %author,
+                                        "!cancel received but no in-flight turn from this author — no-op"
+                                    );
+                                }
+                                continue; // consume control event; never queue as a prompt
                             }
 
                             let matched = filter::match_event(&buzz_event.event, buzz_event.channel_id, &rules, &pubkey_hex).await;
@@ -3190,6 +3232,13 @@ async fn tokio_main() -> Result<()> {
                     tracing::error!("all agents dead — exiting");
                     break;
                 }
+                for (channel_id, thread_tags) in
+                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
+                {
+                    typing_channels.insert(channel_id, thread_tags);
+                }
+            }
+            Some(PoolEvent::QueueRetryReady) => {
                 for (channel_id, thread_tags) in
                     dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
                 {
@@ -3594,6 +3643,38 @@ fn signal_in_flight_task(
     false
 }
 
+/// Send a control signal only when the in-flight turn was triggered by an
+/// event from `author_pubkey`. This lets an authorized community member cancel
+/// their own turn without granting channel-wide cancellation authority.
+fn signal_in_flight_task_for_author(
+    pool: &mut AgentPool,
+    channel_id: uuid::Uuid,
+    author_pubkey: &str,
+    mode: ControlSignal,
+) -> bool {
+    let entry = pool.task_map_mut().values_mut().find(|meta| {
+        meta.channel_id == Some(channel_id)
+            && meta
+                .prompt_author_pubkeys
+                .iter()
+                .any(|pubkey| pubkey == author_pubkey)
+    });
+
+    if let Some(meta) = entry {
+        if let Some(tx) = meta.control_tx.take() {
+            tracing::info!(
+                channel = %channel_id,
+                author = %author_pubkey,
+                ?mode,
+                "author-scoped control signal sent to in-flight task"
+            );
+            let _ = tx.send(mode);
+            return true;
+        }
+    }
+    false
+}
+
 /// Attempt the non-cancelling (ACP) steer for a freshly-queued event.
 ///
 /// Caller invariants:
@@ -3735,6 +3816,14 @@ fn dispatch_pending(
         };
         tracing::debug!(agent = agent.index, channel = %channel_id, affinity_hit, "agent_claimed");
 
+        let prompt_author_pubkeys = batch
+            .events
+            .iter()
+            .chain(batch.cancelled_events.iter())
+            .map(|entry| entry.event.pubkey.to_hex())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
         let recoverable_batch = match ctx.dedup_mode {
             DedupMode::Queue => Some(batch.clone()),
             DedupMode::Drop => None,
@@ -3781,6 +3870,7 @@ fn dispatch_pending(
             pool::TaskMeta {
                 agent_index,
                 channel_id: Some(channel_id),
+                prompt_author_pubkeys,
                 turn_id,
                 recoverable_batch,
                 control_tx: Some(control_tx),
@@ -3900,7 +3990,6 @@ fn handle_prompt_result(
     // branch below records what actually happened; only the hard-timeout
     // match arm in the death_message construction reads it.
     let mut hard_timeout_fate_suffix: Option<&'static str> = None;
-
     // Requeue BEFORE mark_complete: requeue() sets retry_after with a future
     // deadline, and mark_complete() checks for it to decide whether to preserve
     // retry_counts. If mark_complete runs first, retry_counts is cleared and
@@ -4417,6 +4506,7 @@ fn dispatch_heartbeat(
         pool::TaskMeta {
             agent_index,
             channel_id: None,
+            prompt_author_pubkeys: Vec::new(),
             turn_id,
             recoverable_batch: None,
             control_tx: None,
@@ -5059,6 +5149,17 @@ fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
                     });
                 }
             }
+            // Preserve the canonical auth authority when the harness dials a
+            // restricted edge alias. Child MCP tools can use the same trusted
+            // community identity instead of treating the alias as a tenant.
+            if let Ok(canonical_relay_url) = std::env::var("BUZZ_CANONICAL_RELAY_URL") {
+                if !canonical_relay_url.trim().is_empty() {
+                    env.push(EnvVar {
+                        name: "BUZZ_CANONICAL_RELAY_URL".into(),
+                        value: canonical_relay_url,
+                    });
+                }
+            }
             // Forward the agent's display name so dev-mcp can use it as the git
             // author name instead of the raw npub. Read from the process env
             // rather than Config: this is a pass-through of a contract owned
@@ -5216,6 +5317,7 @@ mod owner_control_command_tests {
             pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                prompt_author_pubkeys: vec!["author-a".to_string()],
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: Some(control_tx),
@@ -5239,6 +5341,51 @@ mod owner_control_command_tests {
             &mut pool,
             channel_id,
             ControlSignal::Rotate
+        ));
+    }
+
+    #[tokio::test]
+    async fn author_scoped_cancel_only_signals_the_triggering_author() {
+        let mut pool = AgentPool::from_slots(vec![]);
+        let channel_id = Uuid::new_v4();
+        let (control_tx, control_rx) = tokio::sync::oneshot::channel();
+
+        let abort_handle = pool.join_set.spawn(async {});
+        pool.task_map_mut().insert(
+            abort_handle.id(),
+            pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                prompt_author_pubkeys: vec!["author-a".to_string()],
+                turn_id: "author-scoped-turn".to_string(),
+                recoverable_batch: None,
+                control_tx: Some(control_tx),
+                steer_tx: None,
+                successful_steer_deliveries: HashSet::new(),
+            },
+        );
+
+        assert!(
+            !signal_in_flight_task_for_author(
+                &mut pool,
+                channel_id,
+                "author-b",
+                ControlSignal::Cancel,
+            ),
+            "another authorized member must not cancel this author's turn"
+        );
+        assert!(signal_in_flight_task_for_author(
+            &mut pool,
+            channel_id,
+            "author-a",
+            ControlSignal::Cancel,
+        ));
+        assert_eq!(control_rx.await.unwrap(), ControlSignal::Cancel);
+        assert!(!signal_in_flight_task_for_author(
+            &mut pool,
+            channel_id,
+            "author-a",
+            ControlSignal::Cancel,
         ));
     }
 
@@ -6840,6 +6987,24 @@ mod build_mcp_servers_tests {
     }
 
     #[test]
+    fn session_new_mcp_server_forwards_canonical_relay_url() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("BUZZ_CANONICAL_RELAY_URL", "wss://relay.example");
+        let config = test_config();
+        let servers = build_mcp_servers(&config);
+        std::env::remove_var("BUZZ_CANONICAL_RELAY_URL");
+
+        let canonical_env = servers[0]
+            .env
+            .iter()
+            .find(|entry| entry.name == "BUZZ_CANONICAL_RELAY_URL");
+        assert_eq!(
+            canonical_env.map(|entry| entry.value.as_str()),
+            Some("wss://relay.example")
+        );
+    }
+
+    #[test]
     fn test_display_name_set_is_forwarded_to_mcp_server() {
         let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("BUZZ_ACP_DISPLAY_NAME", "Duncan");
@@ -7034,11 +7199,16 @@ mod error_outcome_emission_tests {
     /// an `OwnedAgent` to move into respawn or return to the pool. The error
     /// branches never talk to the subprocess.
     async fn dummy_agent(index: usize) -> OwnedAgent {
+        #[cfg(windows)]
+        let (command, args): (&str, Vec<String>) =
+            ("cmd", vec!["/C".to_string(), "more".to_string()]);
+        #[cfg(not(windows))]
+        let (command, args): (&str, Vec<String>) = ("cat", vec![]);
         OwnedAgent {
             index,
-            acp: AcpClient::spawn("cat", &[], &[], false)
+            acp: AcpClient::spawn(command, &args, &[], false)
                 .await
-                .expect("spawn cat as inert agent"),
+                .expect("spawn inert agent"),
             state: Default::default(),
             model_capabilities: None,
             desired_model: None,
@@ -7075,6 +7245,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                prompt_author_pubkeys: Vec::new(),
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7147,6 +7318,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                prompt_author_pubkeys: Vec::new(),
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7262,6 +7434,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                prompt_author_pubkeys: Vec::new(),
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7327,6 +7500,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                prompt_author_pubkeys: Vec::new(),
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7404,6 +7578,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                prompt_author_pubkeys: Vec::new(),
                 turn_id: "panic-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7497,6 +7672,7 @@ mod error_outcome_emission_tests {
                 crate::pool::TaskMeta {
                     agent_index: 0,
                     channel_id: None,
+                    prompt_author_pubkeys: Vec::new(),
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -7589,6 +7765,7 @@ mod error_outcome_emission_tests {
                 crate::pool::TaskMeta {
                     agent_index: 0,
                     channel_id: None,
+                    prompt_author_pubkeys: Vec::new(),
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -7695,6 +7872,7 @@ mod error_outcome_emission_tests {
                 crate::pool::TaskMeta {
                     agent_index: 0,
                     channel_id: None,
+                    prompt_author_pubkeys: Vec::new(),
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -7772,6 +7950,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                prompt_author_pubkeys: Vec::new(),
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7867,6 +8046,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                prompt_author_pubkeys: Vec::new(),
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7984,6 +8164,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                prompt_author_pubkeys: Vec::new(),
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -8124,6 +8305,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                prompt_author_pubkeys: Vec::new(),
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -8276,13 +8458,7 @@ mod error_outcome_emission_tests {
         );
     }
 
-    // ── auth error dead-letter behavior ────────────────────────────────────
-
-    /// An auth-class `PromptOutcome::Error` must dead-letter immediately
-    /// (the batch is never requeued) so the user sees a re-auth hint at once
-    /// rather than after 10 futile retries.
-    #[tokio::test]
-    async fn auth_error_dead_letters_immediately_without_requeueing() {
+    async fn assert_agent_error_dead_letters_immediately(error: acp::AcpError) {
         let keys = nostr::Keys::generate();
         let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "test")
             .sign_with_keys(&keys)
@@ -8298,13 +8474,6 @@ mod error_outcome_emission_tests {
             cancelled_events: vec![],
             cancel_reason: None,
         };
-
-        let auth_error = acp::AcpError::AgentError {
-            code: -32000,
-            message: "API Error: 401 OAuth access token has expired. Re-authenticate to continue."
-                .to_string(),
-        };
-
         let agent = dummy_agent(0).await;
         let mut pool = AgentPool::from_slots(vec![None]);
         let task_id = pool.join_set.spawn(async {}).id();
@@ -8313,6 +8482,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                prompt_author_pubkeys: Vec::new(),
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -8335,7 +8505,7 @@ mod error_outcome_emission_tests {
             agent,
             source: PromptSource::Channel(channel_id),
             turn_id: "test-turn-id".to_string(),
-            outcome: PromptOutcome::Error(auth_error),
+            outcome: PromptOutcome::Error(error),
             batch: Some(batch),
         };
         handle_prompt_result(
@@ -8352,17 +8522,23 @@ mod error_outcome_emission_tests {
             None,
         );
 
-        // The batch must not be requeued: pending_channels returns 0.
-        assert_eq!(
-            queue.pending_channels(),
-            0,
-            "auth error must dead-letter immediately — batch must not be requeued"
-        );
-        assert_eq!(
-            queue.queued_event_count(&channel_id),
-            0,
-            "auth error must dead-letter immediately — no events should be pending"
-        );
+        assert_eq!(queue.pending_channels(), 0);
+        assert_eq!(queue.queued_event_count(&channel_id), 0);
+    }
+
+    // ── auth error dead-letter behavior ────────────────────────────────────
+
+    /// An auth-class `PromptOutcome::Error` must dead-letter immediately
+    /// (the batch is never requeued) so the user sees a re-auth hint at once
+    /// rather than after 10 futile retries.
+    #[tokio::test]
+    async fn auth_error_dead_letters_immediately_without_requeueing() {
+        let auth_error = acp::AcpError::AgentError {
+            code: -32000,
+            message: "API Error: 401 OAuth access token has expired. Re-authenticate to continue."
+                .to_string(),
+        };
+        assert_agent_error_dead_letters_immediately(auth_error).await;
     }
 
     /// A non-auth application error (e.g. usage credits) must still follow the
@@ -8399,6 +8575,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                prompt_author_pubkeys: Vec::new(),
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,

--- a/crates/buzz-acp/src/local_publication.rs
+++ b/crates/buzz-acp/src/local_publication.rs
@@ -1,0 +1,1188 @@
+//! Optional local publication boundary for ACP adapters.
+//!
+//! The remote compute process never receives the Buzz agent's private key.
+//! Instead, an adapter emits a structured ACP update after it has acquired a
+//! server-side publication fence. `buzz-acp` validates that update, signs the
+//! message locally, submits it through the normal relay REST path, and reports
+//! the resulting Nostr event id to the configured completion endpoint.
+
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+use nostr::{Alphabet, EventBuilder, Filter, Kind, SingleLetterTag, Tag, Timestamp};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use crate::relay::RestClient;
+
+const COMPLETE_TIMEOUT: Duration = Duration::from_secs(5);
+const RELAY_LOOKUP_TIMEOUT: Duration = Duration::from_secs(3);
+const COMPLETE_RETRY_DELAYS: [Duration; 4] = [
+    Duration::from_millis(100),
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+    Duration::from_secs(1),
+];
+const PUBLISH_RETRY_DELAYS: [Duration; 9] = [
+    Duration::from_millis(100),
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+    Duration::from_secs(5),
+    Duration::from_secs(10),
+    Duration::from_secs(15),
+    Duration::from_secs(30),
+];
+const PUBLISH_RETRY_MAX_ELAPSED: Duration = Duration::from_secs(15 * 60);
+const STATUS_PUBLISH_RETRY_MAX_ELAPSED: Duration = Duration::from_secs(15);
+const STATUS_PUBLISH_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(10);
+const TERMINAL_RECEIPT_RETENTION: Duration = Duration::from_secs(5 * 60);
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LocalPublicationIntent {
+    #[serde(rename = "sessionUpdate")]
+    pub session_update: String,
+    pub community_id: String,
+    pub agent_public_key: String,
+    pub receipt_id: String,
+    pub fence_id: String,
+    #[serde(default)]
+    pub status_surface_fence_id: Option<String>,
+    pub channel_id: String,
+    pub thread_root_event_id: Option<String>,
+    pub reply_to_event_id: String,
+    pub publication_kind: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LocalPublicationPublisher {
+    worker: Arc<LocalPublicationWorker>,
+    queue: mpsc::UnboundedSender<LocalPublicationIntent>,
+}
+
+#[derive(Debug)]
+struct LocalPublicationWorker {
+    rest: RestClient,
+    completion_api_base_url: String,
+    internal_token: String,
+    last_status_edit_created_at: AtomicU64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LocalPublicationMode {
+    Create,
+    EditStatusSurface,
+    DeleteStatusSurfaceThenCreate,
+}
+
+#[derive(Debug, Default)]
+struct LocalPublicationQueueState {
+    pending: VecDeque<LocalPublicationIntent>,
+    superseded: HashMap<String, Vec<LocalPublicationIntent>>,
+    terminal_receipts: HashMap<String, TerminalPublicationState>,
+}
+
+#[derive(Debug)]
+struct TerminalPublicationState {
+    event_id: Option<String>,
+    updated_at: Instant,
+}
+
+impl LocalPublicationQueueState {
+    fn accept(&mut self, intent: LocalPublicationIntent) {
+        self.prune_terminal_receipts();
+        if is_terminal_publication(&intent) {
+            let receipt_id = intent.receipt_id.clone();
+            self.terminal_receipts
+                .entry(receipt_id.clone())
+                .or_insert_with(|| TerminalPublicationState {
+                    event_id: None,
+                    updated_at: Instant::now(),
+                });
+            let mut retained = VecDeque::with_capacity(self.pending.len());
+            while let Some(pending) = self.pending.pop_front() {
+                if pending.receipt_id == receipt_id && is_status_publication(&pending) {
+                    self.supersede(pending);
+                } else {
+                    retained.push_back(pending);
+                }
+            }
+            self.pending = retained;
+            self.pending.push_front(intent);
+            return;
+        }
+
+        if is_status_publication(&intent) {
+            if self.terminal_receipts.contains_key(&intent.receipt_id) {
+                self.supersede(intent);
+                return;
+            }
+            if let Some(position) = self.pending.iter().position(|pending| {
+                pending.receipt_id == intent.receipt_id && is_status_publication(pending)
+            }) {
+                if let Some(previous) = self.pending.remove(position) {
+                    self.supersede(previous);
+                }
+                self.pending.insert(position, intent);
+                return;
+            }
+        }
+
+        self.pending.push_back(intent);
+    }
+
+    fn should_preempt(
+        &self,
+        current: &LocalPublicationIntent,
+        incoming: &LocalPublicationIntent,
+    ) -> bool {
+        if is_terminal_publication(incoming) && !is_terminal_publication(current) {
+            // A terminal edit depends on the original receipt/status surface, and a
+            // same-turn approval/action must remain visible before the final response.
+            // Let either critical publication finish if it is already in flight.
+            return incoming.status_surface_fence_id.as_deref() != Some(current.fence_id.as_str())
+                && !(current.publication_kind == "action"
+                    && current.receipt_id == incoming.receipt_id);
+        }
+        is_status_publication(current)
+            && is_status_publication(incoming)
+            && current.receipt_id == incoming.receipt_id
+    }
+
+    fn requeue_preempted(&mut self, intent: LocalPublicationIntent) {
+        if is_status_publication(&intent) {
+            self.supersede(intent);
+        } else {
+            self.pending.push_back(intent);
+        }
+    }
+
+    fn supersede(&mut self, intent: LocalPublicationIntent) {
+        self.superseded
+            .entry(intent.receipt_id.clone())
+            .or_default()
+            .push(intent);
+    }
+
+    fn take_next(&mut self) -> Option<LocalPublicationIntent> {
+        self.pending.pop_front()
+    }
+
+    fn take_superseded(&mut self, receipt_id: &str) -> Vec<LocalPublicationIntent> {
+        self.superseded.remove(receipt_id).unwrap_or_default()
+    }
+
+    fn mark_terminal_published(&mut self, receipt_id: &str, event_id: &str) {
+        self.terminal_receipts.insert(
+            receipt_id.to_string(),
+            TerminalPublicationState {
+                event_id: Some(event_id.to_string()),
+                updated_at: Instant::now(),
+            },
+        );
+    }
+
+    fn take_terminal_reconciliations(&mut self) -> Vec<(Vec<LocalPublicationIntent>, String)> {
+        let ready = self
+            .terminal_receipts
+            .iter()
+            .filter_map(|(receipt_id, terminal)| {
+                terminal
+                    .event_id
+                    .as_ref()
+                    .filter(|_| self.superseded.contains_key(receipt_id))
+                    .map(|event_id| (receipt_id.clone(), event_id.clone()))
+            })
+            .collect::<Vec<_>>();
+        ready
+            .into_iter()
+            .filter_map(|(receipt_id, event_id)| {
+                self.superseded
+                    .remove(&receipt_id)
+                    .map(|intents| (intents, event_id))
+            })
+            .collect()
+    }
+
+    fn prune_terminal_receipts(&mut self) {
+        let superseded = &self.superseded;
+        self.terminal_receipts.retain(|receipt_id, terminal| {
+            terminal.event_id.is_none()
+                || terminal.updated_at.elapsed() < TERMINAL_RECEIPT_RETENTION
+                || superseded.contains_key(receipt_id)
+        });
+    }
+}
+
+impl LocalPublicationPublisher {
+    pub(crate) fn from_env(rest: RestClient) -> Option<Self> {
+        if !matches!(
+            std::env::var("BUZZ_ACP_LOCAL_PUBLICATION_ENABLED")
+                .ok()
+                .as_deref(),
+            Some("1" | "true" | "TRUE")
+        ) {
+            return None;
+        }
+        let completion_api_base_url = std::env::var("BUZZ_ACP_PUBLICATION_API_BASE_URL")
+            .ok()?
+            .trim()
+            .trim_end_matches('/')
+            .to_string();
+        if !(completion_api_base_url.starts_with("https://")
+            || completion_api_base_url.starts_with("http://127.0.0.1")
+            || completion_api_base_url.starts_with("http://localhost"))
+        {
+            tracing::error!(
+                target: "buzz::local_publication",
+                "BUZZ_ACP_PUBLICATION_API_BASE_URL must use HTTPS (loopback HTTP is allowed for tests)"
+            );
+            return None;
+        }
+        let internal_token = std::env::var("BUZZ_ACP_PUBLICATION_TOKEN").ok()?;
+        if internal_token.trim().is_empty() {
+            return None;
+        }
+        let worker = Arc::new(LocalPublicationWorker {
+            rest,
+            completion_api_base_url,
+            internal_token,
+            last_status_edit_created_at: AtomicU64::new(0),
+        });
+        let (queue, mut receiver) = mpsc::unbounded_channel();
+        let queued_worker = Arc::clone(&worker);
+        tokio::spawn(async move {
+            queued_worker.run(&mut receiver).await;
+        });
+        Some(Self { worker, queue })
+    }
+
+    pub(crate) fn enqueue(&self, intent: LocalPublicationIntent) {
+        if let Err(error) = validate_intent(&intent, &self.worker.rest) {
+            tracing::error!(
+                target: "buzz::local_publication",
+                receipt_id = %intent.receipt_id,
+                fence_id = %intent.fence_id,
+                publication_kind = %intent.publication_kind,
+                error = %error,
+                "rejected invalid local Buzz publication"
+            );
+            return;
+        }
+        if self.queue.send(intent).is_err() {
+            tracing::error!(
+                target: "buzz::local_publication",
+                "local Buzz publication queue is unavailable"
+            );
+        }
+    }
+}
+
+impl LocalPublicationWorker {
+    async fn run(self: Arc<Self>, receiver: &mut mpsc::UnboundedReceiver<LocalPublicationIntent>) {
+        let mut state = LocalPublicationQueueState::default();
+        let mut input_open = true;
+        loop {
+            while let Ok(intent) = receiver.try_recv() {
+                state.accept(intent);
+            }
+            self.spawn_terminal_reconciliations(&mut state);
+
+            let Some(intent) = state.take_next() else {
+                if !input_open {
+                    return;
+                }
+                match receiver.recv().await {
+                    Some(intent) => {
+                        state.accept(intent);
+                        continue;
+                    }
+                    None => {
+                        input_open = false;
+                        continue;
+                    }
+                }
+            };
+
+            let mut preempted = false;
+            let mut published_event_id = None;
+            let mut publication = Box::pin(self.publish_with_retry(&intent));
+            loop {
+                tokio::select! {
+                    biased;
+                    incoming = receiver.recv(), if input_open && !is_terminal_publication(&intent) => {
+                        match incoming {
+                            Some(incoming) => {
+                                let should_preempt = state.should_preempt(&intent, &incoming);
+                                state.accept(incoming);
+                                if should_preempt {
+                                    preempted = true;
+                                    break;
+                                }
+                            }
+                            None => input_open = false,
+                        }
+                    }
+                    result = &mut publication => {
+                        published_event_id = result;
+                        break;
+                    }
+                }
+            }
+            drop(publication);
+
+            if preempted {
+                tracing::debug!(
+                    target: "buzz::local_publication",
+                    receipt_id = %intent.receipt_id,
+                    fence_id = %intent.fence_id,
+                    publication_kind = %intent.publication_kind,
+                    "preempted a local Buzz publication for newer or terminal output"
+                );
+                state.requeue_preempted(intent);
+                continue;
+            }
+
+            if let Some(event_id) = published_event_id {
+                let receipt_id = intent.receipt_id.clone();
+                if is_terminal_publication(&intent) {
+                    state.mark_terminal_published(&receipt_id, &event_id);
+                }
+                if is_status_publication(&intent) || is_terminal_publication(&intent) {
+                    let superseded = state.take_superseded(&receipt_id);
+                    self.spawn_superseded_reconciliation(superseded, event_id);
+                }
+            }
+        }
+    }
+
+    fn spawn_terminal_reconciliations(self: &Arc<Self>, state: &mut LocalPublicationQueueState) {
+        for (intents, event_id) in state.take_terminal_reconciliations() {
+            self.spawn_superseded_reconciliation(intents, event_id);
+        }
+    }
+
+    fn spawn_superseded_reconciliation(
+        self: &Arc<Self>,
+        intents: Vec<LocalPublicationIntent>,
+        replacement_event_id: String,
+    ) {
+        if intents.is_empty() {
+            return;
+        }
+        let worker = Arc::clone(self);
+        tokio::spawn(async move {
+            for intent in intents {
+                worker
+                    .reconcile_superseded_fence(&intent, &replacement_event_id)
+                    .await;
+            }
+        });
+    }
+
+    async fn reconcile_superseded_fence(
+        &self,
+        intent: &LocalPublicationIntent,
+        replacement_event_id: &str,
+    ) {
+        let fence_tag_value = format!("buzz-local-publication:{}", intent.fence_id);
+        let event_id = match self.find_existing_event(40003, &fence_tag_value).await {
+            Ok(Some(event)) => {
+                event_id(&event).unwrap_or_else(|_| replacement_event_id.to_string())
+            }
+            Ok(None) | Err(_) => replacement_event_id.to_string(),
+        };
+        match self.complete_fence(intent, &event_id).await {
+            Ok(()) => tracing::debug!(
+                target: "buzz::local_publication",
+                receipt_id = %intent.receipt_id,
+                fence_id = %intent.fence_id,
+                "reconciled a superseded Buzz progress publication"
+            ),
+            Err(error) => tracing::warn!(
+                target: "buzz::local_publication",
+                receipt_id = %intent.receipt_id,
+                fence_id = %intent.fence_id,
+                error = %error,
+                "could not reconcile a superseded Buzz progress publication"
+            ),
+        }
+    }
+
+    async fn publish_with_retry(&self, intent: &LocalPublicationIntent) -> Option<String> {
+        let started_at = tokio::time::Instant::now();
+        let mut attempt = 1usize;
+        loop {
+            let result = if is_status_publication(intent) {
+                tokio::time::timeout(STATUS_PUBLISH_ATTEMPT_TIMEOUT, self.publish(intent))
+                    .await
+                    .map_err(|_| "status publication attempt timed out".to_string())
+                    .and_then(|result| result)
+            } else {
+                self.publish(intent).await
+            };
+            match result {
+                Ok(event_id) => return Some(event_id),
+                Err(error) => {
+                    let delay = publication_retry_delay(attempt);
+                    if started_at.elapsed().saturating_add(delay)
+                        > publication_retry_max_elapsed(intent)
+                    {
+                        tracing::error!(
+                            target: "buzz::local_publication",
+                            receipt_id = %intent.receipt_id,
+                            fence_id = %intent.fence_id,
+                            publication_kind = %intent.publication_kind,
+                            attempt,
+                            error = %error,
+                            "local Buzz publication exhausted its relay-recovery window"
+                        );
+                        return None;
+                    }
+                    tracing::warn!(
+                        target: "buzz::local_publication",
+                        receipt_id = %intent.receipt_id,
+                        fence_id = %intent.fence_id,
+                        publication_kind = %intent.publication_kind,
+                        attempt,
+                        retry_delay_ms = delay.as_millis(),
+                        error = %error,
+                        "local Buzz publication will retry after a transient boundary failure"
+                    );
+                    tokio::time::sleep(delay).await;
+                    attempt = attempt.saturating_add(1);
+                }
+            }
+        }
+    }
+
+    async fn publish(&self, intent: &LocalPublicationIntent) -> Result<String, String> {
+        validate_intent(intent, &self.rest)?;
+        match publication_mode(intent) {
+            LocalPublicationMode::EditStatusSurface => {
+                let status_surface_fence_id = intent
+                    .status_surface_fence_id
+                    .as_deref()
+                    .ok_or_else(|| "status edit is missing its target fence".to_string())?;
+                self.publish_status_edit(intent, status_surface_fence_id)
+                    .await
+            }
+            LocalPublicationMode::DeleteStatusSurfaceThenCreate => {
+                let status_surface_fence_id =
+                    intent.status_surface_fence_id.as_deref().ok_or_else(|| {
+                        "terminal publication is missing its target fence".to_string()
+                    })?;
+                self.publish_terminal(intent, status_surface_fence_id).await
+            }
+            LocalPublicationMode::Create => self.publish_message(intent).await,
+        }
+    }
+
+    async fn publish_message(&self, intent: &LocalPublicationIntent) -> Result<String, String> {
+        let fence_tag_value = format!("buzz-local-publication:{}", intent.fence_id);
+        if let Some(event) = self.find_existing_event(9, &fence_tag_value).await? {
+            let event_id = event_id(&event)?;
+            self.complete_fence(intent, &event_id).await?;
+            tracing::info!(
+                target: "buzz::local_publication",
+                receipt_id = %intent.receipt_id,
+                fence_id = %intent.fence_id,
+                buzz_event_id = %event_id,
+                "reconciled an already-published Buzz event"
+            );
+            return Ok(event_id);
+        }
+
+        let channel_id = Uuid::parse_str(&intent.channel_id)
+            .map_err(|_| "publication channel_id is not a UUID".to_string())?;
+        let root_hex = intent
+            .thread_root_event_id
+            .as_deref()
+            .unwrap_or(&intent.reply_to_event_id);
+        let root = nostr::EventId::from_hex(root_hex)
+            .map_err(|_| "publication thread root event id is invalid".to_string())?;
+        let thread_ref = buzz_sdk::ThreadRef {
+            root_event_id: root,
+            // Adapter-authored replies remain flat under the root.
+            parent_event_id: root,
+        };
+        let builder = buzz_sdk::build_message_with_extra_tags(
+            channel_id,
+            &intent.content,
+            Some(&thread_ref),
+            &[],
+            false,
+            &[],
+            &[vec!["d".to_string(), fence_tag_value]],
+        )
+        .map_err(|error| format!("publication build failed: {error}"))?;
+        let event_id = self.submit_builder(builder).await?;
+        self.complete_fence(intent, &event_id).await?;
+        tracing::info!(
+            target: "buzz::local_publication",
+            receipt_id = %intent.receipt_id,
+            fence_id = %intent.fence_id,
+            publication_kind = %intent.publication_kind,
+            buzz_event_id = %event_id,
+            "published locally signed adapter output"
+        );
+        Ok(event_id)
+    }
+
+    async fn publish_status_edit(
+        &self,
+        intent: &LocalPublicationIntent,
+        status_surface_fence_id: &str,
+    ) -> Result<String, String> {
+        let fence_tag_value = format!("buzz-local-publication:{}", intent.fence_id);
+        if let Some(event) = self.find_existing_event(40003, &fence_tag_value).await? {
+            let event_id = event_id(&event)?;
+            self.complete_fence(intent, &event_id).await?;
+            return Ok(event_id);
+        }
+        let target_event_id = self
+            .find_status_surface_event_id(status_surface_fence_id)
+            .await?
+            .ok_or_else(|| "status surface is not visible on the relay yet".to_string())?;
+        let channel_id = Uuid::parse_str(&intent.channel_id)
+            .map_err(|_| "publication channel_id is not a UUID".to_string())?;
+        let builder = build_status_mutation(
+            40003,
+            channel_id,
+            &target_event_id,
+            &intent.content,
+            &fence_tag_value,
+        )?
+        .custom_created_at(self.next_status_edit_created_at());
+        let event_id = self.submit_builder(builder).await?;
+        self.complete_fence(intent, &event_id).await?;
+        tracing::info!(
+            target: "buzz::local_publication",
+            receipt_id = %intent.receipt_id,
+            fence_id = %intent.fence_id,
+            publication_kind = %intent.publication_kind,
+            buzz_event_id = %event_id,
+            "edited the locally signed Buzz progress surface"
+        );
+        Ok(event_id)
+    }
+
+    async fn publish_terminal(
+        &self,
+        intent: &LocalPublicationIntent,
+        status_surface_fence_id: &str,
+    ) -> Result<String, String> {
+        self.delete_status_surface(intent, status_surface_fence_id)
+            .await?;
+        self.publish_message(intent).await
+    }
+
+    async fn delete_status_surface(
+        &self,
+        intent: &LocalPublicationIntent,
+        status_surface_fence_id: &str,
+    ) -> Result<(), String> {
+        let delete_tag_value = format!("buzz-local-publication:{}:status-delete", intent.fence_id);
+        if self
+            .find_existing_event(5, &delete_tag_value)
+            .await?
+            .is_some()
+        {
+            return Ok(());
+        }
+        let target_event_id = self
+            .find_status_surface_event_id(status_surface_fence_id)
+            .await?;
+        let Some(target_event_id) = target_event_id else {
+            // NIP-09 deletions remove the status event from normal relay queries.
+            // If a terminal retry reaches this point after deletion succeeded but
+            // final creation or fence completion failed, absence therefore means
+            // cleanup is already complete. Continue to the idempotent final create
+            // instead of retrying the now-impossible status lookup forever.
+            tracing::debug!(
+                target: "buzz::local_publication",
+                receipt_id = %intent.receipt_id,
+                fence_id = %intent.fence_id,
+                "terminal status surface is already absent"
+            );
+            return Ok(());
+        };
+        let channel_id = Uuid::parse_str(&intent.channel_id)
+            .map_err(|_| "publication channel_id is not a UUID".to_string())?;
+        let builder =
+            build_status_mutation(5, channel_id, &target_event_id, "", &delete_tag_value)?;
+        let delete_event_id = self.submit_builder(builder).await?;
+        tracing::info!(
+            target: "buzz::local_publication",
+            receipt_id = %intent.receipt_id,
+            fence_id = %intent.fence_id,
+            buzz_event_id = %delete_event_id,
+            "deleted the completed Buzz progress surface"
+        );
+        Ok(())
+    }
+
+    async fn find_status_surface_event_id(
+        &self,
+        status_surface_fence_id: &str,
+    ) -> Result<Option<String>, String> {
+        let status_tag_value = format!("buzz-local-publication:{status_surface_fence_id}");
+        self.find_existing_event(9, &status_tag_value)
+            .await?
+            .map(|event| event_id(&event))
+            .transpose()
+    }
+
+    async fn submit_builder(&self, builder: EventBuilder) -> Result<String, String> {
+        let event = builder
+            .sign_with_keys(&self.rest.keys)
+            .map_err(|error| format!("publication signing failed: {error}"))?;
+        let event_id = event.id.to_hex();
+        tokio::time::timeout(Duration::from_secs(5), self.rest.submit_event(&event))
+            .await
+            .map_err(|_| "publication relay submission timed out".to_string())?
+            .map_err(|error| format!("publication relay submission failed: {error}"))?;
+        Ok(event_id)
+    }
+
+    fn next_status_edit_created_at(&self) -> Timestamp {
+        let now = Timestamp::now().as_secs();
+        let created_at = self
+            .last_status_edit_created_at
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |previous| {
+                Some(monotonic_status_edit_created_at(now, previous))
+            })
+            .map_or(now, |previous| {
+                monotonic_status_edit_created_at(now, previous)
+            });
+        Timestamp::from(created_at)
+    }
+
+    async fn find_existing_event(
+        &self,
+        kind: u16,
+        fence_tag_value: &str,
+    ) -> Result<Option<serde_json::Value>, String> {
+        let filter = Filter::new()
+            .kind(Kind::Custom(kind))
+            .author(self.rest.keys.public_key())
+            .custom_tags(SingleLetterTag::lowercase(Alphabet::D), [fence_tag_value])
+            .limit(1);
+        let response = tokio::time::timeout(RELAY_LOOKUP_TIMEOUT, self.rest.query(&[filter]))
+            .await
+            .map_err(|_| "publication reconciliation query timed out".to_string())?
+            .map_err(|error| format!("publication reconciliation query failed: {error}"))?;
+        Ok(response
+            .as_array()
+            .and_then(|events| events.first())
+            .cloned())
+    }
+
+    async fn complete_fence(
+        &self,
+        intent: &LocalPublicationIntent,
+        event_id: &str,
+    ) -> Result<(), String> {
+        let url = format!(
+            "{}/api/buzz-bridge/publications/{}/complete",
+            self.completion_api_base_url, intent.fence_id
+        );
+        let body = serde_json::json!({
+            "receipt_id": intent.receipt_id,
+            "community_id": intent.community_id,
+            "agent_public_key": intent.agent_public_key,
+            "buzz_event_id": event_id,
+        });
+        let mut last_error = "publication fence completion failed".to_string();
+        for attempt in 0..=COMPLETE_RETRY_DELAYS.len() {
+            let result = tokio::time::timeout(
+                COMPLETE_TIMEOUT,
+                self.rest
+                    .http
+                    .post(&url)
+                    .bearer_auth(&self.internal_token)
+                    .json(&body)
+                    .send(),
+            )
+            .await;
+            match result {
+                Ok(Ok(response)) if response.status().is_success() => return Ok(()),
+                Ok(Ok(response)) => {
+                    last_error = format!(
+                        "publication fence completion returned HTTP {}",
+                        response.status().as_u16()
+                    );
+                }
+                Ok(Err(error)) => {
+                    last_error = format!("publication fence completion failed: {error}")
+                }
+                Err(_) => last_error = "publication fence completion timed out".to_string(),
+            }
+            if let Some(delay) = COMPLETE_RETRY_DELAYS.get(attempt) {
+                tokio::time::sleep(*delay).await;
+            }
+        }
+        Err(last_error)
+    }
+}
+
+fn event_id(event: &serde_json::Value) -> Result<String, String> {
+    event
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| {
+            value.len() == 64 && value.chars().all(|character| character.is_ascii_hexdigit())
+        })
+        .map(str::to_string)
+        .ok_or_else(|| "publication reconciliation returned an invalid event id".to_string())
+}
+
+fn publication_tag(parts: &[&str]) -> Result<Tag, String> {
+    Tag::parse(parts.iter().copied())
+        .map_err(|error| format!("publication tag build failed: {error}"))
+}
+
+fn build_status_mutation(
+    kind: u16,
+    channel_id: Uuid,
+    target_event_id: &str,
+    content: &str,
+    fence_tag_value: &str,
+) -> Result<EventBuilder, String> {
+    if !matches!(kind, 5 | 40003) {
+        return Err("status mutation kind is not allowed".to_string());
+    }
+    if kind == 40003 && content.trim().is_empty() {
+        return Err("status edit content is empty".to_string());
+    }
+    let target = nostr::EventId::from_hex(target_event_id)
+        .map_err(|_| "status mutation target event id is invalid".to_string())?;
+    let channel = channel_id.to_string();
+    let target = target.to_hex();
+    let tags = vec![
+        publication_tag(&["h", &channel])?,
+        publication_tag(&["e", &target])?,
+        publication_tag(&["d", fence_tag_value])?,
+    ];
+    Ok(EventBuilder::new(Kind::Custom(kind), content).tags(tags))
+}
+
+fn monotonic_status_edit_created_at(now: u64, previous: u64) -> u64 {
+    now.max(previous.saturating_add(1))
+}
+
+fn publication_mode(intent: &LocalPublicationIntent) -> LocalPublicationMode {
+    match (
+        intent.publication_kind.as_str(),
+        intent.status_surface_fence_id.as_deref(),
+    ) {
+        ("progress" | "capacity", Some(_)) => LocalPublicationMode::EditStatusSurface,
+        ("final" | "error" | "cancelled", Some(_)) => {
+            LocalPublicationMode::DeleteStatusSurfaceThenCreate
+        }
+        _ => LocalPublicationMode::Create,
+    }
+}
+
+fn is_status_publication(intent: &LocalPublicationIntent) -> bool {
+    publication_mode(intent) == LocalPublicationMode::EditStatusSurface
+}
+
+fn is_terminal_publication(intent: &LocalPublicationIntent) -> bool {
+    matches!(
+        intent.publication_kind.as_str(),
+        "final" | "error" | "cancelled"
+    )
+}
+
+fn publication_retry_max_elapsed(intent: &LocalPublicationIntent) -> Duration {
+    if is_status_publication(intent) {
+        STATUS_PUBLISH_RETRY_MAX_ELAPSED
+    } else {
+        PUBLISH_RETRY_MAX_ELAPSED
+    }
+}
+
+fn publication_retry_delay(attempt: usize) -> Duration {
+    PUBLISH_RETRY_DELAYS
+        .get(attempt.saturating_sub(1))
+        .copied()
+        .unwrap_or(PUBLISH_RETRY_DELAYS[PUBLISH_RETRY_DELAYS.len() - 1])
+}
+
+fn validate_intent(intent: &LocalPublicationIntent, rest: &RestClient) -> Result<(), String> {
+    if intent.session_update != "buzz_local_publication" {
+        return Err("publication ACP update discriminator is invalid".to_string());
+    }
+    let agent_public_key = intent.agent_public_key.trim().to_ascii_lowercase();
+    if agent_public_key != rest.keys.public_key().to_hex() {
+        return Err("publication agent key does not match the local signer".to_string());
+    }
+    if intent.community_id.trim().is_empty()
+        || intent.receipt_id.trim().is_empty()
+        || intent.fence_id.trim().is_empty()
+        || intent.reply_to_event_id.len() != 64
+        || !intent
+            .reply_to_event_id
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+        || intent.content.trim().is_empty()
+        || intent.content.len() > 64 * 1024
+        || intent
+            .status_surface_fence_id
+            .as_deref()
+            .is_some_and(|fence_id| fence_id.trim().is_empty() || fence_id.len() > 256)
+    {
+        return Err("publication intent failed local validation".to_string());
+    }
+    if !matches!(
+        intent.publication_kind.as_str(),
+        "receipt" | "progress" | "capacity" | "final" | "error" | "cancelled" | "action"
+    ) {
+        return Err("publication kind is not allowed".to_string());
+    }
+    if let Some(root) = intent.thread_root_event_id.as_deref() {
+        if root.len() != 64 || !root.chars().all(|character| character.is_ascii_hexdigit()) {
+            return Err("publication thread root event id is invalid".to_string());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr::Keys;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    fn rest(keys: Keys) -> RestClient {
+        RestClient {
+            http: reqwest::Client::new(),
+            base_url: "http://127.0.0.1:3000".to_string(),
+            keys,
+            auth_tag_json: None,
+        }
+    }
+
+    fn intent(agent_public_key: String) -> LocalPublicationIntent {
+        LocalPublicationIntent {
+            session_update: "buzz_local_publication".to_string(),
+            community_id: "example-community".to_string(),
+            agent_public_key,
+            receipt_id: Uuid::new_v4().to_string(),
+            fence_id: Uuid::new_v4().to_string(),
+            status_surface_fence_id: None,
+            channel_id: Uuid::new_v4().to_string(),
+            thread_root_event_id: None,
+            reply_to_event_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .to_string(),
+            publication_kind: "final".to_string(),
+            content: "Done".to_string(),
+        }
+    }
+
+    fn has_tag(event: &nostr::Event, key: &str, value: &str) -> bool {
+        event.tags.iter().any(|tag| {
+            let parts = tag.as_slice();
+            parts.first().map(String::as_str) == Some(key)
+                && parts.get(1).map(String::as_str) == Some(value)
+        })
+    }
+
+    async fn empty_query_server(request_count: usize) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            for _ in 0..request_count {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut request = Vec::new();
+                let mut buffer = [0_u8; 4096];
+                loop {
+                    let read = stream.read(&mut buffer).await.unwrap();
+                    if read == 0 {
+                        break;
+                    }
+                    request.extend_from_slice(&buffer[..read]);
+                    if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                stream
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n[]",
+                    )
+                    .await
+                    .unwrap();
+            }
+        });
+        (format!("http://{address}"), task)
+    }
+
+    #[tokio::test]
+    async fn terminal_retry_treats_an_absent_status_surface_as_already_deleted() {
+        let keys = Keys::generate();
+        let (base_url, server) = empty_query_server(2).await;
+        let worker = LocalPublicationWorker {
+            rest: RestClient {
+                http: reqwest::Client::new(),
+                base_url,
+                keys: keys.clone(),
+                auth_tag_json: None,
+            },
+            completion_api_base_url: "http://127.0.0.1:1".to_string(),
+            internal_token: "test-token".to_string(),
+            last_status_edit_created_at: AtomicU64::new(0),
+        };
+        let mut terminal = intent(keys.public_key().to_hex());
+        terminal.status_surface_fence_id = Some("already-deleted-surface".to_string());
+
+        assert!(worker
+            .delete_status_surface(&terminal, "already-deleted-surface")
+            .await
+            .is_ok());
+        server.await.unwrap();
+    }
+
+    #[test]
+    fn accepts_intent_only_for_the_local_signer() {
+        let keys = Keys::generate();
+        let rest = rest(keys.clone());
+        assert!(validate_intent(&intent(keys.public_key().to_hex()), &rest).is_ok());
+        let other = Keys::generate();
+        assert!(validate_intent(&intent(other.public_key().to_hex()), &rest).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_publication_fields_and_kinds() {
+        let keys = Keys::generate();
+        let mut value = serde_json::to_value(intent(keys.public_key().to_hex())).unwrap();
+        value["private_key"] = serde_json::json!("must-not-cross-boundary");
+        assert!(serde_json::from_value::<LocalPublicationIntent>(value).is_err());
+
+        let mut invalid = intent(keys.public_key().to_hex());
+        invalid.publication_kind = "arbitrary_write".to_string();
+        assert!(validate_intent(&invalid, &rest(keys)).is_err());
+    }
+
+    #[test]
+    fn accepts_legacy_intents_without_a_status_surface() {
+        let keys = Keys::generate();
+        let mut value = serde_json::to_value(intent(keys.public_key().to_hex())).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("status_surface_fence_id");
+
+        let parsed = serde_json::from_value::<LocalPublicationIntent>(value).unwrap();
+        assert!(parsed.status_surface_fence_id.is_none());
+        assert_eq!(publication_mode(&parsed), LocalPublicationMode::Create);
+    }
+
+    #[test]
+    fn routes_progress_to_edit_and_terminal_output_to_delete_then_create() {
+        let keys = Keys::generate();
+        let mut progress = intent(keys.public_key().to_hex());
+        progress.publication_kind = "progress".to_string();
+        progress.status_surface_fence_id = Some(Uuid::new_v4().to_string());
+        assert_eq!(
+            publication_mode(&progress),
+            LocalPublicationMode::EditStatusSurface
+        );
+
+        progress.publication_kind = "final".to_string();
+        assert_eq!(
+            publication_mode(&progress),
+            LocalPublicationMode::DeleteStatusSurfaceThenCreate
+        );
+
+        progress.publication_kind = "action".to_string();
+        assert_eq!(publication_mode(&progress), LocalPublicationMode::Create);
+    }
+
+    #[test]
+    fn builds_scoped_idempotent_status_edits_and_deletes() {
+        let keys = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let target = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let edit_tag = "buzz-local-publication:edit-fence";
+        let edit = build_status_mutation(40003, channel_id, target, "Working...", edit_tag)
+            .unwrap()
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert_eq!(edit.kind.as_u16(), 40003);
+        assert_eq!(edit.content, "Working...");
+        assert!(has_tag(&edit, "h", &channel_id.to_string()));
+        assert!(has_tag(&edit, "e", target));
+        assert!(has_tag(&edit, "d", edit_tag));
+
+        let delete_tag = "buzz-local-publication:terminal-fence:status-delete";
+        let delete = build_status_mutation(5, channel_id, target, "", delete_tag)
+            .unwrap()
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert_eq!(delete.kind.as_u16(), 5);
+        assert!(delete.content.is_empty());
+        assert!(has_tag(&delete, "h", &channel_id.to_string()));
+        assert!(has_tag(&delete, "e", target));
+        assert!(has_tag(&delete, "d", delete_tag));
+    }
+
+    #[test]
+    fn rejects_invalid_status_surface_targets_and_mutation_kinds() {
+        let keys = Keys::generate();
+        let rest = rest(keys.clone());
+        let mut invalid = intent(keys.public_key().to_hex());
+        invalid.status_surface_fence_id = Some("   ".to_string());
+        assert!(validate_intent(&invalid, &rest).is_err());
+        assert!(build_status_mutation(
+            9,
+            Uuid::new_v4(),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "message",
+            "fence"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn accepts_scoped_action_publications_claimed_by_the_bridge() {
+        let keys = Keys::generate();
+        let rest = rest(keys.clone());
+        let mut action = intent(keys.public_key().to_hex());
+        action.publication_kind = "action".to_string();
+
+        assert!(validate_intent(&action, &rest).is_ok());
+    }
+
+    #[test]
+    fn coalesces_queued_progress_per_receipt_without_cross_receipt_loss() {
+        let keys = Keys::generate();
+        let mut first = intent(keys.public_key().to_hex());
+        first.receipt_id = "receipt-one".to_string();
+        first.publication_kind = "progress".to_string();
+        first.status_surface_fence_id = Some("surface-one".to_string());
+        first.content = "Preparing capacity...".to_string();
+        let mut latest = first.clone();
+        latest.fence_id = Uuid::new_v4().to_string();
+        latest.content = "Starting Codex...".to_string();
+        let mut other = first.clone();
+        other.receipt_id = "receipt-two".to_string();
+        other.fence_id = Uuid::new_v4().to_string();
+        other.content = "Preparing another turn...".to_string();
+
+        let mut state = LocalPublicationQueueState::default();
+        state.accept(first);
+        state.accept(latest.clone());
+        state.accept(other.clone());
+
+        assert_eq!(state.pending.len(), 2);
+        assert_eq!(state.superseded["receipt-one"].len(), 1);
+        assert_eq!(
+            state.take_next().map(|item| item.content),
+            Some(latest.content)
+        );
+        assert_eq!(
+            state.take_next().map(|item| item.content),
+            Some(other.content)
+        );
+    }
+
+    #[test]
+    fn terminal_output_discards_pending_and_late_progress_for_its_receipt() {
+        let keys = Keys::generate();
+        let mut progress = intent(keys.public_key().to_hex());
+        progress.receipt_id = "terminal-receipt".to_string();
+        progress.publication_kind = "progress".to_string();
+        progress.status_surface_fence_id = Some("status-surface".to_string());
+        let mut terminal = progress.clone();
+        terminal.fence_id = Uuid::new_v4().to_string();
+        terminal.publication_kind = "final".to_string();
+        terminal.content = "Finished".to_string();
+        let mut late_progress = progress.clone();
+        late_progress.fence_id = Uuid::new_v4().to_string();
+
+        let mut state = LocalPublicationQueueState::default();
+        state.accept(progress);
+        state.accept(terminal.clone());
+        state.accept(late_progress);
+
+        assert_eq!(
+            state.take_next().map(|item| item.fence_id),
+            Some(terminal.fence_id)
+        );
+        assert!(state.take_next().is_none());
+        assert_eq!(state.superseded["terminal-receipt"].len(), 2);
+
+        state.mark_terminal_published("terminal-receipt", "terminal-event");
+        let reconciliations = state.take_terminal_reconciliations();
+        assert_eq!(reconciliations.len(), 1);
+        assert_eq!(reconciliations[0].0.len(), 2);
+        assert_eq!(reconciliations[0].1, "terminal-event");
+    }
+
+    #[test]
+    fn terminal_preempts_status_but_not_same_turn_surface_or_action_creation() {
+        let keys = Keys::generate();
+        let mut receipt = intent(keys.public_key().to_hex());
+        receipt.publication_kind = "receipt".to_string();
+        receipt.fence_id = "surface-fence".to_string();
+        let mut progress = receipt.clone();
+        progress.publication_kind = "progress".to_string();
+        progress.fence_id = "progress-fence".to_string();
+        progress.status_surface_fence_id = Some("surface-fence".to_string());
+        let mut terminal = progress.clone();
+        terminal.publication_kind = "final".to_string();
+        terminal.fence_id = "terminal-fence".to_string();
+        let mut action = progress.clone();
+        action.publication_kind = "action".to_string();
+        action.fence_id = "action-fence".to_string();
+        let mut unrelated_action = action.clone();
+        unrelated_action.receipt_id = "another-receipt".to_string();
+
+        let state = LocalPublicationQueueState::default();
+        assert!(state.should_preempt(&progress, &terminal));
+        assert!(!state.should_preempt(&receipt, &terminal));
+        assert!(!state.should_preempt(&action, &terminal));
+        assert!(state.should_preempt(&unrelated_action, &terminal));
+    }
+
+    #[test]
+    fn publication_retry_backoff_is_fast_then_bounded() {
+        assert_eq!(publication_retry_delay(1), Duration::from_millis(100));
+        assert_eq!(publication_retry_delay(4), Duration::from_secs(1));
+        assert_eq!(publication_retry_delay(9), Duration::from_secs(30));
+        assert_eq!(publication_retry_delay(10_000), Duration::from_secs(30));
+
+        let keys = Keys::generate();
+        let mut status = intent(keys.public_key().to_hex());
+        status.publication_kind = "progress".to_string();
+        status.status_surface_fence_id = Some("surface-fence".to_string());
+        assert_eq!(
+            publication_retry_max_elapsed(&status),
+            STATUS_PUBLISH_RETRY_MAX_ELAPSED
+        );
+        status.publication_kind = "final".to_string();
+        assert_eq!(
+            publication_retry_max_elapsed(&status),
+            PUBLISH_RETRY_MAX_ELAPSED
+        );
+    }
+
+    #[test]
+    fn status_edit_timestamps_are_strictly_monotonic_within_one_second() {
+        assert_eq!(monotonic_status_edit_created_at(1_000, 0), 1_000);
+        assert_eq!(monotonic_status_edit_created_at(1_000, 1_000), 1_001);
+        assert_eq!(monotonic_status_edit_created_at(1_000, 1_001), 1_002);
+        assert_eq!(monotonic_status_edit_created_at(1_005, 1_002), 1_005);
+    }
+}

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -59,6 +59,10 @@ pub struct SuccessfulSteerDelivery {
 pub struct TaskMeta {
     pub agent_index: usize,
     pub channel_id: Option<Uuid>,
+    /// Authors whose events are part of this prompt turn. Exact control
+    /// commands from an authorized community member may only cancel a turn
+    /// when that member owns at least one triggering event.
+    pub prompt_author_pubkeys: Vec<String>,
     /// Identifies terminal events when the task panics before returning a result.
     pub turn_id: String,
     /// Clone of batch for Queue mode panic recovery.
@@ -1791,6 +1795,9 @@ pub async fn run_prompt_task(
         turn_id.clone(),
         turn_started_at.clone(),
     ));
+    agent.acp.set_local_publication_publisher(
+        crate::local_publication::LocalPublicationPublisher::from_env(ctx.rest_client.clone()),
+    );
     let triggering_event_ids: Vec<String> = batch
         .as_ref()
         .map(|b| b.events.iter().map(|be| be.event.id.to_hex()).collect())
@@ -2310,6 +2317,7 @@ pub async fn run_prompt_task(
     // successful turn; failed/cancelled prompts must be retryable without loss.
     let mut pending_delivered_event_ids = HashSet::new();
     let prompt_sections: Vec<String> = if let Some(text) = prompt_text {
+        agent.acp.set_buzz_prompt_metadata(None);
         // Heartbeats create their session before this point, so a Goose method-not-found
         // probe has already selected the correct framing for this process.
         //
@@ -2367,6 +2375,65 @@ pub async fn run_prompt_task(
         pending_delivered_event_ids.extend(conversation_context_event_ids(
             conversation_context.as_ref(),
         ));
+
+        if let Some(trigger) = b.events.last() {
+            let trigger_event_id = trigger.event.id.to_hex();
+            let thread = crate::queue::parse_thread_tags(&trigger.event);
+            let tags: Vec<&[String]> = trigger
+                .event
+                .tags
+                .iter()
+                .map(|tag| tag.as_slice())
+                .collect();
+            let structured_context = conversation_context.as_ref().map(|context| {
+                let (kind, messages, total, truncated) = match context {
+                    ConversationContext::Thread {
+                        messages,
+                        total,
+                        truncated,
+                    } => ("thread", messages, total, truncated),
+                    ConversationContext::Dm {
+                        messages,
+                        total,
+                        truncated,
+                    } => ("dm", messages, total, truncated),
+                };
+                serde_json::json!({
+                    "kind": kind,
+                    "total": total,
+                    "truncated": truncated,
+                    "messages": messages
+                        .iter()
+                        .filter(|message| message.event_id != trigger_event_id)
+                        .map(|message| serde_json::json!({
+                            "eventId": message.event_id,
+                            "authorPublicKey": message.pubkey,
+                            "authoredAt": message.timestamp,
+                            "text": message.content,
+                        }))
+                        .collect::<Vec<_>>(),
+                })
+            });
+            agent.acp.set_buzz_prompt_metadata(Some(serde_json::json!({
+                "contractVersion": 2,
+                "eventId": trigger_event_id,
+                "channelId": b.channel_id.to_string(),
+                "channelName": channel_info.as_ref().map(|info| info.name.as_str()),
+                "kind": trigger.event.kind.as_u16() as u32,
+                "authorPublicKey": trigger.event.pubkey.to_hex(),
+                "authoredAt": chrono::DateTime::from_timestamp(
+                    trigger.event.created_at.as_secs() as i64,
+                    0,
+                ).map(|time| time.to_rfc3339()),
+                "text": trigger.event.content,
+                "tags": tags,
+                "threadRootEventId": thread.root_event_id,
+                "replyToEventId": trigger_event_id,
+                "conversationContext": structured_context,
+            })));
+        } else {
+            agent.acp.set_buzz_prompt_metadata(None);
+        }
 
         let profile_lookup =
             fetch_prompt_profile_lookup(b, conversation_context.as_ref(), &ctx.rest_client).await;
@@ -3789,6 +3856,19 @@ fn parse_dm_response(json: serde_json::Value, limit: u32) -> Option<Conversation
 ///
 /// Works with both thread reply objects and channel message objects.
 fn json_to_context_message(obj: &serde_json::Value) -> Option<ContextMessage> {
+    let event_id = match obj
+        .get("id")
+        .or_else(|| obj.get("event_id"))
+        .and_then(|v| v.as_str())
+    {
+        None => String::new(),
+        Some(event_id)
+            if event_id.len() == 64 && event_id.chars().all(|c| c.is_ascii_hexdigit()) =>
+        {
+            event_id.to_ascii_lowercase()
+        }
+        Some(_) => return None,
+    };
     let content = obj.get("content").and_then(|v| v.as_str())?;
     let pubkey = obj
         .get("pubkey")
@@ -3807,12 +3887,6 @@ fn json_to_context_message(obj: &serde_json::Value) -> Option<ContextMessage> {
             })
         })
         .unwrap_or_else(|| "unknown".to_string());
-
-    let event_id = obj
-        .get("id")
-        .and_then(|v| v.as_str())
-        .unwrap_or_default()
-        .to_string();
 
     Some(ContextMessage {
         event_id,
@@ -5055,14 +5129,14 @@ mod tests {
     fn test_parse_thread_response_basic() {
         let json = json!({
             "root": {
-                "event_id": "abc123",
+                "event_id": "a".repeat(64),
                 "pubkey": "pub1",
                 "content": "root message",
                 "created_at": 1710518400
             },
             "replies": [
                 {
-                    "event_id": "def456",
+                    "event_id": "b".repeat(64),
                     "pubkey": "pub2",
                     "content": "first reply",
                     "created_at": 1710518460
@@ -5092,14 +5166,14 @@ mod tests {
     fn test_parse_thread_response_truncated() {
         let json = json!({
             "root": {
-                "event_id": "abc",
+                "event_id": "a".repeat(64),
                 "pubkey": "pub1",
                 "content": "root",
                 "created_at": 1710518400
             },
             "replies": [
                 {
-                    "event_id": "def",
+                    "event_id": "b".repeat(64),
                     "pubkey": "pub2",
                     "content": "reply1",
                     "created_at": 1710518460
@@ -5145,13 +5219,13 @@ mod tests {
         let json = json!({
             "messages": [
                 {
-                    "event_id": "msg2",
+                    "event_id": "b".repeat(64),
                     "pubkey": "pub2",
                     "content": "newer message",
                     "created_at": 1710518500
                 },
                 {
-                    "event_id": "msg1",
+                    "event_id": "a".repeat(64),
                     "pubkey": "pub1",
                     "content": "older message",
                     "created_at": 1710518400
@@ -5184,7 +5258,7 @@ mod tests {
         let json = json!({
             "messages": [
                 {
-                    "event_id": "msg1",
+                    "event_id": "a".repeat(64),
                     "pubkey": "pub1",
                     "content": "message",
                     "created_at": 1710518400
@@ -5213,7 +5287,7 @@ mod tests {
         let json = json!({
             "messages": [
                 {
-                    "event_id": "msg1",
+                    "event_id": "a".repeat(64),
                     "pubkey": "pub1",
                     "content": "only message",
                     "created_at": 1710518400
@@ -5819,6 +5893,7 @@ mod tests {
     #[test]
     fn test_json_to_context_message_integer_timestamp() {
         let obj = json!({
+            "id": "a".repeat(64),
             "pubkey": "abc",
             "content": "hello",
             "created_at": 1710518400
@@ -5832,6 +5907,7 @@ mod tests {
     #[test]
     fn test_json_to_context_message_string_timestamp() {
         let obj = json!({
+            "id": "a".repeat(64),
             "pubkey": "abc",
             "content": "hello",
             "created_at": "2026-03-15T16:30:00+00:00"
@@ -5844,6 +5920,26 @@ mod tests {
     fn test_json_to_context_message_missing_content() {
         let obj = json!({ "pubkey": "abc" });
         assert!(json_to_context_message(&obj).is_none());
+    }
+
+    #[test]
+    fn test_json_to_context_message_legacy_missing_event_id() {
+        let obj = json!({ "pubkey": "abc", "content": "hello" });
+        let msg = json_to_context_message(&obj).expect("legacy REST fixture should parse");
+        assert!(msg.event_id.is_empty());
+    }
+
+    #[test]
+    fn test_json_to_context_message_rejects_malformed_event_id() {
+        let obj = json!({ "id": "not-an-event-id", "content": "hello" });
+        assert!(json_to_context_message(&obj).is_none());
+    }
+
+    #[test]
+    fn test_json_to_context_message_normalizes_event_id() {
+        let obj = json!({ "id": "A".repeat(64), "content": "hello" });
+        let msg = json_to_context_message(&obj).expect("valid event ID should parse");
+        assert_eq!(msg.event_id, "a".repeat(64));
     }
 
     #[test]
@@ -5871,7 +5967,7 @@ mod tests {
         };
         let context = ConversationContext::Thread {
             messages: vec![ContextMessage {
-                event_id: String::new(),
+                event_id: "a".repeat(64),
                 pubkey: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".into(),
                 timestamp: "2026-03-25T05:51:25Z".into(),
                 content: "follow up".into(),
@@ -6590,7 +6686,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
 
     #[test]
     fn test_json_to_context_message_missing_pubkey_uses_default() {
-        let obj = json!({ "content": "hello" });
+        let obj = json!({ "id": "a".repeat(64), "content": "hello" });
         let msg = json_to_context_message(&obj).expect("should parse");
         assert_eq!(msg.pubkey, "unknown");
     }

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -590,6 +590,22 @@ impl EventQueue {
             .any(|id| !self.in_flight_channels.contains(id))
     }
 
+    /// Earliest retry throttle for queued, non-in-flight work.
+    ///
+    /// The relay can be completely quiet after a failed turn. Exposing the
+    /// exact deadline lets the main loop wake itself when the backoff expires
+    /// instead of waiting for an unrelated relay or pool event.
+    pub fn next_retry_deadline(&self) -> Option<Instant> {
+        self.retry_after
+            .iter()
+            .filter(|(id, _)| {
+                !self.in_flight_channels.contains(id)
+                    && self.queues.get(id).is_some_and(|queue| !queue.is_empty())
+            })
+            .map(|(_, deadline)| *deadline)
+            .min()
+    }
+
     /// Returns `true` if any undispatched work remains for a channel that is
     /// NOT currently in-flight — *including* work held back only by a
     /// `retry_after` backoff throttle.
@@ -1023,8 +1039,10 @@ pub enum ConversationContext {
 /// A single message in a conversation context section.
 #[derive(Debug, Clone)]
 pub struct ContextMessage {
-    /// Nostr event ID. Legacy REST fixtures may omit it, in which case it is
-    /// empty and cannot participate in delivery deduplication.
+    /// Normalized relay event ID. This stays out of the human-readable prompt
+    /// but lets trusted ACP adapters preserve and deduplicate authorized
+    /// history. Legacy REST fixtures may omit it, in which case it is empty
+    /// and cannot participate in delivery deduplication.
     pub event_id: String,
     pub pubkey: String,
     pub timestamp: String,
@@ -2741,7 +2759,7 @@ mod tests {
 
         let ctx = ConversationContext::Thread {
             messages: vec![ContextMessage {
-                event_id: String::new(),
+                event_id: "a".repeat(64),
                 pubkey: "npub1test".into(),
                 content: "prior message".into(),
                 timestamp: "2024-01-01T00:00:00Z".into(),
@@ -3104,6 +3122,28 @@ mod tests {
     }
 
     #[test]
+    fn retry_deadline_is_exposed_for_quiet_channel_wakeup() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        q.push(make_queued(ch, "retry me"));
+        let batch = q.flush_next().expect("initial batch");
+        assert!(q.requeue(batch).is_none(), "retry remains within budget");
+        q.mark_complete(ch);
+
+        let deadline = q
+            .next_retry_deadline()
+            .expect("queued retry must expose a wake deadline");
+        assert!(deadline > Instant::now());
+
+        q.retry_after.insert(ch, Instant::now());
+        assert!(q.next_retry_deadline().is_some());
+        assert!(q.has_flushable_work());
+        let retry = q.flush_next().expect("expired retry must dispatch");
+        assert_eq!(retry.channel_id, ch);
+        assert!(q.next_retry_deadline().is_none());
+    }
+
+    #[test]
     fn test_requeue_dead_letters_after_max_retries() {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
@@ -3358,13 +3398,13 @@ mod tests {
         let ctx = ConversationContext::Thread {
             messages: vec![
                 ContextMessage {
-                    event_id: String::new(),
+                    event_id: "a".repeat(64),
                     pubkey: "npub1xyz".into(),
                     timestamp: "2026-03-15T16:30:00Z".into(),
                     content: "Let's refactor auth".into(),
                 },
                 ContextMessage {
-                    event_id: String::new(),
+                    event_id: "b".repeat(64),
                     pubkey: "npub1def".into(),
                     timestamp: "2026-03-15T16:35:00Z".into(),
                     content: "yes go ahead".into(),
@@ -3408,7 +3448,7 @@ mod tests {
         };
         let ctx = ConversationContext::Dm {
             messages: vec![ContextMessage {
-                event_id: String::new(),
+                event_id: "a".repeat(64),
                 pubkey: "npub1abc".into(),
                 timestamp: "2026-03-15T16:00:00Z".into(),
                 content: "Can you deploy?".into(),
@@ -3454,7 +3494,7 @@ mod tests {
         };
         let ctx = ConversationContext::Thread {
             messages: vec![ContextMessage {
-                event_id: String::new(),
+                event_id: "a".repeat(64),
                 pubkey: author_hex.clone(),
                 timestamp: "2026-03-25T05:51:25Z".into(),
                 content: "follow up".into(),
@@ -3668,7 +3708,7 @@ mod tests {
         // Thread context fetched (as the fetch path does for DM replies).
         let ctx = ConversationContext::Thread {
             messages: vec![ContextMessage {
-                event_id: String::new(),
+                event_id: "a".repeat(64),
                 pubkey: "npub1xyz".into(),
                 timestamp: "2026-03-15T16:30:00Z".into(),
                 content: "Should I deploy?".into(),

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -229,6 +229,31 @@ pub fn build_message(
     broadcast: bool,
     media_tags: &[Vec<String>],
 ) -> Result<EventBuilder, SdkError> {
+    build_message_with_extra_tags(
+        channel_id,
+        content,
+        thread_ref,
+        mentions,
+        broadcast,
+        media_tags,
+        &[],
+    )
+}
+
+/// Build a stream message (kind 9) with additional caller-owned tags.
+///
+/// This is intended for durable integration identifiers that must survive a
+/// process restart. The normal Buzz tags are still constructed and validated
+/// here; every extra tag is parsed by the Nostr library before it is attached.
+pub fn build_message_with_extra_tags(
+    channel_id: Uuid,
+    content: &str,
+    thread_ref: Option<&ThreadRef>,
+    mentions: &[&str],
+    broadcast: bool,
+    media_tags: &[Vec<String>],
+    extra_tags: &[Vec<String>],
+) -> Result<EventBuilder, SdkError> {
     check_content(content, 64 * 1024)?;
     let mut tags = vec![tag(&["h", &channel_id.to_string()])?];
     if let Some(tr) = thread_ref {
@@ -239,6 +264,10 @@ pub fn build_message(
         tags.push(tag(&["broadcast", "1"])?);
     }
     imeta_tags(media_tags, &mut tags)?;
+    for extra_tag in extra_tags {
+        let parts: Vec<&str> = extra_tag.iter().map(String::as_str).collect();
+        tags.push(Tag::parse(parts).map_err(|e| SdkError::InvalidTag(e.to_string()))?);
+    }
     Ok(EventBuilder::new(Kind::Custom(9), content)
         .tags(tags)
         .allow_self_tagging())
@@ -2383,6 +2412,19 @@ mod tests {
         let ev = sign(build_message(cid, "hello", None, &[], false, &[]).unwrap());
         assert_eq!(ev.kind.as_u16(), 9);
         assert_eq!(ev.content, "hello");
+        assert!(has_tag(&ev, "h", &cid.to_string()));
+    }
+
+    #[test]
+    fn message_with_extra_tags_preserves_durable_fence() {
+        let cid = uuid();
+        let extra = vec![vec![
+            "d".to_string(),
+            "buzz-local-publication:fence-123".to_string(),
+        ]];
+        let ev =
+            sign(build_message_with_extra_tags(cid, "hi", None, &[], false, &[], &extra).unwrap());
+        assert!(has_tag(&ev, "d", "buzz-local-publication:fence-123"));
         assert!(has_tag(&ev, "h", &cid.to_string()));
     }
 


### PR DESCRIPTION
## Summary
- add a provider-neutral, locally signed publication worker with durable fences, idempotent receipts, editable progress, terminal replacement, bounded retries, and relay recovery
- preserve same-turn publication ordering while prioritizing terminal output and coalescing stale progress
- forward bounded canonical conversation context and wake quiet channels for due retries
- make cancellation author-scoped, classify terminal enrollment/auth failures without retry loops, and forward canonical relay context to child MCP sessions
- extend the SDK message builder with validated caller-owned durable tags

## Why this is one change
The publication queue, ACP turn queue, process pool, error classification, and SDK fence tag form one turn-lifecycle state machine. Splitting them would create intermediate branches that compile but cannot preserve receipt ordering or terminal reconciliation. No provider name, credential, hosted service, or deployment policy is embedded here.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p buzz-acp -p buzz-sdk --all-targets --locked -- -D warnings`
- `cargo test -p buzz-acp local_publication --locked` (13 passed)
- `cargo test -p buzz-sdk message_with_extra_tags_preserves_durable_fence --locked` (1 passed)
- seven added focused ACP tests covering author-scoped cancellation, MCP relay forwarding, terminal auth handling, event-id context normalization, and retry wakeups (7 passed)
- changed-diff scan found no Kiingo/provider identifier or common credential literal
- `git diff --check`

The commit is signed off under the DCO.