### PR TITLE
fix(sdk): reject overlong pubkeys in add/remove member builders

### DIFF
--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -578,10 +578,10 @@ pub fn build_add_member(
     target_pubkey: &str,
     role: Option<MemberRole>,
 ) -> Result<EventBuilder, SdkError> {
-    check_hex_len(target_pubkey, 64, "target_pubkey")?;
+    let normalized = check_pubkey_hex(target_pubkey, "target_pubkey")?;
     let mut tags = vec![
         tag(&["h", &channel_id.to_string()])?,
-        tag(&["p", &target_pubkey.to_ascii_lowercase()])?,
+        tag(&["p", &normalized])?,
     ];
     if let Some(r) = role {
         tags.push(tag(&["role", r.as_str()])?);
@@ -594,10 +594,10 @@ pub fn build_remove_member(
     channel_id: Uuid,
     target_pubkey: &str,
 ) -> Result<EventBuilder, SdkError> {
-    check_hex_len(target_pubkey, 64, "target_pubkey")?;
+    let normalized = check_pubkey_hex(target_pubkey, "target_pubkey")?;
     let tags = vec![
         tag(&["h", &channel_id.to_string()])?,
-        tag(&["p", &target_pubkey.to_ascii_lowercase()])?,
+        tag(&["p", &normalized])?,
     ];
     Ok(EventBuilder::new(Kind::Custom(9001), "").tags(tags))
 }
@@ -4866,5 +4866,35 @@ mod tests {
 
         assert_eq!(accept_count, 11, "expected 11 accept cases");
         assert_eq!(reject_count, 20, "expected 20 reject cases");
+    }
+
+    #[test]
+    fn build_add_member_rejects_overlong_pubkey() {
+        let cid = uuid();
+        let overlong = "a".repeat(65);
+        assert!(matches!(
+            build_add_member(cid, &overlong, None),
+            Err(SdkError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn build_remove_member_rejects_overlong_pubkey() {
+        let cid = uuid();
+        let overlong = "a".repeat(65);
+        assert!(matches!(
+            build_remove_member(cid, &overlong),
+            Err(SdkError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn add_remove_member_lowercases_pubkey() {
+        let cid = uuid();
+        let upper = "A".repeat(64);
+        let ev = sign(build_add_member(cid, &upper, None).unwrap());
+        assert_eq!(tag_values(&ev, "p"), vec!["a".repeat(64)]);
+        let ev2 = sign(build_remove_member(cid, &upper).unwrap());
+        assert_eq!(tag_values(&ev2, "p"), vec!["a".repeat(64)]);
     }
 }


### PR DESCRIPTION
## Problem

`build_add_member` and `build_remove_member` validate `target_pubkey` with `check_hex_len(s, 64, ...)`. That helper is a **minimum**-length check:

```rust
fn check_hex_len(s: &str, min_len: usize, field: &str) -> Result<(), SdkError> {
    if s.len() < min_len || !s.chars().all(|c| c.is_ascii_hexdigit()) {
```

So a 65-or-more character hex string passes validation and is written straight into the `p` tag. Every other pubkey site in `builders.rs` uses `check_pubkey_hex`, which is the exact-length check (`s.len() != 64`) and returns the value lowercased. These two builders are the only ones that reached for the git-object helper instead.

`check_hex_len` also returns `SdkError::InvalidDiffMeta`, which is the wrong variant for a member operation — `check_pubkey_hex` returns `InvalidInput`.

## Change

Use the existing `check_pubkey_hex` in both builders and take the normalized value it already returns, replacing the separate `to_ascii_lowercase()` call at the tag site. No new helper, no behaviour change for valid 64-char input.

## Tests

Three tests in the existing `mod tests`:

- `build_add_member_rejects_overlong_pubkey` — a 65-char pubkey now returns `InvalidInput`; fails on `main`.
- `build_remove_member_rejects_overlong_pubkey` — same for remove.
- `add_remove_member_lowercases_pubkey` — an uppercase 64-char pubkey still lands lowercased in the `p` tag, so the normalization is not lost in the swap.

## Verification

```
cargo fmt --all -- --check              # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test -p buzz-sdk                  # 265 passed, 0 failed
```
