### PR TITLE
feat(acp): isolate sessions by conversation thread

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -41,7 +41,7 @@ use pool::{
     PromptResult, PromptSource, SessionState, TimeoutKind,
 };
 use pool_lifecycle::PoolLifecycle;
-use queue::{CancelReason, EventQueue, FlushBatch, QueuedEvent, ThreadTags};
+use queue::{CancelReason, ConversationKey, EventQueue, FlushBatch, QueuedEvent, ThreadTags};
 use relay::{HarnessRelay, RelayEventPublisher};
 use tokio::sync::{mpsc, watch};
 use tracing_subscriber::EnvFilter;
@@ -1274,6 +1274,10 @@ fn emit_project_owner_control_result(
 }
 
 /// Handle a `cancel_turn` control frame: signal the in-flight task to cancel.
+///
+/// An optional `threadRootEventId` targets one conversation lane exactly.
+/// Without it, every in-flight turn for the channel is cancelled — identical
+/// to the historical behavior when at most one turn per channel existed.
 fn handle_cancel_turn_control(
     payload: &serde_json::Value,
     pool: &mut AgentPool,
@@ -1288,7 +1292,21 @@ fn handle_cancel_turn_control(
         return;
     };
 
-    let fired = signal_in_flight_task(pool, channel_id, ControlSignal::Cancel);
+    let thread_root = payload
+        .get("threadRootEventId")
+        .and_then(|value| value.as_str())
+        .map(str::to_owned);
+    let fired = match thread_root {
+        Some(root) => signal_in_flight_task(
+            pool,
+            &ConversationKey {
+                channel_id,
+                thread_root: Some(root),
+            },
+            ControlSignal::Cancel,
+        ),
+        None => signal_channel_in_flight_tasks(pool, channel_id, ControlSignal::Cancel) > 0,
+    };
     let status = if fired { "sent" } else { "no_active_turn" };
     if let Some(observer) = observer {
         observer.emit(
@@ -1346,24 +1364,28 @@ fn handle_switch_model_control(
 
     // A turn is in flight for this channel iff a task_map entry exists. The
     // agent is moved out of the pool during a turn, so the control oneshot is
-    // the only reachable lever; an idle channel has no such entry.
-    let turn_in_flight = pool
-        .task_map()
-        .values()
-        .any(|m| m.channel_id == Some(channel_id));
+    // the only reachable lever; an idle channel has no such entry. With
+    // per-thread concurrency several turns may be in flight — the switch is
+    // channel-scoped, so signal them all.
+    let turn_in_flight = pool.task_map().values().any(|m| {
+        m.conversation
+            .as_ref()
+            .is_some_and(|key| key.channel_id == channel_id)
+    });
 
     let status = if turn_in_flight {
-        // Busy path: deliver over the oneshot. `false` means the oneshot was
-        // already consumed this turn (a prior cancel/interrupt) — the turn is
-        // already ending, so the switch cannot land on it.
-        if signal_in_flight_task(
+        // Busy path: deliver over the oneshots. `0` means every oneshot was
+        // already consumed this turn (a prior cancel/interrupt) — the turns
+        // are already ending, so the switch cannot land on them.
+        if signal_channel_in_flight_tasks(
             pool,
             channel_id,
             ControlSignal::SwitchModel {
                 model_id: model_id.to_string(),
                 request_id: request_id.clone(),
             },
-        ) {
+        ) > 0
+        {
             "sent"
         } else {
             "turn_ending"
@@ -1546,10 +1568,10 @@ struct RespawnResult {
 /// stream.
 ///
 /// Carries enough identity to operate on the right withheld event in
-/// `EventQueue::withheld_native_steer`: `channel_id` is the routing key,
+/// `EventQueue::withheld_native_steer`: `conversation` is the routing key,
 /// `event_id` is the hex id of the single event the steer carried.
 struct SteerAckEvent {
-    channel_id: Uuid,
+    conversation: ConversationKey,
     event_id: String,
     /// `Ok` if the read loop sent any of the locked `SteerAck` variants.
     /// `Err` if the oneshot was dropped without a send — should not happen
@@ -2246,7 +2268,7 @@ async fn tokio_main() -> Result<()> {
     } else {
         None
     };
-    let mut typing_channels: HashMap<Uuid, ThreadTags> = HashMap::new();
+    let mut typing_channels: HashMap<ConversationKey, ThreadTags> = HashMap::new();
     let mut presence_task: Option<tokio::task::JoinHandle<()>> = None;
 
     // Independent of pool readiness: a never-mentioned lazy agent must still
@@ -2458,10 +2480,10 @@ async fn tokio_main() -> Result<()> {
             // called on relay events or pool results, neither of which
             // arrive when the channel is silent.
             if queue.has_flushable_work() {
-                for (channel_id, thread_tags) in
+                for (conversation, thread_tags) in
                     dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
                 {
-                    typing_channels.insert(channel_id, thread_tags);
+                    typing_channels.insert(conversation, thread_tags);
                 }
             }
         }
@@ -2510,10 +2532,10 @@ async fn tokio_main() -> Result<()> {
         // this, batches requeued during crash recovery sit idle until the
         // next relay event arrives — which can be minutes on quiet channels.
         if respawn_collected {
-            for (channel_id, thread_tags) in
+            for (conversation, thread_tags) in
                 dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
             {
-                typing_channels.insert(channel_id, thread_tags);
+                typing_channels.insert(conversation, thread_tags);
             }
         }
 
@@ -2704,7 +2726,7 @@ async fn tokio_main() -> Result<()> {
                                     // Track removed channels so checked-out agents get
                                     // their sessions stripped when they return to the pool.
                                     removed_channels.insert(ch);
-                                    typing_channels.remove(&ch);
+                                    typing_channels.retain(|key, _| key.channel_id != ch);
                                     // Best-effort: clean up 👀 on drained events.
                                     // Note: the relay revokes membership before
                                     // emitting the notification, so this DELETE may
@@ -2778,11 +2800,27 @@ async fn tokio_main() -> Result<()> {
                             if is_cancel {
                                 if let Some(owner) = owner_cache.get() {
                                     if buzz_event.event.pubkey.to_hex() == *owner {
-                                        let fired = signal_in_flight_task(
-                                            &mut pool,
+                                        // Sent inside a thread: cancel that
+                                        // thread's turn. Sent top-level:
+                                        // cancel every in-flight turn in the
+                                        // channel (historical behavior).
+                                        let key = ConversationKey::for_event(
                                             buzz_event.channel_id,
-                                            ControlSignal::Cancel,
+                                            &buzz_event.event,
                                         );
+                                        let fired = if key.thread_root.is_some() {
+                                            signal_in_flight_task(
+                                                &mut pool,
+                                                &key,
+                                                ControlSignal::Cancel,
+                                            )
+                                        } else {
+                                            signal_channel_in_flight_tasks(
+                                                &mut pool,
+                                                buzz_event.channel_id,
+                                                ControlSignal::Cancel,
+                                            ) > 0
+                                        };
                                         if !fired {
                                             tracing::warn!(
                                                 channel_id = %buzz_event.channel_id,
@@ -2816,11 +2854,26 @@ async fn tokio_main() -> Result<()> {
                             if is_rotate {
                                 if let Some(owner) = owner_cache.get() {
                                     if buzz_event.event.pubkey.to_hex() == *owner {
-                                        let fired = signal_in_flight_task(
-                                            &mut pool,
+                                        // Same scoping as !cancel: thread-
+                                        // scoped inside a thread, channel-wide
+                                        // when sent top-level.
+                                        let key = ConversationKey::for_event(
                                             buzz_event.channel_id,
-                                            ControlSignal::Rotate,
+                                            &buzz_event.event,
                                         );
+                                        let fired = if key.thread_root.is_some() {
+                                            signal_in_flight_task(
+                                                &mut pool,
+                                                &key,
+                                                ControlSignal::Rotate,
+                                            )
+                                        } else {
+                                            signal_channel_in_flight_tasks(
+                                                &mut pool,
+                                                buzz_event.channel_id,
+                                                ControlSignal::Rotate,
+                                            ) > 0
+                                        };
                                         if fired {
                                             tracing::info!(
                                                 channel_id = %buzz_event.channel_id,
@@ -2851,13 +2904,13 @@ async fn tokio_main() -> Result<()> {
                             // launched by the same human). Allowlist adds the
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
+                            let is_dm =
+                                is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                             {
                                 let author = buzz_event.event.pubkey.to_hex();
                                 // DM hardening: resolve channel type (fail-closed
                                 // to DM) so allowlist/anyone modes cannot be
                                 // exercised by non-owner authors inside DMs.
-                                let is_dm =
-                                    is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                                 let allowed = author_allowed(
                                     &config.respond_to,
                                     &config.respond_to_allowlist,
@@ -2903,8 +2956,13 @@ async fn tokio_main() -> Result<()> {
                             // backed payload) so the cost is negligible.
                             let event_for_steer = buzz_event.event.clone();
                             let prompt_tag_for_steer = prompt_tag.clone();
+                            let conversation = ConversationKey::for_inbound(
+                                buzz_event.channel_id,
+                                &buzz_event.event,
+                                is_dm,
+                            );
                             let accepted = queue.push(QueuedEvent {
-                                channel_id: buzz_event.channel_id,
+                                conversation: conversation.clone(),
                                 event: buzz_event.event,
                                 received_at: std::time::Instant::now(),
                                 prompt_tag,
@@ -2922,9 +2980,9 @@ async fn tokio_main() -> Result<()> {
                                 });
                             }
                             // Event is already queued. If mode requires it AND
-                            // the channel has an in-flight task, fire cancel —
+                            // the conversation has an in-flight task, fire cancel —
                             // OR take the non-cancelling (ACP steer) fork for Steer signals.
-                            if accepted && queue.is_channel_in_flight(buzz_event.channel_id) {
+                            if accepted && queue.is_conversation_in_flight(&conversation) {
                                 // Author eligibility (owner ∪ allowlist ∪ siblings)
                                 // is already enforced by the inbound author gate
                                 // above, so the mid-turn signal fires for every
@@ -2951,7 +3009,7 @@ async fn tokio_main() -> Result<()> {
                                         && try_native_steer(
                                             &mut pool,
                                             &mut queue,
-                                            buzz_event.channel_id,
+                                            &conversation,
                                             event_for_steer,
                                             prompt_tag_for_steer,
                                             &steer_ack_tx,
@@ -2959,17 +3017,17 @@ async fn tokio_main() -> Result<()> {
                                     if !native_attempted {
                                         signal_in_flight_task(
                                             &mut pool,
-                                            buzz_event.channel_id,
+                                            &conversation,
                                             signal,
                                         );
                                     }
                                 }
                             }
                             if pool_ready {
-                                for (channel_id, thread_tags) in
+                                for (conversation, thread_tags) in
                                     dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
                                 {
-                                    typing_channels.insert(channel_id, thread_tags);
+                                    typing_channels.insert(conversation, thread_tags);
                                 }
                             }
                         }
@@ -3066,10 +3124,10 @@ async fn tokio_main() -> Result<()> {
                         tracing::debug!("heartbeat_skipped_pool_not_ready");
                     } else if queue.has_flushable_work() {
                         tracing::debug!("heartbeat_skipped_events");
-                        for (channel_id, thread_tags) in
+                        for (conversation, thread_tags) in
                             dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
                         {
-                            typing_channels.insert(channel_id, thread_tags);
+                            typing_channels.insert(conversation, thread_tags);
                         }
                     } else if pool.any_idle() {
                         dispatch_heartbeat(&mut pool, &ctx, &mut heartbeat_in_flight);
@@ -3108,14 +3166,14 @@ async fn tokio_main() -> Result<()> {
                     // Use try_publish (non-blocking) for typing indicators —
                     // they're ephemeral and must not block the main loop during
                     // relay reconnection (#35).
-                    for (&ch, thread_tags) in &typing_channels {
+                    for (key, thread_tags) in &typing_channels {
                         if let Ok(event) = relay.build_typing_event(
-                            ch,
+                            key.channel_id,
                             thread_tags.root_event_id.as_deref(),
                             thread_tags.parent_event_id.as_deref(),
                         ) {
                             if let Err(e) = relay.try_publish_event(event) {
-                                tracing::debug!("typing indicator dropped for {ch}: {e}");
+                                tracing::debug!("typing indicator dropped for {key}: {e}");
                             }
                         }
                     }
@@ -3130,9 +3188,9 @@ async fn tokio_main() -> Result<()> {
 
         match pool_event {
             Some(PoolEvent::Result(result)) => {
-                // Stop typing indicator for the completed channel.
-                if let PromptSource::Channel(ch) = &result.source {
-                    typing_channels.remove(ch);
+                // Stop typing indicator for the completed conversation.
+                if let PromptSource::Channel(key) = &result.source {
+                    typing_channels.remove(key);
                 }
                 if handle_prompt_result(
                     &mut pool,
@@ -3165,10 +3223,10 @@ async fn tokio_main() -> Result<()> {
                 {
                     break;
                 }
-                for (channel_id, thread_tags) in
+                for (conversation, thread_tags) in
                     dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
                 {
-                    typing_channels.insert(channel_id, thread_tags);
+                    typing_channels.insert(conversation, thread_tags);
                 }
             }
             Some(PoolEvent::Panic(join_error)) => {
@@ -3190,14 +3248,14 @@ async fn tokio_main() -> Result<()> {
                     tracing::error!("all agents dead — exiting");
                     break;
                 }
-                for (channel_id, thread_tags) in
+                for (conversation, thread_tags) in
                     dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
                 {
-                    typing_channels.insert(channel_id, thread_tags);
+                    typing_channels.insert(conversation, thread_tags);
                 }
             }
             Some(PoolEvent::SteerAck(SteerAckEvent {
-                channel_id,
+                conversation,
                 event_id,
                 ack,
             })) => {
@@ -3302,7 +3360,7 @@ async fn tokio_main() -> Result<()> {
                     Err(_recv_err) => (true, false, false),
                 };
                 tracing::info!(
-                    channel = %channel_id,
+                    conversation = %conversation,
                     event_id = %event_id,
                     ?ack,
                     release_withheld,
@@ -3311,44 +3369,44 @@ async fn tokio_main() -> Result<()> {
                     "non-cancelling steer ack received"
                 );
                 if let Ok(pool::SteerAck::Success { session_id }) = &ack {
-                    queue.extend_in_flight_deadline(channel_id, config.max_turn_duration_secs);
+                    queue.extend_in_flight_deadline(&conversation, config.max_turn_duration_secs);
                     if !pool.record_successful_steer(
-                        channel_id,
+                        &conversation,
                         event_id.clone(),
                         session_id.clone(),
                     ) {
                         tracing::warn!(
-                            channel = %channel_id,
+                            conversation = %conversation,
                             event_id = %event_id,
                             "successful steer lost its in-flight delivery ledger"
                         );
                     }
                 }
                 if drop_withheld {
-                    queue.remove_event(channel_id, &event_id);
+                    queue.remove_event(&conversation, &event_id);
                 }
                 if release_withheld {
-                    queue.release_native_steer(channel_id, &event_id);
+                    queue.release_native_steer(&conversation, &event_id);
                 }
                 if signal_fallback {
                     // Universal cancel+merge fallback. Note: the
                     // queued event has already been released to the
-                    // front of `queues[channel_id]`, so the cancel
+                    // front of `queues[conversation]`, so the cancel
                     // will pick it up as part of the merged batch and
                     // re-prompt the agent.
-                    signal_in_flight_task(&mut pool, channel_id, ControlSignal::Steer);
+                    signal_in_flight_task(&mut pool, &conversation, ControlSignal::Steer);
                 }
                 // After releasing a withheld event, give dispatch a chance
                 // to re-flush. If the prompt is still in flight, the
-                // channel stays `in_flight_channels` and `flush_next`
+                // conversation stays `in_flight` and `flush_next`
                 // skips it — but a Steer fallback signal sent above will
                 // tear down the in-flight task; on its completion the
                 // queue drains. We still try here in case the in-flight
                 // task has already returned.
-                for (channel_id, thread_tags) in
+                for (conversation, thread_tags) in
                     dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
                 {
-                    typing_channels.insert(channel_id, thread_tags);
+                    typing_channels.insert(conversation, thread_tags);
                 }
             }
             Some(PoolEvent::Wake(attempt, result)) => {
@@ -3373,10 +3431,10 @@ async fn tokio_main() -> Result<()> {
                             "ready",
                             None,
                         );
-                        for (channel_id, thread_tags) in
+                        for (conversation, thread_tags) in
                             dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
                         {
-                            typing_channels.insert(channel_id, thread_tags);
+                            typing_channels.insert(conversation, thread_tags);
                         }
                     }
                     Err(error) => {
@@ -3576,22 +3634,49 @@ fn mode_gate_signal(
 /// Returns `true` if a signal was sent, `false` if no in-flight task was found.
 fn signal_in_flight_task(
     pool: &mut AgentPool,
-    channel_id: uuid::Uuid,
+    conversation: &ConversationKey,
     mode: ControlSignal,
 ) -> bool {
     let entry = pool
         .task_map_mut()
         .values_mut()
-        .find(|m| m.channel_id == Some(channel_id));
+        .find(|m| m.conversation.as_ref() == Some(conversation));
 
     if let Some(meta) = entry {
         if let Some(tx) = meta.control_tx.take() {
-            tracing::info!(channel = %channel_id, ?mode, "control signal sent to in-flight task");
+            tracing::info!(conversation = %conversation, ?mode, "control signal sent to in-flight task");
             let _ = tx.send(mode);
             return true;
         }
     }
     false
+}
+
+/// Send a control signal to every in-flight task for `channel_id`, across
+/// all of its conversation lanes. Used by observer control frames, which
+/// historically identified a turn by channel alone — with per-thread
+/// concurrency there may be several. Returns the number of tasks signalled.
+fn signal_channel_in_flight_tasks(
+    pool: &mut AgentPool,
+    channel_id: uuid::Uuid,
+    mode: ControlSignal,
+) -> usize {
+    let mut sent = 0;
+    for meta in pool.task_map_mut().values_mut() {
+        let matches_channel = meta
+            .conversation
+            .as_ref()
+            .is_some_and(|key| key.channel_id == channel_id);
+        if !matches_channel {
+            continue;
+        }
+        if let Some(tx) = meta.control_tx.take() {
+            tracing::info!(channel = %channel_id, ?mode, "control signal sent to in-flight task");
+            let _ = tx.send(mode.clone());
+            sent += 1;
+        }
+    }
+    sent
 }
 
 /// Attempt the non-cancelling (ACP) steer for a freshly-queued event.
@@ -3613,7 +3698,7 @@ fn signal_in_flight_task(
 /// Returns `false` if `pool.send_steer` failed (no in-flight task,
 /// `steer_tx` already full from a prior in-flight steer, or read loop
 /// torn down). The caller MUST fall through to
-/// `signal_in_flight_task(channel_id, ControlSignal::Steer)` so the
+/// `signal_in_flight_task(conversation, ControlSignal::Steer)` so the
 /// event still reaches the agent via the universal path.
 ///
 /// The withheld event is NOT released here on `false` because no withhold
@@ -3621,7 +3706,7 @@ fn signal_in_flight_task(
 fn try_native_steer(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
-    channel_id: uuid::Uuid,
+    conversation: &ConversationKey,
     event: nostr::Event,
     prompt_tag: String,
     steer_ack_tx: &mpsc::UnboundedSender<SteerAckEvent>,
@@ -3646,7 +3731,7 @@ fn try_native_steer(
         prompt_tag: prompt_tag.clone(),
         received_at: std::time::Instant::now(),
     };
-    let event_block = queue::format_event_block(channel_id, None, &be, None);
+    let event_block = queue::format_event_block(conversation.channel_id, None, &be, None);
     let body = format!("{header}\n\n[Buzz event: {prompt_tag}]\n{event_block}\n\n{closing}");
 
     let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<pool::SteerAck>();
@@ -3655,14 +3740,14 @@ fn try_native_steer(
         ack_tx,
     };
 
-    match pool.send_steer(channel_id, request) {
+    match pool.send_steer(conversation, request) {
         Ok(()) => {
             // Withhold the queued event synchronously BEFORE spawning
             // the watcher: this closes the race where `mark_complete`
-            // clears `in_flight_channels` and a stray `flush_next` could
+            // clears `in_flight` and a stray `flush_next` could
             // re-deliver the event via normal dispatch. See
             // `EventQueue::mark_native_steer_pending` docs at queue.rs:606.
-            let withheld = queue.mark_native_steer_pending(channel_id, &event_id_hex);
+            let withheld = queue.mark_native_steer_pending(conversation, &event_id_hex);
             if !withheld {
                 // Race: the event was already drained out of the queue
                 // before we got here (e.g. a concurrent flush picked it
@@ -3672,7 +3757,7 @@ fn try_native_steer(
                 // the same message twice). Log so this is visible if it
                 // ever happens in production.
                 tracing::warn!(
-                    channel = %channel_id,
+                    conversation = %conversation,
                     event_id = %event_id_hex,
                     "native steer accepted by read loop but event was not in queue to withhold \
                      — possible duplicate delivery if steer succeeds"
@@ -3680,10 +3765,11 @@ fn try_native_steer(
             }
             let ack_tx_clone = steer_ack_tx.clone();
             let event_id_for_watcher = event_id_hex.clone();
+            let conversation_for_watcher = conversation.clone();
             tokio::spawn(async move {
                 let ack = ack_rx.await;
                 let _ = ack_tx_clone.send(SteerAckEvent {
-                    channel_id,
+                    conversation: conversation_for_watcher,
                     event_id: event_id_for_watcher,
                     ack,
                 });
@@ -3692,7 +3778,7 @@ fn try_native_steer(
         }
         Err(e) => {
             tracing::info!(
-                channel = %channel_id,
+                conversation = %conversation,
                 error = ?e,
                 "non-cancelling steer not accepted — falling back to cancel+merge"
             );
@@ -3709,31 +3795,31 @@ fn dispatch_pending(
     queue: &mut EventQueue,
     ctx: &Arc<PromptContext>,
     last_activity: &mut tokio::time::Instant,
-) -> Vec<(Uuid, ThreadTags)> {
-    let mut dispatched_channels = Vec::new();
+) -> Vec<(ConversationKey, ThreadTags)> {
+    let mut dispatched_conversations = Vec::new();
     loop {
         let batch = match queue.flush_next() {
             Some(b) => b,
             None => break,
         };
-        let channel_id = batch.channel_id;
+        let conversation = batch.conversation.clone();
         let typing_scope = batch
             .events
             .last()
             .map(|event| queue::parse_thread_tags(&event.event))
             .unwrap_or_default();
-        let affinity_hit = pool.has_session_for(channel_id);
-        let mut agent = match pool.try_claim(Some(channel_id)) {
+        let affinity_hit = pool.has_session_for(&conversation);
+        let mut agent = match pool.try_claim(Some(&conversation)) {
             Some(a) => a,
             None => {
-                let pending = queue.pending_channels();
-                tracing::debug!(pending_channels = pending, "pool_exhausted");
+                let pending = queue.pending_conversations();
+                tracing::debug!(pending_conversations = pending, "pool_exhausted");
                 queue.requeue_preserve_timestamps(batch);
-                queue.mark_complete(channel_id);
+                queue.mark_complete(&conversation);
                 break;
             }
         };
-        tracing::debug!(agent = agent.index, channel = %channel_id, affinity_hit, "agent_claimed");
+        tracing::debug!(agent = agent.index, conversation = %conversation, affinity_hit, "agent_claimed");
 
         let recoverable_batch = match ctx.dedup_mode {
             DedupMode::Queue => Some(batch.clone()),
@@ -3780,7 +3866,7 @@ fn dispatch_pending(
             abort_handle.id(),
             pool::TaskMeta {
                 agent_index,
-                channel_id: Some(channel_id),
+                conversation: Some(conversation.clone()),
                 turn_id,
                 recoverable_batch,
                 control_tx: Some(control_tx),
@@ -3788,15 +3874,15 @@ fn dispatch_pending(
                 successful_steer_deliveries: HashSet::new(),
             },
         );
-        dispatched_channels.push((channel_id, typing_scope));
+        dispatched_conversations.push((conversation, typing_scope));
         *last_activity = tokio::time::Instant::now();
     }
     tracing::debug!(
-        dispatched = dispatched_channels.len(),
-        queue_depth = queue.pending_channels(),
+        dispatched = dispatched_conversations.len(),
+        queue_depth = queue.pending_conversations(),
         "dispatch_pending"
     );
-    dispatched_channels
+    dispatched_conversations
 }
 
 /// Returns `true` when `error` is a non-retryable authentication failure.
@@ -3844,7 +3930,7 @@ fn spawn_failure_notice(
             .map(|be| queue::parse_thread_tags(&be.event))
             .unwrap_or_default();
         let rest = rest.clone();
-        let channel_id = batch.channel_id;
+        let channel_id = batch.channel_id();
         tokio::spawn(async move {
             pool::post_failure_notice(&rest, channel_id, &thread_tags, &content).await;
         });
@@ -3876,11 +3962,11 @@ fn handle_prompt_result(
     pool.task_map_mut()
         .retain(|_, meta| meta.agent_index != agent_index);
     debug_assert_eq!(before, pool.task_map().len() + 1);
-    if let PromptSource::Channel(channel_id) = &result.source {
+    if let PromptSource::Channel(conversation) = &result.source {
         // The task may have invalidated this session before returning. Never
         // resurrect delivery state for a dead session; its replacement must
         // receive fresh standing context and history.
-        if let Some(live_session_id) = result.agent.state.sessions.get(channel_id).cloned() {
+        if let Some(live_session_id) = result.agent.state.sessions.get(conversation).cloned() {
             let event_ids = successful_steer_deliveries
                 .into_iter()
                 .filter(|delivery| delivery.session_id == live_session_id)
@@ -3888,7 +3974,7 @@ fn handle_prompt_result(
             result
                 .agent
                 .state
-                .mark_channel_delivery_success(*channel_id, false, event_ids);
+                .mark_conversation_delivery_success(conversation, false, event_ids);
         }
     }
 
@@ -3909,7 +3995,7 @@ fn handle_prompt_result(
     if let Some(batch) = result.batch.take() {
         // Don't requeue batches for channels the agent was removed from —
         // those events are stale and should be silently dropped.
-        if !removed_channels.contains(&batch.channel_id) {
+        if !removed_channels.contains(&batch.channel_id()) {
             if matches!(
                 result.outcome,
                 PromptOutcome::Cancelled | PromptOutcome::CancelDrainTimeout(_)
@@ -3937,7 +4023,7 @@ fn handle_prompt_result(
                 })
             ) {
                 tracing::error!(
-                    channel_id = %batch.channel_id,
+                    channel_id = %batch.channel_id(),
                     events = batch.events.len(),
                     "dead-lettering batch after hard-cap timeout (no recent activity) — discarding {} events",
                     batch.events.len(),
@@ -3955,7 +4041,7 @@ fn handle_prompt_result(
                 })
             ) {
                 tracing::warn!(
-                    channel_id = %batch.channel_id,
+                    channel_id = %batch.channel_id(),
                     events = batch.events.len(),
                     "hard-cap timeout with recent activity — requeueing for retry"
                 );
@@ -3975,7 +4061,7 @@ fn handle_prompt_result(
                 // delays the visible failure. Dead-letter immediately and tell
                 // the user to re-authenticate the CLI.
                 tracing::warn!(
-                    channel_id = %batch.channel_id,
+                    channel_id = %batch.channel_id(),
                     events = batch.events.len(),
                     "dead-lettering batch immediately — non-retryable auth error"
                 );
@@ -4001,7 +4087,7 @@ fn handle_prompt_result(
             }
         } else {
             tracing::debug!(
-                channel_id = %batch.channel_id,
+                channel_id = %batch.channel_id(),
                 events = batch.events.len(),
                 "dropping failed batch for removed channel"
             );
@@ -4010,7 +4096,7 @@ fn handle_prompt_result(
     }
 
     match &result.source {
-        PromptSource::Channel(ch) => queue.mark_complete(*ch),
+        PromptSource::Channel(key) => queue.mark_complete(key),
         PromptSource::Heartbeat => *heartbeat_in_flight = false,
     }
 
@@ -4046,7 +4132,7 @@ fn handle_prompt_result(
     let harness_pid = std::process::id();
 
     let channel_id = match &result.source {
-        PromptSource::Channel(ch) => Some(*ch),
+        PromptSource::Channel(key) => Some(key.channel_id),
         PromptSource::Heartbeat => None,
     };
     let turn_id = result.turn_id.clone();
@@ -4248,7 +4334,7 @@ fn recover_panicked_agent(
     join_error: tokio::task::JoinError,
     heartbeat_in_flight: &mut bool,
     removed_channels: &HashSet<Uuid>,
-    typing_channels: &mut HashMap<Uuid, ThreadTags>,
+    typing_channels: &mut HashMap<ConversationKey, ThreadTags>,
     crash_history: &mut [SlotCircuit],
     respawn_tx: &mpsc::Sender<RespawnResult>,
     respawn_tasks: &mut tokio::task::JoinSet<()>,
@@ -4263,25 +4349,25 @@ fn recover_panicked_agent(
 
     // Requeue BEFORE mark_complete (same rationale as handle_prompt_result).
     if let Some(batch) = meta.recoverable_batch {
-        if let Some(ch) = meta.channel_id {
-            if !removed_channels.contains(&ch) {
+        if let Some(key) = &meta.conversation {
+            if !removed_channels.contains(&key.channel_id) {
                 // Dead-letter on exhaustion is logged inside requeue(); a
                 // panic path has no outcome to report, so no notice here.
                 let _ = queue.requeue(batch);
                 tracing::warn!("requeued batch for panicked agent {i}");
             } else {
                 tracing::debug!(
-                    channel_id = %ch,
+                    conversation = %key,
                     "dropping panicked batch for removed channel"
                 );
             }
         }
     }
 
-    if let Some(ch) = meta.channel_id {
-        queue.mark_complete(ch);
-        typing_channels.remove(&ch);
-        tracing::warn!("cleared wedged in-flight channel {ch} from panicked agent {i}");
+    if let Some(key) = &meta.conversation {
+        queue.mark_complete(key);
+        typing_channels.remove(key);
+        tracing::warn!("cleared wedged in-flight conversation {key} from panicked agent {i}");
     } else {
         *heartbeat_in_flight = false;
         tracing::warn!("cleared wedged heartbeat_in_flight from panicked agent {i}");
@@ -4291,7 +4377,11 @@ fn recover_panicked_agent(
         observer.emit(
             "agent_panic",
             Some(i),
-            &observer::context_for(meta.channel_id, None, Some(meta.turn_id)),
+            &observer::context_for(
+                meta.conversation.as_ref().map(|key| key.channel_id),
+                None,
+                Some(meta.turn_id),
+            ),
             serde_json::json!({
                 "outcome": "panic",
                 "error": format!("Agent task panicked: {join_error}"),
@@ -4346,7 +4436,7 @@ fn drain_ready_join_results(
     config: &Config,
     heartbeat_in_flight: &mut bool,
     removed_channels: &HashSet<Uuid>,
-    typing_channels: &mut HashMap<Uuid, ThreadTags>,
+    typing_channels: &mut HashMap<ConversationKey, ThreadTags>,
     crash_history: &mut [SlotCircuit],
     respawn_tx: &mpsc::Sender<RespawnResult>,
     respawn_tasks: &mut tokio::task::JoinSet<()>,
@@ -4416,7 +4506,7 @@ fn dispatch_heartbeat(
         abort_handle.id(),
         pool::TaskMeta {
             agent_index,
-            channel_id: None,
+            conversation: None,
             turn_id,
             recoverable_batch: None,
             control_tx: None,
@@ -5119,6 +5209,14 @@ mod owner_control_command_tests {
     use super::*;
     use nostr::{EventBuilder, Keys, Kind, Tag};
 
+    /// Top-level conversation lane for `channel_id` (no thread root).
+    fn key(channel_id: Uuid) -> ConversationKey {
+        ConversationKey {
+            channel_id,
+            thread_root: None,
+        }
+    }
+
     fn make_event(kind: u32, content: &str, p_hex: Option<&str>) -> nostr::Event {
         let keys = Keys::generate();
         let tags = match p_hex {
@@ -5215,7 +5313,7 @@ mod owner_control_command_tests {
             abort_handle.id(),
             pool::TaskMeta {
                 agent_index: 0,
-                channel_id: Some(channel_id),
+                conversation: Some(key(channel_id)),
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: Some(control_tx),
@@ -5226,18 +5324,18 @@ mod owner_control_command_tests {
 
         assert!(!signal_in_flight_task(
             &mut pool,
-            other_channel_id,
+            &key(other_channel_id),
             ControlSignal::Rotate
         ));
         assert!(signal_in_flight_task(
             &mut pool,
-            channel_id,
+            &key(channel_id),
             ControlSignal::Rotate
         ));
         assert_eq!(control_rx.await.unwrap(), ControlSignal::Rotate);
         assert!(!signal_in_flight_task(
             &mut pool,
-            channel_id,
+            &key(channel_id),
             ControlSignal::Rotate
         ));
     }
@@ -6959,7 +7057,15 @@ mod error_outcome_emission_tests {
     use crate::pool::{
         AgentPool, OwnedAgent, PromptOutcome, PromptResult, PromptSource, TimeoutKind,
     };
-    use crate::queue::{BatchEvent, FlushBatch};
+    use crate::queue::{BatchEvent, ConversationKey, FlushBatch};
+
+    /// Top-level conversation lane for `channel_id` (no thread root).
+    fn key(channel_id: Uuid) -> ConversationKey {
+        ConversationKey {
+            channel_id,
+            thread_root: None,
+        }
+    }
     use nostr::{EventBuilder, Keys, Kind};
     use std::collections::HashSet;
 
@@ -7057,16 +7163,17 @@ mod error_outcome_emission_tests {
     #[tokio::test]
     async fn successful_native_steer_is_transferred_to_live_session_delivery_state() {
         let channel_id = Uuid::new_v4();
+        let conversation = key(channel_id);
         let steer_event_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let mut agent = dummy_agent(0).await;
         agent
             .state
             .sessions
-            .insert(channel_id, "live-session".into());
+            .insert(conversation.clone(), "live-session".into());
         agent
             .state
             .deliveries
-            .insert(channel_id, Default::default());
+            .insert(conversation.clone(), Default::default());
 
         let mut pool = AgentPool::from_slots(vec![None]);
         let task_id = pool.join_set.spawn(async {}).id();
@@ -7074,7 +7181,7 @@ mod error_outcome_emission_tests {
             task_id,
             crate::pool::TaskMeta {
                 agent_index: 0,
-                channel_id: Some(channel_id),
+                conversation: Some(conversation.clone()),
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7101,7 +7208,7 @@ mod error_outcome_emission_tests {
         let mut respawn_tasks = tokio::task::JoinSet::new();
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(channel_id),
+            source: PromptSource::Channel(conversation.clone()),
             turn_id: "test-turn-id".into(),
             outcome: PromptOutcome::Ok(crate::acp::StopReason::EndTurn),
             batch: None,
@@ -7122,7 +7229,7 @@ mod error_outcome_emission_tests {
         );
 
         let returned = pool.agents_mut()[0].as_ref().expect("returned agent");
-        assert!(returned.state.deliveries[&channel_id]
+        assert!(returned.state.deliveries[&conversation]
             .delivered_event_ids
             .contains(steer_event_id));
     }
@@ -7130,15 +7237,16 @@ mod error_outcome_emission_tests {
     #[tokio::test]
     async fn in_flight_stale_native_steer_ack_cannot_update_replacement_session() {
         let channel_id = Uuid::new_v4();
+        let conversation = key(channel_id);
         let mut agent = dummy_agent(0).await;
         agent
             .state
             .sessions
-            .insert(channel_id, "replacement-session".into());
+            .insert(conversation.clone(), "replacement-session".into());
         agent
             .state
             .deliveries
-            .insert(channel_id, Default::default());
+            .insert(conversation.clone(), Default::default());
 
         let mut pool = AgentPool::from_slots(vec![None]);
         let task_id = pool.join_set.spawn(async {}).id();
@@ -7146,7 +7254,7 @@ mod error_outcome_emission_tests {
             task_id,
             crate::pool::TaskMeta {
                 agent_index: 0,
-                channel_id: Some(channel_id),
+                conversation: Some(conversation.clone()),
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7173,7 +7281,7 @@ mod error_outcome_emission_tests {
         let mut respawn_tasks = tokio::task::JoinSet::new();
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(channel_id),
+            source: PromptSource::Channel(conversation.clone()),
             turn_id: "test-turn-id".into(),
             outcome: PromptOutcome::Ok(crate::acp::StopReason::EndTurn),
             batch: None,
@@ -7194,7 +7302,7 @@ mod error_outcome_emission_tests {
         );
 
         let returned = pool.agents_mut()[0].as_ref().expect("returned agent");
-        assert!(returned.state.deliveries[&channel_id]
+        assert!(returned.state.deliveries[&conversation]
             .delivered_event_ids
             .is_empty());
     }
@@ -7202,25 +7310,26 @@ mod error_outcome_emission_tests {
     #[tokio::test]
     async fn successful_native_steer_ack_after_task_return_updates_matching_live_session() {
         let channel_id = Uuid::new_v4();
+        let conversation = key(channel_id);
         let steer_event_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
         let mut agent = dummy_agent(0).await;
         agent
             .state
             .sessions
-            .insert(channel_id, "live-session".into());
+            .insert(conversation.clone(), "live-session".into());
         agent
             .state
             .deliveries
-            .insert(channel_id, Default::default());
+            .insert(conversation.clone(), Default::default());
         let mut pool = AgentPool::from_slots(vec![Some(agent)]);
 
         assert!(pool.record_successful_steer(
-            channel_id,
+            &conversation,
             steer_event_id.into(),
             "live-session".into(),
         ));
         let returned = pool.agents_mut()[0].as_ref().expect("idle returned agent");
-        assert!(returned.state.deliveries[&channel_id]
+        assert!(returned.state.deliveries[&conversation]
             .delivered_event_ids
             .contains(steer_event_id));
     }
@@ -7228,24 +7337,25 @@ mod error_outcome_emission_tests {
     #[tokio::test]
     async fn late_native_steer_ack_cannot_update_replacement_session() {
         let channel_id = Uuid::new_v4();
+        let conversation = key(channel_id);
         let mut agent = dummy_agent(0).await;
         agent
             .state
             .sessions
-            .insert(channel_id, "replacement-session".into());
+            .insert(conversation.clone(), "replacement-session".into());
         agent
             .state
             .deliveries
-            .insert(channel_id, Default::default());
+            .insert(conversation.clone(), Default::default());
         let mut pool = AgentPool::from_slots(vec![Some(agent)]);
 
         assert!(!pool.record_successful_steer(
-            channel_id,
+            &conversation,
             "stale-event".into(),
             "old-session".into(),
         ));
         let returned = pool.agents_mut()[0].as_ref().expect("replacement agent");
-        assert!(returned.state.deliveries[&channel_id]
+        assert!(returned.state.deliveries[&conversation]
             .delivered_event_ids
             .is_empty());
     }
@@ -7253,6 +7363,7 @@ mod error_outcome_emission_tests {
     #[tokio::test]
     async fn invalidated_session_does_not_resurrect_successful_steer_delivery_state() {
         let channel_id = Uuid::new_v4();
+        let conversation = key(channel_id);
         let agent = dummy_agent(0).await;
         // No live session: simulates the prompt task invalidating before return.
         let mut pool = AgentPool::from_slots(vec![None]);
@@ -7261,7 +7372,7 @@ mod error_outcome_emission_tests {
             task_id,
             crate::pool::TaskMeta {
                 agent_index: 0,
-                channel_id: Some(channel_id),
+                conversation: Some(conversation.clone()),
                 turn_id: "test-turn-id".into(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7287,7 +7398,7 @@ mod error_outcome_emission_tests {
         let mut respawn_tasks = tokio::task::JoinSet::new();
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(channel_id),
+            source: PromptSource::Channel(conversation.clone()),
             turn_id: "test-turn-id".into(),
             outcome: PromptOutcome::Ok(crate::acp::StopReason::EndTurn),
             batch: None,
@@ -7308,7 +7419,7 @@ mod error_outcome_emission_tests {
         );
 
         let returned = pool.agents_mut()[0].as_ref().expect("returned agent");
-        assert!(!returned.state.deliveries.contains_key(&channel_id));
+        assert!(!returned.state.deliveries.contains_key(&conversation));
     }
 
     /// Drive one error outcome through `handle_prompt_result` and return how
@@ -7326,7 +7437,7 @@ mod error_outcome_emission_tests {
             task_id,
             crate::pool::TaskMeta {
                 agent_index: 0,
-                channel_id: None,
+                conversation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7350,7 +7461,7 @@ mod error_outcome_emission_tests {
 
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(Uuid::new_v4()),
+            source: PromptSource::Channel(key(Uuid::new_v4())),
             turn_id: "test-turn-id".to_string(),
             outcome,
             batch: None,
@@ -7403,7 +7514,7 @@ mod error_outcome_emission_tests {
             task_id,
             crate::pool::TaskMeta {
                 agent_index: 0,
-                channel_id: Some(channel_id),
+                conversation: Some(key(channel_id)),
                 turn_id: "panic-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7496,7 +7607,7 @@ mod error_outcome_emission_tests {
                 task_id,
                 crate::pool::TaskMeta {
                     agent_index: 0,
-                    channel_id: None,
+                    conversation: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -7518,7 +7629,7 @@ mod error_outcome_emission_tests {
             let observer = ObserverHandle::in_process();
             let result = PromptResult {
                 agent,
-                source: PromptSource::Channel(Uuid::new_v4()),
+                source: PromptSource::Channel(key(Uuid::new_v4())),
                 turn_id: "test-turn-id".to_string(),
                 outcome,
                 batch: None,
@@ -7567,7 +7678,7 @@ mod error_outcome_emission_tests {
                 .sign_with_keys(&keys)
                 .unwrap();
             FlushBatch {
-                channel_id: Uuid::new_v4(),
+                conversation: key(Uuid::new_v4()),
                 events: vec![BatchEvent {
                     event,
                     prompt_tag: "test".into(),
@@ -7580,7 +7691,7 @@ mod error_outcome_emission_tests {
 
         // Returns (pending_channels, queued_event_count_for_channel).
         let run = |outcome: PromptOutcome, batch: FlushBatch| async move {
-            let channel_id = batch.channel_id;
+            let channel_id = batch.channel_id();
             let agent = dummy_agent(0).await;
             let mut pool = AgentPool::from_slots(vec![None]);
             let task_id = pool.join_set.spawn(async {}).id();
@@ -7588,7 +7699,7 @@ mod error_outcome_emission_tests {
                 task_id,
                 crate::pool::TaskMeta {
                     agent_index: 0,
-                    channel_id: None,
+                    conversation: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -7609,7 +7720,7 @@ mod error_outcome_emission_tests {
             let mut respawn_tasks = tokio::task::JoinSet::new();
             let result = PromptResult {
                 agent,
-                source: PromptSource::Channel(channel_id),
+                source: PromptSource::Channel(key(channel_id)),
                 turn_id: "test-turn-id".to_string(),
                 outcome,
                 batch: Some(batch),
@@ -7628,8 +7739,8 @@ mod error_outcome_emission_tests {
                 None,
             );
             (
-                queue.pending_channels(),
-                queue.queued_event_count(&channel_id),
+                queue.pending_conversations(),
+                queue.queued_event_count(&key(channel_id)),
             )
         };
 
@@ -7674,7 +7785,7 @@ mod error_outcome_emission_tests {
                 .sign_with_keys(&keys)
                 .unwrap();
             FlushBatch {
-                channel_id,
+                conversation: key(channel_id),
                 events: vec![BatchEvent {
                     event,
                     prompt_tag: "test".into(),
@@ -7686,7 +7797,7 @@ mod error_outcome_emission_tests {
         };
 
         let run = |outcome: PromptOutcome, batch: FlushBatch| async move {
-            let channel_id = batch.channel_id;
+            let channel_id = batch.channel_id();
             let agent = dummy_agent(0).await;
             let mut pool = AgentPool::from_slots(vec![None]);
             let task_id = pool.join_set.spawn(async {}).id();
@@ -7694,7 +7805,7 @@ mod error_outcome_emission_tests {
                 task_id,
                 crate::pool::TaskMeta {
                     agent_index: 0,
-                    channel_id: None,
+                    conversation: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -7715,7 +7826,7 @@ mod error_outcome_emission_tests {
             let mut respawn_tasks = tokio::task::JoinSet::new();
             let result = PromptResult {
                 agent,
-                source: PromptSource::Channel(channel_id),
+                source: PromptSource::Channel(key(channel_id)),
                 turn_id: "test-turn-id".to_string(),
                 outcome,
                 batch: Some(batch),
@@ -7734,8 +7845,8 @@ mod error_outcome_emission_tests {
                 None,
             );
             (
-                queue.pending_channels(),
-                queue.queued_event_count(&channel_id),
+                queue.pending_conversations(),
+                queue.queued_event_count(&key(channel_id)),
             )
         };
 
@@ -7771,7 +7882,7 @@ mod error_outcome_emission_tests {
             task_id,
             crate::pool::TaskMeta {
                 agent_index: 0,
-                channel_id: None,
+                conversation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7792,7 +7903,7 @@ mod error_outcome_emission_tests {
         let mut respawn_tasks = tokio::task::JoinSet::new();
         let observer = ObserverHandle::in_process();
         let batch = FlushBatch {
-            channel_id,
+            conversation: key(channel_id),
             events: vec![BatchEvent {
                 event: EventBuilder::new(Kind::Custom(9), "test")
                     .sign_with_keys(&Keys::generate())
@@ -7805,7 +7916,7 @@ mod error_outcome_emission_tests {
         };
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(channel_id),
+            source: PromptSource::Channel(key(channel_id)),
             turn_id: "test-turn-id".to_string(),
             outcome: PromptOutcome::Timeout(TimeoutKind::Hard {
                 recently_active: true,
@@ -7839,7 +7950,7 @@ mod error_outcome_emission_tests {
             ),
         );
         assert_eq!(
-            queue.pending_channels(),
+            queue.pending_conversations(),
             1,
             "batch must be requeued, not dead-lettered, while within the retry budget"
         );
@@ -7857,7 +7968,7 @@ mod error_outcome_emission_tests {
         // Simulate MAX_RETRIES prior failed attempts on this channel so the
         // upcoming requeue() call in handle_prompt_result crosses the
         // dead-letter threshold.
-        queue.set_retry_count_for_test(channel_id, crate::queue::MAX_RETRIES);
+        queue.set_retry_count_for_test(key(channel_id), crate::queue::MAX_RETRIES);
 
         let agent = dummy_agent(0).await;
         let mut pool = AgentPool::from_slots(vec![None]);
@@ -7866,7 +7977,7 @@ mod error_outcome_emission_tests {
             task_id,
             crate::pool::TaskMeta {
                 agent_index: 0,
-                channel_id: None,
+                conversation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7886,7 +7997,7 @@ mod error_outcome_emission_tests {
         let mut respawn_tasks = tokio::task::JoinSet::new();
         let observer = ObserverHandle::in_process();
         let batch = FlushBatch {
-            channel_id,
+            conversation: key(channel_id),
             events: vec![BatchEvent {
                 event: EventBuilder::new(Kind::Custom(9), "final-attempt")
                     .sign_with_keys(&Keys::generate())
@@ -7899,7 +8010,7 @@ mod error_outcome_emission_tests {
         };
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(channel_id),
+            source: PromptSource::Channel(key(channel_id)),
             turn_id: "test-turn-id".to_string(),
             outcome: PromptOutcome::Timeout(TimeoutKind::Hard {
                 recently_active: true,
@@ -7933,7 +8044,7 @@ mod error_outcome_emission_tests {
             ),
         );
         assert_eq!(
-            queue.queued_event_count(&channel_id),
+            queue.queued_event_count(&key(channel_id)),
             0,
             "batch with an exhausted retry budget must be dead-lettered, not requeued"
         );
@@ -7966,7 +8077,7 @@ mod error_outcome_emission_tests {
         );
         let channel_id = Uuid::new_v4();
         let batch = FlushBatch {
-            channel_id,
+            conversation: key(channel_id),
             events: vec![BatchEvent {
                 event: original_event.clone(),
                 prompt_tag: "test".into(),
@@ -7983,7 +8094,7 @@ mod error_outcome_emission_tests {
             task_id,
             crate::pool::TaskMeta {
                 agent_index: 0,
-                channel_id: None,
+                conversation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7997,7 +8108,7 @@ mod error_outcome_emission_tests {
         // out on drain — so it is already queued by the time
         // handle_prompt_result runs.
         queue.push(QueuedEvent {
-            channel_id,
+            conversation: key(channel_id),
             event: new_event.clone(),
             received_at: std::time::Instant::now(),
             prompt_tag: "test".into(),
@@ -8016,7 +8127,7 @@ mod error_outcome_emission_tests {
         let grace = std::time::Duration::from_secs(5);
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(channel_id),
+            source: PromptSource::Channel(key(channel_id)),
             turn_id: "test-turn-id".to_string(),
             outcome: PromptOutcome::CancelDrainTimeout(grace),
             batch: Some(batch),
@@ -8123,7 +8234,7 @@ mod error_outcome_emission_tests {
             task_id,
             crate::pool::TaskMeta {
                 agent_index: 0,
-                channel_id: None,
+                conversation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -8146,7 +8257,7 @@ mod error_outcome_emission_tests {
         let grace = std::time::Duration::from_secs(5);
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(Uuid::new_v4()),
+            source: PromptSource::Channel(key(Uuid::new_v4())),
             turn_id: "test-turn-id".to_string(),
             outcome: PromptOutcome::CancelDrainTimeout(grace),
             // Explicit Stop already dropped the batch upstream in
@@ -8171,7 +8282,7 @@ mod error_outcome_emission_tests {
 
         // No batch to merge — the queue has nothing pending for any channel.
         assert_eq!(
-            queue.pending_channels(),
+            queue.pending_conversations(),
             0,
             "a dropped Stop batch must not leave anything queued"
         );
@@ -8289,7 +8400,7 @@ mod error_outcome_emission_tests {
             .unwrap();
         let channel_id = uuid::Uuid::new_v4();
         let batch = FlushBatch {
-            channel_id,
+            conversation: key(channel_id),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -8312,7 +8423,7 @@ mod error_outcome_emission_tests {
             task_id,
             crate::pool::TaskMeta {
                 agent_index: 0,
-                channel_id: None,
+                conversation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -8333,7 +8444,7 @@ mod error_outcome_emission_tests {
         let mut respawn_tasks = tokio::task::JoinSet::new();
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(channel_id),
+            source: PromptSource::Channel(key(channel_id)),
             turn_id: "test-turn-id".to_string(),
             outcome: PromptOutcome::Error(auth_error),
             batch: Some(batch),
@@ -8354,12 +8465,12 @@ mod error_outcome_emission_tests {
 
         // The batch must not be requeued: pending_channels returns 0.
         assert_eq!(
-            queue.pending_channels(),
+            queue.pending_conversations(),
             0,
             "auth error must dead-letter immediately — batch must not be requeued"
         );
         assert_eq!(
-            queue.queued_event_count(&channel_id),
+            queue.queued_event_count(&key(channel_id)),
             0,
             "auth error must dead-letter immediately — no events should be pending"
         );
@@ -8375,7 +8486,7 @@ mod error_outcome_emission_tests {
             .unwrap();
         let channel_id = uuid::Uuid::new_v4();
         let batch = FlushBatch {
-            channel_id,
+            conversation: key(channel_id),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -8398,7 +8509,7 @@ mod error_outcome_emission_tests {
             task_id,
             crate::pool::TaskMeta {
                 agent_index: 0,
-                channel_id: None,
+                conversation: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -8419,7 +8530,7 @@ mod error_outcome_emission_tests {
         let mut respawn_tasks = tokio::task::JoinSet::new();
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(channel_id),
+            source: PromptSource::Channel(key(channel_id)),
             turn_id: "test-turn-id".to_string(),
             outcome: PromptOutcome::Error(usage_error),
             batch: Some(batch),
@@ -8440,12 +8551,12 @@ mod error_outcome_emission_tests {
 
         // Non-auth application error: batch IS requeued (first attempt, retry budget > 0).
         assert_eq!(
-            queue.pending_channels(),
+            queue.pending_conversations(),
             1,
             "non-auth application error must requeue the batch for retry"
         );
         assert_eq!(
-            queue.queued_event_count(&channel_id),
+            queue.queued_event_count(&key(channel_id)),
             1,
             "non-auth application error must preserve the event for retry"
         );

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -37,8 +37,8 @@ use crate::acp::{
 use crate::config::{compose_session_title, DedupMode, PermissionMode};
 use crate::observer;
 use crate::queue::{
-    CancelReason, ContextMessage, ConversationContext, FlushBatch, PromptChannelInfo,
-    PromptProfile, PromptProfileLookup, ThreadTags,
+    CancelReason, ContextMessage, ConversationContext, ConversationKey, FlushBatch,
+    PromptChannelInfo, PromptProfile, PromptProfileLookup, ThreadTags,
 };
 use crate::relay::{ChannelInfo, RestClient};
 
@@ -58,7 +58,7 @@ pub struct SuccessfulSteerDelivery {
 
 pub struct TaskMeta {
     pub agent_index: usize,
-    pub channel_id: Option<Uuid>,
+    pub conversation: Option<ConversationKey>,
     /// Identifies terminal events when the task panics before returning a result.
     pub turn_id: String,
     /// Clone of batch for Queue mode panic recovery.
@@ -96,9 +96,9 @@ pub struct AgentModelCapabilities {
     pub thought_level_config_id: Option<String>,
 }
 
-/// Successful deliveries associated with one live channel session.
+/// Successful deliveries associated with one live conversation session.
 #[derive(Default)]
-pub struct ChannelDeliveryState {
+pub struct ConversationDeliveryState {
     /// Whether a legacy user message has successfully carried standing context.
     pub standing_context_sent: bool,
     /// Buzz event IDs already delivered to this ACP session, either as trigger
@@ -106,18 +106,23 @@ pub struct ChannelDeliveryState {
     pub delivered_event_ids: HashSet<String>,
 }
 
-/// Per-channel session IDs, turn counters, and delivery state.
+/// Per-conversation session IDs and turn counters.
+///
+/// Sessions are keyed by [`ConversationKey`] — one thread within a channel —
+/// so different threads in the same channel run in independent sessions.
+/// Owner core and canvas sections stay channel-keyed: they are channel-scoped
+/// facts shared by every conversation in that channel.
 ///
 /// Separated from `OwnedAgent` so the state machine is testable without
 /// spawning a real agent subprocess.
 #[derive(Default)]
 pub struct SessionState {
-    /// channel_id → session_id
-    pub sessions: HashMap<Uuid, String>,
+    /// conversation → session_id
+    pub sessions: HashMap<ConversationKey, String>,
     pub heartbeat_session: Option<String>,
-    /// Per-channel turn counters for proactive session rotation.
+    /// Per-conversation turn counters for proactive session rotation.
     /// Incremented on each successful prompt; reset when the session is rotated.
-    pub turn_counts: HashMap<Uuid, u32>,
+    pub turn_counts: HashMap<ConversationKey, u32>,
     /// Turn counter for the heartbeat session.
     pub heartbeat_turn_count: u32,
     /// Whether the live heartbeat session has successfully received `[Base]`.
@@ -132,17 +137,17 @@ pub struct SessionState {
     /// fetch fails — all fail open. Cleared on session invalidation alongside
     /// `core_sections` so the next session picks up any canvas change.
     pub canvas_sections: HashMap<Uuid, String>,
-    /// Per-channel successful-delivery state. Created with the ACP session and
+    /// Per-conversation successful-delivery state. Created with the ACP session and
     /// cleared atomically with every invalidation path.
-    pub deliveries: HashMap<Uuid, ChannelDeliveryState>,
+    pub deliveries: HashMap<ConversationKey, ConversationDeliveryState>,
 }
 
 impl SessionState {
     /// Invalidate the session (and turn counter) for a specific prompt source.
     pub fn invalidate(&mut self, source: &PromptSource) {
         match source {
-            PromptSource::Channel(cid) => {
-                self.invalidate_channel(cid);
+            PromptSource::Channel(key) => {
+                self.invalidate_conversation(key);
             }
             PromptSource::Heartbeat => {
                 self.heartbeat_session = None;
@@ -152,14 +157,29 @@ impl SessionState {
         }
     }
 
-    /// Invalidate a single channel's session and turn counter.
-    /// Returns `true` if the channel had an active session.
+    /// Invalidate a single conversation's session and turn counter. The
+    /// channel's cached core/canvas sections are also cleared so the next
+    /// session in that channel re-fetches them.
+    /// Returns `true` if the conversation had an active session.
+    pub fn invalidate_conversation(&mut self, conversation: &ConversationKey) -> bool {
+        self.turn_counts.remove(conversation);
+        self.core_sections.remove(&conversation.channel_id);
+        self.canvas_sections.remove(&conversation.channel_id);
+        self.deliveries.remove(conversation);
+        self.sessions.remove(conversation).is_some()
+    }
+
+    /// Invalidate every conversation session (and turn counter) in a channel.
+    /// Returns `true` if the channel had at least one active session.
     pub fn invalidate_channel(&mut self, channel_id: &Uuid) -> bool {
-        self.turn_counts.remove(channel_id);
+        let before = self.sessions.len();
+        self.sessions.retain(|k, _| k.channel_id != *channel_id);
+        self.turn_counts.retain(|k, _| k.channel_id != *channel_id);
         self.core_sections.remove(channel_id);
         self.canvas_sections.remove(channel_id);
-        self.deliveries.remove(channel_id);
-        self.sessions.remove(channel_id).is_some()
+        self.deliveries
+            .retain(|key, _| key.channel_id != *channel_id);
+        self.sessions.len() != before
     }
 
     /// Invalidate all sessions and turn counters (e.g. after agent exit).
@@ -174,24 +194,27 @@ impl SessionState {
         self.deliveries.clear();
     }
 
-    pub(crate) fn mark_channel_delivery_success(
+    pub(crate) fn mark_conversation_delivery_success(
         &mut self,
-        channel_id: Uuid,
+        conversation: &ConversationKey,
         standing_context_sent: bool,
         event_ids: impl IntoIterator<Item = String>,
     ) {
-        let delivery = self.deliveries.entry(channel_id).or_default();
+        let delivery = self.deliveries.entry(conversation.clone()).or_default();
         delivery.standing_context_sent |= standing_context_sent;
         delivery.delivered_event_ids.extend(event_ids);
     }
 
     #[cfg(test)]
     fn has_channel_state(&self, channel_id: &Uuid) -> bool {
-        self.sessions.contains_key(channel_id)
-            || self.turn_counts.contains_key(channel_id)
+        self.sessions.keys().any(|k| k.channel_id == *channel_id)
+            || self.turn_counts.keys().any(|k| k.channel_id == *channel_id)
             || self.core_sections.contains_key(channel_id)
             || self.canvas_sections.contains_key(channel_id)
-            || self.deliveries.contains_key(channel_id)
+            || self
+                .deliveries
+                .keys()
+                .any(|key| key.channel_id == *channel_id)
     }
 }
 
@@ -311,10 +334,10 @@ pub struct PromptResult {
     pub batch: Option<FlushBatch>,
 }
 
-/// Whether the prompt came from a channel event or a heartbeat.
+/// Whether the prompt came from a channel conversation or a heartbeat.
 #[derive(Debug)]
 pub enum PromptSource {
-    Channel(Uuid),
+    Channel(ConversationKey),
     Heartbeat,
 }
 
@@ -661,18 +684,36 @@ impl AgentPool {
         }
     }
 
-    /// Try to claim an idle agent for the given channel (or heartbeat if `None`).
+    /// Try to claim an idle agent for the given conversation (or heartbeat if
+    /// `None`).
     ///
-    /// Pass 1: prefer an agent that already has a session for `channel_id`.
-    /// Pass 2: any idle agent.
+    /// Pass 1: prefer an agent that already has a session for `conversation`.
+    /// Pass 2: prefer an agent with a session elsewhere in the same channel
+    ///         (its cached core/canvas sections are reusable).
+    /// Pass 3: any idle agent.
     ///
     /// Returns `None` if all agents are checked out.
-    pub fn try_claim(&mut self, channel_id: Option<Uuid>) -> Option<OwnedAgent> {
-        // Pass 1: prefer agent with existing session for this channel.
-        if let Some(cid) = channel_id {
+    pub fn try_claim(&mut self, conversation: Option<&ConversationKey>) -> Option<OwnedAgent> {
+        if let Some(key) = conversation {
+            // Pass 1: agent with existing session for this conversation.
             let idx = self.agents.iter().position(|slot| {
                 slot.as_ref()
-                    .map(|a| a.state.sessions.contains_key(&cid))
+                    .map(|a| a.state.sessions.contains_key(key))
+                    .unwrap_or(false)
+            });
+            if let Some(i) = idx {
+                return self.agents[i].take();
+            }
+
+            // Pass 2: agent with a session in the same channel.
+            let idx = self.agents.iter().position(|slot| {
+                slot.as_ref()
+                    .map(|a| {
+                        a.state
+                            .sessions
+                            .keys()
+                            .any(|k| k.channel_id == key.channel_id)
+                    })
                     .unwrap_or(false)
             });
             if let Some(i) = idx {
@@ -680,7 +721,7 @@ impl AgentPool {
             }
         }
 
-        // Pass 2: first idle agent.
+        // Pass 3: first idle agent.
         let idx = self.agents.iter().position(|slot| slot.is_some());
         idx.map(|i| self.agents[i].take().unwrap())
     }
@@ -706,12 +747,12 @@ impl AgentPool {
         self.agents.iter().any(|slot| slot.is_some())
     }
 
-    /// Whether any idle agent already has a session for `channel_id`.
+    /// Whether any idle agent already has a session for `conversation`.
     /// Used to compute `affinity_hit` before calling `try_claim`.
-    pub fn has_session_for(&self, channel_id: Uuid) -> bool {
+    pub fn has_session_for(&self, conversation: &ConversationKey) -> bool {
         self.agents.iter().any(|slot| {
             slot.as_ref()
-                .map(|a| a.state.sessions.contains_key(&channel_id))
+                .map(|a| a.state.sessions.contains_key(conversation))
                 .unwrap_or(false)
         })
     }
@@ -751,19 +792,19 @@ impl AgentPool {
     /// watcher, to close the result-vs-ack race.
     ///
     /// Returns `Err(SteerError::PromptCompleted)` if no task is in flight
-    /// for `channel_id` (the prompt completed between the mode-gate check
-    /// and this call, or the channel was never in flight). This is
+    /// for `conversation` (the prompt completed between the mode-gate check
+    /// and this call, or the conversation was never in flight). This is
     /// semantically a soft no-op — the caller should release any withheld
     /// event and let normal dispatch handle delivery.
     pub fn send_steer(
         &mut self,
-        channel_id: Uuid,
+        conversation: &ConversationKey,
         request: SteerRequest,
     ) -> Result<(), SteerError> {
         let meta = self
             .task_map
             .values_mut()
-            .find(|m| m.channel_id == Some(channel_id))
+            .find(|m| m.conversation.as_ref() == Some(conversation))
             .ok_or(SteerError::PromptCompleted)?;
         let tx = meta
             .steer_tx
@@ -779,14 +820,14 @@ impl AgentPool {
     /// we write directly to the idle agent's matching live-session ledger.
     pub fn record_successful_steer(
         &mut self,
-        channel_id: Uuid,
+        conversation: &ConversationKey,
         event_id: String,
         session_id: String,
     ) -> bool {
         if let Some(meta) = self
             .task_map
             .values_mut()
-            .find(|meta| meta.channel_id == Some(channel_id))
+            .find(|meta| meta.conversation.as_ref() == Some(conversation))
         {
             meta.successful_steer_deliveries
                 .insert(SuccessfulSteerDelivery {
@@ -797,13 +838,13 @@ impl AgentPool {
         }
 
         let Some(agent) = self.agents.iter_mut().flatten().find(|agent| {
-            agent.state.sessions.get(&channel_id).map(String::as_str) == Some(session_id.as_str())
+            agent.state.sessions.get(conversation).map(String::as_str) == Some(session_id.as_str())
         }) else {
             return false;
         };
         agent
             .state
-            .mark_channel_delivery_success(channel_id, false, [event_id]);
+            .mark_conversation_delivery_success(conversation, false, [event_id]);
         true
     }
 
@@ -881,33 +922,45 @@ impl AgentPool {
         model_id: &str,
         request_id: Option<String>,
     ) -> IdleSwitchResult {
-        let Some(agent) = self
-            .agents
-            .iter_mut()
-            .flatten()
-            .find(|a| a.state.sessions.contains_key(&channel_id))
-        else {
-            return IdleSwitchResult::NoIdleAgent;
-        };
+        let has_channel_session =
+            |a: &OwnedAgent| a.state.sessions.keys().any(|k| k.channel_id == channel_id);
 
-        // Pre-cancel guard against the cached catalog. None = catalog not yet
-        // populated (no session ever created); defer validation to apply time.
-        if let Some(caps) = agent.model_capabilities.as_ref() {
-            if !model_in_catalog(
-                &caps.config_options_raw,
-                caps.available_models_raw.as_ref(),
-                model_id,
-            ) {
-                return IdleSwitchResult::UnsupportedModel;
+        if !self.agents.iter().flatten().any(&has_channel_session) {
+            return IdleSwitchResult::NoIdleAgent;
+        }
+
+        // Pre-cancel guard against the cached catalogs of every matching idle
+        // agent, *before* mutating any of them — an unsupported pick must not
+        // disturb existing sessions. None = catalog not yet populated (no
+        // session ever created); defer validation to apply time.
+        for agent in self
+            .agents
+            .iter()
+            .flatten()
+            .filter(|a| has_channel_session(a))
+        {
+            if let Some(caps) = agent.model_capabilities.as_ref() {
+                if !model_in_catalog(
+                    &caps.config_options_raw,
+                    caps.available_models_raw.as_ref(),
+                    model_id,
+                ) {
+                    return IdleSwitchResult::UnsupportedModel;
+                }
             }
         }
 
-        agent.desired_model = Some(model_id.to_string());
-        agent.model_overridden = true;
-        // Carry the pick's correlator so a deferred-validation miss on the next
-        // turn's session creation emits a late frame the Desktop can match.
-        agent.desired_model_request_id = request_id;
-        agent.state.invalidate_channel(&channel_id);
+        for agent in self.agents.iter_mut().flatten() {
+            if !has_channel_session(agent) {
+                continue;
+            }
+            agent.desired_model = Some(model_id.to_string());
+            agent.model_overridden = true;
+            // Carry the pick's correlator so a deferred-validation miss on the next
+            // turn's session creation emits a late frame the Desktop can match.
+            agent.desired_model_request_id = request_id.clone();
+            agent.state.invalidate_channel(&channel_id);
+        }
         IdleSwitchResult::Switched
     }
 }
@@ -1777,11 +1830,11 @@ pub async fn run_prompt_task(
 ) {
     // Is this a channel prompt or a heartbeat?
     let source = match &batch {
-        Some(b) => PromptSource::Channel(b.channel_id),
+        Some(b) => PromptSource::Channel(b.conversation.clone()),
         None => PromptSource::Heartbeat,
     };
     let observer_channel_id = match &source {
-        PromptSource::Channel(channel_id) => Some(*channel_id),
+        PromptSource::Channel(key) => Some(key.channel_id),
         PromptSource::Heartbeat => None,
     };
     let turn_started_at = chrono::Utc::now().to_rfc3339();
@@ -1880,10 +1933,11 @@ pub async fn run_prompt_task(
     //
     // Operator opt-out: `--no-memory` / `BUZZ_ACP_NO_MEMORY` skips the fetch.
     if ctx.memory_enabled {
-        if let (PromptSource::Channel(cid), Some(owner_pk)) =
+        if let (PromptSource::Channel(key), Some(owner_pk)) =
             (&source, ctx.agent_owner_pubkey.as_ref())
         {
-            let is_new_channel_session = !agent.state.sessions.contains_key(cid);
+            let cid = &key.channel_id;
+            let is_new_channel_session = !agent.state.sessions.contains_key(key);
             if is_new_channel_session && !agent.state.core_sections.contains_key(cid) {
                 // Bounded — we'd rather start the session with no core hint
                 // than block session creation on a stalled relay.
@@ -1936,8 +1990,9 @@ pub async fn run_prompt_task(
     // canvas DM check uses — see `resolve_new_session_channel_context`.
     let mut title_channel: Option<String> = None;
     let mut origin_channel_type: Option<String> = None;
-    if let PromptSource::Channel(cid) = &source {
-        let is_new_channel_session = !agent.state.sessions.contains_key(cid);
+    if let PromptSource::Channel(key) = &source {
+        let cid = &key.channel_id;
+        let is_new_channel_session = !agent.state.sessions.contains_key(key);
         let needs_canvas = is_new_channel_session && !agent.state.canvas_sections.contains_key(cid);
         if is_new_channel_session {
             let (is_dm, resolved_channel, resolved_channel_type) =
@@ -1961,25 +2016,25 @@ pub async fn run_prompt_task(
     // The core section to fold into the system prompt for this turn's session.
     // Channel-scoped; heartbeats carry no owner core.
     let agent_core: Option<String> = match &source {
-        PromptSource::Channel(cid) => agent.state.core_sections.get(cid).cloned(),
+        PromptSource::Channel(key) => agent.state.core_sections.get(&key.channel_id).cloned(),
         PromptSource::Heartbeat => None,
     };
 
     // The canvas metadata section — channel-scoped, absent for heartbeats/DMs.
     // Prefer the committed cache; fall back to pending (for new sessions being created now).
     let agent_canvas: Option<String> = match &source {
-        PromptSource::Channel(cid) => agent
+        PromptSource::Channel(key) => agent
             .state
             .canvas_sections
-            .get(cid)
+            .get(&key.channel_id)
             .cloned()
             .or_else(|| pending_canvas.as_ref().map(|(_, s)| s.clone())),
         PromptSource::Heartbeat => None,
     };
 
     let (session_id, is_new_session) = match &source {
-        PromptSource::Channel(cid) => {
-            if let Some(sid) = agent.state.sessions.get(cid) {
+        PromptSource::Channel(key) => {
+            if let Some(sid) = agent.state.sessions.get(key) {
                 (sid.clone(), false)
             } else {
                 // The title is channel-qualified (`Agent · #channel`) so one
@@ -1994,7 +2049,7 @@ pub async fn run_prompt_task(
                         huddle_instructions: huddle_instructions.as_deref(),
                         canvas: agent_canvas.as_deref(),
                         name: title_channel.as_deref(),
-                        id: Some(*cid),
+                        id: Some(key.channel_id),
                         channel_type: origin_channel_type.as_deref(),
                     },
                 )
@@ -2003,13 +2058,13 @@ pub async fn run_prompt_task(
                     Ok(sid) => {
                         tracing::info!(
                             target: "pool::session",
-                            "created session {sid} for channel {cid}"
+                            "created session {sid} for conversation {key}"
                         );
-                        agent.state.sessions.insert(*cid, sid.clone());
+                        agent.state.sessions.insert(key.clone(), sid.clone());
                         agent
                             .state
                             .deliveries
-                            .insert(*cid, ChannelDeliveryState::default());
+                            .insert(key.clone(), ConversationDeliveryState::default());
                         // Seed a zero usage baseline: buzz-acp spawned this session
                         // so prior usage is zero by definition — first turn is reliable.
                         agent.acp.notify_session_spawned(&sid);
@@ -2139,20 +2194,20 @@ pub async fn run_prompt_task(
     // sessions created before this field existed fail safe by behaving as
     // undelivered once, rather than silently omitting standing context.
     let mut standing_context_sent = match &source {
-        PromptSource::Channel(cid) => agent
+        PromptSource::Channel(key) => agent
             .state
             .deliveries
-            .get(cid)
+            .get(key)
             .is_some_and(|delivery| delivery.standing_context_sent),
         PromptSource::Heartbeat => agent.state.heartbeat_standing_context_sent,
     };
 
     if is_new_session {
-        if let (PromptSource::Channel(cid), Some(ref initial_msg)) = (&source, &ctx.initial_message)
+        if let (PromptSource::Channel(key), Some(ref initial_msg)) = (&source, &ctx.initial_message)
         {
             tracing::info!(
                 target: "pool::session",
-                "sending initial_message to session {session_id} for channel {cid}"
+                "sending initial_message to session {session_id} for conversation {key}"
             );
             let init_msg = prepend_standing_for_legacy(
                 if agent.has_system_prompt_support() {
@@ -2177,19 +2232,21 @@ pub async fn run_prompt_task(
                 Ok(stop_reason) => {
                     tracing::info!(
                         target: "pool::session",
-                        "initial_message complete for channel {cid}: {stop_reason:?}"
+                        "initial_message complete for conversation {key}: {stop_reason:?}"
                     );
                     // The legacy agent has its standing context now; the turn
                     // prompt below must not repeat it. Every other arm returns.
                     standing_context_sent = true;
                     if !agent.has_system_prompt_support() {
-                        agent.state.mark_channel_delivery_success(*cid, true, []);
+                        agent
+                            .state
+                            .mark_conversation_delivery_success(key, true, []);
                     }
                     let usage = agent.acp.take_turn_usage();
                     publish_agent_turn_metric(
                         &ctx,
                         usage,
-                        Some(*cid),
+                        Some(key.channel_id),
                         &session_id,
                         &format!("{turn_id}:initial"),
                         Some(acp_stop_to_core(&stop_reason)),
@@ -2211,7 +2268,7 @@ pub async fn run_prompt_task(
                 Err(AcpError::IdleTimeout(_)) => {
                     tracing::warn!(
                         target: "pool::session",
-                        "initial_message idle timeout ({}s) for channel {cid} — cancelling",
+                        "initial_message idle timeout ({}s) for conversation {key} — cancelling",
                         ctx.idle_timeout.as_secs()
                     );
                     match agent
@@ -2224,7 +2281,7 @@ pub async fn run_prompt_task(
                             publish_agent_turn_metric(
                                 &ctx,
                                 usage,
-                                Some(*cid),
+                                Some(key.channel_id),
                                 &session_id,
                                 &format!("{turn_id}:initial"),
                                 Some(acp_stop_to_core(&stop_reason)),
@@ -2266,7 +2323,7 @@ pub async fn run_prompt_task(
                     let recently_active = silence < RECENT_ACTIVITY_WINDOW;
                     tracing::error!(
                         target: "pool::session",
-                        "hard timeout ({}s cap, silence {silence:?}, recently_active={recently_active}) during initial_message for channel {cid} — agent process is unrecoverable",
+                        "hard timeout ({}s cap, silence {silence:?}, recently_active={recently_active}) during initial_message for conversation {key} — agent process is unrecoverable",
                         ctx.max_turn_duration.as_secs()
                     );
                     agent.state.invalidate_all();
@@ -2283,7 +2340,7 @@ pub async fn run_prompt_task(
                 Err(e) => {
                     tracing::error!(
                         target: "pool::session",
-                        "initial_message failed for channel {cid}: {e} — invalidating session"
+                        "initial_message failed for conversation {key}: {e} — invalidating session"
                     );
                     agent.state.invalidate(&source);
                     send_prompt_result(
@@ -2335,7 +2392,7 @@ pub async fn run_prompt_task(
     } else if let Some(ref b) = batch {
         // Build prompt from batch with context enrichment.
         // Try startup cache first; lazy-fetch via REST for dynamic channels.
-        let channel_info = ctx.channel_info.resolve(b.channel_id).await;
+        let channel_info = ctx.channel_info.resolve(b.channel_id()).await;
 
         let conversation_context = if ctx.context_message_limit > 0 {
             fetch_conversation_context(b, &channel_info, &ctx).await
@@ -2351,7 +2408,7 @@ pub async fn run_prompt_task(
         let delivered_ids = agent
             .state
             .deliveries
-            .get(&b.channel_id)
+            .get(&b.conversation)
             .map(|delivery| &delivery.delivered_event_ids)
             .cloned()
             .unwrap_or_default();
@@ -2381,7 +2438,7 @@ pub async fn run_prompt_task(
         if let Some(ref cmd) = slash_command {
             tracing::info!(
                 target: "pool::prompt",
-                channel = %b.channel_id,
+                channel = %b.channel_id(),
                 command = %cmd,
                 "slash-command pass-through"
             );
@@ -2619,10 +2676,10 @@ pub async fn run_prompt_task(
                                 "control signal arrived but turn already completed — treating as success"
                             );
                         }
-                        if let PromptSource::Channel(cid) = &source {
+                        if let PromptSource::Channel(key) = &source {
                             let standing_sent = !agent.has_system_prompt_support();
-                            agent.state.mark_channel_delivery_success(
-                                *cid,
+                            agent.state.mark_conversation_delivery_success(
+                                key,
                                 standing_sent,
                                 pending_delivered_event_ids.iter().cloned(),
                             );
@@ -2661,10 +2718,10 @@ pub async fn run_prompt_task(
         Ok(stop_reason) => {
             log_stop_reason(&source, &stop_reason);
 
-            if let PromptSource::Channel(cid) = &source {
+            if let PromptSource::Channel(key) = &source {
                 let standing_sent = !agent.has_system_prompt_support();
-                agent.state.mark_channel_delivery_success(
-                    *cid,
+                agent.state.mark_conversation_delivery_success(
+                    key,
                     standing_sent,
                     pending_delivered_event_ids.iter().cloned(),
                 );
@@ -2681,8 +2738,8 @@ pub async fn run_prompt_task(
                 let limit = ctx.max_turns_per_session;
                 if limit > 0 {
                     match &source {
-                        PromptSource::Channel(cid) => {
-                            let count = agent.state.turn_counts.entry(*cid).or_insert(0);
+                        PromptSource::Channel(key) => {
+                            let count = agent.state.turn_counts.entry(key.clone()).or_insert(0);
                             *count += 1;
                             *count >= limit
                         }
@@ -3323,7 +3380,7 @@ async fn fetch_conversation_context(
     let tags = crate::queue::parse_thread_tags(&last_event.event);
     if let Some(root_id) = tags.root_event_id {
         return fetch_thread_context(
-            batch.channel_id,
+            batch.channel_id(),
             &root_id,
             limit,
             ctx.agent_keys.public_key(),
@@ -3334,7 +3391,7 @@ async fn fetch_conversation_context(
 
     // DM non-reply: fetch recent conversation history.
     if is_dm {
-        return fetch_dm_context(batch.channel_id, limit, &ctx.rest_client).await;
+        return fetch_dm_context(batch.channel_id(), limit, &ctx.rest_client).await;
     }
 
     None
@@ -5860,7 +5917,7 @@ mod tests {
             .unwrap();
         let author_hex = event.pubkey.to_hex();
         let batch = FlushBatch {
-            channel_id: Uuid::new_v4(),
+            conversation: conv(Uuid::new_v4()),
             events: vec![crate::queue::BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -6073,6 +6130,7 @@ done"#
             .await
             .expect("spawn channel lifecycle ACP script");
         let channel_id = Uuid::new_v4();
+        let conversation = conv(channel_id);
         let mut agent = OwnedAgent {
             index: 0,
             acp,
@@ -6090,11 +6148,11 @@ done"#
         agent
             .state
             .sessions
-            .insert(channel_id, "live-session".into());
+            .insert(conversation.clone(), "live-session".into());
         agent
             .state
             .deliveries
-            .insert(channel_id, ChannelDeliveryState::default());
+            .insert(conversation.clone(), ConversationDeliveryState::default());
 
         let mut ctx = make_prompt_context_no_owner();
         ctx.base_prompt = Some("standing-once");
@@ -6107,7 +6165,7 @@ done"#
                 .unwrap();
             let event_id = event.id.to_hex();
             let batch = FlushBatch {
-                channel_id,
+                conversation: conversation.clone(),
                 events: vec![crate::queue::BatchEvent {
                     event,
                     prompt_tag: "test".into(),
@@ -6134,7 +6192,7 @@ done"#
                     PromptOutcome::Ok(StopReason::EndTurn)
                 )),
             }
-            let delivery = &result.agent.state.deliveries[&channel_id];
+            let delivery = &result.agent.state.deliveries[&conversation];
             assert_eq!(
                 delivery.standing_context_sent,
                 turn >= 2,
@@ -6176,6 +6234,7 @@ done"#
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
         let channel_id = Uuid::new_v4();
+        let conversation = conv(channel_id);
         let keys = Keys::generate();
         let carry_over = EventBuilder::new(Kind::Custom(9), "merged carry-over sentinel")
             .sign_with_keys(&keys)
@@ -6189,7 +6248,7 @@ done"#
             .sign_with_keys(&keys)
             .unwrap();
         let merged_batch = FlushBatch {
-            channel_id,
+            conversation: conversation.clone(),
             events: vec![crate::queue::BatchEvent {
                 event: new_event.clone(),
                 prompt_tag: "test".into(),
@@ -6203,7 +6262,7 @@ done"#
             cancel_reason: Some(crate::queue::CancelReason::Steer),
         };
         let next_batch = FlushBatch {
-            channel_id,
+            conversation: conversation.clone(),
             events: vec![crate::queue::BatchEvent {
                 event: next_event,
                 prompt_tag: "test".into(),
@@ -6265,11 +6324,11 @@ done"#
         agent
             .state
             .sessions
-            .insert(channel_id, "live-session".into());
+            .insert(conversation.clone(), "live-session".into());
         agent
             .state
             .deliveries
-            .insert(channel_id, ChannelDeliveryState::default());
+            .insert(conversation.clone(), ConversationDeliveryState::default());
 
         let mut ctx = make_prompt_context_no_owner();
         ctx.context_message_limit = 10;
@@ -6311,7 +6370,7 @@ done"#
             ));
             agent = result.agent;
         }
-        let delivery = &agent.state.deliveries[&channel_id];
+        let delivery = &agent.state.deliveries[&conversation];
         assert!(delivery.delivered_event_ids.contains(&carry_over_id));
         assert!(delivery.delivered_event_ids.contains(&new_event_id));
         agent.acp.shutdown().await;
@@ -6349,6 +6408,7 @@ done"#
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
         let channel_id = Uuid::new_v4();
+        let conversation = conv(channel_id);
         let keys = Keys::generate();
         let steered_event = EventBuilder::new(Kind::Custom(9), "steered context must not replay")
             .sign_with_keys(&keys)
@@ -6358,7 +6418,7 @@ done"#
             .sign_with_keys(&keys)
             .unwrap();
         let batch = FlushBatch {
-            channel_id,
+            conversation: conversation.clone(),
             events: vec![crate::queue::BatchEvent {
                 event: trigger,
                 prompt_tag: "test".into(),
@@ -6418,22 +6478,22 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         agent
             .state
             .sessions
-            .insert(channel_id, "live-session".into());
+            .insert(conversation.clone(), "live-session".into());
         agent
             .state
             .deliveries
-            .insert(channel_id, ChannelDeliveryState::default());
+            .insert(conversation.clone(), ConversationDeliveryState::default());
 
         // Model the adversarial ordering: the task result has already retired
         // its TaskMeta and returned the agent before the successful ack arrives.
         let mut pool = AgentPool::from_slots(vec![Some(agent)]);
         assert!(pool.record_successful_steer(
-            channel_id,
+            &conversation,
             steered_event_id.clone(),
             "live-session".into(),
         ));
         let agent = pool
-            .try_claim(Some(channel_id))
+            .try_claim(Some(&conversation))
             .expect("claim returned agent");
 
         let mut ctx = make_prompt_context_no_owner();
@@ -6493,22 +6553,23 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     #[test]
     fn delivery_state_commits_only_when_explicitly_marked_successful() {
         let channel = Uuid::new_v4();
+        let conversation = conv(channel);
         let mut state = SessionState::default();
         state
             .deliveries
-            .insert(channel, ChannelDeliveryState::default());
+            .insert(conversation.clone(), ConversationDeliveryState::default());
 
         // Building or attempting a prompt does not mutate delivery state.
-        let delivery = state.deliveries.get(&channel).unwrap();
+        let delivery = state.deliveries.get(&conversation).unwrap();
         assert!(!delivery.standing_context_sent);
         assert!(delivery.delivered_event_ids.is_empty());
 
-        state.mark_channel_delivery_success(
-            channel,
+        state.mark_conversation_delivery_success(
+            &conversation,
             true,
             ["trigger".to_string(), "context".to_string()],
         );
-        let delivery = state.deliveries.get(&channel).unwrap();
+        let delivery = state.deliveries.get(&conversation).unwrap();
         assert!(delivery.standing_context_sent);
         assert_eq!(delivery.delivered_event_ids.len(), 2);
     }
@@ -6516,18 +6577,23 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     #[test]
     fn delivery_state_is_cleared_on_rotation_and_restarts_empty() {
         let channel = Uuid::new_v4();
+        let conversation = conv(channel);
         let mut state = SessionState::default();
-        state.sessions.insert(channel, "old-session".into());
-        state.mark_channel_delivery_success(channel, true, ["old-event".to_string()]);
+        state
+            .sessions
+            .insert(conversation.clone(), "old-session".into());
+        state.mark_conversation_delivery_success(&conversation, true, ["old-event".to_string()]);
 
         assert!(state.invalidate_channel(&channel));
-        assert!(!state.deliveries.contains_key(&channel));
+        assert!(!state.deliveries.contains_key(&conversation));
 
-        state.sessions.insert(channel, "new-session".into());
+        state
+            .sessions
+            .insert(conversation.clone(), "new-session".into());
         state
             .deliveries
-            .insert(channel, ChannelDeliveryState::default());
-        let delivery = state.deliveries.get(&channel).unwrap();
+            .insert(conversation.clone(), ConversationDeliveryState::default());
+        let delivery = state.deliveries.get(&conversation).unwrap();
         assert!(!delivery.standing_context_sent);
         assert!(delivery.delivered_event_ids.is_empty());
     }
@@ -6630,26 +6696,34 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         assert_eq!(pct_encode(" "), "%20");
     }
 
-    fn make_state() -> (SessionState, Uuid, Uuid) {
-        let ch_a = Uuid::new_v4();
-        let ch_b = Uuid::new_v4();
+    /// Top-level (thread_root = None) conversation key for a channel.
+    fn conv(channel_id: Uuid) -> ConversationKey {
+        ConversationKey {
+            channel_id,
+            thread_root: None,
+        }
+    }
+
+    fn make_state() -> (SessionState, ConversationKey, ConversationKey) {
+        let ch_a = conv(Uuid::new_v4());
+        let ch_b = conv(Uuid::new_v4());
         let mut s = SessionState::default();
-        s.sessions.insert(ch_a, "sess-a".into());
-        s.sessions.insert(ch_b, "sess-b".into());
-        s.turn_counts.insert(ch_a, 5);
-        s.turn_counts.insert(ch_b, 3);
-        s.core_sections.insert(ch_a, "core-a".into());
-        s.core_sections.insert(ch_b, "core-b".into());
+        s.sessions.insert(ch_a.clone(), "sess-a".into());
+        s.sessions.insert(ch_b.clone(), "sess-b".into());
+        s.turn_counts.insert(ch_a.clone(), 5);
+        s.turn_counts.insert(ch_b.clone(), 3);
+        s.core_sections.insert(ch_a.channel_id, "core-a".into());
+        s.core_sections.insert(ch_b.channel_id, "core-b".into());
         s.deliveries.insert(
-            ch_a,
-            ChannelDeliveryState {
+            ch_a.clone(),
+            ConversationDeliveryState {
                 standing_context_sent: true,
                 delivered_event_ids: HashSet::from(["event-a".into()]),
             },
         );
         s.deliveries.insert(
-            ch_b,
-            ChannelDeliveryState {
+            ch_b.clone(),
+            ConversationDeliveryState {
                 standing_context_sent: true,
                 delivered_event_ids: HashSet::from(["event-b".into()]),
             },
@@ -6666,17 +6740,17 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
 
         apply_completed_before_control_signal(
             &mut s,
-            &PromptSource::Channel(ch_a),
+            &PromptSource::Channel(ch_a.clone()),
             &ControlSignal::Rotate,
         );
 
         assert!(!s.sessions.contains_key(&ch_a));
         assert!(!s.turn_counts.contains_key(&ch_a));
-        assert!(!s.core_sections.contains_key(&ch_a));
-        assert!(!s.has_channel_state(&ch_a));
+        assert!(!s.core_sections.contains_key(&ch_a.channel_id));
+        assert!(!s.has_channel_state(&ch_a.channel_id));
         assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
         assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
-        assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
+        assert_eq!(s.core_sections.get(&ch_b.channel_id).unwrap(), "core-b");
         assert_eq!(s.heartbeat_session.as_deref(), Some("sess-hb"));
         assert_eq!(s.heartbeat_turn_count, 7);
     }
@@ -6687,29 +6761,29 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
 
         apply_completed_before_control_signal(
             &mut s,
-            &PromptSource::Channel(ch_a),
+            &PromptSource::Channel(ch_a.clone()),
             &ControlSignal::Cancel,
         );
 
         assert_eq!(s.sessions.get(&ch_a).unwrap(), "sess-a");
         assert_eq!(*s.turn_counts.get(&ch_a).unwrap(), 5);
-        assert_eq!(s.core_sections.get(&ch_a).unwrap(), "core-a");
+        assert_eq!(s.core_sections.get(&ch_a.channel_id).unwrap(), "core-a");
         assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
     }
 
     #[test]
     fn test_invalidate_channel_clears_session_and_turn_count() {
         let (mut s, ch_a, ch_b) = make_state();
-        s.invalidate(&PromptSource::Channel(ch_a));
+        s.invalidate(&PromptSource::Channel(ch_a.clone()));
 
         assert!(!s.sessions.contains_key(&ch_a));
         assert!(!s.turn_counts.contains_key(&ch_a));
-        assert!(!s.core_sections.contains_key(&ch_a));
-        assert!(!s.has_channel_state(&ch_a));
+        assert!(!s.core_sections.contains_key(&ch_a.channel_id));
+        assert!(!s.has_channel_state(&ch_a.channel_id));
         // ch_b untouched
         assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
         assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
-        assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
+        assert_eq!(s.core_sections.get(&ch_b.channel_id).unwrap(), "core-b");
         // heartbeat untouched
         assert_eq!(s.heartbeat_session.as_deref(), Some("sess-hb"));
         assert_eq!(s.heartbeat_turn_count, 7);
@@ -6727,8 +6801,8 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         assert_eq!(s.sessions.len(), 2);
         assert_eq!(*s.turn_counts.get(&ch_a).unwrap(), 5);
         assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
-        assert_eq!(s.core_sections.get(&ch_a).unwrap(), "core-a");
-        assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
+        assert_eq!(s.core_sections.get(&ch_a.channel_id).unwrap(), "core-a");
+        assert_eq!(s.core_sections.get(&ch_b.channel_id).unwrap(), "core-b");
     }
 
     #[test]
@@ -6747,7 +6821,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     #[test]
     fn test_invalidate_nonexistent_channel_is_noop() {
         let (mut s, ch_a, ch_b) = make_state();
-        let ghost = Uuid::new_v4();
+        let ghost = conv(Uuid::new_v4());
         s.invalidate(&PromptSource::Channel(ghost));
 
         // Everything still intact.
@@ -6755,8 +6829,8 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         assert_eq!(s.turn_counts.len(), 2);
         assert_eq!(*s.turn_counts.get(&ch_a).unwrap(), 5);
         assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
-        assert_eq!(s.core_sections.get(&ch_a).unwrap(), "core-a");
-        assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
+        assert_eq!(s.core_sections.get(&ch_a.channel_id).unwrap(), "core-a");
+        assert_eq!(s.core_sections.get(&ch_b.channel_id).unwrap(), "core-b");
     }
 
     #[test]
@@ -6771,15 +6845,15 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     #[test]
     fn test_invalidate_channel_returns_true_when_session_existed() {
         let (mut s, ch_a, ch_b) = make_state();
-        assert!(s.invalidate_channel(&ch_a));
+        assert!(s.invalidate_channel(&ch_a.channel_id));
         assert!(!s.sessions.contains_key(&ch_a));
         assert!(!s.turn_counts.contains_key(&ch_a));
-        assert!(!s.core_sections.contains_key(&ch_a));
-        assert!(!s.has_channel_state(&ch_a));
+        assert!(!s.core_sections.contains_key(&ch_a.channel_id));
+        assert!(!s.has_channel_state(&ch_a.channel_id));
         // ch_b untouched
         assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
         assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
-        assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
+        assert_eq!(s.core_sections.get(&ch_b.channel_id).unwrap(), "core-b");
         // heartbeat untouched
         assert_eq!(s.heartbeat_session.as_deref(), Some("sess-hb"));
         assert_eq!(s.heartbeat_turn_count, 7);
@@ -6800,17 +6874,17 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         // Simulates handle_prompt_result: channels removed while agent
         // was checked out should have both sessions and turn_counts stripped.
         let (mut s, ch_a, ch_b) = make_state();
-        let removed = vec![ch_a];
+        let removed = vec![ch_a.channel_id];
         for ch in &removed {
             s.invalidate_channel(ch);
         }
         assert!(!s.sessions.contains_key(&ch_a));
         assert!(!s.turn_counts.contains_key(&ch_a));
-        assert!(!s.core_sections.contains_key(&ch_a));
-        assert!(!s.has_channel_state(&ch_a));
+        assert!(!s.core_sections.contains_key(&ch_a.channel_id));
+        assert!(!s.has_channel_state(&ch_a.channel_id));
         assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
         assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
-        assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
+        assert_eq!(s.core_sections.get(&ch_b.channel_id).unwrap(), "core-b");
     }
 
     // ── ControlSignal::SwitchModel (Phase 3a, Option ii) ─────────────────────
@@ -6823,14 +6897,14 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         // re-creates a fresh session that re-applies the new desired_model.
         apply_completed_before_control_signal(
             &mut s,
-            &PromptSource::Channel(ch_a),
+            &PromptSource::Channel(ch_a.clone()),
             &ControlSignal::SwitchModel {
                 model_id: "gpt-5".into(),
                 request_id: None,
             },
         );
 
-        assert!(!s.has_channel_state(&ch_a));
+        assert!(!s.has_channel_state(&ch_a.channel_id));
         // ch_b untouched — the switch is channel-scoped.
         assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
         assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
@@ -6850,7 +6924,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             .sign_with_keys(&keys)
             .unwrap();
         FlushBatch {
-            channel_id,
+            conversation: conv(channel_id),
             events: vec![crate::queue::BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -8064,14 +8138,14 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
     fn test_invalidate_channel_clears_canvas_section() {
         let ch = Uuid::new_v4();
         let mut s = SessionState::default();
-        s.sessions.insert(ch, "sess".into());
+        s.sessions.insert(conv(ch), "sess".into());
         s.canvas_sections
             .insert(ch, "[Channel Canvas]\nrev abc".into());
 
         s.invalidate_channel(&ch);
 
         assert!(!s.canvas_sections.contains_key(&ch));
-        assert!(!s.sessions.contains_key(&ch));
+        assert!(!s.sessions.contains_key(&conv(ch)));
     }
 
     #[test]
@@ -8081,7 +8155,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         let mut s = SessionState::default();
         s.canvas_sections.insert(ch_a, "canvas-a".into());
         s.canvas_sections.insert(ch_b, "canvas-b".into());
-        s.sessions.insert(ch_a, "sess-a".into());
+        s.sessions.insert(conv(ch_a), "sess-a".into());
 
         s.invalidate_all();
 
@@ -8094,8 +8168,8 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         let ch_a = Uuid::new_v4();
         let ch_b = Uuid::new_v4();
         let mut s = SessionState::default();
-        s.sessions.insert(ch_a, "sess-a".into());
-        s.sessions.insert(ch_b, "sess-b".into());
+        s.sessions.insert(conv(ch_a), "sess-a".into());
+        s.sessions.insert(conv(ch_b), "sess-b".into());
         s.canvas_sections.insert(ch_a, "canvas-a".into());
         s.canvas_sections.insert(ch_b, "canvas-b".into());
 
@@ -8111,6 +8185,57 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         let mut s = SessionState::default();
         s.canvas_sections.insert(ch, "canvas".into());
         assert!(s.has_channel_state(&ch));
+    }
+
+    // ── Per-thread concurrency: sessions and affinity are conversation-keyed ─
+
+    /// Conversation key for a threaded lane in `channel_id`.
+    fn thread_conv(channel_id: Uuid, root: &str) -> ConversationKey {
+        ConversationKey {
+            channel_id,
+            thread_root: Some(root.into()),
+        }
+    }
+
+    #[test]
+    fn test_session_state_keeps_threads_in_one_channel_independent() {
+        let ch = Uuid::new_v4();
+        let thread_a = thread_conv(ch, "aaaa");
+        let thread_b = thread_conv(ch, "bbbb");
+        let mut s = SessionState::default();
+        s.sessions.insert(thread_a.clone(), "sess-a".into());
+        s.sessions.insert(thread_b.clone(), "sess-b".into());
+        s.turn_counts.insert(thread_a.clone(), 4);
+
+        assert!(s.invalidate_conversation(&thread_a));
+
+        assert!(!s.sessions.contains_key(&thread_a));
+        assert!(!s.turn_counts.contains_key(&thread_a));
+        assert_eq!(
+            s.sessions.get(&thread_b).unwrap(),
+            "sess-b",
+            "invalidating one thread must not touch a sibling thread's session"
+        );
+    }
+
+    #[test]
+    fn test_invalidate_channel_removes_every_thread_lane() {
+        let ch = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        let mut s = SessionState::default();
+        s.sessions.insert(conv(ch), "sess-top".into());
+        s.sessions.insert(thread_conv(ch, "aaaa"), "sess-a".into());
+        s.sessions.insert(thread_conv(ch, "bbbb"), "sess-b".into());
+        s.sessions.insert(conv(other), "sess-other".into());
+
+        assert!(s.invalidate_channel(&ch));
+
+        assert!(!s.has_channel_state(&ch));
+        assert_eq!(
+            s.sessions.get(&conv(other)).unwrap(),
+            "sess-other",
+            "other channels are untouched"
+        );
     }
 
     // ── canvas_section_from_query_response ───────────────────────────────────

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1,16 +1,20 @@
 //! Event queue state machine for buzz-acp.
 //!
-//! Manages per-channel event queues with per-channel in-flight tracking.
-//! When the harness is ready to prompt the agent, it flushes the channel with
-//! the oldest pending event, draining ALL events for that channel into a single
-//! batch. Multiple channels can be in-flight simultaneously; each channel is
-//! independent.
+//! Manages per-conversation event queues with per-conversation in-flight
+//! tracking. A conversation ([`ConversationKey`]) is one thread within a
+//! channel (keyed by its NIP-10 root event id), or the channel's top-level
+//! lane for events with no thread root. When the harness is ready to prompt
+//! the agent, it flushes the conversation with the oldest pending event,
+//! draining ALL events for that conversation into a single batch. Multiple
+//! conversations can be in-flight simultaneously — including different
+//! threads of the same channel; each conversation is independent.
 //!
 //! ## Dedup modes
 //!
-//! - **Drop** (default) — while a prompt is in-flight for channel C, new events
-//!   for channel C are silently dropped (debug-logged). Events for other channels
-//!   still queue normally.
+//! - **Drop** (default) — while a prompt is in-flight for conversation C, new
+//!   events for C are silently dropped (debug-logged). Events for other
+//!   conversations — including other threads in the same channel — still
+//!   queue normally.
 //! - **Queue** — all events accumulate; batched on the next flush cycle.
 
 use nostr::{Event, ToBech32};
@@ -41,10 +45,61 @@ const IN_FLIGHT_DEADLINE_BUFFER_SECS: u64 = 100;
 /// Default in-flight deadline: default max_turn (7200s) + 100s buffer.
 const DEFAULT_IN_FLIGHT_DEADLINE_SECS: u64 = 7300;
 
+/// Unit of turn concurrency: one thread within a channel, or one DM channel.
+///
+/// Queueing, in-flight exclusion, retry/backoff, cancellation, and steer
+/// routing are all keyed by this, so distinct threads in one channel can run
+/// turns concurrently while events within one conversation stay serialized
+/// and batch together.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ConversationKey {
+    pub channel_id: Uuid,
+    /// Thread root event id (hex) for channel threads; `None` for DMs and
+    /// channel-wide control fallback.
+    pub thread_root: Option<String>,
+}
+
+impl ConversationKey {
+    /// Key for an event in `channel_id`, derived from its NIP-10 thread tags.
+    pub fn for_event(channel_id: Uuid, event: &Event) -> Self {
+        Self {
+            channel_id,
+            thread_root: parse_thread_tags(event).root_event_id,
+        }
+    }
+
+    /// Key for an accepted inbound agent event.
+    ///
+    /// A channel top-level post starts a new thread session under its own event
+    /// ID. Replies reuse the canonical root ID. DMs keep channel continuity.
+    pub fn for_inbound(channel_id: Uuid, event: &Event, is_dm: bool) -> Self {
+        let thread_root = if is_dm {
+            None
+        } else {
+            parse_thread_tags(event)
+                .root_event_id
+                .or_else(|| Some(event.id.to_hex()))
+        };
+        Self {
+            channel_id,
+            thread_root,
+        }
+    }
+}
+
+impl std::fmt::Display for ConversationKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.thread_root {
+            Some(root) => write!(f, "{}#{}", self.channel_id, &root[..root.len().min(8)]),
+            None => write!(f, "{}", self.channel_id),
+        }
+    }
+}
+
 /// An event waiting in the queue.
 #[derive(Debug, Clone)]
 pub struct QueuedEvent {
-    pub channel_id: Uuid,
+    pub conversation: ConversationKey,
     pub event: Event,
     pub received_at: Instant,
     /// Tag identifying which rule (or mode) matched this event.
@@ -75,7 +130,7 @@ pub enum CancelReason {
 /// A batch of events to prompt the agent with.
 #[derive(Debug, Clone)]
 pub struct FlushBatch {
-    pub channel_id: Uuid,
+    pub conversation: ConversationKey,
     pub events: Vec<BatchEvent>,
     /// Events from a cancelled batch that triggered this re-prompt.
     /// Empty for normal (non-cancel) batches. When non-empty, `format_prompt()`
@@ -89,70 +144,77 @@ pub struct FlushBatch {
     pub cancel_reason: Option<CancelReason>,
 }
 
-/// Per-channel event queue with per-channel in-flight enforcement.
+impl FlushBatch {
+    pub fn channel_id(&self) -> Uuid {
+        self.conversation.channel_id
+    }
+}
+
+/// Per-conversation event queue with per-conversation in-flight enforcement.
 ///
 /// # State Machine
 ///
 /// ```text
 /// State:
-///   queues:               Map<channel_id, VecDeque<QueuedEvent>>  (capped at MAX_PENDING_PER_CHANNEL)
-///   in_flight_channels:   HashSet<Uuid>
-///   in_flight_deadlines:  Map<channel_id, Instant>                (auto-expire after in_flight_deadline)
-///   retry_after:          Map<channel_id, Instant>
-///   retry_counts:         Map<channel_id, u32>                    (dead-letter after MAX_RETRIES)
+///   queues:               Map<conversation, VecDeque<QueuedEvent>>  (capped at MAX_PENDING_PER_CHANNEL)
+///   in_flight:            HashSet<ConversationKey>
+///   in_flight_deadlines:  Map<conversation, Instant>                (auto-expire after in_flight_deadline)
+///   retry_after:          Map<conversation, Instant>
+///   retry_counts:         Map<conversation, u32>                    (dead-letter after MAX_RETRIES)
 ///   dedup_mode:           DedupMode
 ///
 /// Transitions:
 ///   push(event):
-///     if dedup_mode == Drop AND in_flight_channels.contains(event.channel_id):
+///     if dedup_mode == Drop AND in_flight.contains(event.conversation):
 ///       debug log + discard
-///     else if queues[channel].len() >= MAX_PENDING_PER_CHANNEL:
+///     else if queues[conversation].len() >= MAX_PENDING_PER_CHANNEL:
 ///       drop oldest (pop_front), warn, push_back new event
 ///     else:
-///       queues[event.channel_id].push_back(event)
+///       queues[event.conversation].push_back(event)
 ///
 ///   flush_next() → Option<FlushBatch>:
 ///     expire any stuck in-flight entries past their deadline
-///     candidates = channels where queue non-empty
-///                  AND NOT in in_flight_channels
+///     candidates = conversations where queue non-empty
+///                  AND NOT in in_flight
 ///                  AND (no retry_after OR retry_after[c] <= now)
 ///     if candidates empty: return None
-///     channel = pick candidate with oldest head event (min received_at)
-///     events = drain up to MAX_BATCH_EVENTS from queues[channel]
-///     in_flight_channels.insert(channel)
-///     in_flight_deadlines.insert(channel, now + in_flight_deadline)
-///     return Some(FlushBatch { channel, events })
+///     conversation = pick candidate with oldest head event (min received_at)
+///     events = drain up to MAX_BATCH_EVENTS from queues[conversation]
+///     in_flight.insert(conversation)
+///     in_flight_deadlines.insert(conversation, now + in_flight_deadline)
+///     return Some(FlushBatch { conversation, events })
 ///
-///   mark_complete(channel_id):
-///     in_flight_channels.remove(channel_id)
-///     in_flight_deadlines.remove(channel_id)
-///     retry_counts.remove(channel_id)
+///   mark_complete(conversation):
+///     in_flight.remove(conversation)
+///     in_flight_deadlines.remove(conversation)
+///     retry_counts.remove(conversation)
 ///     clean up expired retry_after entry if present
 ///
 ///   requeue(batch):
-///     increment retry_counts[channel]
-///     if retry_counts[channel] > MAX_RETRIES: dead-letter (log ERROR, return batch to caller)
+///     increment retry_counts[conversation]
+///     if retry_counts[conversation] > MAX_RETRIES: dead-letter (log ERROR, return batch to caller)
 ///     else: push_front with original received_at, set exponential backoff retry_after with jitter
 /// ```
 pub struct EventQueue {
-    queues: HashMap<Uuid, VecDeque<QueuedEvent>>,
-    in_flight_channels: HashSet<Uuid>,
-    /// Per-channel deadline for auto-expiring stuck in-flight entries.
-    in_flight_deadlines: HashMap<Uuid, Instant>,
+    queues: HashMap<ConversationKey, VecDeque<QueuedEvent>>,
+    in_flight: HashSet<ConversationKey>,
+    /// Per-conversation deadline for auto-expiring stuck in-flight entries.
+    in_flight_deadlines: HashMap<ConversationKey, Instant>,
     /// Number of events in each in-flight batch (for expiry logging).
-    in_flight_batch_sizes: HashMap<Uuid, usize>,
-    retry_after: HashMap<Uuid, Instant>,
-    /// Per-channel retry attempt counter for exponential backoff / dead-lettering.
-    retry_counts: HashMap<Uuid, u32>,
+    in_flight_batch_sizes: HashMap<ConversationKey, usize>,
+    retry_after: HashMap<ConversationKey, Instant>,
+    /// Per-conversation retry attempt counter for exponential backoff / dead-lettering.
+    retry_counts: HashMap<ConversationKey, u32>,
     dedup_mode: DedupMode,
-    /// Events from cancelled batches, keyed by channel. Merged into the next
-    /// `FlushBatch` for that channel as `cancelled_events` so `format_prompt()`
-    /// can produce annotated "[Previous request — interrupted]" sections.
-    cancelled_batches: HashMap<Uuid, Vec<BatchEvent>>,
-    /// Why each channel's cancelled batch was cancelled (steer vs interrupt).
-    /// Set by `requeue_as_cancelled`, consumed by `flush_next` to set
-    /// `FlushBatch::cancel_reason`. Keyed by channel, cleared on flush.
-    cancel_reasons: HashMap<Uuid, CancelReason>,
+    /// Events from cancelled batches, keyed by conversation. Merged into the
+    /// next `FlushBatch` for that conversation as `cancelled_events` so
+    /// `format_prompt()` can produce annotated "[Previous request —
+    /// interrupted]" sections.
+    cancelled_batches: HashMap<ConversationKey, Vec<BatchEvent>>,
+    /// Why each conversation's cancelled batch was cancelled (steer vs
+    /// interrupt). Set by `requeue_as_cancelled`, consumed by `flush_next` to
+    /// set `FlushBatch::cancel_reason`. Keyed by conversation, cleared on flush.
+    cancel_reasons: HashMap<ConversationKey, CancelReason>,
     /// Events withheld from `queues` while a goose-native steer is in flight
     /// for that event. Invisible to `flush_next` / `has_flushable_work` /
     /// `drain` (the events have been moved out of `queues`), so the queue's
@@ -163,8 +225,8 @@ pub struct EventQueue {
     /// at line 453). Bulk recovery on in-flight deadline expiry is performed
     /// by `flush_next` / `has_flushable_work` (recover, not log-and-drop —
     /// the events were never delivered to the agent).
-    withheld_native_steer: HashMap<Uuid, Vec<QueuedEvent>>,
-    /// Duration after which an in-flight channel is auto-expired as orphaned.
+    withheld_native_steer: HashMap<ConversationKey, Vec<QueuedEvent>>,
+    /// Duration after which an in-flight conversation is auto-expired as orphaned.
     /// Must be strictly greater than `max_turn_duration` so a turn running to
     /// the hard cap returns via `mark_complete` before the backstop fires.
     in_flight_deadline: Duration,
@@ -179,7 +241,7 @@ impl EventQueue {
     pub fn new(dedup_mode: DedupMode) -> Self {
         Self {
             queues: HashMap::new(),
-            in_flight_channels: HashSet::new(),
+            in_flight: HashSet::new(),
             in_flight_deadlines: HashMap::new(),
             in_flight_batch_sizes: HashMap::new(),
             retry_after: HashMap::new(),
@@ -200,20 +262,24 @@ impl EventQueue {
         self
     }
 
-    /// Monotonically extend an existing in-flight deadline for `channel_id`.
+    /// Monotonically extend an existing in-flight deadline for `conversation`.
     ///
     /// Called when a successful steer grants a fresh turn budget. The new
     /// deadline is `max(current, now + max_turn_secs + buffer)` — it never
-    /// moves backward. If the channel is not in-flight (already completed
+    /// moves backward. If the conversation is not in-flight (already completed
     /// via `mark_complete`), this is a no-op: a late ack never resurrects
     /// a deadline.
-    pub fn extend_in_flight_deadline(&mut self, channel_id: Uuid, max_turn_secs: u64) {
-        if let Some(current) = self.in_flight_deadlines.get_mut(&channel_id) {
+    pub fn extend_in_flight_deadline(
+        &mut self,
+        conversation: &ConversationKey,
+        max_turn_secs: u64,
+    ) {
+        if let Some(current) = self.in_flight_deadlines.get_mut(conversation) {
             let extended = Instant::now()
                 + Duration::from_secs(max_turn_secs + IN_FLIGHT_DEADLINE_BUFFER_SECS);
             if extended > *current {
                 tracing::info!(
-                    %channel_id,
+                    %conversation,
                     "extending in-flight deadline by {max_turn_secs}s + {IN_FLIGHT_DEADLINE_BUFFER_SECS}s buffer"
                 );
                 *current = extended;
@@ -221,28 +287,28 @@ impl EventQueue {
         }
     }
 
-    /// Push an event into the queue for its channel.
+    /// Push an event into the queue for its conversation.
     ///
-    /// In [`DedupMode::Drop`], events for any currently in-flight channel are
-    /// silently discarded (debug-logged).
+    /// In [`DedupMode::Drop`], events for any currently in-flight conversation
+    /// are silently discarded (debug-logged).
     ///
     /// Returns `true` if the event was accepted, `false` if dropped.
     pub fn push(&mut self, event: QueuedEvent) -> bool {
         if matches!(self.dedup_mode, DedupMode::Drop)
-            && self.in_flight_channels.contains(&event.channel_id)
+            && self.in_flight.contains(&event.conversation)
         {
             tracing::debug!(
-                channel_id = %event.channel_id,
-                "dropping event for in-flight channel (drop mode)"
+                conversation = %event.conversation,
+                "dropping event for in-flight conversation (drop mode)"
             );
             return false;
         }
-        let queue = self.queues.entry(event.channel_id).or_default();
-        // Enforce per-channel depth cap: drop oldest to make room.
+        let queue = self.queues.entry(event.conversation.clone()).or_default();
+        // Enforce per-conversation depth cap: drop oldest to make room.
         if queue.len() >= MAX_PENDING_PER_CHANNEL {
             queue.pop_front();
             tracing::warn!(
-                channel_id = %event.channel_id,
+                conversation = %event.conversation,
                 limit = MAX_PENDING_PER_CHANNEL,
                 "queue depth cap reached — dropped oldest event"
             );
@@ -254,74 +320,75 @@ impl EventQueue {
     /// Try to flush the next batch.
     ///
     /// Returns `None` if all non-in-flight, non-throttled queues are empty.
-    /// Otherwise picks the channel with the oldest pending event (FIFO fairness
-    /// across channels), drains ALL events for that channel into a single batch,
-    /// inserts into `in_flight_channels`, and returns the batch.
+    /// Otherwise picks the conversation with the oldest pending event (FIFO
+    /// fairness across conversations), drains ALL events for that conversation
+    /// into a single batch, inserts into `in_flight`, and returns the batch.
     pub fn flush_next(&mut self) -> Option<FlushBatch> {
         let now = Instant::now();
 
         // Auto-expire any stuck in-flight entries that missed mark_complete.
-        let expired: Vec<Uuid> = self
+        let expired: Vec<ConversationKey> = self
             .in_flight_deadlines
             .iter()
             .filter(|(_, deadline)| now >= **deadline)
-            .map(|(id, _)| *id)
+            .map(|(key, _)| key.clone())
             .collect();
-        for id in expired {
-            let lost_events = self.in_flight_batch_sizes.remove(&id).unwrap_or(0);
+        for key in expired {
+            let lost_events = self.in_flight_batch_sizes.remove(&key).unwrap_or(0);
             tracing::error!(
-                channel_id = %id,
+                conversation = %key,
                 lost_events,
                 deadline_secs = self.in_flight_deadline.as_secs(),
-                "BUG: in-flight channel expired without mark_complete — \
+                "BUG: in-flight conversation expired without mark_complete — \
                  auto-releasing; {lost_events} dispatched event(s) orphaned"
             );
-            self.in_flight_channels.remove(&id);
-            self.in_flight_deadlines.remove(&id);
+            self.in_flight.remove(&key);
+            self.in_flight_deadlines.remove(&key);
             // Recover any withheld goose-native steer events for the expired
-            // channel back to the queue front so normal dispatch delivers
+            // conversation back to the queue front so normal dispatch delivers
             // them. Unlike the in-flight batch above (already delivered to a
             // now-hung prompt — nothing to recover), these events were never
             // delivered to the agent.
-            self.recover_withheld_for_expired_channel(id);
+            self.recover_withheld_for_expired(&key);
         }
 
-        // Find the channel whose head event has the oldest received_at,
-        // excluding in-flight channels and throttled channels.
-        let channel_id = self
+        // Find the conversation whose head event has the oldest received_at,
+        // excluding in-flight and throttled conversations.
+        let conversation = self
             .queues
             .iter()
-            .filter(|(id, q)| {
+            .filter(|(key, q)| {
                 !q.is_empty()
-                    && !self.in_flight_channels.contains(id)
-                    && self.retry_after.get(id).is_none_or(|&t| t <= now)
+                    && !self.in_flight.contains(*key)
+                    && self.retry_after.get(*key).is_none_or(|&t| t <= now)
             })
             .min_by_key(|(_, q)| q.front().unwrap().received_at)
-            .map(|(id, _)| *id);
+            .map(|(key, _)| key.clone());
 
-        // Fallback: if no queued events are ready but a channel has cancelled
-        // events waiting (e.g., explicit !cancel with no new @mention), flush
-        // those as a regular batch (re-dispatch unchanged).
-        let channel_id = match channel_id {
-            Some(id) => id,
+        // Fallback: if no queued events are ready but a conversation has
+        // cancelled events waiting (e.g., explicit !cancel with no new
+        // @mention), flush those as a regular batch (re-dispatch unchanged).
+        let conversation = match conversation {
+            Some(key) => key,
             None => {
-                let cancelled_id = self
+                let cancelled_key = self
                     .cancelled_batches
                     .keys()
-                    .find(|id| !self.in_flight_channels.contains(id))
-                    .copied();
-                match cancelled_id {
-                    Some(id) => {
+                    .find(|key| !self.in_flight.contains(*key))
+                    .cloned();
+                match cancelled_key {
+                    Some(key) => {
                         // Move cancelled events into the regular events slot.
                         // No new events to merge — re-dispatch the original batch.
-                        let cancelled = self.cancelled_batches.remove(&id).unwrap_or_default();
-                        let cancel_reason = self.cancel_reasons.remove(&id);
-                        self.in_flight_channels.insert(id);
+                        let cancelled = self.cancelled_batches.remove(&key).unwrap_or_default();
+                        let cancel_reason = self.cancel_reasons.remove(&key);
+                        self.in_flight.insert(key.clone());
                         self.in_flight_deadlines
-                            .insert(id, now + self.in_flight_deadline);
-                        self.in_flight_batch_sizes.insert(id, cancelled.len());
+                            .insert(key.clone(), now + self.in_flight_deadline);
+                        self.in_flight_batch_sizes
+                            .insert(key.clone(), cancelled.len());
                         return Some(FlushBatch {
-                            channel_id: id,
+                            conversation: key,
                             events: cancelled,
                             cancelled_events: vec![],
                             cancel_reason,
@@ -333,7 +400,7 @@ impl EventQueue {
         };
 
         // Drain up to MAX_BATCH_EVENTS; leave any remainder in the queue.
-        let queue = self.queues.entry(channel_id).or_default();
+        let queue = self.queues.entry(conversation.clone()).or_default();
         let drain_count = MAX_BATCH_EVENTS.min(queue.len());
         let mut events: Vec<BatchEvent> = queue
             .drain(..drain_count)
@@ -350,103 +417,104 @@ impl EventQueue {
         events.sort_by_key(|be| be.event.created_at);
 
         // Remove the queue entry if now empty.
-        if self.queues.get(&channel_id).is_some_and(|q| q.is_empty()) {
-            self.queues.remove(&channel_id);
+        if self.queues.get(&conversation).is_some_and(|q| q.is_empty()) {
+            self.queues.remove(&conversation);
         }
 
-        self.in_flight_channels.insert(channel_id);
+        self.in_flight.insert(conversation.clone());
         self.in_flight_deadlines
-            .insert(channel_id, now + self.in_flight_deadline);
-        self.in_flight_batch_sizes.insert(channel_id, events.len());
+            .insert(conversation.clone(), now + self.in_flight_deadline);
+        self.in_flight_batch_sizes
+            .insert(conversation.clone(), events.len());
 
         // Merge any cancelled events stored by requeue_as_cancelled().
         let cancelled_events = self
             .cancelled_batches
-            .remove(&channel_id)
+            .remove(&conversation)
             .unwrap_or_default();
         let cancel_reason = if cancelled_events.is_empty() {
-            self.cancel_reasons.remove(&channel_id);
+            self.cancel_reasons.remove(&conversation);
             None
         } else {
-            self.cancel_reasons.remove(&channel_id)
+            self.cancel_reasons.remove(&conversation)
         };
 
         Some(FlushBatch {
-            channel_id,
+            conversation,
             events,
             cancelled_events,
             cancel_reason,
         })
     }
 
-    /// Mark the prompt for `channel_id` as complete.
+    /// Mark the prompt for `conversation` as complete.
     ///
-    /// Removes the channel from `in_flight_channels` and `in_flight_deadlines`.
+    /// Removes the conversation from `in_flight` and `in_flight_deadlines`.
     ///
-    /// If the channel was NOT requeued (no active `retry_after` throttle), the
-    /// retry counter is reset — the channel is healthy and the next failure
-    /// starts fresh. If the channel WAS requeued, `retry_counts` is left intact
-    /// so the backoff sequence continues on the next attempt.
+    /// If the conversation was NOT requeued (no active `retry_after` throttle),
+    /// the retry counter is reset — the conversation is healthy and the next
+    /// failure starts fresh. If the conversation WAS requeued, `retry_counts`
+    /// is left intact so the backoff sequence continues on the next attempt.
     ///
     /// Also cleans up any already-expired `retry_after` entry.
-    pub fn mark_complete(&mut self, channel_id: Uuid) {
-        self.in_flight_channels.remove(&channel_id);
-        self.in_flight_deadlines.remove(&channel_id);
-        self.in_flight_batch_sizes.remove(&channel_id);
+    pub fn mark_complete(&mut self, conversation: &ConversationKey) {
+        self.in_flight.remove(conversation);
+        self.in_flight_deadlines.remove(conversation);
+        self.in_flight_batch_sizes.remove(conversation);
         let now = Instant::now();
-        match self.retry_after.get(&channel_id) {
-            // Active throttle → channel was requeued; keep retry_counts intact.
+        match self.retry_after.get(conversation) {
+            // Active throttle → conversation was requeued; keep retry_counts intact.
             Some(&deadline) if deadline > now => {}
             // Expired or absent throttle → successful completion; reset counter
             // and clean up the stale retry_after entry.
             Some(_) => {
-                self.retry_after.remove(&channel_id);
-                self.retry_counts.remove(&channel_id);
+                self.retry_after.remove(conversation);
+                self.retry_counts.remove(conversation);
             }
             None => {
-                self.retry_counts.remove(&channel_id);
+                self.retry_counts.remove(conversation);
             }
         }
     }
 
     /// Re-queue a batch of events that failed to process.
     ///
-    /// Events are pushed back to the **front** of the channel's queue so they
-    /// are processed first on the next flush cycle. This prevents event loss
-    /// when session creation or `session/prompt` fails transiently.
+    /// Events are pushed back to the **front** of the conversation's queue so
+    /// they are processed first on the next flush cycle. This prevents event
+    /// loss when session creation or `session/prompt` fails transiently.
     ///
-    /// Original `received_at` timestamps are preserved so the channel retains
-    /// its fairness position. The retry delay comes from exponential backoff,
-    /// not from resetting received_at.
+    /// Original `received_at` timestamps are preserved so the conversation
+    /// retains its fairness position. The retry delay comes from exponential
+    /// backoff, not from resetting received_at.
     ///
     /// After [`MAX_RETRIES`] attempts the batch is dead-lettered: logged at
     /// ERROR and returned to the caller (rather than requeued) so a visible
     /// failure notice can be posted to the channel. Returns `None` when the
     /// batch was requeued for another attempt.
     ///
-    /// Note: does NOT remove from `in_flight_channels` — caller must call
+    /// Note: does NOT remove from `in_flight` — caller must call
     /// `mark_complete` separately.
     pub fn requeue(&mut self, batch: FlushBatch) -> Option<FlushBatch> {
-        let channel_id = batch.channel_id;
+        let conversation = batch.conversation.clone();
         let attempt = {
-            let count = self.retry_counts.entry(channel_id).or_insert(0);
+            let count = self.retry_counts.entry(conversation.clone()).or_insert(0);
             *count += 1;
             *count
         };
 
         if attempt > MAX_RETRIES {
             tracing::error!(
-                channel_id = %channel_id,
+                conversation = %conversation,
                 attempt,
                 events = batch.events.len(),
                 "dead-lettering batch after {} retries — discarding {} events",
                 MAX_RETRIES,
                 batch.events.len(),
             );
-            self.retry_counts.remove(&channel_id);
-            // Also clear retry_after so fresh traffic on this channel isn't
-            // throttled by stale backoff from the discarded poison batch.
-            self.retry_after.remove(&channel_id);
+            self.retry_counts.remove(&conversation);
+            // Also clear retry_after so fresh traffic on this conversation
+            // isn't throttled by stale backoff from the discarded poison batch.
+            self.retry_after.remove(&conversation);
             return Some(batch);
         }
 
@@ -464,7 +532,7 @@ impl EventQueue {
         let delay = Duration::from_secs_f64(capped_secs as f64 * jitter);
 
         tracing::warn!(
-            channel_id = %channel_id,
+            conversation = %conversation,
             attempt,
             max = MAX_RETRIES,
             delay_secs = delay.as_secs_f64(),
@@ -472,56 +540,57 @@ impl EventQueue {
             "requeueing failed batch with backoff"
         );
 
-        let queue = self.queues.entry(channel_id).or_default();
+        let queue = self.queues.entry(conversation.clone()).or_default();
         // Push to front in reverse order so original order is preserved.
         for be in batch.events.into_iter().rev() {
             queue.push_front(QueuedEvent {
-                channel_id,
+                conversation: conversation.clone(),
                 event: be.event,
                 prompt_tag: be.prompt_tag,
                 received_at: be.received_at, // preserve original timestamp (#46)
             });
         }
-        // Enforce per-channel cap: trim oldest (back) events if requeue pushed
-        // the queue over the limit. Without this, repeated requeue+push cycles
-        // can grow the queue unboundedly.
+        // Enforce per-conversation cap: trim oldest (back) events if requeue
+        // pushed the queue over the limit. Without this, repeated requeue+push
+        // cycles can grow the queue unboundedly.
         while queue.len() > MAX_PENDING_PER_CHANNEL {
             queue.pop_back();
             tracing::warn!(
-                channel_id = %channel_id,
+                conversation = %conversation,
                 limit = MAX_PENDING_PER_CHANNEL,
                 "requeue overflow — dropped oldest event to enforce cap"
             );
         }
-        self.retry_after.insert(channel_id, Instant::now() + delay);
+        self.retry_after
+            .insert(conversation, Instant::now() + delay);
         None
     }
 
     /// Re-queue a batch preserving original `received_at` timestamps.
     ///
     /// Used when a batch was flushed but no agent was available — we want to
-    /// retry without penalizing the channel's position in the fairness queue
-    /// and without imposing a retry throttle.
+    /// retry without penalizing the conversation's position in the fairness
+    /// queue and without imposing a retry throttle.
     ///
-    /// Does NOT set `retry_after`. Does NOT remove from `in_flight_channels` —
+    /// Does NOT set `retry_after`. Does NOT remove from `in_flight` —
     /// caller must call `mark_complete` separately.
     pub fn requeue_preserve_timestamps(&mut self, batch: FlushBatch) {
-        let channel_id = batch.channel_id;
-        let queue = self.queues.entry(channel_id).or_default();
+        let conversation = batch.conversation.clone();
+        let queue = self.queues.entry(conversation.clone()).or_default();
         // Push to front in reverse order so original order is preserved.
         for be in batch.events.into_iter().rev() {
             queue.push_front(QueuedEvent {
-                channel_id,
+                conversation: conversation.clone(),
                 event: be.event,
                 prompt_tag: be.prompt_tag,
                 received_at: be.received_at,
             });
         }
-        // Enforce per-channel cap: trim newest (back) events if over limit.
+        // Enforce per-conversation cap: trim newest (back) events if over limit.
         while queue.len() > MAX_PENDING_PER_CHANNEL {
             queue.pop_back();
             tracing::warn!(
-                channel_id = %channel_id,
+                conversation = %conversation,
                 limit = MAX_PENDING_PER_CHANNEL,
                 "requeue_preserve overflow — dropped newest event to enforce cap"
             );
@@ -529,7 +598,7 @@ impl EventQueue {
     }
 
     /// Requeue a cancelled batch so its events appear as `cancelled_events`
-    /// in the next `FlushBatch` for this channel (enabling the annotated
+    /// in the next `FlushBatch` for this conversation (enabling the annotated
     /// merged-prompt format in `format_prompt()`).
     ///
     /// `reason` records why the turn was cancelled (steer vs interrupt) so the
@@ -540,15 +609,18 @@ impl EventQueue {
     /// the generic queue — they are stored separately and merged by
     /// `flush_next()`. No retry throttle, no backoff.
     pub fn requeue_as_cancelled(&mut self, batch: FlushBatch, reason: CancelReason) {
-        let entry = self.cancelled_batches.entry(batch.channel_id).or_default();
+        let entry = self
+            .cancelled_batches
+            .entry(batch.conversation.clone())
+            .or_default();
         // Preserve any already-cancelled events from a prior cancel (double-cancel).
         entry.extend(batch.cancelled_events);
         entry.extend(batch.events);
-        self.cancel_reasons.insert(batch.channel_id, reason);
+        self.cancel_reasons.insert(batch.conversation, reason);
     }
 
-    /// Returns `true` if any channel has pending events that are not in-flight
-    /// and not throttled by `retry_after`.
+    /// Returns `true` if any conversation has pending events that are not
+    /// in-flight and not throttled by `retry_after`.
     ///
     /// Also auto-expires any stuck in-flight entries whose deadline has passed.
     /// This is a `&mut self` method so expiry can happen without requiring a
@@ -557,37 +629,37 @@ impl EventQueue {
         let now = Instant::now();
 
         // Auto-expire stuck in-flight entries (same logic as flush_next).
-        let expired: Vec<Uuid> = self
+        let expired: Vec<ConversationKey> = self
             .in_flight_deadlines
             .iter()
             .filter(|(_, deadline)| now >= **deadline)
-            .map(|(id, _)| *id)
+            .map(|(key, _)| key.clone())
             .collect();
-        for id in expired {
-            let lost_events = self.in_flight_batch_sizes.remove(&id).unwrap_or(0);
+        for key in expired {
+            let lost_events = self.in_flight_batch_sizes.remove(&key).unwrap_or(0);
             tracing::error!(
-                channel_id = %id,
+                conversation = %key,
                 lost_events,
                 deadline_secs = self.in_flight_deadline.as_secs(),
-                "BUG: in-flight channel expired without mark_complete — \
+                "BUG: in-flight conversation expired without mark_complete — \
                  auto-releasing; {lost_events} dispatched event(s) orphaned"
             );
-            self.in_flight_channels.remove(&id);
-            self.in_flight_deadlines.remove(&id);
+            self.in_flight.remove(&key);
+            self.in_flight_deadlines.remove(&key);
             // Symmetric with the flush_next expiry block: recover withheld
-            // goose-native steer events for the expired channel so they are
-            // not permanently orphaned in the side table.
-            self.recover_withheld_for_expired_channel(id);
+            // goose-native steer events for the expired conversation so they
+            // are not permanently orphaned in the side table.
+            self.recover_withheld_for_expired(&key);
         }
 
-        self.queues.iter().any(|(id, q)| {
+        self.queues.iter().any(|(key, q)| {
             !q.is_empty()
-                && !self.in_flight_channels.contains(id)
-                && self.retry_after.get(id).is_none_or(|&t| t <= now)
+                && !self.in_flight.contains(key)
+                && self.retry_after.get(key).is_none_or(|&t| t <= now)
         }) || self
             .cancelled_batches
             .keys()
-            .any(|id| !self.in_flight_channels.contains(id))
+            .any(|key| !self.in_flight.contains(key))
     }
 
     /// Returns `true` if any undispatched work remains for a channel that is
@@ -611,40 +683,41 @@ impl EventQueue {
         let has_queued = self
             .queues
             .iter()
-            .any(|(id, q)| !q.is_empty() && !self.in_flight_channels.contains(id));
+            .any(|(key, q)| !q.is_empty() && !self.in_flight.contains(key));
         let has_cancelled = self
             .cancelled_batches
             .keys()
-            .any(|id| !self.in_flight_channels.contains(id));
+            .any(|key| !self.in_flight.contains(key));
         let has_withheld = self
             .withheld_native_steer
             .iter()
-            .any(|(id, v)| !v.is_empty() && !self.in_flight_channels.contains(id));
+            .any(|(key, v)| !v.is_empty() && !self.in_flight.contains(key));
         has_queued || has_cancelled || has_withheld
     }
 
-    /// Number of channels with pending events.
-    pub fn pending_channels(&self) -> usize {
+    /// Number of conversations with pending events.
+    pub fn pending_conversations(&self) -> usize {
         self.queues.len()
     }
 
-    /// Number of queued events for a specific channel. Test-only.
+    /// Number of queued events for a specific conversation. Test-only.
     #[cfg(test)]
-    pub fn queued_event_count(&self, channel_id: &Uuid) -> usize {
-        self.queues.get(channel_id).map_or(0, |q| q.len())
+    pub fn queued_event_count(&self, conversation: &ConversationKey) -> usize {
+        self.queues.get(conversation).map_or(0, |q| q.len())
     }
 
-    /// Force a channel's retry-attempt counter to `count`, simulating `count`
-    /// prior failed attempts without needing to drive fake flush/requeue
-    /// cycles through the queue (which would leave artifact events behind).
-    /// Test-only — lets integration tests outside this module exercise
-    /// `requeue()`'s dead-letter threshold directly.
+    /// Force a conversation's retry-attempt counter to `count`, simulating
+    /// `count` prior failed attempts without needing to drive fake
+    /// flush/requeue cycles through the queue (which would leave artifact
+    /// events behind). Test-only — lets integration tests outside this module
+    /// exercise `requeue()`'s dead-letter threshold directly.
     #[cfg(test)]
-    pub fn set_retry_count_for_test(&mut self, channel_id: Uuid, count: u32) {
-        self.retry_counts.insert(channel_id, count);
+    pub fn set_retry_count_for_test(&mut self, conversation: ConversationKey, count: u32) {
+        self.retry_counts.insert(conversation, count);
     }
 
-    /// Drop all queued (non-in-flight) events for a channel.
+    /// Drop all queued (non-in-flight) events for a channel, across every
+    /// conversation lane belonging to it.
     ///
     /// Used when the agent is removed from a channel — any pending events
     /// for that channel are stale and should not be prompted. Does NOT
@@ -656,32 +729,41 @@ impl EventQueue {
     /// Returns the event IDs of dropped events so the caller can clean up
     /// any reactions (👀) that were added at queue-push time.
     pub fn drain_channel(&mut self, channel_id: Uuid) -> Vec<String> {
-        let ids = self
-            .queues
-            .remove(&channel_id)
-            .map(|q| q.into_iter().map(|e| e.event.id.to_hex()).collect())
-            .unwrap_or_default();
-        self.retry_after.remove(&channel_id);
-        self.retry_counts.remove(&channel_id);
-        self.cancelled_batches.remove(&channel_id);
-        self.cancel_reasons.remove(&channel_id);
-        self.withheld_native_steer.remove(&channel_id);
-        // Preserve in_flight_channels AND in_flight_deadlines: the in-flight
+        let mut ids = Vec::new();
+        self.queues.retain(|key, q| {
+            if key.channel_id == channel_id {
+                ids.extend(q.iter().map(|e| e.event.id.to_hex()));
+                false
+            } else {
+                true
+            }
+        });
+        self.retry_after
+            .retain(|key, _| key.channel_id != channel_id);
+        self.retry_counts
+            .retain(|key, _| key.channel_id != channel_id);
+        self.cancelled_batches
+            .retain(|key, _| key.channel_id != channel_id);
+        self.cancel_reasons
+            .retain(|key, _| key.channel_id != channel_id);
+        self.withheld_native_steer
+            .retain(|key, _| key.channel_id != channel_id);
+        // Preserve in_flight AND in_flight_deadlines: the in-flight
         // task will eventually complete (calling mark_complete) or the deadline
-        // will expire (auto-cleaning the channel). Removing deadlines without
-        // removing in_flight_channels would disable auto-expiry and leave a
-        // wedged task permanently blocking the channel.
+        // will expire (auto-cleaning the conversation). Removing deadlines
+        // without removing in_flight would disable auto-expiry and leave a
+        // wedged task permanently blocking the conversation.
         ids
     }
 
-    /// Whether a prompt is currently in-flight for the given channel.
-    pub fn is_channel_in_flight(&self, channel_id: Uuid) -> bool {
-        self.in_flight_channels.contains(&channel_id)
+    /// Whether a prompt is currently in-flight for the given conversation.
+    pub fn is_conversation_in_flight(&self, conversation: &ConversationKey) -> bool {
+        self.in_flight.contains(conversation)
     }
 
-    /// Whether any channel currently has a turn in flight.
+    /// Whether any conversation currently has a turn in flight.
     pub fn has_in_flight(&self) -> bool {
-        !self.in_flight_channels.is_empty()
+        !self.in_flight.is_empty()
     }
 
     // ── Goose-native steer withhold (side table) ──────────────────────────
@@ -690,26 +772,30 @@ impl EventQueue {
     // for a specific queued event, that event is moved out of `queues` into
     // `withheld_native_steer` so `flush_next` / `has_flushable_work` / the
     // contiguous drain at line 285 cannot see it — closing the race window
-    // between `mark_complete` (which clears `in_flight_channels`) and the
+    // between `mark_complete` (which clears `in_flight`) and the
     // ack arriving on the main loop. On `Success` the event is consumed
     // (`remove_event`); on `Err` / `PromptCompletedNeutral` it is released
     // back to the queue front (`release_native_steer`), preserving its
     // original `received_at` for FIFO fairness.
 
-    /// Move a queued event out of `queues[channel_id]` into the side table
+    /// Move a queued event out of `queues[conversation]` into the side table
     /// to withhold it from `flush_next` while a goose-native steer is in
     /// flight.
     ///
     /// Returns `true` if the event was found and withheld, `false` if the
-    /// event id was not present in `queues[channel_id]` (race-safe no-op:
+    /// event id was not present in `queues[conversation]` (race-safe no-op:
     /// the event may have already been drained, removed, or never queued).
     ///
     /// Must be called synchronously from the mode-gate fork immediately
     /// after `pool.send_steer` returns `Ok(())` and before any watcher task
     /// is spawned, so the withhold is established before `mark_complete` /
     /// any subsequent `flush_next` tick can run.
-    pub fn mark_native_steer_pending(&mut self, channel_id: Uuid, event_id: &str) -> bool {
-        let Some(q) = self.queues.get_mut(&channel_id) else {
+    pub fn mark_native_steer_pending(
+        &mut self,
+        conversation: &ConversationKey,
+        event_id: &str,
+    ) -> bool {
+        let Some(q) = self.queues.get_mut(conversation) else {
             return false;
         };
         let Some(pos) = q.iter().position(|qe| qe.event.id.to_hex() == event_id) else {
@@ -719,17 +805,17 @@ impl EventQueue {
             .remove(pos)
             .expect("position came from iter so remove must succeed");
         if q.is_empty() {
-            self.queues.remove(&channel_id);
+            self.queues.remove(conversation);
         }
         self.withheld_native_steer
-            .entry(channel_id)
+            .entry(conversation.clone())
             .or_default()
             .push(qe);
         true
     }
 
     /// Release a single withheld event back to the front of
-    /// `queues[channel_id]`, preserving its original `received_at`.
+    /// `queues[conversation]`, preserving its original `received_at`.
     ///
     /// Called on `SteerAck::Err(_)` and `SteerAck::PromptCompletedNeutral`
     /// (delivery unknown after prompt completion; restoring queued event
@@ -737,9 +823,9 @@ impl EventQueue {
     /// removed or never withheld.
     ///
     /// Push-to-front matches the discipline of `requeue_preserve_timestamps`
-    /// at line 453, preserving fairness across channels.
-    pub fn release_native_steer(&mut self, channel_id: Uuid, event_id: &str) {
-        let Some(entries) = self.withheld_native_steer.get_mut(&channel_id) else {
+    /// at line 453, preserving fairness across conversations.
+    pub fn release_native_steer(&mut self, conversation: &ConversationKey, event_id: &str) {
+        let Some(entries) = self.withheld_native_steer.get_mut(conversation) else {
             return;
         };
         let Some(pos) = entries
@@ -750,17 +836,17 @@ impl EventQueue {
         };
         let qe = entries.remove(pos);
         if entries.is_empty() {
-            self.withheld_native_steer.remove(&channel_id);
+            self.withheld_native_steer.remove(conversation);
         }
         // Push to FRONT so original `received_at` keeps the event at the head
-        // of the channel's queue. Per-channel cap is enforced below in case
-        // a flood of events arrived during the ack window.
-        let queue = self.queues.entry(channel_id).or_default();
+        // of the conversation's queue. Per-conversation cap is enforced below
+        // in case a flood of events arrived during the ack window.
+        let queue = self.queues.entry(conversation.clone()).or_default();
         queue.push_front(qe);
         while queue.len() > MAX_PENDING_PER_CHANNEL {
             queue.pop_back();
             tracing::warn!(
-                channel_id = %channel_id,
+                conversation = %conversation,
                 limit = MAX_PENDING_PER_CHANNEL,
                 "release_native_steer overflow — dropped newest event to enforce cap"
             );
@@ -773,22 +859,22 @@ impl EventQueue {
     /// Called on `SteerAck::Success` — the agent received the steer, so the
     /// event has been "delivered" via the non-cancelling path and must not
     /// be redelivered via normal dispatch. Idempotent across both stores.
-    pub fn remove_event(&mut self, channel_id: Uuid, event_id: &str) {
-        if let Some(entries) = self.withheld_native_steer.get_mut(&channel_id) {
+    pub fn remove_event(&mut self, conversation: &ConversationKey, event_id: &str) {
+        if let Some(entries) = self.withheld_native_steer.get_mut(conversation) {
             entries.retain(|qe| qe.event.id.to_hex() != event_id);
             if entries.is_empty() {
-                self.withheld_native_steer.remove(&channel_id);
+                self.withheld_native_steer.remove(conversation);
             }
         }
-        if let Some(q) = self.queues.get_mut(&channel_id) {
+        if let Some(q) = self.queues.get_mut(conversation) {
             q.retain(|qe| qe.event.id.to_hex() != event_id);
             if q.is_empty() {
-                self.queues.remove(&channel_id);
+                self.queues.remove(conversation);
             }
         }
     }
 
-    /// Bulk-release every withheld event for `channel_id` back to the queue
+    /// Bulk-release every withheld event for `conversation` back to the queue
     /// front, preserving relative FIFO order.
     ///
     /// Called from the `in_flight_deadline` expiry blocks in
@@ -801,25 +887,25 @@ impl EventQueue {
     /// Iterates the stored entries in reverse so per-entry `push_front`
     /// composes to original-FIFO order at the queue front (same discipline
     /// as `requeue_preserve_timestamps` at line 453).
-    fn recover_withheld_for_expired_channel(&mut self, channel_id: Uuid) {
-        let Some(entries) = self.withheld_native_steer.remove(&channel_id) else {
+    fn recover_withheld_for_expired(&mut self, conversation: &ConversationKey) {
+        let Some(entries) = self.withheld_native_steer.remove(conversation) else {
             return;
         };
         let n = entries.len();
-        let queue = self.queues.entry(channel_id).or_default();
+        let queue = self.queues.entry(conversation.clone()).or_default();
         for qe in entries.into_iter().rev() {
             queue.push_front(qe);
         }
         while queue.len() > MAX_PENDING_PER_CHANNEL {
             queue.pop_back();
             tracing::warn!(
-                channel_id = %channel_id,
+                conversation = %conversation,
                 limit = MAX_PENDING_PER_CHANNEL,
                 "withheld-steer recovery overflow — dropped newest event to enforce cap"
             );
         }
         tracing::warn!(
-            channel_id = %channel_id,
+            conversation = %conversation,
             recovered = n,
             "in-flight expiry recovered withheld steer event(s) — \
              steer ack never arrived; normal dispatch will deliver"
@@ -845,13 +931,13 @@ impl EventQueue {
     pub fn compact_expired_state(&mut self) {
         let now = Instant::now();
         self.retry_after.retain(|_, deadline| *deadline > now);
-        // Remove retry_counts for channels with no active throttle, no
+        // Remove retry_counts for conversations with no active throttle, no
         // queued events, AND no in-flight prompt — they completed their
         // retry cycle and are truly idle.
-        self.retry_counts.retain(|ch, _| {
-            self.retry_after.contains_key(ch)
-                || self.queues.get(ch).is_some_and(|q| !q.is_empty())
-                || self.in_flight_channels.contains(ch)
+        self.retry_counts.retain(|key, _| {
+            self.retry_after.contains_key(key)
+                || self.queues.get(key).is_some_and(|q| !q.is_empty())
+                || self.in_flight.contains(key)
         });
     }
 }
@@ -1626,7 +1712,7 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
         )
     };
     sections.push(format_context_hints(
-        batch.channel_id,
+        batch.channel_id(),
         args.channel_info,
         &thread_tags,
         is_dm,
@@ -1657,7 +1743,12 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
                 "\n\n--- Event {} ({}) ---\n{}",
                 i + 1,
                 be.prompt_tag,
-                format_event_block(batch.channel_id, args.channel_info, be, args.profile_lookup)
+                format_event_block(
+                    batch.channel_id(),
+                    args.channel_info,
+                    be,
+                    args.profile_lookup
+                )
             ));
         }
         sections.push(s);
@@ -1671,13 +1762,23 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
                 "{}\n\n--- Event 1 ({}) ---\n{}",
                 framing.new_header_single,
                 be.prompt_tag,
-                format_event_block(batch.channel_id, args.channel_info, be, args.profile_lookup)
+                format_event_block(
+                    batch.channel_id(),
+                    args.channel_info,
+                    be,
+                    args.profile_lookup
+                )
             )
         } else {
             format!(
                 "[Buzz event: {}]\n{}",
                 be.prompt_tag,
-                format_event_block(batch.channel_id, args.channel_info, be, args.profile_lookup)
+                format_event_block(
+                    batch.channel_id(),
+                    args.channel_info,
+                    be,
+                    args.profile_lookup
+                )
             )
         }
     } else {
@@ -1696,7 +1797,12 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
                 "\n\n--- Event {} ({}) ---\n{}",
                 i + 1,
                 be.prompt_tag,
-                format_event_block(batch.channel_id, args.channel_info, be, args.profile_lookup)
+                format_event_block(
+                    batch.channel_id(),
+                    args.channel_info,
+                    be,
+                    args.profile_lookup
+                )
             ));
         }
         s
@@ -1779,6 +1885,14 @@ mod tests {
     use nostr::{EventBuilder, Keys, Kind, Timestamp};
     use std::time::Duration;
 
+    /// Top-level conversation lane for `channel_id` (no thread root).
+    fn key(channel_id: Uuid) -> ConversationKey {
+        ConversationKey {
+            channel_id,
+            thread_root: None,
+        }
+    }
+
     /// Build a test event with the given content and kind.
     fn make_event(content: &str) -> Event {
         let keys = Keys::generate();
@@ -1791,7 +1905,7 @@ mod tests {
     /// Build a QueuedEvent for the given channel.
     fn make_queued(channel_id: Uuid, content: &str) -> QueuedEvent {
         QueuedEvent {
-            channel_id,
+            conversation: key(channel_id),
             event: make_event(content),
             received_at: Instant::now(),
             prompt_tag: "test".into(),
@@ -1801,7 +1915,7 @@ mod tests {
     /// Build a QueuedEvent with a specific `received_at` offset from now.
     fn make_queued_at(channel_id: Uuid, content: &str, age: Duration) -> QueuedEvent {
         QueuedEvent {
-            channel_id,
+            conversation: key(channel_id),
             event: make_event(content),
             received_at: Instant::now() - age,
             prompt_tag: "test".into(),
@@ -1821,7 +1935,7 @@ mod tests {
             .sign_with_keys(&keys)
             .unwrap();
         QueuedEvent {
-            channel_id,
+            conversation: key(channel_id),
             event,
             received_at: Instant::now(),
             prompt_tag: "test".into(),
@@ -1833,7 +1947,7 @@ mod tests {
     }
 
     fn any_in_flight(q: &EventQueue) -> bool {
-        !q.in_flight_channels.is_empty()
+        !q.in_flight.is_empty()
     }
 
     #[test]
@@ -1854,7 +1968,7 @@ mod tests {
         q.push(make_queued(ch, "hello"));
 
         let batch = q.flush_next().expect("should return a batch");
-        assert_eq!(batch.channel_id, ch);
+        assert_eq!(batch.channel_id(), ch);
         assert_eq!(batch.events.len(), 1);
         assert_eq!(batch.events[0].event.content, "hello");
 
@@ -1893,12 +2007,12 @@ mod tests {
         assert!(q.flush_next().is_none());
 
         // Complete the in-flight prompt.
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
         assert!(!any_in_flight(&q));
 
         // Now flush should succeed.
         let batch = q.flush_next().expect("should flush after mark_complete");
-        assert_eq!(batch.channel_id, ch);
+        assert_eq!(batch.channel_id(), ch);
         assert_eq!(batch.events.len(), 1);
         assert_eq!(batch.events[0].event.content, "second");
     }
@@ -1915,7 +2029,7 @@ mod tests {
         assert_eq!(pending_count(&q), 3);
 
         let batch = q.flush_next().expect("should return batch");
-        assert_eq!(batch.channel_id, ch);
+        assert_eq!(batch.channel_id(), ch);
         assert_eq!(batch.events.len(), 3);
         assert_eq!(batch.events[0].event.content, "msg1");
         assert_eq!(batch.events[1].event.content, "msg2");
@@ -1966,7 +2080,7 @@ mod tests {
 
         let batch = q.flush_next().expect("should return batch");
         // A is older, so it should be picked first.
-        assert_eq!(batch.channel_id, ch_a);
+        assert_eq!(batch.channel_id(), ch_a);
         assert_eq!(batch.events[0].event.content, "from A");
     }
 
@@ -1982,18 +2096,18 @@ mod tests {
 
         // First flush picks A.
         let batch_a = q.flush_next().expect("first flush");
-        assert_eq!(batch_a.channel_id, ch_a);
+        assert_eq!(batch_a.channel_id(), ch_a);
         assert!(any_in_flight(&q));
 
         // B still pending.
         assert_eq!(pending_count(&q), 1);
         assert_eq!(q.queues.len(), 1);
 
-        q.mark_complete(ch_a);
+        q.mark_complete(&key(ch_a));
 
         // Second flush picks B.
         let batch_b = q.flush_next().expect("second flush");
-        assert_eq!(batch_b.channel_id, ch_b);
+        assert_eq!(batch_b.channel_id(), ch_b);
         assert_eq!(batch_b.events[0].event.content, "B-event");
 
         assert_eq!(pending_count(&q), 0);
@@ -2015,7 +2129,7 @@ mod tests {
             .unwrap_or_else(|_| event.pubkey.to_hex());
 
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -2045,7 +2159,7 @@ mod tests {
     fn make_merged_batch(reason: Option<CancelReason>) -> FlushBatch {
         let ch = Uuid::new_v4();
         FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event: make_event("the new message"),
                 prompt_tag: "@mention".into(),
@@ -2140,7 +2254,7 @@ mod tests {
         // The mode gate fires Steer → cancel → requeue as cancelled, carrying
         // the steer reason (exactly the lib.rs requeue path).
         q.requeue_as_cancelled(batch, CancelReason::Steer);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // The re-prompt the agent actually receives.
         let merged = q.flush_next().unwrap();
@@ -2176,7 +2290,7 @@ mod tests {
         // Multi-event header path must also branch on reason.
         let ch = Uuid::new_v4();
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![
                 BatchEvent {
                     event: make_event("new one"),
@@ -2233,7 +2347,7 @@ mod tests {
         let _steering_id = steering.id.to_hex();
 
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event: steering,
                 prompt_tag: "@mention".into(),
@@ -2282,10 +2396,10 @@ mod tests {
 
         // Simulate failure — requeue the batch.
         queue.requeue(batch);
-        queue.mark_complete(ch);
+        queue.mark_complete(&key(ch));
 
         // retry_after is set, so manually clear it for this test.
-        queue.retry_after.remove(&ch);
+        queue.retry_after.remove(&key(ch));
 
         // Should be able to flush again and get the same events in order.
         let batch2 = queue.flush_next().unwrap();
@@ -2318,7 +2432,7 @@ mod tests {
             queue.requeue(batch).is_none(),
             "batch requeued, not dead-lettered"
         );
-        queue.mark_complete(ch);
+        queue.mark_complete(&key(ch));
 
         // The batch is back in the queue, no longer in-flight, and throttled by
         // a future `retry_after`. BASE_RETRY_DELAY guarantees the deadline is in
@@ -2326,7 +2440,7 @@ mod tests {
         assert!(
             queue
                 .retry_after
-                .get(&ch)
+                .get(&key(ch))
                 .is_some_and(|&t| t > Instant::now()),
             "requeue must have set a future backoff deadline"
         );
@@ -2368,7 +2482,7 @@ mod tests {
         );
 
         // Completed cleanly (no requeue): fully drained, nothing left.
-        queue.mark_complete(batch.channel_id);
+        queue.mark_complete(&batch.conversation);
         assert!(!queue.has_undispatched_work());
         assert!(!queue.has_in_flight());
     }
@@ -2385,15 +2499,15 @@ mod tests {
 
         // Flush ch_a first (older).
         let batch_a = queue.flush_next().unwrap();
-        assert_eq!(batch_a.channel_id, ch_a);
+        assert_eq!(batch_a.channel_id(), ch_a);
 
         // Requeue ch_a (simulating failure) and complete.
         queue.requeue(batch_a);
-        queue.mark_complete(ch_a);
+        queue.mark_complete(&key(ch_a));
 
         // After requeue, ch_a has retry_after set (5s), so ch_b goes first.
         let next_batch = queue.flush_next().unwrap();
-        assert_eq!(next_batch.channel_id, ch_b);
+        assert_eq!(next_batch.channel_id(), ch_b);
     }
 
     #[test]
@@ -2404,7 +2518,7 @@ mod tests {
         let e3 = make_event("third message");
 
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![
                 BatchEvent {
                     event: e1,
@@ -2444,7 +2558,7 @@ mod tests {
         let event = make_event("hello");
 
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2467,7 +2581,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hi");
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2499,7 +2613,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hi");
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2529,7 +2643,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hi");
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2556,7 +2670,7 @@ mod tests {
         let event = make_event("hello");
 
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2580,7 +2694,7 @@ mod tests {
         let event = make_event("hello");
 
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2638,7 +2752,7 @@ mod tests {
         // evicting real channel history sooner.
         let ch = Uuid::new_v4();
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event: make_event("hello"),
                 prompt_tag: "test".into(),
@@ -2691,7 +2805,7 @@ mod tests {
         let event = make_event("hello");
 
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2729,7 +2843,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hello");
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2796,7 +2910,7 @@ mod tests {
         q.push(make_queued(ch, "dropped"));
         assert_eq!(pending_count(&q), 0, "event should be dropped");
 
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
         // Nothing to flush.
         assert!(q.flush_next().is_none());
     }
@@ -2815,9 +2929,9 @@ mod tests {
         q.push(make_queued(ch_b, "B-event"));
         assert_eq!(pending_count(&q), 1);
 
-        q.mark_complete(ch_a);
+        q.mark_complete(&key(ch_a));
         let batch_b = q.flush_next().expect("flush B");
-        assert_eq!(batch_b.channel_id, ch_b);
+        assert_eq!(batch_b.channel_id(), ch_b);
     }
 
     #[test]
@@ -2831,22 +2945,22 @@ mod tests {
 
         // Flush A — now A is in-flight.
         let batch_a = q.flush_next().expect("flush A");
-        assert_eq!(batch_a.channel_id, ch_a);
+        assert_eq!(batch_a.channel_id(), ch_a);
         assert!(any_in_flight(&q));
 
         // Flush B — B should also be flushable (different channel).
         let batch_b = q.flush_next().expect("flush B while A in-flight");
-        assert_eq!(batch_b.channel_id, ch_b);
+        assert_eq!(batch_b.channel_id(), ch_b);
 
         // Both in-flight.
-        assert_eq!(q.in_flight_channels.len(), 2);
+        assert_eq!(q.in_flight.len(), 2);
 
         // Complete A only.
-        q.mark_complete(ch_a);
+        q.mark_complete(&key(ch_a));
         assert!(any_in_flight(&q)); // B still in-flight.
 
         // Complete B.
-        q.mark_complete(ch_b);
+        q.mark_complete(&key(ch_b));
         assert!(!any_in_flight(&q));
     }
 
@@ -2866,7 +2980,7 @@ mod tests {
 
         // flush_next should pick ch2, not ch (ch is in-flight).
         let batch2 = q.flush_next().expect("should flush ch2");
-        assert_eq!(batch2.channel_id, ch2);
+        assert_eq!(batch2.channel_id(), ch2);
 
         // ch still in-flight — no more candidates.
         assert!(q.flush_next().is_none());
@@ -2890,8 +3004,8 @@ mod tests {
         q.push(make_queued(ch_b, "B-dropped"));
         assert_eq!(pending_count(&q), 0);
 
-        q.mark_complete(ch_a);
-        q.mark_complete(ch_b);
+        q.mark_complete(&key(ch_a));
+        q.mark_complete(&key(ch_b));
     }
 
     #[test]
@@ -2908,22 +3022,22 @@ mod tests {
 
         // Flush A (oldest).
         let batch = q.flush_next().expect("flush A");
-        assert_eq!(batch.channel_id, ch_a);
+        assert_eq!(batch.channel_id(), ch_a);
 
         // A is in-flight; next oldest non-in-flight is B.
         let batch2 = q.flush_next().expect("flush B");
-        assert_eq!(batch2.channel_id, ch_b);
+        assert_eq!(batch2.channel_id(), ch_b);
 
         // A and B in-flight; only C left.
         let batch3 = q.flush_next().expect("flush C");
-        assert_eq!(batch3.channel_id, ch_c);
+        assert_eq!(batch3.channel_id(), ch_c);
 
         // All in-flight.
         assert!(q.flush_next().is_none());
 
-        q.mark_complete(ch_a);
-        q.mark_complete(ch_b);
-        q.mark_complete(ch_c);
+        q.mark_complete(&key(ch_a));
+        q.mark_complete(&key(ch_b));
+        q.mark_complete(&key(ch_c));
     }
 
     #[test]
@@ -2938,18 +3052,18 @@ mod tests {
         let _batch_a = q.flush_next().expect("flush A");
         let _batch_b = q.flush_next().expect("flush B");
 
-        assert_eq!(q.in_flight_channels.len(), 2);
+        assert_eq!(q.in_flight.len(), 2);
 
         // Complete only A.
-        q.mark_complete(ch_a);
-        assert_eq!(q.in_flight_channels.len(), 1);
-        assert!(q.in_flight_channels.contains(&ch_b));
-        assert!(!q.in_flight_channels.contains(&ch_a));
+        q.mark_complete(&key(ch_a));
+        assert_eq!(q.in_flight.len(), 1);
+        assert!(q.in_flight.contains(&key(ch_b)));
+        assert!(!q.in_flight.contains(&key(ch_a)));
 
         // B still in-flight.
         assert!(any_in_flight(&q));
 
-        q.mark_complete(ch_b);
+        q.mark_complete(&key(ch_b));
         assert!(!any_in_flight(&q));
     }
 
@@ -2960,7 +3074,7 @@ mod tests {
         let old_time = Instant::now() - Duration::from_secs(10);
 
         q.push(QueuedEvent {
-            channel_id: ch,
+            conversation: key(ch),
             event: make_event("old-msg"),
             received_at: old_time,
             prompt_tag: "test".into(),
@@ -2971,7 +3085,7 @@ mod tests {
 
         // requeue_preserve_timestamps should keep the original timestamp.
         q.requeue_preserve_timestamps(batch);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // No retry_after set — should be immediately flushable.
         let batch2 = q.flush_next().expect("flush after requeue_preserve");
@@ -2987,10 +3101,10 @@ mod tests {
         let batch = q.flush_next().expect("flush");
 
         q.requeue_preserve_timestamps(batch);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // No retry_after — channel should be immediately flushable.
-        assert!(!q.retry_after.contains_key(&ch));
+        assert!(!q.retry_after.contains_key(&key(ch)));
         assert!(q.flush_next().is_some());
     }
 
@@ -3054,7 +3168,7 @@ mod tests {
 
         // Requeue — older events go to front, overflow trims from back (newest).
         q.requeue_preserve_timestamps(batch);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // The requeued events should be at the front of the queue.
         let batch2 = q.flush_next().expect("should flush after requeue");
@@ -3081,14 +3195,14 @@ mod tests {
         assert!(!q.has_flushable_work());
 
         // Complete — no pending events, no flushable work.
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
         assert!(!q.has_flushable_work());
 
         // Requeue with retry_after — throttled, no flushable work.
         q.push(make_queued(ch, "msg2"));
         let batch2 = q.flush_next().expect("flush2");
         q.requeue(batch2);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
         assert!(
             !q.has_flushable_work(),
             "throttled channel should not be flushable"
@@ -3096,7 +3210,7 @@ mod tests {
 
         // Manually expire the retry_after to simulate time passing.
         q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+            .insert(key(ch), Instant::now() - Duration::from_secs(1));
         assert!(
             q.has_flushable_work(),
             "expired throttle should be flushable"
@@ -3111,26 +3225,26 @@ mod tests {
         q.push(make_queued(ch, "poison"));
         for attempt in 1..=MAX_RETRIES {
             q.retry_after
-                .insert(ch, Instant::now() - Duration::from_secs(1));
+                .insert(key(ch), Instant::now() - Duration::from_secs(1));
             let batch = q.flush_next().expect("flush");
             assert!(
                 q.requeue(batch).is_none(),
                 "attempt {attempt} should requeue, not dead-letter"
             );
-            q.mark_complete(ch);
+            q.mark_complete(&key(ch));
         }
 
         // The MAX_RETRIES+1'th failure dead-letters: batch is returned.
         q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+            .insert(key(ch), Instant::now() - Duration::from_secs(1));
         let batch = q.flush_next().expect("flush");
         let dead = q.requeue(batch).expect("should dead-letter");
-        assert_eq!(dead.channel_id, ch);
+        assert_eq!(dead.channel_id(), ch);
         assert_eq!(dead.events.len(), 1);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
         // Retry state is cleared so fresh traffic isn't throttled.
-        assert!(!q.retry_counts.contains_key(&ch));
-        assert!(!q.retry_after.contains_key(&ch));
+        assert!(!q.retry_counts.contains_key(&key(ch)));
+        assert!(!q.retry_after.contains_key(&key(ch)));
     }
 
     #[test]
@@ -3144,7 +3258,7 @@ mod tests {
 
         // Requeue sets retry_after.
         q.requeue(batch);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // Channel is throttled — flush_next should return None (no other channels).
         assert!(q.flush_next().is_none());
@@ -3152,16 +3266,16 @@ mod tests {
         // Add a different channel — it should be flushable.
         q.push(make_queued(ch2, "other"));
         let batch2 = q.flush_next().expect("ch2 should be flushable");
-        assert_eq!(batch2.channel_id, ch2);
+        assert_eq!(batch2.channel_id(), ch2);
 
         // After retry_after expires, ch should be flushable again.
         q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
-        q.mark_complete(ch2);
+            .insert(key(ch), Instant::now() - Duration::from_secs(1));
+        q.mark_complete(&key(ch2));
         let batch3 = q
             .flush_next()
             .expect("ch should be flushable after throttle expires");
-        assert_eq!(batch3.channel_id, ch);
+        assert_eq!(batch3.channel_id(), ch);
     }
 
     /// Build an event with specific tags for thread testing.
@@ -3247,7 +3361,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hello");
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -3279,7 +3393,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hey");
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "dm".into(),
@@ -3318,7 +3432,7 @@ mod tests {
             ]],
         );
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -3346,7 +3460,7 @@ mod tests {
             ]],
         );
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -3392,7 +3506,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("ok do that");
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "dm".into(),
@@ -3443,7 +3557,7 @@ mod tests {
         );
         let author_hex = event.pubkey.to_hex();
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -3651,7 +3765,7 @@ mod tests {
             ]],
         );
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "dm".into(),
@@ -3718,7 +3832,7 @@ mod tests {
             ]],
         );
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -3751,7 +3865,7 @@ mod tests {
     fn test_format_prompt_empty_dm_delta_distinguishes_trigger_only_from_delivered() {
         let ch = Uuid::new_v4();
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event: make_event("follow up"),
                 prompt_tag: "dm".into(),
@@ -3800,7 +3914,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hey there");
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "dm".into(),
@@ -3841,7 +3955,7 @@ mod tests {
         let event = make_event("test");
         let event_id = event.id.to_hex();
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -3865,7 +3979,7 @@ mod tests {
         let hex = event.pubkey.to_hex();
         let npub = event.pubkey.to_bech32().unwrap();
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -3888,7 +4002,7 @@ mod tests {
         // Kind 9 (stream message) — tags were previously stripped.
         let event = make_event_with_tags("hello", vec![vec!["h".into(), ch.to_string()]]);
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -3941,7 +4055,7 @@ mod tests {
         q.push(make_queued(ch, "msg"));
         let batch = q.flush_next().unwrap();
         q.requeue(batch); // sets retry_after
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // Channel is throttled — verify drain clears it.
         assert!(!q.has_flushable_work());
@@ -3985,26 +4099,26 @@ mod tests {
         q.push(make_queued(ch, "msg1"));
         let batch = q.flush_next().unwrap();
         q.requeue(batch);
-        q.mark_complete(ch);
-        assert!(q.retry_after.contains_key(&ch));
-        assert!(q.retry_counts.contains_key(&ch));
+        q.mark_complete(&key(ch));
+        assert!(q.retry_after.contains_key(&key(ch)));
+        assert!(q.retry_counts.contains_key(&key(ch)));
 
         // The requeued event is back in the queue. Flush it again so the
         // queue is empty (simulating a successful retry dispatch).
         // We need to wait for retry_after to expire first.
         q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+            .insert(key(ch), Instant::now() - Duration::from_secs(1));
         let _batch2 = q.flush_next().unwrap();
         // Now mark_complete with no active throttle — clears retry_counts.
-        q.mark_complete(ch);
-        assert!(!q.retry_counts.contains_key(&ch));
+        q.mark_complete(&key(ch));
+        assert!(!q.retry_counts.contains_key(&key(ch)));
 
         // Re-create the orphan scenario: manually insert stale retry_counts
         // with no queue, no throttle, and no in-flight.
-        q.retry_counts.insert(ch, 3);
+        q.retry_counts.insert(key(ch), 3);
         q.compact_expired_state();
         assert!(
-            !q.retry_counts.contains_key(&ch),
+            !q.retry_counts.contains_key(&key(ch)),
             "orphaned retry_counts should be removed"
         );
     }
@@ -4018,21 +4132,21 @@ mod tests {
         q.push(make_queued(ch, "msg1"));
         let batch = q.flush_next().unwrap();
         q.requeue(batch);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // Expire the throttle so the requeued event can be flushed.
         q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+            .insert(key(ch), Instant::now() - Duration::from_secs(1));
         let _batch2 = q.flush_next().unwrap();
         // Channel is now in-flight with empty queue and expired throttle.
-        assert!(q.in_flight_channels.contains(&ch));
-        assert!(q.queues.get(&ch).is_none_or(|q| q.is_empty()));
+        assert!(q.in_flight.contains(&key(ch)));
+        assert!(q.queues.get(&key(ch)).is_none_or(|q| q.is_empty()));
 
         // compact must NOT remove retry_counts — the in-flight attempt
         // may fail and requeue, which needs the existing count.
         q.compact_expired_state();
         assert!(
-            q.retry_counts.contains_key(&ch),
+            q.retry_counts.contains_key(&key(ch)),
             "retry_counts must survive while channel is in-flight"
         );
     }
@@ -4044,11 +4158,11 @@ mod tests {
 
         // Manually set up: retry_counts exists, queue is non-empty, no throttle.
         q.push(make_queued(ch, "msg1"));
-        q.retry_counts.insert(ch, 2);
+        q.retry_counts.insert(key(ch), 2);
 
         q.compact_expired_state();
         assert!(
-            q.retry_counts.contains_key(&ch),
+            q.retry_counts.contains_key(&key(ch)),
             "retry_counts should survive when queue is non-empty"
         );
     }
@@ -4069,7 +4183,7 @@ mod tests {
 
         // Cancel the original batch and release the channel.
         q.requeue_as_cancelled(batch, CancelReason::Interrupt);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // flush_next should merge: events=[new-1], cancelled_events=[old-1, old-2].
         let next = q.flush_next().unwrap();
@@ -4091,27 +4205,27 @@ mod tests {
         let batch = q.flush_next().unwrap();
         q.push(make_queued(ch, "new"));
         q.requeue_as_cancelled(batch, CancelReason::Steer);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
         let merged = q.flush_next().unwrap();
         assert_eq!(
             merged.cancel_reason,
             Some(CancelReason::Steer),
             "steer reason should reach the merged batch"
         );
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // Fallback path (no new event): reason still rides through.
         q.push(make_queued(ch, "only"));
         let batch = q.flush_next().unwrap();
         q.requeue_as_cancelled(batch, CancelReason::Interrupt);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
         let fallback = q.flush_next().unwrap();
         assert_eq!(
             fallback.cancel_reason,
             Some(CancelReason::Interrupt),
             "interrupt reason should reach the re-dispatched batch"
         );
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // A normal (non-cancel) flush carries no reason.
         q.push(make_queued(ch, "plain"));
@@ -4127,12 +4241,12 @@ mod tests {
         let batch1 = q.flush_next().unwrap();
         q.push(make_queued(ch, "new-1"));
         q.requeue_as_cancelled(batch1, CancelReason::Interrupt);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
         let batch2 = q.flush_next().unwrap();
         // Second cancel with a different reason — the latest reason wins.
         q.requeue_as_cancelled(batch2, CancelReason::Steer);
         q.push(make_queued(ch, "new-2"));
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
         let batch3 = q.flush_next().unwrap();
         assert_eq!(batch3.cancel_reason, Some(CancelReason::Steer));
     }
@@ -4150,7 +4264,7 @@ mod tests {
 
         // Cancel the batch (no new events pushed) and release the channel.
         q.requeue_as_cancelled(batch, CancelReason::Interrupt);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // Fallback path: cancelled events become regular events, cancelled_events is empty.
         let next = q.flush_next().unwrap();
@@ -4174,7 +4288,7 @@ mod tests {
         q.push(make_queued(ch, "msg"));
         let batch = q.flush_next().unwrap();
         q.requeue_as_cancelled(batch, CancelReason::Interrupt);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // Channel has only cancelled events — should still be considered flushable.
         assert!(
@@ -4192,7 +4306,7 @@ mod tests {
         q.push(make_queued(ch, "msg"));
         let batch = q.flush_next().unwrap();
         q.requeue_as_cancelled(batch, CancelReason::Interrupt);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // drain_channel should clear cancelled_batches for the channel.
         q.drain_channel(ch);
@@ -4220,7 +4334,7 @@ mod tests {
 
         // First cancel: store 2 cancelled events.
         q.requeue_as_cancelled(batch1, CancelReason::Interrupt);
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // Second flush: events=[new-1], cancelled_events=[orig-1, orig-2].
         let batch2 = q.flush_next().unwrap();
@@ -4233,7 +4347,7 @@ mod tests {
 
         // Push 1 more new event and release channel.
         q.push(make_queued(ch, "new-2"));
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // Third flush: events=[new-2], cancelled_events=[orig-1, orig-2, new-1].
         let batch3 = q.flush_next().unwrap();
@@ -4254,7 +4368,7 @@ mod tests {
             vec![vec!["e".into(), root_id.clone(), "".into(), "reply".into()]],
         );
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -4296,7 +4410,7 @@ mod tests {
         );
         let event_id = event.id.to_hex();
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -4331,7 +4445,7 @@ mod tests {
         let event = make_event("hello world");
         let event_id = event.id.to_hex();
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -4360,7 +4474,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hey there");
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -4403,7 +4517,7 @@ mod tests {
         );
         let event_id = event.id.to_hex();
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -4439,7 +4553,7 @@ mod tests {
             vec![vec!["e".into(), root_id.clone(), "".into(), "reply".into()]],
         );
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -4474,7 +4588,7 @@ mod tests {
             vec![vec!["e".into(), root_id.clone(), "".into(), "reply".into()]],
         );
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![
                 BatchEvent {
                     event: plain,
@@ -4511,7 +4625,7 @@ mod tests {
         let plain = make_event("latest top-level");
         let plain_id = plain.id.to_hex();
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![
                 BatchEvent {
                     event: threaded,
@@ -4544,7 +4658,7 @@ mod tests {
     /// Build a single-event FlushBatch with the given content.
     fn make_single_batch(content: &str) -> FlushBatch {
         FlushBatch {
-            channel_id: Uuid::new_v4(),
+            conversation: key(Uuid::new_v4()),
             events: vec![BatchEvent {
                 event: make_event(content),
                 prompt_tag: "test".into(),
@@ -4668,7 +4782,7 @@ mod tests {
         let event_id = qe.event.id.to_hex();
         q.push(qe);
 
-        assert!(q.mark_native_steer_pending(ch, &event_id));
+        assert!(q.mark_native_steer_pending(&key(ch), &event_id));
 
         assert!(
             q.flush_next().is_none(),
@@ -4679,7 +4793,10 @@ mod tests {
             "withheld-only channel must not register as flushable work"
         );
         assert_eq!(pending_count(&q), 0);
-        assert_eq!(q.withheld_native_steer.get(&ch).map(|v| v.len()), Some(1));
+        assert_eq!(
+            q.withheld_native_steer.get(&key(ch)).map(|v| v.len()),
+            Some(1)
+        );
     }
 
     /// Earlier events on the same channel must flush normally during the
@@ -4705,25 +4822,25 @@ mod tests {
         q.push(e3);
 
         // Steer in flight for e3 — withhold it from normal dispatch.
-        assert!(q.mark_native_steer_pending(ch, &e3_id));
+        assert!(q.mark_native_steer_pending(&key(ch), &e3_id));
 
         // Earlier events flush as a normal batch; e3 is invisible.
         let batch = q
             .flush_next()
             .expect("e1+e2 should flush during ack window");
-        assert_eq!(batch.channel_id, ch);
+        assert_eq!(batch.channel_id(), ch);
         assert_eq!(batch.events.len(), 2);
         assert_eq!(batch.events[0].event.id.to_hex(), e1_id);
         assert_eq!(batch.events[1].event.id.to_hex(), e2_id);
 
         // Earlier batch completes; channel is no longer in flight.
-        q.mark_complete(ch);
+        q.mark_complete(&key(ch));
 
         // Ack arrives as Err or PromptCompletedNeutral → release e3.
-        q.release_native_steer(ch, &e3_id);
+        q.release_native_steer(&key(ch), &e3_id);
 
         let next = q.flush_next().expect("released e3 should now flush");
-        assert_eq!(next.channel_id, ch);
+        assert_eq!(next.channel_id(), ch);
         assert_eq!(next.events.len(), 1);
         assert_eq!(next.events[0].event.id.to_hex(), e3_id);
 
@@ -4747,17 +4864,17 @@ mod tests {
 
         // Simulate a prompt in flight for `ch`, then withhold the queued
         // event for an in-flight goose-native steer.
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, Instant::now());
-        q.in_flight_batch_sizes.insert(ch, 1);
-        assert!(q.mark_native_steer_pending(ch, &event_id));
+        q.in_flight.insert(key(ch));
+        q.in_flight_deadlines.insert(key(ch), Instant::now());
+        q.in_flight_batch_sizes.insert(key(ch), 1);
+        assert!(q.mark_native_steer_pending(&key(ch), &event_id));
 
         // Force the in-flight deadline to be in the past, simulating the
         // steer ack never arriving and the read loop hanging long enough
         // for `in_flight_deadline` to elapse. Same expiry-simulation
         // trick used by `test_retry_throttle_blocks_requeue_channel`.
         q.in_flight_deadlines
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+            .insert(key(ch), Instant::now() - Duration::from_secs(1));
 
         // `has_flushable_work` runs the expiry block first; it must recover
         // the withheld event so the channel registers as flushable.
@@ -4774,7 +4891,7 @@ mod tests {
         let batch = q
             .flush_next()
             .expect("recovered event should flush via normal dispatch");
-        assert_eq!(batch.channel_id, ch);
+        assert_eq!(batch.channel_id(), ch);
         assert_eq!(batch.events.len(), 1);
         assert_eq!(batch.events[0].event.id.to_hex(), event_id);
     }
@@ -4805,24 +4922,27 @@ mod tests {
         // tests. What matters here is that the bulk-recovery path
         // (reverse iter + push_front) composes to original FIFO at the
         // queue front.
-        assert!(q.mark_native_steer_pending(ch, &e1_id));
-        assert!(q.mark_native_steer_pending(ch, &e2_id));
-        assert!(q.mark_native_steer_pending(ch, &e3_id));
+        assert!(q.mark_native_steer_pending(&key(ch), &e1_id));
+        assert!(q.mark_native_steer_pending(&key(ch), &e2_id));
+        assert!(q.mark_native_steer_pending(&key(ch), &e3_id));
         assert_eq!(pending_count(&q), 0);
-        assert_eq!(q.withheld_native_steer.get(&ch).map(|v| v.len()), Some(3));
+        assert_eq!(
+            q.withheld_native_steer.get(&key(ch)).map(|v| v.len()),
+            Some(3)
+        );
 
         // Trigger expiry → bulk-release path.
-        q.in_flight_channels.insert(ch);
+        q.in_flight.insert(key(ch));
         q.in_flight_deadlines
-            .insert(ch, Instant::now() - Duration::from_secs(1));
-        q.in_flight_batch_sizes.insert(ch, 3);
+            .insert(key(ch), Instant::now() - Duration::from_secs(1));
+        q.in_flight_batch_sizes.insert(key(ch), 3);
         assert!(q.has_flushable_work());
 
         // After recovery, the queue front-to-back order must match the
         // original FIFO: e1, e2, e3.
         let recovered: Vec<String> = q
             .queues
-            .get(&ch)
+            .get(&key(ch))
             .expect("queue restored")
             .iter()
             .map(|qe| qe.event.id.to_hex())
@@ -4838,7 +4958,7 @@ mod tests {
         let canvas = "[Channel Canvas]\nCanvas revision (event ID): abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234\nLast modified: 2024-01-15T10:30:00+00:00\nFetch current content with: buzz canvas get --channel 00f1ccaf-1506-4dd7-9a0e-fa67e9e486ae";
         let ch = Uuid::new_v4();
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event: make_event("hi"),
                 prompt_tag: "test".into(),
@@ -4867,7 +4987,7 @@ mod tests {
         let canvas = "[Channel Canvas]\nCanvas revision (event ID): abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234\nLast modified: 2024-01-15T10:30:00+00:00\nFetch current content with: buzz canvas get --channel 00f1ccaf-1506-4dd7-9a0e-fa67e9e486ae";
         let ch = Uuid::new_v4();
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event: make_event("hi"),
                 prompt_tag: "test".into(),
@@ -4895,7 +5015,7 @@ mod tests {
     fn test_format_prompt_no_canvas_produces_no_canvas_section() {
         let ch = Uuid::new_v4();
         let batch = FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event: make_event("hi"),
                 prompt_tag: "test".into(),
@@ -4944,11 +5064,11 @@ mod tests {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
         let old_deadline = Instant::now() + Duration::from_secs(100);
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, old_deadline);
+        q.in_flight.insert(key(ch));
+        q.in_flight_deadlines.insert(key(ch), old_deadline);
 
-        q.extend_in_flight_deadline(ch, 7200);
-        let new = *q.in_flight_deadlines.get(&ch).unwrap();
+        q.extend_in_flight_deadline(&key(ch), 7200);
+        let new = *q.in_flight_deadlines.get(&key(ch)).unwrap();
         assert!(
             new > old_deadline,
             "extended deadline must be past the original"
@@ -4960,11 +5080,11 @@ mod tests {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
         let far_future = Instant::now() + Duration::from_secs(999_999);
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, far_future);
+        q.in_flight.insert(key(ch));
+        q.in_flight_deadlines.insert(key(ch), far_future);
 
-        q.extend_in_flight_deadline(ch, 7200);
-        let after = *q.in_flight_deadlines.get(&ch).unwrap();
+        q.extend_in_flight_deadline(&key(ch), 7200);
+        let after = *q.in_flight_deadlines.get(&key(ch)).unwrap();
         assert_eq!(after, far_future, "deadline must never move backward");
     }
 
@@ -4972,17 +5092,17 @@ mod tests {
     fn extend_in_flight_deadline_noop_after_mark_complete() {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
-        q.in_flight_channels.insert(ch);
+        q.in_flight.insert(key(ch));
         q.in_flight_deadlines
-            .insert(ch, Instant::now() + Duration::from_secs(100));
-        q.in_flight_batch_sizes.insert(ch, 1);
+            .insert(key(ch), Instant::now() + Duration::from_secs(100));
+        q.in_flight_batch_sizes.insert(key(ch), 1);
 
-        q.mark_complete(ch);
-        assert!(!q.in_flight_deadlines.contains_key(&ch));
+        q.mark_complete(&key(ch));
+        assert!(!q.in_flight_deadlines.contains_key(&key(ch)));
 
-        q.extend_in_flight_deadline(ch, 7200);
+        q.extend_in_flight_deadline(&key(ch), 7200);
         assert!(
-            !q.in_flight_deadlines.contains_key(&ch),
+            !q.in_flight_deadlines.contains_key(&key(ch)),
             "extend after mark_complete must not resurrect a deadline"
         );
     }
@@ -4992,17 +5112,17 @@ mod tests {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
         let extended = Instant::now() + Duration::from_secs(9999);
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, extended);
+        q.in_flight.insert(key(ch));
+        q.in_flight_deadlines.insert(key(ch), extended);
 
         q.compact_expired_state();
 
         assert!(
-            q.in_flight_deadlines.contains_key(&ch),
+            q.in_flight_deadlines.contains_key(&key(ch)),
             "compaction must not touch in-flight deadlines"
         );
         assert_eq!(
-            *q.in_flight_deadlines.get(&ch).unwrap(),
+            *q.in_flight_deadlines.get(&key(ch)).unwrap(),
             extended,
             "compaction must leave extended deadline intact"
         );
@@ -5021,9 +5141,9 @@ mod tests {
 
         // Insert the channel as in-flight with a deadline already in the past
         // (Instant::now() — by the time flush_next runs, now >= deadline).
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, Instant::now());
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight.insert(key(ch));
+        q.in_flight_deadlines.insert(key(ch), Instant::now());
+        q.in_flight_batch_sizes.insert(key(ch), 1);
 
         // Also push an event so flush_next has something to do after expiry.
         q.push(make_queued(ch, "after-expiry"));
@@ -5033,7 +5153,7 @@ mod tests {
         let batch = q
             .flush_next()
             .expect("channel should be dispatchable after auto-expiry");
-        assert_eq!(batch.channel_id, ch);
+        assert_eq!(batch.channel_id(), ch);
         assert_eq!(batch.events[0].event.content, "after-expiry");
     }
 
@@ -5049,10 +5169,10 @@ mod tests {
         let ch = Uuid::new_v4();
 
         // Put the channel in-flight with an extended deadline far in the future.
-        q.in_flight_channels.insert(ch);
+        q.in_flight.insert(key(ch));
         q.in_flight_deadlines
-            .insert(ch, Instant::now() + Duration::from_secs(9999));
-        q.in_flight_batch_sizes.insert(ch, 1);
+            .insert(key(ch), Instant::now() + Duration::from_secs(9999));
+        q.in_flight_batch_sizes.insert(key(ch), 1);
 
         // Push an event for another channel so flush_next has work to do.
         let ch2 = Uuid::new_v4();
@@ -5060,17 +5180,18 @@ mod tests {
 
         let batch = q.flush_next().expect("other channel should flush");
         assert_eq!(
-            batch.channel_id, ch2,
+            batch.channel_id(),
+            ch2,
             "only ch2 should be flushed; ch is still in-flight with extended deadline"
         );
 
         // ch must still be in-flight — the extended deadline did not expire.
         assert!(
-            q.in_flight_channels.contains(&ch),
+            q.in_flight.contains(&key(ch)),
             "ch must remain in-flight after flush_next with an extended deadline"
         );
         assert!(
-            q.in_flight_deadlines.contains_key(&ch),
+            q.in_flight_deadlines.contains_key(&key(ch)),
             "in-flight deadline for ch must not be removed by flush_next"
         );
     }
@@ -5087,10 +5208,10 @@ mod tests {
         let ch = Uuid::new_v4();
 
         // In-flight channel with extended (far-future) deadline.
-        q.in_flight_channels.insert(ch);
+        q.in_flight.insert(key(ch));
         q.in_flight_deadlines
-            .insert(ch, Instant::now() + Duration::from_secs(9999));
-        q.in_flight_batch_sizes.insert(ch, 1);
+            .insert(key(ch), Instant::now() + Duration::from_secs(9999));
+        q.in_flight_batch_sizes.insert(key(ch), 1);
 
         // No other channels — nothing flushable.
         assert!(
@@ -5098,7 +5219,7 @@ mod tests {
             "has_flushable_work must return false when the only channel is in-flight with extended deadline"
         );
         assert!(
-            q.in_flight_channels.contains(&ch),
+            q.in_flight.contains(&key(ch)),
             "ch must remain in-flight after has_flushable_work with extended deadline"
         );
 
@@ -5111,7 +5232,7 @@ mod tests {
         );
         // ch still in-flight and not expired.
         assert!(
-            q.in_flight_channels.contains(&ch),
+            q.in_flight.contains(&key(ch)),
             "ch must still be in-flight after has_flushable_work finds ch2 work"
         );
     }
@@ -5126,15 +5247,15 @@ mod tests {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
 
-        q.in_flight_channels.insert(ch);
+        q.in_flight.insert(key(ch));
         q.in_flight_deadlines
-            .insert(ch, Instant::now() + Duration::from_secs(100));
+            .insert(key(ch), Instant::now() + Duration::from_secs(100));
 
-        q.extend_in_flight_deadline(ch, 7200);
-        let after_first = *q.in_flight_deadlines.get(&ch).unwrap();
+        q.extend_in_flight_deadline(&key(ch), 7200);
+        let after_first = *q.in_flight_deadlines.get(&key(ch)).unwrap();
 
-        q.extend_in_flight_deadline(ch, 7200);
-        let after_second = *q.in_flight_deadlines.get(&ch).unwrap();
+        q.extend_in_flight_deadline(&key(ch), 7200);
+        let after_second = *q.in_flight_deadlines.get(&key(ch)).unwrap();
 
         assert!(
             after_second >= after_first,
@@ -5264,7 +5385,7 @@ mod tests {
 
     fn description_batch(ch: Uuid, event: Event) -> FlushBatch {
         FlushBatch {
-            channel_id: ch,
+            conversation: key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -5300,6 +5421,164 @@ mod tests {
         assert!(
             prompt.contains("Description: Engineering discussions and planning."),
             "description must appear in [Context] for channel turns; got: {prompt}"
+        );
+    }
+
+    // ── Per-thread concurrency: conversations in one channel are independent ─
+
+    /// Build a QueuedEvent in `channel_id` replying into the thread rooted at
+    /// `root_hex` (NIP-10 marker-based root tag).
+    fn make_queued_in_thread(channel_id: Uuid, content: &str, root_hex: &str) -> QueuedEvent {
+        let keys = Keys::generate();
+        let root_tag = nostr::Tag::parse(["e", root_hex, "", "root"]).unwrap();
+        let event = EventBuilder::new(Kind::Custom(9), content)
+            .tags([root_tag])
+            .sign_with_keys(&keys)
+            .unwrap();
+        QueuedEvent {
+            conversation: ConversationKey::for_event(channel_id, &event),
+            event,
+            received_at: Instant::now(),
+            prompt_tag: "test".into(),
+        }
+    }
+
+    fn root_hex(seed: u8) -> String {
+        format!("{:064x}", seed as u128)
+    }
+
+    #[test]
+    fn inbound_top_level_posts_start_distinct_thread_sessions() {
+        let channel = Uuid::new_v4();
+        let first = make_event("first");
+        let second = make_event("second");
+
+        let first_key = ConversationKey::for_inbound(channel, &first, false);
+        let second_key = ConversationKey::for_inbound(channel, &second, false);
+
+        assert_eq!(
+            first_key.thread_root.as_deref(),
+            Some(first.id.to_hex().as_str())
+        );
+        assert_eq!(
+            second_key.thread_root.as_deref(),
+            Some(second.id.to_hex().as_str())
+        );
+        assert_ne!(first_key, second_key);
+    }
+
+    #[test]
+    fn inbound_reply_reuses_top_level_thread_session() {
+        let channel = Uuid::new_v4();
+        let root = make_event("root");
+        let root_id = root.id.to_hex();
+        let reply = make_event_with_tags(
+            "reply",
+            vec![vec!["e".into(), root_id.clone(), "".into(), "root".into()]],
+        );
+
+        assert_eq!(
+            ConversationKey::for_inbound(channel, &root, false),
+            ConversationKey::for_inbound(channel, &reply, false),
+        );
+    }
+
+    #[test]
+    fn inbound_dm_events_keep_channel_session_continuity() {
+        let channel = Uuid::new_v4();
+        let first = make_event("first");
+        let second = make_event("second");
+
+        assert_eq!(
+            ConversationKey::for_inbound(channel, &first, true),
+            ConversationKey::for_inbound(channel, &second, true),
+        );
+    }
+
+    #[test]
+    fn two_threads_in_one_channel_flush_and_run_concurrently() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+
+        q.push(make_queued_in_thread(ch, "thread a", &root_hex(1)));
+        q.push(make_queued_in_thread(ch, "thread b", &root_hex(2)));
+
+        let first = q.flush_next().expect("first thread must flush");
+        let second = q
+            .flush_next()
+            .expect("second thread must flush while the first is in flight");
+
+        assert_eq!(first.channel_id(), ch);
+        assert_eq!(second.channel_id(), ch);
+        assert_ne!(
+            first.conversation, second.conversation,
+            "the two flushes must be distinct conversations"
+        );
+        assert!(q.is_conversation_in_flight(&first.conversation));
+        assert!(q.is_conversation_in_flight(&second.conversation));
+    }
+
+    #[test]
+    fn same_thread_stays_serialized_while_in_flight() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let root = root_hex(3);
+
+        q.push(make_queued_in_thread(ch, "first", &root));
+        let batch = q.flush_next().expect("first event must flush");
+
+        q.push(make_queued_in_thread(ch, "second", &root));
+        assert!(
+            q.flush_next().is_none(),
+            "same-thread event must not flush while its conversation is in flight"
+        );
+
+        q.mark_complete(&batch.conversation);
+        let next = q
+            .flush_next()
+            .expect("queued event must flush after completion");
+        assert_eq!(next.conversation, batch.conversation);
+    }
+
+    #[test]
+    fn top_level_lane_stays_serialized_alongside_threads() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+
+        q.push(make_queued(ch, "top-level one"));
+        q.push(make_queued(ch, "top-level two"));
+        q.push(make_queued_in_thread(ch, "threaded", &root_hex(4)));
+
+        let first = q.flush_next().expect("top-level lane must flush");
+        assert_eq!(first.conversation, key(ch));
+        assert_eq!(
+            first.events.len(),
+            2,
+            "both top-level events batch into the single None lane"
+        );
+
+        let second = q
+            .flush_next()
+            .expect("threaded lane must flush concurrently");
+        assert_ne!(second.conversation, key(ch));
+    }
+
+    #[test]
+    fn mark_complete_releases_only_the_matching_thread() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+
+        q.push(make_queued_in_thread(ch, "thread a", &root_hex(5)));
+        q.push(make_queued_in_thread(ch, "thread b", &root_hex(6)));
+        let a = q.flush_next().unwrap();
+        let b = q.flush_next().unwrap();
+
+        q.mark_complete(&a.conversation);
+
+        assert!(!q.is_conversation_in_flight(&a.conversation));
+        assert!(
+            q.is_conversation_in_flight(&b.conversation),
+            "completing thread a must not release thread b"
         );
     }
 
@@ -5390,5 +5669,23 @@ mod tests {
             !prompt.contains("Description:"),
             "unresolved metadata must not render a Description field; got: {prompt}"
         );
+    }
+
+    #[test]
+    fn drain_channel_drains_every_thread_lane() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let other = Uuid::new_v4();
+
+        q.push(make_queued(ch, "top-level"));
+        q.push(make_queued_in_thread(ch, "thread a", &root_hex(7)));
+        q.push(make_queued_in_thread(ch, "thread b", &root_hex(8)));
+        q.push(make_queued(other, "other channel"));
+
+        let drained = q.drain_channel(ch);
+
+        assert_eq!(drained.len(), 3, "all three lanes in the channel drain");
+        assert_eq!(pending_count(&q), 1, "the other channel is untouched");
+        assert!(q.flush_next().unwrap().channel_id() == other);
     }
 }

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -714,6 +714,13 @@ export const ChannelPane = React.memo(function ChannelPane({
                   onSend={handleSendMessage}
                   profiles={profiles}
                   showBackgroundUploadProgress={false}
+                  toolbarExtraActions={
+                    activeChannel?.channelType === "stream" ? (
+                      <span className="whitespace-nowrap text-xs text-muted-foreground">
+                        New thread · new agent session
+                      </span>
+                    ) : undefined
+                  }
                   placeholder={
                     timeoutState.active
                       ? "You're timed out by community moderators."
@@ -727,7 +734,9 @@ export const ChannelPane = React.memo(function ChannelPane({
                               ? activeChannel.channelType === "dm" &&
                                 directMessageIntro
                                 ? `Message ${directMessageIntro.displayName}`
-                                : `Message #${activeChannel.name}`
+                                : activeChannel.channelType === "stream"
+                                  ? `Start a new thread in #${activeChannel.name}`
+                                  : `Message #${activeChannel.name}`
                               : "Select a channel"
                   }
                   showTopBorder={false}

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -922,7 +922,7 @@ export function MessageThreadPanel({
               placeholder={
                 isHuddleTranscript
                   ? "Message the huddle"
-                  : `Reply in thread to ${threadHead.author}`
+                  : "Reply in thread · same agent session"
               }
               profiles={profiles}
               replyTarget={composerReplyTarget}


### PR DESCRIPTION
## Summary

- Key ACP queues, in-flight state, sessions, affinity, and delivery tracking by `(channel_id, thread_root)`.
- Treat each top-level non-DM post as its own thread session; replies reuse the canonical root; DMs remain continuous.
- Allow different threads in one channel to run concurrently while serializing turns within one thread.
- Label new-session and same-session behavior in the desktop composers.

## Context

Addresses #5009 and #3563.

Ports the thread-session direction from #3379 and #2331 onto current `main` while retaining current per-conversation delivery tracking.

## Validation

- `cargo test -p buzz-acp`: 821 passed
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- All repository `just ci` stages passed with the pinned Hermit toolchain:
  - workspace and unit suites
  - desktop: 5,122 tests, typecheck, and build
  - Tauri workspace: 2,702 desktop tests plus crate tests
  - web build
  - mobile: 1,552 tests
  - file-size ratchet

No merge performed; upstream review is required.
