### PR TITLE
fix(acp): log inbound author-gate drops at info, with event id and kind

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2868,9 +2868,20 @@ async fn tokio_main() -> Result<()> {
                                 )
                                 .await;
                                 if !allowed {
-                                    tracing::debug!(
+                                    // info!, deliberately: this drop is the only
+                                    // signal that an event addressed to this agent
+                                    // was rejected. At debug level a fleet running
+                                    // at info sees nothing — a mis-scoped
+                                    // `respond_to`, a workflow message signed by an
+                                    // unexpected key, or a revoked sibling all
+                                    // present as the agent silently ignoring a
+                                    // mention, indistinguishable from a stall
+                                    // until someone attaches a debugger.
+                                    tracing::info!(
                                         channel_id = %buzz_event.channel_id,
                                         author = %buzz_event.event.pubkey.to_hex(),
+                                        event_id = %buzz_event.event.id.to_hex(),
+                                        kind = buzz_event.event.kind.as_u16(),
                                         mode = %config.respond_to,
                                         is_dm,
                                         "inbound author gate — dropping event"


### PR DESCRIPTION
## Problem

When `author_allowed` rejects an inbound event, the drop logs at `debug` — so a deployment running at the default `info` level sees nothing at all. The gate is the only place this rejection is observable: there is no sender feedback and no counter. In practice that means a mis-scoped `respond_to`, a workflow message signed by an unexpected key (see the #6129/#6311 history — the silent death of workflow wake-ups at this exact gate is what made that bug take days to find), or a revoked sibling all present identically: the agent appears to ignore a mention, indistinguishable from a stalled session.

Running agent fleets against a Buzz relay, we have paid this invisibility tax twice — both diagnoses required reproducing the drop under a debug build, and both would have been a single grep at info.

## Change

Promote the drop line to `info` and add `event_id` and `kind` to the structured fields, so one log line identifies which event died at the gate and under which mode. A comment at the site records why info is the deliberate level.

Volume note: drops here fire on configuration mismatches, not message floods — the line is rare in a healthy deployment. Filtering a targeted line down is trivial for anyone who disagrees; reconstructing an invisible drop is not.

## Validation

`cargo check -p buzz-acp` clean on current `main`; the change is a log statement only, no behavior change.