### PR TITLE
fix(desktop): make triple-click select only the clicked composer line

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -66,6 +66,7 @@ export default defineConfig({
         "**/composer-link-shortcut.spec.ts",
         "**/entity-link-recipient-cards.spec.ts",
         "**/composer-selection-formatting.spec.ts",
+        "**/composer-triple-click-selection.spec.ts",
         "**/composer-tooltip-dismiss.spec.ts",
         "**/mentions.spec.ts",
         "**/team-mentions.spec.ts",

--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -348,6 +348,48 @@ export function useRichTextEditor({
             };
           },
         }),
+        // Triple-click selects only the clicked *line* (the text between
+        // the nearest hard breaks), not the whole paragraph. Shift+Enter
+        // never starts a new paragraph — a multi-line typed message is one
+        // <p> containing inline <br> (hardBreak) nodes — so the browser's
+        // native "expand triple-click to nearest block" resolves to the
+        // entire message. Override it to match textarea/Slack-style
+        // per-line selection. Pasted multi-line text is unaffected: it
+        // parses into separate <p> nodes via TiptapMarkdown below, so the
+        // browser default already does the right thing there.
+        Extension.create({
+          name: "tripleClickSelectsLine",
+          addProseMirrorPlugins() {
+            return [
+              new Plugin({
+                props: {
+                  handleTripleClick(view, pos) {
+                    const $pos = view.state.doc.resolve(pos);
+                    if (!$pos.parent.inlineContent) return false;
+
+                    const { start, end } = hardBreakLineBounds($pos);
+                    const parentStart = $pos.start();
+                    const parentEnd = parentStart + $pos.parent.content.size;
+                    // No hard breaks in this block (e.g. a single-line
+                    // paragraph, a pasted block's own <p>, or a code
+                    // block) -> identical to the default paragraph-wide
+                    // selection. Let ProseMirror handle it natively.
+                    if (start === parentStart && end === parentEnd) {
+                      return false;
+                    }
+
+                    view.dispatch(
+                      view.state.tr.setSelection(
+                        TextSelection.create(view.state.doc, start, end),
+                      ),
+                    );
+                    return true;
+                  },
+                },
+              }),
+            ];
+          },
+        }),
         // Shift+Enter inside lists/blockquotes: split the node instead of
         // inserting a hard break so continuation lines keep their formatting.
         Extension.create({

--- a/desktop/tests/e2e/composer-triple-click-selection.spec.ts
+++ b/desktop/tests/e2e/composer-triple-click-selection.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+async function openGeneral(page: Page) {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+}
+
+async function tripleClickText(page: Page, input: Locator, text: string) {
+  const point = await input.evaluate((element, targetText) => {
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+
+    while (walker.nextNode()) {
+      const node = walker.currentNode;
+      const value = node.textContent ?? "";
+      const index = value.indexOf(targetText);
+      if (index < 0) continue;
+
+      const range = document.createRange();
+      range.setStart(node, index);
+      range.setEnd(node, index + targetText.length);
+      const rect = range.getBoundingClientRect();
+      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    }
+
+    throw new Error(`Could not locate "${targetText}" for triple-click`);
+  }, text);
+
+  await page.mouse.click(point.x, point.y, { clickCount: 3 });
+}
+
+test.beforeEach(async ({ page }) => {
+  await installMockBridge(page);
+});
+
+test("triple-clicking a composer line selects only that line, not the whole message", async ({
+  page,
+}) => {
+  await openGeneral(page);
+
+  const input = page.getByTestId("message-input");
+  await input.click();
+  await input.pressSequentially("before");
+  await input.press("Shift+Enter");
+  await input.pressSequentially("selected line");
+  await input.press("Shift+Enter");
+  await input.pressSequentially("after");
+
+  await tripleClickText(page, input, "selected line");
+
+  await expect
+    .poll(() => page.evaluate(() => window.getSelection()?.toString()))
+    .toBe("selected line");
+});


### PR DESCRIPTION
Shift+Enter never starts a new paragraph in the Tiptap composer -- a multi-line typed message is one <p> with inline hardBreak (<br>) nodes. Browsers resolve triple-click by expanding to the nearest block container, so triple-clicking any line selected the entire composer content instead of just that line. Pasted multi-line text is unaffected since it parses into separate <p> nodes.

Adds a tripleClickSelectsLine ProseMirror plugin that intercepts handleTripleClick and reuses the existing hardBreakLineBounds() helper (already used for Ctrl-A/Ctrl-E/Ctrl-K Emacs-style shortcuts) to select just the text between the surrounding hard breaks.

Adds an E2E regression spec verifying triple-click on a middle line of a three-line hard-break message selects only that line.

## Summary
<!-- What does this change and why? -->

### Related issue
<!-- Fixes #1234, or N/A. Before opening: search existing issues/PRs for duplicates — link the closest one, or say "none found". -->

### Testing
<!-- How was this verified? UI change? Include before/after screenshots (or a short recording). -->
