### PR TITLE
fix(desktop): accept just-now channel activity in tooltip spec

### DIFF
--- a/desktop/tests/e2e/tooltip-semantics.spec.ts
+++ b/desktop/tests/e2e/tooltip-semantics.spec.ts
@@ -142,7 +142,7 @@ for (const theme of THEMES) {
     await expect(row).toBeVisible();
     await expectMutedSupportingText(
       row.getByRole("button", { name: "Open channel general" }),
-      /Public channel · Active \d+[mhdw] ago/,
+      /Public channel · Active (just now|\d+[mhdw] ago)/,
     );
     await page.mouse.move(0, 0);
     await expectMutedSupportingText(


### PR DESCRIPTION
Desktop Smoke E2E shard 4 has been red on main since `de8a2741c` (#6252): the channel-link tooltip expectation only allows `Active Nm ago`, but the spec sends a message to #general immediately before hovering, so the footer deterministically renders `Active just now` (fails 3/3 retries, both themes — e.g. [main run](https://github.com/block/buzz/actions/runs/32443163358)).

#6252's sibling message-link assertion already allows the `just now` bucket; this aligns the channel one:

```
/Public channel · Active (just now|\d+[mhdw] ago)/
```