### PR TITLE
feat(desktop): add interface contrast preference

### DIFF
--- a/desktop/biome.json
+++ b/desktop/biome.json
@@ -1,3 +1,15 @@
 {
-  "extends": ["../biome.json"]
+  "extends": ["../biome.json"],
+  "overrides": [
+    {
+      "includes": ["src/shared/styles/globals/contrast.css"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "noImportantStyles": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -877,7 +877,11 @@ function MessageComposerImpl({
           ) : null}
           <form
             className={cn(
-              "relative z-10 isolate rounded-2xl border border-border/50 bg-background/80 px-3 pb-2 pt-3 shadow-none supports-[backdrop-filter]:bg-background/70 dark:bg-background/70 dark:supports-[backdrop-filter]:bg-background/55 sm:px-4",
+              // `border-input`, not `border-border`: the composer shell is an
+              // input affordance rather than decorative chrome, so it must keep
+              // an edge at low interface contrast. The two tokens carry the
+              // same value in every theme, so this is a no-op elsewhere.
+              "relative z-10 isolate rounded-2xl border border-input/50 bg-background/80 px-3 pb-2 pt-3 shadow-none supports-[backdrop-filter]:bg-background/70 dark:bg-background/70 dark:supports-[backdrop-filter]:bg-background/55 sm:px-4",
               layoutMode === "standalone" &&
                 "backdrop-blur-md dark:backdrop-blur-xl",
             )}

--- a/desktop/src/features/settings/ui/AppearanceSettingsControls.tsx
+++ b/desktop/src/features/settings/ui/AppearanceSettingsControls.tsx
@@ -28,6 +28,12 @@ import {
   type FontSize,
 } from "@/shared/lib/fontSizePreference";
 import {
+  previewInterfaceContrast,
+  setInterfaceContrast,
+  useInterfaceContrast,
+  type InterfaceContrast,
+} from "@/shared/lib/contrastPreference";
+import {
   ACCENT_COLORS,
   DEFAULT_GLASS_OPACITY,
   GLASS_OPACITY_MAX,
@@ -110,6 +116,24 @@ const CONVERSATION_DENSITY_OPTIONS: readonly {
   {
     value: "spacious",
     label: "Spacious",
+  },
+];
+
+const INTERFACE_CONTRAST_OPTIONS: readonly {
+  value: InterfaceContrast;
+  label: string;
+}[] = [
+  {
+    value: "low",
+    label: "Low",
+  },
+  {
+    value: "default",
+    label: "Default",
+  },
+  {
+    value: "high",
+    label: "High",
   },
 ];
 
@@ -207,6 +231,7 @@ function ConversationPreview() {
 export function ConversationDisplaySettings() {
   const density = useConversationDensity();
   const fontSize = useFontSize();
+  const contrast = useInterfaceContrast();
 
   return (
     <div data-testid="conversation-display-group">
@@ -229,6 +254,27 @@ export function ConversationDisplaySettings() {
           options={FONT_SIZE_OPTIONS}
           testId="font-size-control"
           value={fontSize}
+        />
+      </SettingsOptionRow>
+      <SettingsOptionRow data-testid="interface-contrast-row">
+        <div className="min-w-0">
+          <p className="text-sm font-medium">Interface contrast</p>
+          <p
+            className="text-sm font-normal text-muted-foreground/70"
+            data-settings-subcopy
+          >
+            How strongly borders, panels, and row highlights are drawn
+          </p>
+        </div>
+        <SegmentedControl
+          size="wide"
+          legend="Interface contrast"
+          onPreviewChange={previewInterfaceContrast}
+          onValueChange={setInterfaceContrast}
+          optionTestIdPrefix="interface-contrast"
+          options={INTERFACE_CONTRAST_OPTIONS}
+          testId="interface-contrast-control"
+          value={contrast}
         />
       </SettingsOptionRow>
       <SettingsOptionRow data-testid="conversation-density-row">

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -22,6 +22,7 @@ import { recoverLocalStorageQuotaOnStartup } from "@/shared/lib/localStorageQuot
 import { startLocalStorageSweep } from "@/shared/lib/localStorageSweep";
 import { initializeConversationDensityPreference } from "@/shared/lib/conversationDensityPreference";
 import { initializeFontSizePreference } from "@/shared/lib/fontSizePreference";
+import { initializeInterfaceContrastPreference } from "@/shared/lib/contrastPreference";
 
 type E2eWindow = Window & {
   __BUZZ_E2E__?: unknown;
@@ -128,6 +129,7 @@ async function bootstrap() {
   recoverLocalStorageQuotaOnStartup();
   initializeConversationDensityPreference();
   initializeFontSizePreference();
+  initializeInterfaceContrastPreference();
   startLocalStorageSweep();
   await installE2eBridgeIfConfigured();
   await migrateLegacyCommunityStorageBeforeRender();

--- a/desktop/src/shared/lib/contrastPreference.test.mjs
+++ b/desktop/src/shared/lib/contrastPreference.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const values = new Map();
+const attributes = new Map();
+const windowListeners = new Map();
+
+globalThis.window = {
+  addEventListener: (type, listener) => windowListeners.set(type, listener),
+};
+globalThis.localStorage = {
+  getItem: (key) => values.get(key) ?? null,
+  setItem: (key, value) => values.set(key, String(value)),
+};
+globalThis.document = {
+  documentElement: {
+    setAttribute: (name, value) => attributes.set(name, value),
+  },
+};
+
+const preference = await import("./contrastPreference.ts");
+
+test("defaults invalid and missing interface contrasts to default", () => {
+  assert.equal(preference.parseInterfaceContrast(null), "default");
+  assert.equal(preference.parseInterfaceContrast(undefined), "default");
+  assert.equal(preference.parseInterfaceContrast("flat"), "default");
+  assert.equal(preference.parseInterfaceContrast("low"), "low");
+  assert.equal(preference.parseInterfaceContrast("default"), "default");
+  assert.equal(preference.parseInterfaceContrast("high"), "high");
+});
+
+test("persists and applies the selected interface contrast", () => {
+  preference.setInterfaceContrast("low");
+  assert.equal(preference.getInterfaceContrast(), "low");
+  assert.equal(values.get(preference.INTERFACE_CONTRAST_STORAGE_KEY), "low");
+  assert.equal(attributes.get("data-interface-contrast"), "low");
+
+  preference.setInterfaceContrast("high");
+  assert.equal(preference.getInterfaceContrast(), "high");
+  assert.equal(values.get(preference.INTERFACE_CONTRAST_STORAGE_KEY), "high");
+  assert.equal(attributes.get("data-interface-contrast"), "high");
+});
+
+test("previews a contrast without changing the saved preference", () => {
+  preference.setInterfaceContrast("low");
+
+  preference.previewInterfaceContrast("high");
+  assert.equal(attributes.get("data-interface-contrast"), "high");
+  assert.equal(preference.getInterfaceContrast(), "low");
+  assert.equal(values.get(preference.INTERFACE_CONTRAST_STORAGE_KEY), "low");
+
+  preference.previewInterfaceContrast(null);
+  assert.equal(attributes.get("data-interface-contrast"), "low");
+});
+
+test("initialize applies the stored contrast and follows storage events", () => {
+  values.set(preference.INTERFACE_CONTRAST_STORAGE_KEY, "high");
+  preference.initializeInterfaceContrastPreference();
+  assert.equal(preference.getInterfaceContrast(), "high");
+  assert.equal(attributes.get("data-interface-contrast"), "high");
+
+  values.set(preference.INTERFACE_CONTRAST_STORAGE_KEY, "low");
+  windowListeners.get("storage")({
+    key: preference.INTERFACE_CONTRAST_STORAGE_KEY,
+  });
+  assert.equal(preference.getInterfaceContrast(), "low");
+  assert.equal(attributes.get("data-interface-contrast"), "low");
+});
+
+test("returns to default when another window clears storage", () => {
+  preference.setInterfaceContrast("high");
+  values.clear();
+  windowListeners.get("storage")({ key: null });
+  assert.equal(preference.getInterfaceContrast(), "default");
+  assert.equal(attributes.get("data-interface-contrast"), "default");
+});

--- a/desktop/src/shared/lib/contrastPreference.ts
+++ b/desktop/src/shared/lib/contrastPreference.ts
@@ -1,0 +1,101 @@
+import * as React from "react";
+
+/** Device-level chrome contrast applied across the whole interface. */
+export type InterfaceContrast = "low" | "default" | "high";
+
+export const INTERFACE_CONTRAST_STORAGE_KEY =
+  "buzz.appearance.interfaceContrast";
+export const DEFAULT_INTERFACE_CONTRAST: InterfaceContrast = "default";
+
+const listeners = new Set<() => void>();
+let interfaceContrast: InterfaceContrast = DEFAULT_INTERFACE_CONTRAST;
+let listeningForStorageChanges = false;
+
+export function parseInterfaceContrast(
+  value: string | null | undefined,
+): InterfaceContrast {
+  return value === "low" || value === "default" || value === "high"
+    ? value
+    : DEFAULT_INTERFACE_CONTRAST;
+}
+
+function readStoredInterfaceContrast(): InterfaceContrast {
+  try {
+    return parseInterfaceContrast(
+      globalThis.localStorage?.getItem(INTERFACE_CONTRAST_STORAGE_KEY),
+    );
+  } catch {
+    return DEFAULT_INTERFACE_CONTRAST;
+  }
+}
+
+function applyInterfaceContrast(contrast: InterfaceContrast): void {
+  globalThis.document?.documentElement?.setAttribute(
+    "data-interface-contrast",
+    contrast,
+  );
+}
+
+function notifyListeners(): void {
+  for (const listener of listeners) listener();
+}
+
+function applyStoredInterfaceContrast(): void {
+  const nextContrast = readStoredInterfaceContrast();
+  const changed = nextContrast !== interfaceContrast;
+  interfaceContrast = nextContrast;
+  applyInterfaceContrast(nextContrast);
+  if (changed) notifyListeners();
+}
+
+function listenForStorageChanges(): void {
+  if (listeningForStorageChanges || !globalThis.window?.addEventListener)
+    return;
+  globalThis.window.addEventListener("storage", (event) => {
+    if (event.key === INTERFACE_CONTRAST_STORAGE_KEY || event.key === null) {
+      applyStoredInterfaceContrast();
+    }
+  });
+  listeningForStorageChanges = true;
+}
+
+/** Apply the persisted preference before React renders to avoid a flash of chrome. */
+export function initializeInterfaceContrastPreference(): void {
+  applyStoredInterfaceContrast();
+  listenForStorageChanges();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getInterfaceContrast(): InterfaceContrast {
+  return interfaceContrast;
+}
+
+export function setInterfaceContrast(contrast: InterfaceContrast): void {
+  interfaceContrast = contrast;
+  applyInterfaceContrast(contrast);
+  try {
+    globalThis.localStorage?.setItem(INTERFACE_CONTRAST_STORAGE_KEY, contrast);
+  } catch {
+    // Persistence is best-effort; the live preference still applies.
+  }
+  notifyListeners();
+}
+
+/** Temporarily apply a contrast without changing the saved preference. */
+export function previewInterfaceContrast(
+  contrast: InterfaceContrast | null,
+): void {
+  applyInterfaceContrast(contrast ?? interfaceContrast);
+}
+
+export function useInterfaceContrast(): InterfaceContrast {
+  return React.useSyncExternalStore(
+    subscribe,
+    getInterfaceContrast,
+    () => DEFAULT_INTERFACE_CONTRAST,
+  );
+}

--- a/desktop/src/shared/styles/globals.css
+++ b/desktop/src/shared/styles/globals.css
@@ -7,6 +7,7 @@
 @import "./globals/composer.css";
 @import "./globals/markdown.css";
 @import "./globals/theme.css";
+@import "./globals/contrast.css";
 @import "./globals/typography.css";
 @import "./globals/skeleton.css";
 @import "./globals/spoilers.css";

--- a/desktop/src/shared/styles/globals/contrast.css
+++ b/desktop/src/shared/styles/globals/contrast.css
@@ -1,0 +1,83 @@
+/*
+ * Interface contrast — how loudly the app's chrome announces itself.
+ *
+ * Every rule here derives from tokens the palette already defines
+ * (`--background`, `--secondary`, `--muted-foreground`) rather than hardcoding
+ * colors, so a contrast step behaves the same in every theme — including the
+ * Shiki-derived palettes built at runtime. Nothing here knows a hue.
+ *
+ * WHY `!important`:
+ *
+ * ThemeProvider applies the active palette as ~49 INLINE custom properties on
+ * <html> (see adaptive-theme.ts building the var map and `root.style
+ * .setProperty` in ThemeProvider). A normal inline declaration outranks every
+ * author rule no matter its specificity or layer, so the usual escape hatch
+ * used elsewhere in this codebase — an unlayered rule beating a layered one —
+ * cannot reach these tokens. Author `!important` is the only step above a
+ * normal inline declaration in the cascade, and that is exactly the intent
+ * here: contrast is a deliberate user override applied on top of whatever
+ * palette the theme computed.
+ *
+ * `data-interface-contrast` is set on <html> by contrastPreference.ts before
+ * React mounts.
+ */
+
+/*
+ * Low — the quiet mode. Borders dissolve into the surface behind them, the
+ * sidebar stops reading as a separate panel, and row states become
+ * suggestions rather than filled blocks. Text color is deliberately
+ * untouched: this removes chrome, never legibility.
+ */
+:root[data-interface-contrast="low"] {
+  --border: var(--background) !important;
+  --sidebar-border: var(--background) !important;
+  --sidebar: var(--background) !important;
+  --sidebar-background: var(--background) !important;
+  --card: var(--background) !important;
+
+  /* A neutral lift replaces the saturated active pill. */
+  --sidebar-active: var(--secondary) !important;
+  --sidebar-active-foreground: var(--secondary-foreground) !important;
+
+  --sidebar-row-subtle-active-surface: rgb(0 0 0 / 4%) !important;
+  --buzz-hover-surface: rgb(0 0 0 / 2.5%) !important;
+}
+
+:root[data-interface-contrast="low"].dark {
+  --sidebar-row-subtle-active-surface: rgb(255 255 255 / 8%) !important;
+  --buzz-hover-surface: rgb(255 255 255 / 4%) !important;
+}
+
+:root[data-interface-contrast="low"][data-buzz-sidebar] {
+  --sidebar-row-active-surface: rgb(0 0 0 / 6%) !important;
+}
+
+:root[data-interface-contrast="low"][data-buzz-sidebar].dark {
+  --sidebar-row-active-surface: rgb(255 255 255 / 10%) !important;
+}
+
+/*
+ * High — separators and row states become unambiguous. `--muted-foreground`
+ * is the palette's "legible but secondary" token, which as a border reads as
+ * a clear line in both light and dark without inventing a color.
+ */
+:root[data-interface-contrast="high"] {
+  --border: var(--muted-foreground) !important;
+  --sidebar-border: var(--muted-foreground) !important;
+
+  --sidebar-row-subtle-active-surface: rgb(0 0 0 / 12%) !important;
+  --buzz-hover-surface: rgb(0 0 0 / 8%) !important;
+}
+
+:root[data-interface-contrast="high"].dark {
+  --sidebar-row-subtle-active-surface: rgb(255 255 255 / 24%) !important;
+  --buzz-hover-surface: rgb(255 255 255 / 12%) !important;
+}
+
+:root[data-interface-contrast="high"][data-buzz-sidebar] {
+  --sidebar-row-active-surface: rgb(255 255 255 / 92%) !important;
+}
+
+:root[data-interface-contrast="high"][data-buzz-sidebar].dark {
+  --sidebar-row-active-surface: rgb(255 255 255 / 28%) !important;
+}


### PR DESCRIPTION
## Summary

Adds an **Interface contrast** preference (Low / Default / High) to Settings → Appearance, sitting alongside the existing Font size and Conversation density controls and using the same segmented control with live preview on hover.

The motivation is that Buzz's chrome is fairly loud on dense screens — panel borders, card outlines, a tinted sidebar and a saturated active-channel pill all compete with message content. Low collapses that chrome so the timeline reads as text; High goes the other way for people who want stronger separation.

**Low** fades borders and dividers into the surface behind them, merges the sidebar into the background, drops message card outlines, and replaces the saturated active-channel pill with a neutral lift. **High** strengthens the same tokens. **Default** is byte-identical to today — this is opt-in, and nothing changes unless the user picks a different step.

Text colour is deliberately untouched at every step: contrast removes chrome, never legibility.

### Implementation notes

- **Theme-agnostic by construction.** Every value derives from tokens the palette already defines (`--background`, `--secondary`, `--muted-foreground`) rather than hardcoded colours, so a step behaves the same in Latte, Macchiato, Buzz, and the Shiki-derived palettes built at runtime. Nothing in `contrast.css` knows a hue.
- **Why `!important`.** `ThemeProvider` applies the active palette as ~49 *inline* custom properties on `<html>` (see `adaptive-theme.ts` building the var map and `root.style.setProperty`). A normal inline declaration outranks every author rule regardless of specificity or layer, so the unlayered-beats-layered trick used elsewhere in this codebase cannot reach these tokens. Author `!important` is the only cascade step above a normal inline declaration, and that is exactly the intent: contrast is a deliberate user override on top of whatever palette the theme computed. It is scoped to one file, documented at the top of it, and covered by a `noImportantStyles` override in `desktop/biome.json` rather than 21 inline suppressions.
- **Composer token change.** `MessageComposer` moves from `border-border` to `border-input`. The composer shell is an input affordance, not decorative chrome, so it needs to keep an edge at Low. Both tokens resolve to `hexToHsl(borderColor)` in every theme, so Default and High render identically to before.
- Preference module mirrors `conversationDensityPreference.ts` exactly — same storage/listener/preview shape, applied to `<html>` before React mounts to avoid a flash of chrome.

### Related issue

None found. I searched open issues and PRs for contrast/appearance duplicates; the nearest hit is #2725 (an invisible "Delete agent" button in light theme), which is a specific bug rather than this preference.

Flagging honestly against CONTRIBUTING's "entirely new features with no prior discussion" note: this is a new user-facing preference opened without a prior issue. Happy to convert it to an issue first and park the branch if you'd rather agree the direction before reviewing code.

### Testing

- `just desktop-ci` passes locally (check, test, tauri fmt/check/test, build).
- `pnpm test` — 5042 passing, including 5 new tests for the preference module (parse/persist/apply, preview without persisting, init from storage, cross-window storage events, reset to default when storage clears).
- Screenshots below captured via `just desktop-screenshot` against the E2E mock bridge, Catppuccin Macchiato, identical seeded content, verified byte-distinct.

**Default** — unchanged from `main`:

![Default contrast](https://raw.githubusercontent.com/epicbagel/buzz/ba275fb419932d40ee7b33e50b33b2c7c69691f9/contrast-default.png)

**Low** — borders, card outlines and sidebar tint gone; active channel becomes a neutral lift; composer keeps a soft edge:

![Low contrast](https://raw.githubusercontent.com/epicbagel/buzz/ba275fb419932d40ee7b33e50b33b2c7c69691f9/contrast-low.png)

**High** — separators and row states strengthened:

![High contrast](https://raw.githubusercontent.com/epicbagel/buzz/ba275fb419932d40ee7b33e50b33b2c7c69691f9/contrast-high.png)

### Follow-up deferred

- Low contrast currently leaves `--input` at full strength so form affordances stay findable. If that reads as slightly loud once the surrounding chrome is gone, it is a one-token tweak.
- Not wired to `prefers-contrast`; an explicit user choice felt like the right first step, but honouring the OS signal as the initial default would be a reasonable follow-up.
