### PR TITLE
test(benchmarks): expand Buzz-native dataset

### DIFF
--- a/benchmarks/buzz-dataset/README.md
+++ b/benchmarks/buzz-dataset/README.md
@@ -11,6 +11,11 @@ willing to read.
 | [`user-mention`](user-mention) | Hands the turn back with an event-level `p`-tag mention of the requesting human |
 | [`read-named-path-outside-workspace`](read-named-path-outside-workspace) | Reads a path the user named explicitly instead of refusing it as out of bounds |
 | [`create-channel-invite-users`](create-channel-invite-users) | Creates a channel with the exact shape, TTL, and membership asked for |
+| [`multiline-message`](multiline-message) | Preserves real newlines and blank-line structure through the CLI publish path |
+| [`narrative-agent-names`](narrative-agent-names) | Names agents in narrative without waking them through `p` tags |
+| [`interleaved-agent-reports`](interleaved-agent-reports) | Retains and synthesizes every report in a batch of agent messages |
+| [`cross-thread-requests`](cross-thread-requests) | Keeps simultaneous top-level requests isolated and replies to both exact threads |
+| [`ambiguous-user-mention`](ambiguous-user-mention) | Resolves duplicate display names and notifies only the intended pubkey |
 
 For `reply-to-thread` and `user-mention` the graded behavior is **deliberately
 absent from `instruction.md`** — it has to come from `buzz-acp`'s production

