### PR TITLE
fix(desktop): repaint composer caret after consecutive Shift+Enter li…

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
         "**/entity-link-recipient-cards.spec.ts",
         "**/composer-selection-formatting.spec.ts",
         "**/composer-tooltip-dismiss.spec.ts",
+        "**/composer-shift-enter-hard-break.spec.ts",
         "**/mentions.spec.ts",
         "**/team-mentions.spec.ts",
         "**/persistent-agent-audience.spec.ts",

--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -61,6 +61,38 @@ function hardBreakLineBounds($from: ResolvedPos) {
 }
 
 /**
+ * Force a synchronous repaint of the editor's contentEditable element.
+ *
+ * Stock Tiptap's `Shift-Enter` hard-break command has a documented
+ * workaround: when the new break lands at the very end of its parent (no
+ * node after it), it inserts an extra default-type node and jumps the
+ * selection there — some engines won't otherwise reposition/repaint a
+ * caret past a trailing <br>. Two consecutive Shift+Enters at end-of-line
+ * hit that workaround twice in a row. In Buzz's Tauri WebView the first
+ * jump's caret glyph isn't reliably erased before the second jump paints
+ * its own, leaving a "ghost" caret rendered one line up (#3219). Toggling
+ * a paint-affecting style with a forced layout read in between is the
+ * standard way to make an engine discard a stale compositor layer and
+ * repaint, without altering any visible layout — the style is restored
+ * before the next task runs.
+ */
+function nudgeCaretRepaint(dom: HTMLElement) {
+  const previousTransform = dom.style.transform;
+  dom.style.transform = "translateZ(0)";
+  // Forces a synchronous layout flush so the browser can't coalesce this
+  // write with the one below and skip the repaint.
+  void dom.offsetHeight;
+  dom.style.transform = previousTransform;
+}
+
+function requestCaretRepaint(editor: Editor) {
+  window.requestAnimationFrame(() => {
+    if (!editor.view.dom.isConnected) return;
+    nudgeCaretRepaint(editor.view.dom as HTMLElement);
+  });
+}
+
+/**
  * Plain-text edit descriptor returned by autocomplete hooks
  * (mentions / channel links / emoji). Offsets are in plain-text space —
  * see `buildPlainTextProjection`.
@@ -429,7 +461,10 @@ export function useRichTextEditor({
                   // Non-empty → split the paragraph within the blockquote.
                   return ed.chain().splitBlock().focus().run();
                 }
-                // Default: hard break (StarterKit handles it).
+                // Default: hard break (StarterKit handles it). Schedule a
+                // WebView caret-repaint nudge before the break lands — see
+                // requestCaretRepaint above and #3219.
+                requestCaretRepaint(ed);
                 return false;
               },
               ArrowDown: ({ editor: ed }) => {

--- a/desktop/tests/e2e/composer-shift-enter-hard-break.spec.ts
+++ b/desktop/tests/e2e/composer-shift-enter-hard-break.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+import { installMockBridge } from "../helpers/bridge";
+
+/**
+ * Regression guard for #3219: a "ghost" caret rendered one line above the
+ * real blinking caret after two consecutive Shift+Enter presses at
+ * end-of-line. The bug is a Tauri-WebView compositor paint artifact — a
+ * headless Chromium run under Playwright is very unlikely to reproduce the
+ * visual glitch itself, so this spec cannot assert the double-caret glyph.
+ * Instead it asserts the underlying document structure is correct: two hard
+ * breaks are inserted (not extra/duplicated), and typed text after both
+ * breaks lands as the true last content — i.e. the caret actually ended up
+ * after both breaks, not stuck behind one of them. The visual repaint fix
+ * (`requestCaretRepaint` in useRichTextEditor.ts) needs manual verification
+ * on a real packaged Tauri build.
+ */
+
+test.beforeEach(async ({ page }) => {
+  await installMockBridge(page);
+});
+
+test("two consecutive Shift+Enter presses land the caret after both hard breaks", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.click();
+  await input.pressSequentially("first line");
+  await input.press("Shift+Enter");
+  await input.press("Shift+Enter");
+  await input.pressSequentially("third line");
+
+  const result = await input.evaluate((el) => {
+    // The composer wraps its content in a single <p> (StarterKit's
+    // paragraph node); descend into it so `lastChild` is the trailing text
+    // node after the hard breaks, not the outer contentEditable wrapper
+    // (whose own lastChild is that same <p>, with a textContent spanning
+    // the whole line).
+    const paragraph = el.querySelector("p") ?? el;
+    return {
+      breakCount: el.querySelectorAll("br").length,
+      lastTextContent: paragraph.lastChild?.textContent ?? paragraph.textContent,
+    };
+  });
+
+  // Exactly two hard breaks — no phantom extra break node left behind by
+  // the stock hard-break end-of-parent workaround.
+  expect(result.breakCount).toBe(2);
+  // The caret truly landed after both breaks: "third line" is the last
+  // text content, not swallowed into an earlier line.
+  expect(result.lastTextContent).toBe("third line");
+
+  await expect(input).toHaveText("first linethird line");
+});


### PR DESCRIPTION
…ne breaks

Stock Tiptap's hard-break command inserts a phantom node and jumps the selection there whenever a hard break lands at the very end of its parent (no node after it) -- a documented workaround so engines that won't otherwise reposition/repaint a caret past a trailing <br> still show it moving. Two consecutive Shift+Enter presses at end-of-line hit that workaround twice in a row, and in Buzz's Tauri WebView the first jump's caret glyph isn't reliably erased before the second jump paints its own, leaving a ghost caret rendered one line above the real one.

Schedule a paint-forcing nudge (toggle a transform + forced layout read, restored before the next task) on the composer's contentEditable element right before the default hard-break command runs, without touching the underlying transaction/selection logic StarterKit's hardBreak already handles (including the keepMarks mark-carrying behavior).

Adds a Playwright regression spec asserting the caret lands after both hard breaks (functional guard only -- the visual repaint fix needs manual verification on a real packaged Tauri build, since a headless Chromium run is unlikely to reproduce a Tauri-WebView-specific compositor paint artifact).

Closes #3219

## Summary
<!-- What does this change and why? -->

### Related issue
<!-- Fixes #1234, or N/A. Before opening: search existing issues/PRs for duplicates — link the closest one, or say "none found". -->

### Testing
<!-- How was this verified? UI change? Include before/after screenshots (or a short recording). -->
