### PR TITLE
feat(llm): stamp thinking effort on call-completed log line

### DIFF
--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -226,6 +226,7 @@ impl Llm {
             tracing::info!(
                 model = effective_model,
                 provider = ?cfg.provider,
+                thinking_effort = ?cfg.thinking_effort,
                 duration_ms,
                 input_tokens = ?response.input_tokens,
                 cached_input_tokens = ?response.cached_input_tokens,


### PR DESCRIPTION
The performance-analysis pipeline measures harness × provider × model × effort from production logs, but thinking effort was the only dimension not stamped per call — it had to be attributed by config-changeover timestamp.

Add `thinking_effort = ?cfg.thinking_effort` to the `llm: call completed` `tracing::info!` in `Llm::complete()` so every call self-describes all four dimensions. `?`-formatting preserves the `None`-vs-`Some(...)` distinction the same way the token fields keep None-vs-zero.