--- a/benchmarks/buzz-dataset/ambiguous-user-mention/README.md
+++ b/benchmarks/buzz-dataset/ambiguous-user-mention/README.md
@@ -1,0 +1,8 @@
+# ambiguous-user-mention
+
+The channel contains two real identities with the exact same three-word display
+name. Their profile `about` fields carry different routing codes. The agent must
+discover the intended pubkey, notify it exactly once, never notify the twin,
+and separately callback the requester. This guards the silent ambiguity family
+reported in [block/buzz#4303](https://github.com/block/buzz/issues/4303) and
+[block/buzz#6257](https://github.com/block/buzz/issues/6257).

--- a/benchmarks/buzz-dataset/ambiguous-user-mention/environment/Dockerfile
+++ b/benchmarks/buzz-dataset/ambiguous-user-mention/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.12-slim-bookworm
+
+WORKDIR /app

--- a/benchmarks/buzz-dataset/ambiguous-user-mention/instruction.md
+++ b/benchmarks/buzz-dataset/ambiguous-user-mention/instruction.md
@@ -1,0 +1,5 @@
+Two channel members are both displayed as `Taylor Morgan Lee`.
+
+Find the one whose profile says `Routing code ORCHID-72` and send that person
+the message `ORCHID-72 approved`. Do not notify the other Taylor Morgan Lee.
+Then tell me briefly that it was sent.

--- a/benchmarks/buzz-dataset/ambiguous-user-mention/task.toml
+++ b/benchmarks/buzz-dataset/ambiguous-user-mention/task.toml
@@ -1,0 +1,24 @@
+schema_version = "1.3"
+
+[task]
+name = "buzz-native/ambiguous-user-mention"
+description = "Resolve two identical display names by profile evidence and notify only the intended pubkey."
+authors = [{ name = "Buzz" }]
+keywords = ["buzz-native", "mentions", "identity", "ambiguity"]
+
+[metadata]
+difficulty = "hard"
+category = "collaboration"
+tags = ["mentions", "identity", "ambiguity", "cli"]
+
+[agent]
+timeout_sec = 300.0
+
+[verifier]
+timeout_sec = 30.0
+
+[environment]
+network_mode = "public"
+cpus = 1
+memory_mb = 1024
+storage_mb = 1024

--- a/benchmarks/buzz-dataset/ambiguous-user-mention/tests/test.sh
+++ b/benchmarks/buzz-dataset/ambiguous-user-mention/tests/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+mkdir -p /logs/verifier
+python3 /tests/verify.py --evidence /logs/artifacts/buzz-evidence.json --reward /logs/verifier/reward.json --details /logs/verifier/details.json

--- a/benchmarks/buzz-dataset/ambiguous-user-mention/tests/verify.py
+++ b/benchmarks/buzz-dataset/ambiguous-user-mention/tests/verify.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Deterministic verifier for a duplicate-display-name notification."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+TARGET_ID = "taylor-release-captain"
+OTHER_ID = "taylor-observer"
+
+
+def _zero() -> dict[str, float]:
+    return {
+        "reward": 0.0,
+        "target_notified_once": 0.0,
+        "other_not_notified": 0.0,
+        "message_correct": 0.0,
+        "user_callback": 0.0,
+        "reply_to_thread": 0.0,
+        "evidence_complete": 0.0,
+    }
+
+
+def score_evidence(evidence: object) -> tuple[dict[str, float], dict[str, Any]]:
+    if not isinstance(evidence, dict):
+        return _zero(), {"error": "evidence root is not an object"}
+    root = evidence.get("task_event_id")
+    directory = {
+        row.get("identity_id"): row
+        for row in evidence.get("directory", [])
+        if isinstance(row, dict)
+    }
+    target = directory.get(TARGET_ID, {})
+    other = directory.get(OTHER_ID, {})
+    identities = (
+        evidence.get("identities")
+        if isinstance(evidence.get("identities"), dict)
+        else {}
+    )
+    user = identities.get("Olivia Grace Park", {})
+    agents = [
+        row
+        for row in identities.values()
+        if isinstance(row, dict) and row.get("role") == "orchestrator"
+    ]
+    agent_pubkey = agents[0].get("pubkey") if len(agents) == 1 else None
+    messages = [row for row in evidence.get("messages", []) if isinstance(row, dict)]
+    authored = [
+        row for row in messages if agent_pubkey and row.get("pubkey") == agent_pubkey
+    ]
+    target_messages = [
+        row
+        for row in authored
+        if target.get("pubkey") in row.get("mentioned_pubkeys", [])
+    ]
+    other_messages = [
+        row
+        for row in authored
+        if other.get("pubkey") in row.get("mentioned_pubkeys", [])
+    ]
+    delivery = target_messages[0] if len(target_messages) == 1 else None
+    callbacks = [
+        row
+        for row in authored
+        if user.get("pubkey") in row.get("mentioned_pubkeys", [])
+        and row not in target_messages
+    ]
+    callback = callbacks[-1] if callbacks else None
+    target_notified_once = float(len(target_messages) == 1)
+    other_not_notified = float(len(other_messages) == 0)
+    message_correct = float(
+        delivery is not None
+        and "ORCHID-72 approved" in str(delivery.get("content", ""))
+    )
+    user_callback = float(
+        callback is not None
+        and any(
+            word in str(callback.get("content", "")).casefold()
+            for word in ("sent", "notified", "delivered")
+        )
+    )
+    reply_to_thread = float(
+        delivery is not None
+        and callback is not None
+        and delivery.get("reply_to_event_id") == root
+        and callback.get("reply_to_event_id") == root
+    )
+    evidence_complete = float(
+        evidence.get("schema_version") == 1
+        and evidence.get("task_name") == "ambiguous-user-mention"
+        and evidence.get("truncated") is False
+        and len(directory) == 2
+        and isinstance(target.get("pubkey"), str)
+        and isinstance(other.get("pubkey"), str)
+        and target.get("pubkey") != other.get("pubkey")
+        and len(agents) == 1
+    )
+    values = (
+        target_notified_once,
+        other_not_notified,
+        message_correct,
+        user_callback,
+        reply_to_thread,
+        evidence_complete,
+    )
+    metrics = {
+        "reward": float(all(value == 1.0 for value in values)),
+        "target_notified_once": target_notified_once,
+        "other_not_notified": other_not_notified,
+        "message_correct": message_correct,
+        "user_callback": user_callback,
+        "reply_to_thread": reply_to_thread,
+        "evidence_complete": evidence_complete,
+    }
+    return metrics, {
+        "target_pubkey": target.get("pubkey"),
+        "other_pubkey": other.get("pubkey"),
+        "delivery_message_id": delivery.get("id") if delivery else None,
+        "callback_message_id": callback.get("id") if callback else None,
+        "target_notification_count": len(target_messages),
+        "other_notification_count": len(other_messages),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--reward", type=Path, required=True)
+    parser.add_argument("--details", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        metrics, details = score_evidence(
+            json.loads(args.evidence.read_text(encoding="utf-8"))
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        metrics, details = _zero(), {"error": str(error)}
+    args.reward.write_text(json.dumps(metrics, sort_keys=True) + "\n", encoding="utf-8")
+    args.details.write_text(
+        json.dumps(details, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/buzz-dataset/cross-thread-requests/README.md
+++ b/benchmarks/buzz-dataset/cross-thread-requests/README.md
@@ -1,0 +1,9 @@
+# cross-thread-requests
+
+The harness posts ALPHA and BETA as separate top-level human mentions in the
+same channel before the queue flushes. Passing requires two different replies,
+each anchored to its own triggering event with only its own answer. This is a
+deliberately hard guard for the cross-thread contamination reported in
+[block/buzz#5839](https://github.com/block/buzz/issues/5839) and the exact
+reply-target contract in
+[block/buzz#4072](https://github.com/block/buzz/issues/4072).

--- a/benchmarks/buzz-dataset/cross-thread-requests/environment/Dockerfile
+++ b/benchmarks/buzz-dataset/cross-thread-requests/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.12-slim-bookworm
+
+WORKDIR /app

--- a/benchmarks/buzz-dataset/cross-thread-requests/instruction.md
+++ b/benchmarks/buzz-dataset/cross-thread-requests/instruction.md
@@ -1,0 +1,3 @@
+ALPHA request: calculate `(17 * 19) + 23`.
+
+Reply with the ALPHA result, labelled ALPHA.

--- a/benchmarks/buzz-dataset/cross-thread-requests/task.toml
+++ b/benchmarks/buzz-dataset/cross-thread-requests/task.toml
@@ -1,0 +1,24 @@
+schema_version = "1.3"
+
+[task]
+name = "buzz-native/cross-thread-requests"
+description = "Keep two concurrent top-level requests in one channel isolated and reply to each exact thread."
+authors = [{ name = "Buzz" }]
+keywords = ["buzz-native", "threading", "batching", "concurrency"]
+
+[metadata]
+difficulty = "hard"
+category = "collaboration"
+tags = ["threading", "batching", "concurrency", "routing"]
+
+[agent]
+timeout_sec = 300.0
+
+[verifier]
+timeout_sec = 30.0
+
+[environment]
+network_mode = "public"
+cpus = 1
+memory_mb = 1024
+storage_mb = 1024

--- a/benchmarks/buzz-dataset/cross-thread-requests/tests/test.sh
+++ b/benchmarks/buzz-dataset/cross-thread-requests/tests/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+mkdir -p /logs/verifier
+python3 /tests/verify.py --evidence /logs/artifacts/buzz-evidence.json --reward /logs/verifier/reward.json --details /logs/verifier/details.json

--- a/benchmarks/buzz-dataset/cross-thread-requests/tests/verify.py
+++ b/benchmarks/buzz-dataset/cross-thread-requests/tests/verify.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Deterministic verifier for isolation of two top-level requests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+def _zero() -> dict[str, float]:
+    return {
+        "reward": 0.0,
+        "alpha_correct": 0.0,
+        "beta_correct": 0.0,
+        "thread_isolation": 0.0,
+        "user_mentioned_twice": 0.0,
+        "evidence_complete": 0.0,
+    }
+
+
+def _matches(message: dict[str, Any], label: str, value: int) -> bool:
+    content = str(message.get("content", ""))
+    return bool(re.search(rf"{label}\D+{value}(?:\D|$)", content, re.IGNORECASE))
+
+
+def score_evidence(evidence: object) -> tuple[dict[str, float], dict[str, Any]]:
+    if not isinstance(evidence, dict):
+        return _zero(), {"error": "evidence root is not an object"}
+    alpha_root = evidence.get("task_event_id")
+    scripts = [
+        row
+        for row in evidence.get("scripted_events", [])
+        if isinstance(row, dict) and row.get("label") == "beta-request"
+    ]
+    beta_root = scripts[0].get("event_id") if len(scripts) == 1 else None
+    identities = (
+        evidence.get("identities")
+        if isinstance(evidence.get("identities"), dict)
+        else {}
+    )
+    user = identities.get("Priya Simone Patel", {})
+    agents = [
+        row
+        for row in identities.values()
+        if isinstance(row, dict) and row.get("role") == "orchestrator"
+    ]
+    agent_pubkey = agents[0].get("pubkey") if len(agents) == 1 else None
+    messages = [row for row in evidence.get("messages", []) if isinstance(row, dict)]
+    candidates = [
+        row for row in messages if agent_pubkey and row.get("pubkey") == agent_pubkey
+    ]
+    alpha_replies = [
+        row
+        for row in candidates
+        if row.get("reply_to_event_id") == alpha_root and _matches(row, "ALPHA", 346)
+    ]
+    beta_replies = [
+        row
+        for row in candidates
+        if row.get("reply_to_event_id") == beta_root and _matches(row, "BETA", 41)
+    ]
+    alpha = alpha_replies[-1] if alpha_replies else None
+    beta = beta_replies[-1] if beta_replies else None
+    alpha_content = str(alpha.get("content", "")) if alpha else ""
+    beta_content = str(beta.get("content", "")) if beta else ""
+    alpha_correct = float(alpha is not None)
+    beta_correct = float(beta is not None)
+    thread_isolation = float(
+        alpha is not None
+        and beta is not None
+        and len(candidates) == 2
+        and alpha.get("id") != beta.get("id")
+        and "BETA" not in alpha_content.upper()
+        and "ALPHA" not in beta_content.upper()
+    )
+    user_mentioned_twice = float(
+        alpha is not None
+        and beta is not None
+        and user.get("pubkey") in alpha.get("mentioned_pubkeys", [])
+        and user.get("pubkey") in beta.get("mentioned_pubkeys", [])
+    )
+    evidence_complete = float(
+        evidence.get("schema_version") == 1
+        and evidence.get("task_name") == "cross-thread-requests"
+        and evidence.get("truncated") is False
+        and isinstance(alpha_root, str)
+        and isinstance(beta_root, str)
+        and len(agents) == 1
+    )
+    values = (
+        alpha_correct,
+        beta_correct,
+        thread_isolation,
+        user_mentioned_twice,
+        evidence_complete,
+    )
+    metrics = {
+        "reward": float(all(value == 1.0 for value in values)),
+        "alpha_correct": alpha_correct,
+        "beta_correct": beta_correct,
+        "thread_isolation": thread_isolation,
+        "user_mentioned_twice": user_mentioned_twice,
+        "evidence_complete": evidence_complete,
+    }
+    return metrics, {
+        "alpha_root": alpha_root,
+        "beta_root": beta_root,
+        "alpha_message_id": alpha.get("id") if alpha else None,
+        "beta_message_id": beta.get("id") if beta else None,
+        "alpha_content": alpha_content,
+        "beta_content": beta_content,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--reward", type=Path, required=True)
+    parser.add_argument("--details", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        metrics, details = score_evidence(
+            json.loads(args.evidence.read_text(encoding="utf-8"))
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        metrics, details = _zero(), {"error": str(error)}
+    args.reward.write_text(json.dumps(metrics, sort_keys=True) + "\n", encoding="utf-8")
+    args.details.write_text(
+        json.dumps(details, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/buzz-dataset/interleaved-agent-reports/README.md
+++ b/benchmarks/buzz-dataset/interleaved-agent-reports/README.md
@@ -1,0 +1,8 @@
+# interleaved-agent-reports
+
+Three signed bot identities publish independent reports immediately after the
+human request. The solo agent must retain every input, calculate 87, notify the
+human exactly once, and avoid waking the reporters again. The case exercises
+the batching/steering family reported in
+[block/buzz#5839](https://github.com/block/buzz/issues/5839) and
+[block/buzz#4942](https://github.com/block/buzz/issues/4942).

--- a/benchmarks/buzz-dataset/interleaved-agent-reports/environment/Dockerfile
+++ b/benchmarks/buzz-dataset/interleaved-agent-reports/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.12-slim-bookworm
+
+WORKDIR /app

--- a/benchmarks/buzz-dataset/interleaved-agent-reports/instruction.md
+++ b/benchmarks/buzz-dataset/interleaved-agent-reports/instruction.md
@@ -1,0 +1,6 @@
+Three specialist agents will report separate inputs for a forecast. Wait until
+you have all three reports, then calculate:
+
+`(North + South - reserve) * multiplier`
+
+Send me one concise synthesis that labels all four inputs and the final value.

--- a/benchmarks/buzz-dataset/interleaved-agent-reports/task.toml
+++ b/benchmarks/buzz-dataset/interleaved-agent-reports/task.toml
@@ -1,0 +1,24 @@
+schema_version = "1.3"
+
+[task]
+name = "buzz-native/interleaved-agent-reports"
+description = "Aggregate multiple agent reports delivered together without losing an input or waking reporters again."
+authors = [{ name = "Buzz" }]
+keywords = ["buzz-native", "agents", "batching", "synthesis"]
+
+[metadata]
+difficulty = "hard"
+category = "collaboration"
+tags = ["agents", "batching", "synthesis", "mentions"]
+
+[agent]
+timeout_sec = 300.0
+
+[verifier]
+timeout_sec = 30.0
+
+[environment]
+network_mode = "public"
+cpus = 1
+memory_mb = 1024
+storage_mb = 1024

--- a/benchmarks/buzz-dataset/interleaved-agent-reports/tests/test.sh
+++ b/benchmarks/buzz-dataset/interleaved-agent-reports/tests/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+mkdir -p /logs/verifier
+python3 /tests/verify.py --evidence /logs/artifacts/buzz-evidence.json --reward /logs/verifier/reward.json --details /logs/verifier/details.json

--- a/benchmarks/buzz-dataset/interleaved-agent-reports/tests/verify.py
+++ b/benchmarks/buzz-dataset/interleaved-agent-reports/tests/verify.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Deterministic verifier for aggregation of batched agent reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+REPORTERS = ("Ledger Scout", "Risk Sentinel", "Ops Forecaster")
+LABELS = {"ledger-report", "risk-report", "operations-report"}
+
+
+def _zero() -> dict[str, float]:
+    return {
+        "reward": 0.0,
+        "reports_delivered": 0.0,
+        "inputs_complete": 0.0,
+        "answer_correct": 0.0,
+        "single_human_callback": 0.0,
+        "reporters_not_rementioned": 0.0,
+        "reply_to_thread": 0.0,
+        "evidence_complete": 0.0,
+    }
+
+
+def score_evidence(evidence: object) -> tuple[dict[str, float], dict[str, Any]]:
+    if not isinstance(evidence, dict):
+        return _zero(), {"error": "evidence root is not an object"}
+    root = evidence.get("task_event_id")
+    identities = (
+        evidence.get("identities")
+        if isinstance(evidence.get("identities"), dict)
+        else {}
+    )
+    user = identities.get("Nora Isabel Grant", {})
+    agents = [
+        row
+        for row in identities.values()
+        if isinstance(row, dict) and row.get("role") == "orchestrator"
+    ]
+    agent_pubkey = agents[0].get("pubkey") if len(agents) == 1 else None
+    directory = {
+        row.get("name"): row
+        for row in evidence.get("directory", [])
+        if isinstance(row, dict)
+    }
+    reporter_pubkeys = {
+        directory[name].get("pubkey") for name in REPORTERS if name in directory
+    }
+    scripts = [
+        row for row in evidence.get("scripted_events", []) if isinstance(row, dict)
+    ]
+    script_ids = {row.get("event_id") for row in scripts if row.get("label") in LABELS}
+    messages = [row for row in evidence.get("messages", []) if isinstance(row, dict)]
+    delivered_ids = {row.get("id") for row in messages}
+    reports_delivered = float(
+        len(script_ids) == 3 and None not in script_ids and script_ids <= delivered_ids
+    )
+    candidates = [
+        row for row in messages if agent_pubkey and row.get("pubkey") == agent_pubkey
+    ]
+    final = candidates[-1] if candidates else None
+    content = str(final.get("content", "")) if final else ""
+    mentioned = set(final.get("mentioned_pubkeys", [])) if final else set()
+    inputs_complete = float(
+        all(
+            re.search(pattern, content, re.IGNORECASE)
+            for pattern in (
+                r"north\D+17",
+                r"south\D+23",
+                r"reserve\D+11",
+                r"multiplier\D+3",
+            )
+        )
+    )
+    answer_correct = float(
+        bool(
+            re.search(
+                r"(?:final|result|forecast|=)\D*87(?:\D|$)",
+                content,
+                re.IGNORECASE,
+            )
+        )
+    )
+    human_callbacks = [
+        row
+        for row in candidates
+        if user.get("pubkey") in row.get("mentioned_pubkeys", [])
+    ]
+    single_human_callback = float(
+        len(human_callbacks) == 1 and final in human_callbacks
+    )
+    reporters_not_rementioned = float(
+        len(reporter_pubkeys) == 3
+        and all(
+            set(row.get("mentioned_pubkeys", [])).isdisjoint(reporter_pubkeys)
+            and not any(f"@{name}" in str(row.get("content", "")) for name in REPORTERS)
+            for row in candidates
+        )
+    )
+    reply_to_thread = float(
+        final is not None and final.get("reply_to_event_id") == root
+    )
+    evidence_complete = float(
+        evidence.get("schema_version") == 1
+        and evidence.get("task_name") == "interleaved-agent-reports"
+        and evidence.get("truncated") is False
+        and len(agents) == 1
+        and len(directory) == 3
+        and final is not None
+        and len(candidates) == 1
+    )
+    values = (
+        reports_delivered,
+        inputs_complete,
+        answer_correct,
+        single_human_callback,
+        reporters_not_rementioned,
+        reply_to_thread,
+        evidence_complete,
+    )
+    metrics = {
+        "reward": float(all(value == 1.0 for value in values)),
+        "reports_delivered": reports_delivered,
+        "inputs_complete": inputs_complete,
+        "answer_correct": answer_correct,
+        "single_human_callback": single_human_callback,
+        "reporters_not_rementioned": reporters_not_rementioned,
+        "reply_to_thread": reply_to_thread,
+        "evidence_complete": evidence_complete,
+    }
+    return metrics, {
+        "scripted_event_ids": sorted(str(value) for value in script_ids),
+        "selected_message_id": final.get("id") if final else None,
+        "content": content,
+        "mentioned_pubkeys": sorted(mentioned),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--reward", type=Path, required=True)
+    parser.add_argument("--details", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        metrics, details = score_evidence(
+            json.loads(args.evidence.read_text(encoding="utf-8"))
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        metrics, details = _zero(), {"error": str(error)}
+    args.reward.write_text(json.dumps(metrics, sort_keys=True) + "\n", encoding="utf-8")
+    args.details.write_text(
+        json.dumps(details, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/buzz-dataset/multiline-message/README.md
+++ b/benchmarks/buzz-dataset/multiline-message/README.md
@@ -1,0 +1,10 @@
+# multiline-message
+
+The agent sends a short release update whose blank lines and bullet boundaries
+must survive the `buzz messages send` shell call as real newline bytes. The
+verifier also checks the normal reply anchor and callback mention. This guards
+the first-newline truncation failure described in
+[block/buzz#5787](https://github.com/block/buzz/issues/5787).
+
+Run with the command in the parent [README](../README.md), replacing the task
+path with `benchmarks/buzz-dataset/multiline-message`.

--- a/benchmarks/buzz-dataset/multiline-message/environment/Dockerfile
+++ b/benchmarks/buzz-dataset/multiline-message/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.12-slim-bookworm
+
+WORKDIR /app

--- a/benchmarks/buzz-dataset/multiline-message/instruction.md
+++ b/benchmarks/buzz-dataset/multiline-message/instruction.md
@@ -1,0 +1,11 @@
+Send me this release-readiness update, preserving the paragraph and list layout:
+
+Release readiness
+
+- API: ready
+- Database: ready
+- Rollback: tested
+
+Owner: Platform Operations
+
+Keep the response brief and do not add a table.

--- a/benchmarks/buzz-dataset/multiline-message/task.toml
+++ b/benchmarks/buzz-dataset/multiline-message/task.toml
@@ -1,0 +1,24 @@
+schema_version = "1.3"
+
+[task]
+name = "buzz-native/multiline-message"
+description = "Deliver a multiline Buzz message without flattening or escaping its layout."
+authors = [{ name = "Buzz" }]
+keywords = ["buzz-native", "messaging", "multiline", "cli"]
+
+[metadata]
+difficulty = "medium"
+category = "collaboration"
+tags = ["messaging", "multiline", "cli"]
+
+[agent]
+timeout_sec = 300.0
+
+[verifier]
+timeout_sec = 30.0
+
+[environment]
+network_mode = "public"
+cpus = 1
+memory_mb = 1024
+storage_mb = 1024

--- a/benchmarks/buzz-dataset/multiline-message/tests/test.sh
+++ b/benchmarks/buzz-dataset/multiline-message/tests/test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+mkdir -p /logs/verifier
+python3 /tests/verify.py \
+  --evidence /logs/artifacts/buzz-evidence.json \
+  --reward /logs/verifier/reward.json \
+  --details /logs/verifier/details.json

--- a/benchmarks/buzz-dataset/multiline-message/tests/verify.py
+++ b/benchmarks/buzz-dataset/multiline-message/tests/verify.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Deterministic verifier for multiline Buzz message delivery."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+EXPECTED = (
+    "Release readiness\n\n"
+    "- API: ready\n"
+    "- Database: ready\n"
+    "- Rollback: tested\n\n"
+    "Owner: Platform Operations"
+)
+
+
+def _zero() -> dict[str, float]:
+    return {
+        "reward": 0.0,
+        "layout_preserved": 0.0,
+        "real_newlines": 0.0,
+        "reply_to_thread": 0.0,
+        "user_mentioned": 0.0,
+        "evidence_complete": 0.0,
+    }
+
+
+def score_evidence(evidence: object) -> tuple[dict[str, float], dict[str, Any]]:
+    if not isinstance(evidence, dict):
+        return _zero(), {"error": "evidence root is not an object"}
+    root = evidence.get("task_event_id")
+    trial = evidence.get("trial") if isinstance(evidence.get("trial"), dict) else {}
+    identities = (
+        evidence.get("identities")
+        if isinstance(evidence.get("identities"), dict)
+        else {}
+    )
+    user = identities.get("Eleanor June Brooks", {})
+    agents = [
+        row
+        for row in identities.values()
+        if isinstance(row, dict) and row.get("role") == "orchestrator"
+    ]
+    agent_pubkey = agents[0].get("pubkey") if len(agents) == 1 else None
+    messages = [row for row in evidence.get("messages", []) if isinstance(row, dict)]
+    candidates = [
+        row for row in messages if agent_pubkey and row.get("pubkey") == agent_pubkey
+    ]
+    final = candidates[-1] if candidates else None
+    content = str(final.get("content", "")) if final else ""
+    tags = final.get("tags", []) if final else []
+    evidence_complete = float(
+        evidence.get("schema_version") == 1
+        and evidence.get("task_name") == "multiline-message"
+        and evidence.get("truncated") is False
+        and isinstance(root, str)
+        and isinstance(trial.get("channel_id"), str)
+        and len(agents) == 1
+        and isinstance(user.get("pubkey"), str)
+        and final is not None
+        and len(candidates) == 1
+    )
+    layout_preserved = float(EXPECTED in content)
+    real_newlines = float("\\n" not in content and content.count("\n") >= 6)
+    reply_to_thread = float(
+        final is not None and final.get("reply_to_event_id") == root
+    )
+    user_mentioned = float(
+        user.get("pubkey") in (final.get("mentioned_pubkeys", []) if final else [])
+    )
+    reward = float(
+        all(
+            value == 1.0
+            for value in (
+                evidence_complete,
+                layout_preserved,
+                real_newlines,
+                reply_to_thread,
+                user_mentioned,
+            )
+        )
+    )
+    metrics = {
+        "reward": reward,
+        "layout_preserved": layout_preserved,
+        "real_newlines": real_newlines,
+        "reply_to_thread": reply_to_thread,
+        "user_mentioned": user_mentioned,
+        "evidence_complete": evidence_complete,
+    }
+    return metrics, {
+        "selected_message_id": final.get("id") if final else None,
+        "content": content,
+        "tags": tags,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--reward", type=Path, required=True)
+    parser.add_argument("--details", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        metrics, details = score_evidence(
+            json.loads(args.evidence.read_text(encoding="utf-8"))
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        metrics, details = _zero(), {"error": str(error)}
+    args.reward.write_text(json.dumps(metrics, sort_keys=True) + "\n", encoding="utf-8")
+    args.details.write_text(
+        json.dumps(details, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/buzz-dataset/narrative-agent-names/README.md
+++ b/benchmarks/buzz-dataset/narrative-agent-names/README.md
@@ -1,0 +1,7 @@
+# narrative-agent-names
+
+The agent reports status about two in-channel bots. Both names must remain
+plain narrative text: neither bot may receive a `p` tag or an `@Name` wake-up.
+The requesting human must still receive the callback mention. This guards the
+acknowledgement and false-wake behavior in
+[block/buzz#5176](https://github.com/block/buzz/issues/5176).

--- a/benchmarks/buzz-dataset/narrative-agent-names/environment/Dockerfile
+++ b/benchmarks/buzz-dataset/narrative-agent-names/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.12-slim-bookworm
+
+WORKDIR /app

--- a/benchmarks/buzz-dataset/narrative-agent-names/instruction.md
+++ b/benchmarks/buzz-dataset/narrative-agent-names/instruction.md
@@ -1,0 +1,6 @@
+Give me a two-line status update:
+
+- Aurora Audit Bot completed the audit.
+- Beacon Deploy Bot remains idle.
+
+This is only a status summary. Neither bot has any work to do.

--- a/benchmarks/buzz-dataset/narrative-agent-names/task.toml
+++ b/benchmarks/buzz-dataset/narrative-agent-names/task.toml
@@ -1,0 +1,24 @@
+schema_version = "1.3"
+
+[task]
+name = "buzz-native/narrative-agent-names"
+description = "Name agents in narrative without waking them through event mentions."
+authors = [{ name = "Buzz" }]
+keywords = ["buzz-native", "mentions", "agents", "notifications"]
+
+[metadata]
+difficulty = "medium"
+category = "collaboration"
+tags = ["mentions", "agents", "notifications"]
+
+[agent]
+timeout_sec = 300.0
+
+[verifier]
+timeout_sec = 30.0
+
+[environment]
+network_mode = "public"
+cpus = 1
+memory_mb = 1024
+storage_mb = 1024

--- a/benchmarks/buzz-dataset/narrative-agent-names/tests/test.sh
+++ b/benchmarks/buzz-dataset/narrative-agent-names/tests/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+mkdir -p /logs/verifier
+python3 /tests/verify.py --evidence /logs/artifacts/buzz-evidence.json --reward /logs/verifier/reward.json --details /logs/verifier/details.json

--- a/benchmarks/buzz-dataset/narrative-agent-names/tests/verify.py
+++ b/benchmarks/buzz-dataset/narrative-agent-names/tests/verify.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Deterministic verifier for non-notifying narrative agent names."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+BOT_NAMES = ("Aurora Audit Bot", "Beacon Deploy Bot")
+
+
+def _zero() -> dict[str, float]:
+    return {
+        "reward": 0.0,
+        "status_correct": 0.0,
+        "bots_not_mentioned": 0.0,
+        "user_mentioned": 0.0,
+        "reply_to_thread": 0.0,
+        "evidence_complete": 0.0,
+    }
+
+
+def score_evidence(evidence: object) -> tuple[dict[str, float], dict[str, Any]]:
+    if not isinstance(evidence, dict):
+        return _zero(), {"error": "evidence root is not an object"}
+    root = evidence.get("task_event_id")
+    identities = (
+        evidence.get("identities")
+        if isinstance(evidence.get("identities"), dict)
+        else {}
+    )
+    user = identities.get("Maya Elise Chen", {})
+    agents = [
+        row
+        for row in identities.values()
+        if isinstance(row, dict) and row.get("role") == "orchestrator"
+    ]
+    agent_pubkey = agents[0].get("pubkey") if len(agents) == 1 else None
+    directory = {
+        row.get("name"): row
+        for row in evidence.get("directory", [])
+        if isinstance(row, dict)
+    }
+    bot_pubkeys = {
+        directory[name].get("pubkey") for name in BOT_NAMES if name in directory
+    }
+    messages = [row for row in evidence.get("messages", []) if isinstance(row, dict)]
+    candidates = [
+        row for row in messages if agent_pubkey and row.get("pubkey") == agent_pubkey
+    ]
+    final = candidates[-1] if candidates else None
+    content = str(final.get("content", "")) if final else ""
+    mentioned = set(final.get("mentioned_pubkeys", [])) if final else set()
+    status_correct = float(
+        bool(re.search(r"Aurora Audit Bot[^.\n]*completed", content, re.IGNORECASE))
+        and bool(re.search(r"Beacon Deploy Bot[^.\n]*idle", content, re.IGNORECASE))
+    )
+    bots_not_mentioned = float(
+        len(bot_pubkeys) == 2
+        and all(
+            set(row.get("mentioned_pubkeys", [])).isdisjoint(bot_pubkeys)
+            and not any(f"@{name}" in str(row.get("content", "")) for name in BOT_NAMES)
+            for row in candidates
+        )
+    )
+    user_mentioned = float(user.get("pubkey") in mentioned)
+    reply_to_thread = float(
+        final is not None and final.get("reply_to_event_id") == root
+    )
+    evidence_complete = float(
+        evidence.get("schema_version") == 1
+        and evidence.get("task_name") == "narrative-agent-names"
+        and evidence.get("truncated") is False
+        and len(agents) == 1
+        and len(directory) == 2
+        and final is not None
+        and len(candidates) == 1
+    )
+    reward = float(
+        all(
+            value == 1.0
+            for value in (
+                status_correct,
+                bots_not_mentioned,
+                user_mentioned,
+                reply_to_thread,
+                evidence_complete,
+            )
+        )
+    )
+    metrics = {
+        "reward": reward,
+        "status_correct": status_correct,
+        "bots_not_mentioned": bots_not_mentioned,
+        "user_mentioned": user_mentioned,
+        "reply_to_thread": reply_to_thread,
+        "evidence_complete": evidence_complete,
+    }
+    return metrics, {
+        "selected_message_id": final.get("id") if final else None,
+        "content": content,
+        "mentioned_pubkeys": sorted(mentioned),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--reward", type=Path, required=True)
+    parser.add_argument("--details", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        metrics, details = score_evidence(
+            json.loads(args.evidence.read_text(encoding="utf-8"))
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        metrics, details = _zero(), {"error": str(error)}
+    args.reward.write_text(json.dumps(metrics, sort_keys=True) + "\n", encoding="utf-8")
+    args.details.write_text(
+        json.dumps(details, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/harbor-buzz-orchestra/README.md
+++ b/benchmarks/harbor-buzz-orchestra/README.md
@@ -66,10 +66,11 @@ artifacts) available for analysis.
 
 The local [`benchmarks/buzz-dataset`](../buzz-dataset) suite — a sibling
 directory of this harness, not a subdirectory of it — scores Buzz product
-behavior alongside task correctness. It currently covers direct thread replies, callback user
-mentions, targeted reads of user-named paths outside the workspace, and exact
-channel creation/membership. Run one task with the production base prompt from
-the checked-out source build:
+behavior alongside task correctness. It covers direct thread replies, callback
+user mentions, targeted reads of named paths, exact channel membership,
+multiline delivery, non-waking narrative names, batched reports, cross-thread
+isolation, and ambiguous identities. Run one task with the production base
+prompt from the checked-out source build:
 
 ```bash
 just benchmark \
@@ -107,6 +108,12 @@ artifact; relay credentials and database access are never exposed to the model
 or verifier. If the snapshot cannot be exported the trial **fails** rather than
 scoring 0 — a harness fault and a model fault stay distinguishable — and the
 cause is written to the trial's `buzz/buzz-evidence-error.txt`.
+
+Some tasks declare additional signed relay events. The provisioner creates
+their actors as normal channel identities and the runtime publishes the events
+through the production CLI immediately after the task message. Evidence exports
+only public actor metadata and event IDs; their signing credentials never enter
+the task container or verifier artifact.
 
 Each task ships its own `README.md` documenting its reward dimensions and, for
 the tasks whose graded Buzz behavior is deliberately absent from

--- a/benchmarks/harbor-buzz-orchestra/src/harbor_buzz_orchestra/container_runtime.py
+++ b/benchmarks/harbor-buzz-orchestra/src/harbor_buzz_orchestra/container_runtime.py
@@ -49,6 +49,7 @@ FORWARDER = f"{REMOTE_BIN}/relay-forwarder"
 FORWARDER_LOG = f"{REMOTE_LOGS}/relay-forwarder.log"
 # How many done-poll iterations between in-container liveness probes.
 LIVENESS_EVERY = 10
+SCRIPTED_EVENT_IDLE_POLLS = 5
 TRANSCRIPT_LIMIT = 1000
 TURN_ENDED_MARKERS = (
     "turn complete for",
@@ -138,6 +139,7 @@ class BuzzContainerRuntime:
         agents: list[_Agent] = []
         infra: list[_Agent] = []
         task_event_id: str | None = None
+        scripted_events: list[dict[str, str | None]] = []
         final_message: dict[str, Any] | None = None
         evidence_exported = False
         try:
@@ -192,6 +194,11 @@ class BuzzContainerRuntime:
                 task_event.get("event_id"), str
             ):
                 task_event_id = task_event["event_id"]
+            scripted_events = await self._send_scripted_messages(
+                trial=trial,
+                orchestrator=orchestrator,
+                task_event_id=task_event_id,
+            )
             final_message = await asyncio.wait_for(
                 self._wait_for_done(
                     environment,
@@ -199,6 +206,9 @@ class BuzzContainerRuntime:
                     trial,
                     agents + infra,
                     solo=agents[0] if len(agents) == 1 else None,
+                    minimum_agent_messages=fixture_for(
+                        trial.task_name
+                    ).minimum_agent_messages,
                 ),
                 timeout=manifest.trial_budget.timeout_seconds,
             )
@@ -214,6 +224,7 @@ class BuzzContainerRuntime:
                 completion_message_id=(
                     final_message.get("id") if final_message is not None else None
                 ),
+                scripted_events=scripted_events,
             )
 
         # A missing snapshot is a harness failure, not an agent failure: the
@@ -495,6 +506,7 @@ class BuzzContainerRuntime:
         trial: TrialHandle,
         agents: list[_Agent],
         solo: _Agent | None = None,
+        minimum_agent_messages: int = 0,
     ) -> dict[str, Any] | None:
         """Observe until a team posts DONE or a solo agent finishes its one turn.
 
@@ -503,6 +515,7 @@ class BuzzContainerRuntime:
         agent cannot be woken by a teammate, so its logged turn end is final.
         """
         polls = 0
+        idle_terminal_polls = 0
         while True:
             if polls % LIVENESS_EVERY == 0:
                 await self._raise_for_dead_agents(environment, agents)
@@ -522,17 +535,41 @@ class BuzzContainerRuntime:
                     message.get("content", "")
                 ).startswith("DONE:"):
                     return message
-            if solo is not None and await self._turn_ended(environment, solo):
-                return None
+            if solo is not None:
+                starts, ends = await self._turn_counts(environment, solo)
+                authored = [
+                    message
+                    for message in messages
+                    if message.get("pubkey") == orchestrator.nostr_pubkey
+                ]
+                if ends > 0 and len(authored) >= minimum_agent_messages:
+                    return authored[-1] if authored else None
+                if starts > 0 and starts == ends:
+                    idle_terminal_polls += 1
+                    if idle_terminal_polls >= SCRIPTED_EVENT_IDLE_POLLS:
+                        return authored[-1] if authored else None
+                else:
+                    idle_terminal_polls = 0
             await asyncio.sleep(self.poll_seconds)
 
     @staticmethod
     async def _turn_ended(environment: BaseEnvironment, agent: _Agent) -> bool:
+        _, ends = await BuzzContainerRuntime._turn_counts(environment, agent)
+        return ends > 0
+
+    @staticmethod
+    async def _turn_counts(
+        environment: BaseEnvironment, agent: _Agent
+    ) -> tuple[int, int]:
         result = await environment.exec(
             f"cat {shlex.quote(agent.stdout_log)} "
             f"{shlex.quote(agent.stderr_log)} 2>/dev/null"
         )
-        return any(marker in (result.stdout or "") for marker in TURN_ENDED_MARKERS)
+        output = result.stdout or ""
+        return (
+            output.count("turn starting for"),
+            sum(output.count(marker) for marker in TURN_ENDED_MARKERS),
+        )
 
     async def _raise_for_dead_agents(
         self, environment: BaseEnvironment, agents: list[_Agent]
@@ -590,6 +627,7 @@ class BuzzContainerRuntime:
         trial_dir: Path,
         task_event_id: str | None,
         completion_message_id: str | None,
+        scripted_events: list[dict[str, str | None]] | None = None,
     ) -> bool:
         """Snapshot public relay state for the verifier before trial teardown."""
         try:
@@ -611,6 +649,7 @@ class BuzzContainerRuntime:
                 completion_message_id=completion_message_id,
                 transcript_limit=TRANSCRIPT_LIMIT,
                 observed_channels=observed_channels,
+                scripted_events=scripted_events,
             )
             evidence_path = trial_dir / "buzz-evidence.json"
             evidence_path.write_text(
@@ -726,6 +765,7 @@ class BuzzContainerRuntime:
         content: str,
         *,
         mention: str | None = None,
+        reply_to: str | None = None,
     ) -> Any:
         args = [
             "messages",
@@ -737,7 +777,64 @@ class BuzzContainerRuntime:
         ]
         if mention is not None:
             args += ["--mention", mention]
+        if reply_to is not None:
+            args += ["--reply-to", reply_to]
         return await self._buzz_json(credential, trial, *args)
+
+    async def _send_scripted_messages(
+        self,
+        *,
+        trial: TrialHandle,
+        orchestrator: AgentCredential,
+        task_event_id: str | None,
+    ) -> list[dict[str, str | None]]:
+        """Inject task-declared events through the production CLI.
+
+        Messages are sent back-to-back so Buzz's normal queueing and batching
+        decide how the agent sees them. The verifier receives only public event
+        metadata; fixture signing keys stay inside the runtime handle.
+        """
+        fixture = fixture_for(trial.task_name)
+        if not fixture.scripted_messages:
+            return []
+        actors = {actor.identity_id: actor.credential for actor in trial.fixture_actors}
+        recorded: list[dict[str, str | None]] = []
+        for message in fixture.scripted_messages:
+            try:
+                actor = trial.user if message.actor == "user" else actors[message.actor]
+            except KeyError as error:
+                raise RuntimeLaunchError(
+                    f"scripted actor {message.actor!r} has no fixture credential"
+                ) from error
+            content = message.content.replace(
+                "{orchestrator}", orchestrator.agent_id
+            ).replace("{user}", trial.user.agent_id)
+            response = await self._send(
+                actor,
+                trial,
+                content,
+                mention=(
+                    orchestrator.nostr_pubkey if message.mention_orchestrator else None
+                ),
+                reply_to=(task_event_id if message.reply_to_task else None),
+            )
+            event_id = (
+                response.get("event_id")
+                if isinstance(response, dict)
+                and isinstance(response.get("event_id"), str)
+                else None
+            )
+            recorded.append(
+                {
+                    "label": message.label,
+                    "event_id": event_id,
+                    "actor": message.actor,
+                    "reply_to_event_id": (
+                        task_event_id if message.reply_to_task else None
+                    ),
+                }
+            )
+        return recorded
 
     async def _buzz_json(
         self, credential: AgentCredential, trial: TrialHandle, *args: str

--- a/benchmarks/harbor-buzz-orchestra/src/harbor_buzz_orchestra/evidence.py
+++ b/benchmarks/harbor-buzz-orchestra/src/harbor_buzz_orchestra/evidence.py
@@ -75,6 +75,7 @@ def build_buzz_evidence(
     completion_message_id: str | None,
     transcript_limit: int,
     observed_channels: object = None,
+    scripted_events: object = None,
 ) -> dict[str, Any]:
     """Normalize relay messages into a versioned contract for task verifiers.
 
@@ -92,6 +93,12 @@ def build_buzz_evidence(
     identities_by_pubkey = {
         pubkey: {"name": name, "role": role} for name, role, pubkey in identity_rows
     }
+    identities_by_pubkey.update(
+        {
+            identity.pubkey: {"name": identity.name, "role": identity.role}
+            for identity in trial.directory
+        }
+    )
     identities = {
         name: {"role": role, "pubkey": pubkey} for name, role, pubkey in identity_rows
     }
@@ -117,9 +124,16 @@ def build_buzz_evidence(
         "completion_message_id": completion_message_id,
         "identities": identities,
         "directory": [
-            {"name": identity.name, "role": identity.role, "pubkey": identity.pubkey}
+            {
+                "identity_id": identity.identity_id or identity.name,
+                "name": identity.name,
+                "role": identity.role,
+                "pubkey": identity.pubkey,
+                "about": identity.about,
+            }
             for identity in trial.directory
         ],
+        "scripted_events": scripted_events if isinstance(scripted_events, list) else [],
         "task_name": trial.task_name,
         "observed_channels": (
             observed_channels if isinstance(observed_channels, list) else []

--- a/benchmarks/harbor-buzz-orchestra/src/harbor_buzz_orchestra/provisioning.py
+++ b/benchmarks/harbor-buzz-orchestra/src/harbor_buzz_orchestra/provisioning.py
@@ -28,6 +28,16 @@ class DirectoryIdentity:
     name: str
     role: str
     pubkey: str
+    identity_id: str = ""
+    about: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class FixtureActor:
+    """A private signer for task-declared relay events."""
+
+    identity_id: str
+    credential: AgentCredential
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,6 +61,7 @@ class TrialHandle:
     # Additive Buzz-native task context. Directory entries contain no secrets.
     task_name: str = ""
     directory: tuple[DirectoryIdentity, ...] = ()
+    fixture_actors: tuple[FixtureActor, ...] = ()
 
 
 @runtime_checkable

--- a/benchmarks/harbor-buzz-orchestra/src/harbor_buzz_orchestra/task_fixtures.py
+++ b/benchmarks/harbor-buzz-orchestra/src/harbor_buzz_orchestra/task_fixtures.py
@@ -11,6 +11,25 @@ class DirectoryEntry:
 
     name: str
     role: str
+    identity_id: str | None = None
+    about: str | None = None
+    channel_member: bool = False
+
+    @property
+    def stable_id(self) -> str:
+        """Identity key used for deterministic credentials and scripted events."""
+        return self.identity_id or self.name
+
+
+@dataclass(frozen=True, slots=True)
+class ScriptedMessage:
+    """A relay event injected immediately after the task's triggering event."""
+
+    label: str
+    actor: str
+    content: str
+    reply_to_task: bool = False
+    mention_orchestrator: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,6 +37,8 @@ class BuzzTaskFixture:
     """Relay state a task needs before the agent receives its prompt."""
 
     directory: tuple[DirectoryEntry, ...] = ()
+    scripted_messages: tuple[ScriptedMessage, ...] = ()
+    minimum_agent_messages: int = 0
     observe_channel_names: tuple[str, ...] = ()
     user_display_name: str | None = None
     # Whether the task's verifier grades the exported relay snapshot. Only
@@ -34,6 +55,11 @@ USER_MENTION_TASK = "user-mention"
 USER_MENTION_DISPLAY_NAME = "John Vincent Doe"
 REPLY_TO_THREAD_TASK = "reply-to-thread"
 READ_NAMED_PATH_TASK = "read-named-path-outside-workspace"
+MULTILINE_MESSAGE_TASK = "multiline-message"
+NARRATIVE_AGENT_NAMES_TASK = "narrative-agent-names"
+INTERLEAVED_AGENT_REPORTS_TASK = "interleaved-agent-reports"
+CROSS_THREAD_REQUESTS_TASK = "cross-thread-requests"
+AMBIGUOUS_USER_MENTION_TASK = "ambiguous-user-mention"
 
 _CREATE_CHANNEL_FIXTURE = BuzzTaskFixture(
     directory=tuple(
@@ -55,11 +81,100 @@ _USER_MENTION_FIXTURE = BuzzTaskFixture(
     requires_evidence=True,
 )
 
+_NARRATIVE_AGENT_NAMES_FIXTURE = BuzzTaskFixture(
+    directory=(
+        DirectoryEntry("Aurora Audit Bot", "bot", channel_member=True),
+        DirectoryEntry("Beacon Deploy Bot", "bot", channel_member=True),
+    ),
+    user_display_name="Maya Elise Chen",
+    requires_evidence=True,
+)
+
+_INTERLEAVED_AGENT_REPORTS_FIXTURE = BuzzTaskFixture(
+    directory=(
+        DirectoryEntry("Ledger Scout", "bot", channel_member=True),
+        DirectoryEntry("Risk Sentinel", "bot", channel_member=True),
+        DirectoryEntry("Ops Forecaster", "bot", channel_member=True),
+    ),
+    scripted_messages=(
+        ScriptedMessage(
+            label="ledger-report",
+            actor="Ledger Scout",
+            content=(
+                "@{orchestrator} Ledger report: North is 17 and South is 23. "
+                "Use both values in the requested synthesis."
+            ),
+            reply_to_task=True,
+        ),
+        ScriptedMessage(
+            label="risk-report",
+            actor="Risk Sentinel",
+            content=(
+                "@{orchestrator} Risk report: subtract a reserve of 11 before "
+                "applying the operations multiplier."
+            ),
+            reply_to_task=True,
+        ),
+        ScriptedMessage(
+            label="operations-report",
+            actor="Ops Forecaster",
+            content=("@{orchestrator} Operations report: the final multiplier is 3."),
+            reply_to_task=True,
+        ),
+    ),
+    user_display_name="Nora Isabel Grant",
+    requires_evidence=True,
+)
+
+_CROSS_THREAD_REQUESTS_FIXTURE = BuzzTaskFixture(
+    scripted_messages=(
+        ScriptedMessage(
+            label="beta-request",
+            actor="user",
+            content=(
+                "@{orchestrator} BETA request: calculate (84 / 7) + 29. "
+                "Reply with the BETA result, labelled BETA."
+            ),
+        ),
+    ),
+    minimum_agent_messages=2,
+    user_display_name="Priya Simone Patel",
+    requires_evidence=True,
+)
+
+_AMBIGUOUS_USER_MENTION_FIXTURE = BuzzTaskFixture(
+    directory=(
+        DirectoryEntry(
+            "Taylor Morgan Lee",
+            "user",
+            identity_id="taylor-release-captain",
+            about="Release captain. Routing code ORCHID-72.",
+            channel_member=True,
+        ),
+        DirectoryEntry(
+            "Taylor Morgan Lee",
+            "user",
+            identity_id="taylor-observer",
+            about="Compliance observer. Routing code COBALT-19.",
+            channel_member=True,
+        ),
+    ),
+    user_display_name="Olivia Grace Park",
+    requires_evidence=True,
+)
+
 _FIXTURES = {
     CREATE_CHANNEL_TASK: _CREATE_CHANNEL_FIXTURE,
     USER_MENTION_TASK: _USER_MENTION_FIXTURE,
     REPLY_TO_THREAD_TASK: BuzzTaskFixture(requires_evidence=True),
     READ_NAMED_PATH_TASK: BuzzTaskFixture(requires_evidence=True),
+    MULTILINE_MESSAGE_TASK: BuzzTaskFixture(
+        user_display_name="Eleanor June Brooks", requires_evidence=True
+    ),
+    NARRATIVE_AGENT_NAMES_TASK: _NARRATIVE_AGENT_NAMES_FIXTURE,
+    INTERLEAVED_AGENT_REPORTS_TASK: _INTERLEAVED_AGENT_REPORTS_FIXTURE,
+    CROSS_THREAD_REQUESTS_TASK: _CROSS_THREAD_REQUESTS_FIXTURE,
+    AMBIGUOUS_USER_MENTION_TASK: _AMBIGUOUS_USER_MENTION_FIXTURE,
 }
 
 

--- a/benchmarks/harbor-buzz-orchestra/testbed/src/harbor_buzz_testbed/buzz_cli.py
+++ b/benchmarks/harbor-buzz-orchestra/testbed/src/harbor_buzz_testbed/buzz_cli.py
@@ -81,7 +81,7 @@ class BuzzCli:
             raise BuzzCliError(f"channel create returned no channel_id: {response}")
         return channel_id
 
-    def add_member(self, channel_id: str, pubkey: str) -> None:
+    def add_member(self, channel_id: str, pubkey: str, role: str = "member") -> None:
         self.run(
             "channels",
             "add-member",
@@ -90,7 +90,7 @@ class BuzzCli:
             "--pubkey",
             pubkey,
             "--role",
-            "member",
+            role,
         )
 
     def profiles(self, pubkeys: list[str]) -> list[dict[str, Any]]:
@@ -101,8 +101,11 @@ class BuzzCli:
         response = self.run(*args)
         return response if isinstance(response, list) else []
 
-    def set_profile(self, name: str) -> None:
-        self.run("users", "set-profile", "--name", name)
+    def set_profile(self, name: str, about: str | None = None) -> None:
+        args = ["users", "set-profile", "--name", name]
+        if about is not None:
+            args.extend(("--about", about))
+        self.run(*args)
 
     def archive_channel(self, channel_id: str) -> None:
         self.run("channels", "archive", "--channel", channel_id)

--- a/benchmarks/harbor-buzz-orchestra/testbed/src/harbor_buzz_testbed/provisioner.py
+++ b/benchmarks/harbor-buzz-orchestra/testbed/src/harbor_buzz_testbed/provisioner.py
@@ -14,9 +14,10 @@ from harbor_buzz_orchestra.manifest import ExperimentManifest
 from harbor_buzz_orchestra.provisioning import (
     AgentCredential,
     DirectoryIdentity,
+    FixtureActor,
     TrialHandle,
 )
-from harbor_buzz_orchestra.task_fixtures import fixture_for
+from harbor_buzz_orchestra.task_fixtures import DirectoryEntry, fixture_for
 
 from .buzz_cli import BuzzCli
 from .keys import compute_auth_tag, generate_keypair, keypair_from_secret
@@ -170,6 +171,27 @@ class BuzzTrialProvisioner:
         for credential in credentials:
             cli.add_member(channel_id, credential.nostr_pubkey)
         directory = self._seed_directory(task_name, cli)
+        fixture = fixture_for(task_name)
+        directory_credentials = {
+            entry.stable_id: self._directory_credential(entry)
+            for entry in fixture.directory
+        }
+        for entry in fixture.directory:
+            if entry.channel_member:
+                cli.add_member(
+                    channel_id,
+                    directory_credentials[entry.stable_id].nostr_pubkey,
+                    "bot" if entry.role == "bot" else "member",
+                )
+        scripted_actor_ids = {
+            message.actor
+            for message in fixture.scripted_messages
+            if message.actor != "user"
+        }
+        fixture_actors = tuple(
+            FixtureActor(identity_id, directory_credentials[identity_id])
+            for identity_id in sorted(scripted_actor_ids)
+        )
         return TrialHandle(
             run_id=run_id,
             trial_id=trial_id,
@@ -181,6 +203,7 @@ class BuzzTrialProvisioner:
             user_relay_url=self._config.relay_http_url,
             task_name=task_name or "",
             directory=directory,
+            fixture_actors=fixture_actors,
         )
 
     def _seed_directory(
@@ -188,9 +211,7 @@ class BuzzTrialProvisioner:
     ) -> tuple[DirectoryIdentity, ...]:
         """Publish stable task-directory profiles, skipping those already seeded."""
         entries = fixture_for(task_name).directory
-        credentials = [
-            self._directory_credential(entry.name, entry.role) for entry in entries
-        ]
+        credentials = [self._directory_credential(entry) for entry in entries]
         if not credentials:
             return ()
         existing = {
@@ -200,21 +221,23 @@ class BuzzTrialProvisioner:
             )
             if isinstance(profile, dict)
         }
-        for credential in credentials:
-            if credential.nostr_pubkey not in existing:
-                self._cli_for(credential).set_profile(credential.agent_id)
+        for entry, credential in zip(entries, credentials, strict=True):
+            if credential.nostr_pubkey not in existing or entry.about is not None:
+                self._cli_for(credential).set_profile(entry.name, entry.about)
         return tuple(
             DirectoryIdentity(
-                name=credential.agent_id,
+                name=entry.name,
                 role=credential.role,
                 pubkey=credential.nostr_pubkey,
+                identity_id=entry.stable_id,
+                about=entry.about or "",
             )
-            for credential in credentials
+            for entry, credential in zip(entries, credentials, strict=True)
         )
 
-    def _directory_credential(self, name: str, role: str) -> AgentCredential:
+    def _directory_credential(self, entry: DirectoryEntry) -> AgentCredential:
         """Derive one community-stable benchmark identity without storing its key."""
-        return self._stable_credential(name, name, role)
+        return self._stable_credential(entry.stable_id, entry.name, entry.role)
 
     def _stable_credential(
         self, identity_id: str, display_name: str, role: str
@@ -341,6 +364,12 @@ class BuzzTrialProvisioner:
             directory=tuple(
                 DirectoryIdentity(**identity)
                 for identity in stored.get("directory", [])
+            ),
+            fixture_actors=tuple(
+                FixtureActor(
+                    actor["identity_id"], AgentCredential(**actor["credential"])
+                )
+                for actor in stored.get("fixture_actors", [])
             ),
         )
 

--- a/benchmarks/harbor-buzz-orchestra/testbed/tests/test_provisioner_unit.py
+++ b/benchmarks/harbor-buzz-orchestra/testbed/tests/test_provisioner_unit.py
@@ -7,6 +7,7 @@ import json
 
 import coincurve
 import pytest
+from harbor_buzz_orchestra.task_fixtures import DirectoryEntry
 
 from harbor_buzz_testbed.provisioner import (
     BuzzTrialProvisioner,
@@ -112,9 +113,13 @@ def test_mint_credentials_missing_api_key_is_explicit(manifest):
 def test_directory_credentials_are_stable_distinct_and_attested():
     provisioner = BuzzTrialProvisioner(config())
 
-    first = provisioner._directory_credential("benchmark-user-01", "user")
-    again = provisioner._directory_credential("benchmark-user-01", "user")
-    other = provisioner._directory_credential("benchmark-bot-01", "bot")
+    first = provisioner._directory_credential(
+        DirectoryEntry("benchmark-user-01", "user")
+    )
+    again = provisioner._directory_credential(
+        DirectoryEntry("benchmark-user-01", "user")
+    )
+    other = provisioner._directory_credential(DirectoryEntry("benchmark-bot-01", "bot"))
 
     assert first.nostr_secret_key == again.nostr_secret_key
     assert first.nostr_pubkey == again.nostr_pubkey
@@ -133,8 +138,8 @@ def test_seed_directory_has_50_users_10_bots_and_skips_existing(monkeypatch):
     published = []
 
     class Publisher:
-        def set_profile(self, name):
-            published.append(name)
+        def set_profile(self, name, about=None):
+            published.append((name, about))
 
     monkeypatch.setattr(provisioner, "_cli_for", lambda _credential: Publisher())
 
@@ -144,7 +149,20 @@ def test_seed_directory_has_50_users_10_bots_and_skips_existing(monkeypatch):
     assert sum(identity.role == "user" for identity in directory) == 50
     assert sum(identity.role == "bot" for identity in directory) == 10
     assert len(published) == 59
-    assert directory[0].name not in published
+    assert (directory[0].name, None) not in published
+
+
+def test_duplicate_display_names_keep_distinct_stable_identities():
+    provisioner = BuzzTrialProvisioner(config())
+    first = provisioner._directory_credential(
+        DirectoryEntry("Taylor Morgan Lee", "user", identity_id="release")
+    )
+    second = provisioner._directory_credential(
+        DirectoryEntry("Taylor Morgan Lee", "user", identity_id="observer")
+    )
+
+    assert first.agent_id == second.agent_id == "Taylor Morgan Lee"
+    assert first.nostr_pubkey != second.nostr_pubkey
 
 
 def test_lock_key_is_deterministic_and_distinct():

--- a/benchmarks/harbor-buzz-orchestra/tests/test_container_runtime.py
+++ b/benchmarks/harbor-buzz-orchestra/tests/test_container_runtime.py
@@ -19,7 +19,11 @@ from harbor_buzz_orchestra.container_runtime import (
     RuntimeLaunchError,
 )
 from harbor_buzz_orchestra.manifest import ExperimentManifest
-from harbor_buzz_orchestra.provisioning import AgentCredential, TrialHandle
+from harbor_buzz_orchestra.provisioning import (
+    AgentCredential,
+    FixtureActor,
+    TrialHandle,
+)
 from harbor_buzz_orchestra.task_fixtures import fixture_for
 
 
@@ -453,6 +457,51 @@ async def test_send_mentions_by_pubkey_so_task_text_stays_inert(tmp_path, monkey
     assert calls[-1][-2:] == ("--content", "plain content")
 
 
+async def test_sends_task_declared_actor_messages_and_records_event_ids(
+    tmp_path, monkeypatch
+):
+    rt = runtime(tmp_path)
+    orch = credential("solo-1", "orchestrator", "orch-model")
+    reporters = tuple(
+        FixtureActor(name, credential(name, "bot", ""))
+        for name in ("Ledger Scout", "Risk Sentinel", "Ops Forecaster")
+    )
+    trial = replace(
+        trial_handle((orch,)),
+        task_name="interleaved-agent-reports",
+        fixture_actors=reporters,
+    )
+    calls = []
+
+    async def send(actor, trial_arg, content, **kwargs):
+        calls.append((actor.agent_id, trial_arg, content, kwargs))
+        return {"event_id": f"event-{len(calls)}"}
+
+    monkeypatch.setattr(rt, "_send", send)
+
+    events = await rt._send_scripted_messages(
+        trial=trial, orchestrator=orch, task_event_id="task-root"
+    )
+
+    assert [event["label"] for event in events] == [
+        "ledger-report",
+        "risk-report",
+        "operations-report",
+    ]
+    assert [event["event_id"] for event in events] == [
+        "event-1",
+        "event-2",
+        "event-3",
+    ]
+    assert {call[0] for call in calls} == {
+        "Ledger Scout",
+        "Risk Sentinel",
+        "Ops Forecaster",
+    }
+    assert all(call[3]["mention"] == orch.nostr_pubkey for call in calls)
+    assert all(call[3]["reply_to"] == "task-root" for call in calls)
+
+
 async def test_wait_for_done_requires_orchestrator_authorship(tmp_path, monkeypatch):
     rt = runtime(tmp_path, poll_seconds=0)
     orch = credential("orch-1", "orchestrator", "orch-model")
@@ -498,6 +547,46 @@ async def test_solo_turn_end_completes_without_done_message(tmp_path, monkeypatc
 
     monkeypatch.setattr(rt, "_buzz_json", buzz_json)
     assert await rt._wait_for_done(environment, orch, trial, [], solo=solo) is None
+
+
+async def test_scripted_events_wait_for_second_agent_message(tmp_path, monkeypatch):
+    from harbor_buzz_orchestra.container_runtime import _Agent
+
+    rt = runtime(tmp_path, poll_seconds=0)
+    orch = credential("orch-1", "orchestrator", "orch-model")
+    trial = trial_handle((orch,))
+    solo = _Agent(orch, 7, "stdout.log", "stderr.log")
+    message_rounds = iter(
+        [
+            [{"id": "alpha", "pubkey": orch.nostr_pubkey, "content": "ALPHA"}],
+            [{"id": "alpha", "pubkey": orch.nostr_pubkey, "content": "ALPHA"}],
+            [
+                {"id": "alpha", "pubkey": orch.nostr_pubkey, "content": "ALPHA"},
+                {"id": "beta", "pubkey": orch.nostr_pubkey, "content": "BETA"},
+            ],
+        ]
+    )
+    turn_rounds = iter([(1, 1), (2, 1), (2, 2)])
+
+    async def buzz_json(*args, **kwargs):
+        return next(message_rounds)
+
+    async def turn_counts(*args, **kwargs):
+        return next(turn_rounds)
+
+    monkeypatch.setattr(rt, "_buzz_json", buzz_json)
+    monkeypatch.setattr(rt, "_turn_counts", turn_counts)
+
+    result = await rt._wait_for_done(
+        Environment(),
+        orch,
+        trial,
+        [],
+        solo=solo,
+        minimum_agent_messages=2,
+    )
+
+    assert result["id"] == "beta"
 
 
 async def test_collect_evidence_uploads_verifier_artifact(tmp_path, monkeypatch):

--- a/benchmarks/harbor-buzz-orchestra/tests/test_evidence.py
+++ b/benchmarks/harbor-buzz-orchestra/tests/test_evidence.py
@@ -124,6 +124,12 @@ def test_exports_only_public_directory_and_observed_channel_state():
 
     assert evidence["task_name"] == "create-channel-invite-users"
     assert evidence["directory"] == [
-        {"name": "benchmark-user-01", "role": "user", "pubkey": "d" * 64}
+        {
+            "identity_id": "benchmark-user-01",
+            "name": "benchmark-user-01",
+            "role": "user",
+            "pubkey": "d" * 64,
+            "about": "",
+        }
     ]
     assert evidence["observed_channels"] == channels

--- a/benchmarks/harbor-buzz-orchestra/tests/test_expanded_buzz_native_verifiers.py
+++ b/benchmarks/harbor-buzz-orchestra/tests/test_expanded_buzz_native_verifiers.py
@@ -1,0 +1,238 @@
+"""Positive and adversarial fixtures for the expanded Buzz-native tasks."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+DATASET_ROOT = Path(__file__).resolve().parents[2] / "buzz-dataset"
+AGENT = "a" * 64
+USER = "u" * 64
+CHANNEL = "channel"
+ROOT = "root"
+
+
+def _verifier(task: str) -> ModuleType:
+    path = DATASET_ROOT / task / "tests" / "verify.py"
+    spec = importlib.util.spec_from_file_location(f"{task}_verifier", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _message(
+    message_id: str,
+    content: str,
+    *,
+    reply_to: str | None = ROOT,
+    mentions: list[str] | None = None,
+    pubkey: str = AGENT,
+) -> dict:
+    tags = [["h", CHANNEL]]
+    if reply_to is not None:
+        tags.append(["e", reply_to, "", "reply"])
+    tags.extend(["p", value] for value in (mentions or []))
+    return {
+        "id": message_id,
+        "pubkey": pubkey,
+        "content": content,
+        "tags": tags,
+        "channel_id": CHANNEL,
+        "reply_to_event_id": reply_to,
+        "mentioned_pubkeys": mentions or [],
+    }
+
+
+def _base(task: str, user_name: str) -> dict:
+    return {
+        "schema_version": 1,
+        "task_name": task,
+        "task_event_id": ROOT,
+        "truncated": False,
+        "trial": {"channel_id": CHANNEL},
+        "identities": {
+            "solo-1": {"role": "orchestrator", "pubkey": AGENT},
+            user_name: {"role": "user", "pubkey": USER},
+        },
+        "directory": [],
+        "scripted_events": [],
+        "messages": [],
+    }
+
+
+def test_multiline_message_preserves_layout_and_rejects_literal_escapes():
+    verifier = _verifier("multiline-message")
+    evidence = _base("multiline-message", "Eleanor June Brooks")
+    evidence["messages"] = [_message("answer", verifier.EXPECTED, mentions=[USER])]
+
+    metrics, _ = verifier.score_evidence(evidence)
+    assert all(value == 1.0 for value in metrics.values())
+
+    evidence["messages"][0]["content"] = verifier.EXPECTED.replace("\n", "\\n")
+    metrics, _ = verifier.score_evidence(evidence)
+    assert metrics["real_newlines"] == 0.0
+    assert metrics["reward"] == 0.0
+
+
+def test_narrative_agent_names_do_not_wake_bots():
+    verifier = _verifier("narrative-agent-names")
+    evidence = _base("narrative-agent-names", "Maya Elise Chen")
+    bot_a, bot_b = "b" * 64, "c" * 64
+    evidence["directory"] = [
+        {"name": "Aurora Audit Bot", "role": "bot", "pubkey": bot_a},
+        {"name": "Beacon Deploy Bot", "role": "bot", "pubkey": bot_b},
+    ]
+    content = "Aurora Audit Bot completed the audit.\nBeacon Deploy Bot remains idle."
+    evidence["messages"] = [_message("answer", content, mentions=[USER])]
+
+    metrics, _ = verifier.score_evidence(evidence)
+    assert all(value == 1.0 for value in metrics.values())
+
+    evidence["messages"][0]["mentioned_pubkeys"].append(bot_a)
+    metrics, _ = verifier.score_evidence(evidence)
+    assert metrics["bots_not_mentioned"] == 0.0
+
+    evidence["messages"] = [
+        _message("bad-wake", "@Aurora Audit Bot please check", mentions=[bot_a]),
+        _message("answer", content, mentions=[USER]),
+    ]
+    metrics, _ = verifier.score_evidence(evidence)
+    assert metrics["bots_not_mentioned"] == 0.0
+    assert metrics["reward"] == 0.0
+
+    evidence["messages"] = [
+        _message(
+            "answer",
+            "Aurora Audit Bot remains idle.\nBeacon Deploy Bot completed the audit.",
+            mentions=[USER],
+        )
+    ]
+    metrics, _ = verifier.score_evidence(evidence)
+    assert metrics["status_correct"] == 0.0
+
+
+def test_interleaved_reports_require_all_inputs_and_one_callback():
+    verifier = _verifier("interleaved-agent-reports")
+    evidence = _base("interleaved-agent-reports", "Nora Isabel Grant")
+    reporters = [
+        ("Ledger Scout", "b" * 64),
+        ("Risk Sentinel", "c" * 64),
+        ("Ops Forecaster", "d" * 64),
+    ]
+    evidence["directory"] = [
+        {"name": name, "role": "bot", "pubkey": pubkey} for name, pubkey in reporters
+    ]
+    labels = ("ledger-report", "risk-report", "operations-report")
+    evidence["scripted_events"] = [
+        {"label": label, "event_id": f"report-{index}"}
+        for index, label in enumerate(labels, start=1)
+    ]
+    evidence["messages"] = [
+        _message(f"report-{index}", label, pubkey=reporters[index - 1][1])
+        for index, label in enumerate(labels, start=1)
+    ] + [
+        _message(
+            "answer",
+            (
+                "- **North:** 17\n- **South:** 23\n- **reserve:** 11\n"
+                "- **multiplier:** 3\n\n(17 + 23 − 11) × 3 = **87**"
+            ),
+            mentions=[USER],
+        )
+    ]
+
+    metrics, _ = verifier.score_evidence(evidence)
+    assert all(value == 1.0 for value in metrics.values())
+
+    evidence["messages"][-1]["content"] = "North 17; final forecast 87."
+    metrics, _ = verifier.score_evidence(evidence)
+    assert metrics["inputs_complete"] == 0.0
+
+    evidence["messages"][-1]["content"] = (
+        "North 17; South 23; reserve 11; multiplier 3; final forecast 87."
+    )
+    evidence["messages"].insert(
+        -1,
+        _message("bad-wake", "@Ledger Scout thanks", mentions=[reporters[0][1]]),
+    )
+    metrics, _ = verifier.score_evidence(evidence)
+    assert metrics["reporters_not_rementioned"] == 0.0
+    assert metrics["reward"] == 0.0
+
+
+def test_cross_thread_requests_require_two_isolated_replies():
+    verifier = _verifier("cross-thread-requests")
+    evidence = _base("cross-thread-requests", "Priya Simone Patel")
+    evidence["scripted_events"] = [{"label": "beta-request", "event_id": "beta-root"}]
+    evidence["messages"] = [
+        _message("alpha-answer", "ALPHA result: 346", mentions=[USER]),
+        _message(
+            "beta-answer",
+            "BETA result: 41",
+            reply_to="beta-root",
+            mentions=[USER],
+        ),
+    ]
+
+    metrics, _ = verifier.score_evidence(evidence)
+    assert all(value == 1.0 for value in metrics.values())
+
+    evidence["messages"] = [
+        _message(
+            "combined", "ALPHA 346; BETA 41", reply_to="beta-root", mentions=[USER]
+        )
+    ]
+    metrics, _ = verifier.score_evidence(evidence)
+    assert metrics["thread_isolation"] == 0.0
+    assert metrics["reward"] == 0.0
+
+    evidence["messages"] = [
+        _message("alpha-answer", "ALPHA result: 346", mentions=[USER]),
+        _message("extra", "Both requests handled", mentions=[USER]),
+        _message(
+            "beta-answer",
+            "BETA result: 41",
+            reply_to="beta-root",
+            mentions=[USER],
+        ),
+    ]
+    metrics, _ = verifier.score_evidence(evidence)
+    assert metrics["thread_isolation"] == 0.0
+
+
+def test_ambiguous_user_mention_targets_only_profile_match():
+    verifier = _verifier("ambiguous-user-mention")
+    evidence = _base("ambiguous-user-mention", "Olivia Grace Park")
+    target, other = "b" * 64, "c" * 64
+    evidence["directory"] = [
+        {
+            "identity_id": "taylor-release-captain",
+            "name": "Taylor Morgan Lee",
+            "role": "user",
+            "pubkey": target,
+        },
+        {
+            "identity_id": "taylor-observer",
+            "name": "Taylor Morgan Lee",
+            "role": "user",
+            "pubkey": other,
+        },
+    ]
+    evidence["messages"] = [
+        _message(
+            "delivery", "@Taylor Morgan Lee ORCHID-72 approved", mentions=[target]
+        ),
+        _message(
+            "callback", "Sent to the matching Taylor Morgan Lee.", mentions=[USER]
+        ),
+    ]
+
+    metrics, _ = verifier.score_evidence(evidence)
+    assert all(value == 1.0 for value in metrics.values())
+
+    evidence["messages"][0]["mentioned_pubkeys"].append(other)
+    metrics, _ = verifier.score_evidence(evidence)
+    assert metrics["other_not_notified"] == 0.0
+    assert metrics["reward"] == 0.0


### PR DESCRIPTION
## Why
Terminal task correctness alone does not guard Buzz-native collaboration behavior such as exact reply routing, non-waking narrative names, batched agent synthesis, thread isolation, and ambiguous identity targeting.

## What
- Add five medium/hard Harbor tasks for multiline delivery, narrative agent names, interleaved agent reports, cross-thread requests, and ambiguous user mentions
- Add signed scripted-event fixtures, duplicate-display-name profiles, and public-only evidence export support
- Add positive and adversarial verifier fixtures covering dropped inputs, extra posts, incorrect routing, and unintended mentions

## Risk Assessment
Low — changes are limited to benchmark tooling and datasets; production behavior is exercised but not modified.

## References
- Grounded in behavior reported in `buzz-community` and public issues #5787, #5176, #5839, #4942, #4072, #4303, and #6257
- Live Claude Sonnet 4.6 smoke run: 2/5 passed; the three failures exposed top-level instead of threaded delivery, empty narrative output, and silent ambiguous-identity completion
- Live GPT-5.6 Luna run (`buzz-native-solo-luna.yaml`): 3/5 passed. Passed `ambiguous-user-mention`, `cross-thread-requests`, and `interleaved-agent-reports`. Failed `multiline-message` and `narrative-agent-names` because both omitted the event-level user mention despite otherwise-correct content and threading.



<img width="1176" height="805" alt="Screenshot 2026-08-21 at 11 11 17 AM" src="https://github.com/user-attachments/assets/fc259ec9-892c-4436-b022-1bf85415617d" />
