### PR TITLE
fix(cli): fail closed when messages get targets a nonexistent channel

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -363,6 +363,22 @@ pub async fn cmd_get_messages(
     format: &crate::OutputFormat,
 ) -> Result<(), CliError> {
     validate_uuid(channel_id)?;
+    // Fail closed: verify the channel exists (kind:39000 by #d) before
+    // returning an empty message list that is indistinguishable from a
+    // wrong UUID.
+    let probe_filter = serde_json::json!({
+        "kinds": [39000],
+        "#d": [channel_id],
+        "limit": 1
+    });
+    let probe_raw = client.query(&probe_filter).await?;
+    let probe_events: Vec<serde_json::Value> = serde_json::from_str(&probe_raw)
+        .map_err(|e| CliError::Other(format!("failed to parse query response: {e}")))?;
+    if probe_events.is_empty() {
+        return Err(CliError::NotFound(format!(
+            "channel '{channel_id}' not found"
+        )));
+    }
     let limit = limit.unwrap_or(50).min(200);
 
     let mut filter = serde_json::json!({
@@ -1542,5 +1558,99 @@ mod tests {
             profile_event(PK_VALID_A, Some("Aaron"), None),
         ];
         assert_eq!(match_profiles_by_name(&events, "Aaron").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cmd_get_messages_fails_when_channel_not_found() {
+        use axum::body::Body;
+        use axum::http::{Response, StatusCode};
+        use axum::routing::post;
+        use axum::Router;
+        use tokio::net::TcpListener;
+
+        let app = Router::new().route(
+            "/query",
+            post(|_body: String| async move {
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .body(Body::from("[]"))
+                    .unwrap()
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client = crate::client::BuzzClient::new(
+            format!("http://{addr}"),
+            nostr::Keys::generate(),
+            None,
+            None,
+        )
+        .unwrap();
+        let channel_id = "00000000-0000-4000-8000-000000000000";
+        let result = super::cmd_get_messages(
+            &client,
+            channel_id,
+            None,
+            None,
+            None,
+            None,
+            &crate::OutputFormat::Json,
+        )
+        .await;
+        assert!(
+            matches!(result, Err(crate::error::CliError::NotFound(_))),
+            "expected NotFound, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cmd_get_messages_succeeds_when_channel_exists() {
+        use axum::body::Body;
+        use axum::http::{Response, StatusCode};
+        use axum::routing::post;
+        use axum::Router;
+        use tokio::net::TcpListener;
+
+        let app = Router::new().route(
+            "/query",
+            post(|body: String| async move {
+                if body.contains("39000") {
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .body(Body::from(r#"[{"id":"abc","kind":39000}]"#))
+                        .unwrap()
+                } else {
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .body(Body::from(
+                            r#"[{"id":"msg1","content":"hi","created_at":1}]"#,
+                        ))
+                        .unwrap()
+                }
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client = crate::client::BuzzClient::new(
+            format!("http://{addr}"),
+            nostr::Keys::generate(),
+            None,
+            None,
+        )
+        .unwrap();
+        let channel_id = "00000000-0000-4000-8000-000000000000";
+        let result = super::cmd_get_messages(
+            &client,
+            channel_id,
+            None,
+            None,
+            None,
+            None,
+            &crate::OutputFormat::Json,
+        )
+        .await;
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
 }


### PR DESCRIPTION
Fixes #6389.

## Problem

`buzz messages get --channel <uuid>` prints `[]` and exits 0 when the channel does not exist or the caller is not a member. That is indistinguishable from a channel with no messages, so scripts cannot tell "no messages yet" from "wrong UUID".

## Change

`cmd_get_messages` probes for the channel's `kind:39000` discovery event by `#d` before querying messages. If the probe returns no event, it returns `CliError::NotFound`, which exits 1.

This also covers the unauthorized case from the issue: `kind:39000` events are stored channel-scoped, so a non-member's probe comes back empty and the command fails closed rather than reporting an empty history.

The probe filter matches the one `cmd_get_channel` already uses in `crates/buzz-cli/src/commands/channels.rs`.

## Before / after

```
$ buzz messages get --channel 00000000-0000-4000-8000-000000000000 --limit 1
[]
$ echo $?
0
```

```
$ buzz messages get --channel 00000000-0000-4000-8000-000000000000 --limit 1
error: channel '00000000-0000-4000-8000-000000000000' not found
$ echo $?
1
```

## Tests

Two unit tests in `crates/buzz-cli/src/commands/messages.rs`, each against a local stub relay:

- `cmd_get_messages_fails_when_channel_not_found` — probe returns `[]`, expect `CliError::NotFound`
- `cmd_get_messages_succeeds_when_channel_exists` — probe returns a `kind:39000` event, expect `Ok` and the messages printed

The first test fails on `main` with `expected NotFound, got Ok(())`.

## Verification

Run on this branch, rebased on `24ec6a4`:

```
cargo clippy --workspace --all-targets -- -D warnings   # exit 0
cargo fmt --all -- --check                              # exit 0
cargo test -p buzz-cli --lib                            # 365 passed, 0 failed
```

## Notes

- Costs one extra relay query per `messages get`. That seemed the right trade for a correct exit code, but I am happy to gate it behind a flag if you would rather not pay it on the hot path.
- Scoped to `messages get` only. `messages thread`, `channels members`, and `canvas get` have the same silent-empty behaviour and are left alone here.
