### PR TITLE
fix(cli): accept --format after a subcommand

### DIFF
--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -91,7 +91,7 @@ struct Cli {
     auth_tag: Option<String>,
 
     /// Output format: 'json' (default, full fields) or 'compact' (reduced fields).
-    #[arg(long, value_enum, default_value = "json")]
+    #[arg(long, value_enum, default_value = "json", global = true)]
     format: OutputFormat,
 
     #[command(subcommand)]
@@ -161,7 +161,7 @@ impl std::fmt::Display for PresenceStatus {
 }
 
 /// Output format for read commands.
-#[derive(Clone, clap::ValueEnum, Default)]
+#[derive(Clone, Debug, PartialEq, clap::ValueEnum, Default)]
 pub enum OutputFormat {
     /// Full normalized JSON (default)
     #[default]
@@ -2124,6 +2124,45 @@ mod tests {
     #[test]
     fn cli_definition_is_valid() {
         Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn format_after_subcommand_parses() {
+        let uuid = "123e4567-e89b-12d3-a456-426614174000";
+        let cli = Cli::try_parse_from([
+            "buzz",
+            "messages",
+            "get",
+            "--format",
+            "compact",
+            "--channel",
+            uuid,
+        ])
+        .unwrap();
+        assert_eq!(cli.format, OutputFormat::Compact);
+    }
+
+    #[test]
+    fn format_before_subcommand_parses() {
+        let uuid = "123e4567-e89b-12d3-a456-426614174000";
+        let cli = Cli::try_parse_from([
+            "buzz",
+            "--format",
+            "compact",
+            "messages",
+            "get",
+            "--channel",
+            uuid,
+        ])
+        .unwrap();
+        assert_eq!(cli.format, OutputFormat::Compact);
+    }
+
+    #[test]
+    fn format_defaults_to_json() {
+        let uuid = "123e4567-e89b-12d3-a456-426614174000";
+        let cli = Cli::try_parse_from(["buzz", "messages", "get", "--channel", uuid]).unwrap();
+        assert_eq!(cli.format, OutputFormat::Json);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Fixes #6391.

`--format` is declared on the top-level `Cli` struct without `global = true`, so clap only accepts it before the subcommand:

```
$ buzz --format compact messages get --channel <uuid>   # works
$ buzz messages get --format compact --channel <uuid>   # error: unexpected argument '--format'
```

The second form is what people actually type, and it is how every other CLI treats an output-format flag.

## Change

One line: add `global = true` to the `format` arg. `OutputFormat` also gains `Debug` and `PartialEq` so the tests can assert on it.

## Tests

Three tests in the existing `mod tests`, all driving the real `Cli` parser via `Cli::try_parse_from`, not a synthetic command:

- `format_after_subcommand_parses` — the previously broken form; fails on `main` with an unexpected-argument error.
- `format_before_subcommand_parses` — the form that already worked, so the fix does not trade one position for the other.
- `format_defaults_to_json` — the default survives.

Deletion probe: removing `global = true` makes `format_after_subcommand_parses` fail.

## Verification

```
cargo fmt --all -- --check                              # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test -p buzz-cli                                  # 366 passed, 0 failed
```
