### PR TITLE
feat(desktop): loosen leading in the spacious conversation density

### DIFF
--- a/desktop/src/shared/styles/globals/typography.css
+++ b/desktop/src/shared/styles/globals/typography.css
@@ -20,7 +20,8 @@
     /*
      * Default conversation type and comfy spacing for channels, DMs, threads,
      * Inbox, and the composer. Font size changes the type tokens only;
-     * Conversation density overrides only spacing.
+     * Conversation density overrides spacing and leading, never font size —
+     * the two preferences stay composable because they touch disjoint tokens.
      */
     --conversation-message-font-size: calc(var(--buzz-type-rem) * 0.875);
     --conversation-message-line-height: calc(var(--buzz-type-rem) * 1.25);
@@ -41,10 +42,17 @@
   }
 
   :root[data-conversation-density="spacious"] {
+    /*
+     * Leading carries most of the airiness here, not the block gaps: at
+     * 0.875rem type, 1.5rem leading is a 1.71 ratio against the 1.43 default.
+     * Font size is deliberately untouched — Spacious changes rhythm, not scale,
+     * so it composes with the Font size preference instead of fighting it.
+     */
+    --conversation-message-line-height: calc(var(--buzz-type-rem) * 1.5);
     --conversation-body-gap: 0.25rem;
     --conversation-row-padding-block: 0.5rem;
-    --conversation-paragraph-gap: 0.625rem;
-    --conversation-list-item-gap: 0.5rem;
+    --conversation-paragraph-gap: 0.875rem;
+    --conversation-list-item-gap: 0.625rem;
   }
 
   body {


### PR DESCRIPTION
## Summary

Gives the **Spacious** conversation density real breathing room by loosening leading, not just block gaps.

Today Spacious differs from Comfy only in gaps — `--conversation-message-line-height` is shared across all three steps at a 1.43 ratio (1.25rem against 0.875rem type). The result reads as slightly padded rather than genuinely airy: multi-line messages, which is where a spacious mode should pay off most, look almost identical to Comfy because the lines within a paragraph are unchanged.

This sets the Spacious message line height to 1.5rem — a **1.71 ratio** — and nudges the paragraph and list-item gaps to stay in proportion with it. For reference, ChatGPT's message body sits around 1.8; matching the *ratio* rather than raw pixels is the right target since Buzz's conversation type is 14px against their ~15px.

```
--conversation-message-line-height: calc(var(--buzz-type-rem) * 1.5)   /* new */
--conversation-paragraph-gap:       0.875rem   /* was 0.625rem */
--conversation-list-item-gap:       0.625rem   /* was 0.5rem   */
```

**Compact and Comfy are untouched**, so this only affects users who have already opted into Spacious.

### Implementation notes

- **Font size is deliberately not changed.** Density changes rhythm, Font size changes scale. Keeping them on disjoint tokens means "Spacious + Larger" composes instead of compounding into something neither setting promises.
- Values stay expressed against `--buzz-type-rem`, so they continue to follow the Font size preference and Cmd +/- zoom. No px literals; `pnpm check:px-text` passes.
- The block comment above these tokens previously read "Conversation density overrides only spacing", which this change makes untrue. Updated it to record that density now overrides spacing *and* leading, and never font size.

### Related issue

None found — I searched open issues and PRs for density, spacing and line-height and turned up nothing covering this.

### Testing

- `just desktop-ci` passes locally (check, test, tauri fmt/check/test, build).
- `pnpm test` — 5042 passing, no changes required (this is a token-only change; the density preference module's own tests already cover persistence and application).
- Screenshots below captured via `just desktop-screenshot` against the E2E mock bridge, Catppuccin Macchiato, identical seeded content, both on the **Spacious** setting so the comparison isolates this change.

**Before** (`main`, Spacious) — line height 20px, list items 28px apart:

![Spacious before](https://raw.githubusercontent.com/epicbagel/buzz/ba275fb419932d40ee7b33e50b33b2c7c69691f9/spacious-before.png)

**After** (Spacious) — line height 24px, list items 34px apart:

![Spacious after](https://raw.githubusercontent.com/epicbagel/buzz/ba275fb419932d40ee7b33e50b33b2c7c69691f9/spacious-after.png)

### Follow-up deferred

- Only conversation surfaces are affected. The sidebar, channel list and other chrome keep their own spacing and do not respond to density; extending density into app chrome would be a larger change and is worth agreeing separately.
