### PR TITLE
Enforce a three-day dependency cooldown

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "minimumReleaseAge": "3 days",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
+  "internalChecksFilter": "strict",
   "prCreation": "immediate",
   "automerge": true,
   "rebaseWhen": "conflicted",


### PR DESCRIPTION
Configure Renovate to wait three days before proposing newly released dependencies.

The policy requires a registry publication timestamp and suppresses branches until the release ages past the window. Renovate security-alert updates continue to bypass minimum-release-age checks, so known fixes are not delayed.

Checked with `renovate-config-validator --strict --no-global renovate.json`, `jq`, and `git diff --check`.
