### PR TITLE
fix(desktop): guard profile reconcile against racing a newer rename

### DIFF
--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -1363,7 +1363,7 @@ use deploy::{ensure_remote_provider_supported, resolve_deploy_model_provider};
 #[path = "agents_profile.rs"]
 mod profile;
 #[cfg(test)]
-use profile::{profile_needs_sync, resolve_legacy_avatar};
+use profile::{profile_needs_sync, resolve_legacy_avatar, snapshot_still_current};
 pub(crate) use profile::{reconcile_agent_profile, ProfileReconcileData};
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/commands/agents_profile.rs
+++ b/desktop/src-tauri/src/commands/agents_profile.rs
@@ -150,6 +150,26 @@ pub(crate) async fn reconcile_agent_profile(
         return Ok(());
     }
 
+    // Guard against racing a newer edit. `data` was snapshotted before this
+    // fire-and-forget task's async spawn/preflight resolved, so a rename
+    // (`update_managed_agent`) can commit and publish the correct profile
+    // while this task is still in flight. Without this check, the stale
+    // snapshot would look "correct" to `profile_needs_sync` above and
+    // silently republish the pre-rename name over the user's fix. Re-reading
+    // the live record right before the write shrinks that window to the
+    // final publish call; `update_managed_agent`'s own rollback guard
+    // (`AgentUpdateRollback`) protects the other direction of the same race.
+    {
+        let _store_guard = state
+            .managed_agents_store_lock
+            .lock()
+            .map_err(|e| e.to_string())?;
+        let records = load_managed_agents(app)?;
+        if !snapshot_still_current(&records, &data.pubkey, &data.name) {
+            return Ok(());
+        }
+    }
+
     sync_managed_agent_profile(
         state,
         &relay_url,
@@ -159,6 +179,20 @@ pub(crate) async fn reconcile_agent_profile(
         data.auth_tag.as_deref(),
     )
     .await
+}
+
+/// Whether a snapshotted reconcile name still matches the live record for
+/// that pubkey. `false` means the record was edited after the snapshot was
+/// taken (or the agent is gone) and the stale snapshot must not be published.
+pub(super) fn snapshot_still_current(
+    records: &[crate::managed_agents::ManagedAgentRecord],
+    pubkey: &str,
+    expected_name: &str,
+) -> bool {
+    records
+        .iter()
+        .find(|r| r.pubkey == pubkey)
+        .is_some_and(|r| r.name == expected_name)
 }
 
 /// Decide whether a published profile is missing or stale relative to the

--- a/desktop/src-tauri/src/commands/agents_tests.rs
+++ b/desktop/src-tauri/src/commands/agents_tests.rs
@@ -661,3 +661,35 @@ fn owner_only_access_deploy_payload_clamps_stale_access() {
         "owner-only-access deploy payload retained a stale allowlist"
     );
 }
+
+#[test]
+fn snapshot_still_current_when_name_unchanged() {
+    let record = bare_agent_record(None, None, None);
+    assert!(snapshot_still_current(
+        std::slice::from_ref(&record),
+        &record.pubkey,
+        &record.name,
+    ));
+}
+
+#[test]
+fn snapshot_stale_when_name_changed_since_snapshot() {
+    let record = bare_agent_record(None, None, None);
+    // Simulates a rename committing between the reconcile snapshot being
+    // taken and the reconcile task actually running.
+    assert!(!snapshot_still_current(
+        std::slice::from_ref(&record),
+        &record.pubkey,
+        "a-name-from-before-the-rename",
+    ));
+}
+
+#[test]
+fn snapshot_stale_when_agent_no_longer_exists() {
+    let record = bare_agent_record(None, None, None);
+    assert!(!snapshot_still_current(
+        std::slice::from_ref(&record),
+        "some-other-pubkey-not-in-records",
+        &record.name,
+    ));
+}


### PR DESCRIPTION
## Summary
- `start_managed_agent` snapshots an agent's name into `ProfileReconcileData` before its async spawn/preflight resolves, then fires a detached background task (`reconcile_agent_profile`) that republishes that name if the relay's current profile doesn't match it.
- If a manual rename (`update_managed_agent`) commits while that background task is still in flight, the task finishes with a stale snapshot, sees the relay's newer/correct name as a "mismatch", and silently republishes the old name over the user's fix.
- Adds `snapshot_still_current`: re-reads the live record right before the publish call and skips the reconcile entirely if the name has changed since the snapshot was taken. Mirrors the guard `update_managed_agent`'s own Phase 2 already has via `AgentUpdateRollback`, for the other direction of the same race.

Reported by a real user who had to retry a rename 7 times before it stuck, while other community members kept seeing the stale name in the interim (the auto-restart watcher and cross-community re-pairing logic both restart agents on their own schedule, each restart giving this race another chance to fire).

## Test plan
- [x] `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib` — 2443 passed, 0 failed
- [x] New unit tests for `snapshot_still_current` (name unchanged / changed-since-snapshot / agent no longer exists)
- [x] `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check` — clean