### PR TITLE
fix(cli): report channels list last-write as updated_at, keep created_at as deprecated alias

### DIFF
--- a/crates/buzz-cli/src/commands/channels.rs
+++ b/crates/buzz-cli/src/commands/channels.rs
@@ -1197,6 +1197,7 @@ pub async fn dispatch_canvas(cmd: crate::CanvasCmd, client: &BuzzClient) -> Resu
 mod tests {
     use super::{
         apply_cardinality_rule, build_template_report, cmd_set_add_policy,
+        extract_channel_metadata,
         finalize_roster_resolution, name_matches, resolve_roster_with_archive_filter,
         validate_ttl_seconds, validate_update_channel_fields, ArchivedExclusion, ChannelSummary,
         ResolvedAgent, RosterResolution, SkippedSlug,
@@ -1746,5 +1747,52 @@ mod tests {
             report.get("archive_state_warning").is_none(),
             "no warning key expected: {report}"
         );
+    }
+}
+
+#[cfg(test)]
+mod extract_channel_metadata_tests {
+    use super::extract_channel_metadata;
+    use serde_json::json;
+
+    #[test]
+    fn updated_at_carries_kind_39000_created_at() {
+        let ev = json!({
+            "kind": 39000,
+            "created_at": 1787300000u64,
+            "tags": [
+                ["d", "11111111-1111-1111-1111-111111111111"],
+                ["name", "general"],
+                ["about", "desc"]
+            ]
+        });
+        let meta = extract_channel_metadata(&ev);
+        assert_eq!(meta.get("updated_at"), Some(&json!(1787300000u64)));
+    }
+
+    #[test]
+    fn created_at_is_deprecated_alias_of_updated_at() {
+        let ev = json!({
+            "kind": 39000,
+            "created_at": 1787300000u64,
+            "tags": [["d", "11111111-1111-1111-1111-111111111111"]]
+        });
+        let meta = extract_channel_metadata(&ev);
+        assert_eq!(
+            meta.get("created_at"),
+            meta.get("updated_at"),
+            "created_at must stay pinned to updated_at until removal"
+        );
+    }
+
+    #[test]
+    fn missing_created_at_yields_zero_for_both_fields() {
+        let ev = json!({
+            "kind": 39000,
+            "tags": [["d", "11111111-1111-1111-1111-111111111111"]]
+        });
+        let meta = extract_channel_metadata(&ev);
+        assert_eq!(meta.get("updated_at"), Some(&json!(0u64)));
+        assert_eq!(meta.get("created_at"), Some(&json!(0u64)));
     }
 }

--- a/crates/buzz-cli/src/commands/channels.rs
+++ b/crates/buzz-cli/src/commands/channels.rs
@@ -13,12 +13,22 @@ use crate::commands::channel_templates::{self, ChannelTemplateRecord, TemplateAg
 use crate::error::CliError;
 use crate::validate::{parse_uuid, read_or_stdin, validate_hex64, validate_uuid};
 
+/// Extracts the channel summary fields from a kind 39000 channel-metadata event.
+///
+/// The timestamp carried here is the time of the **last channel-metadata write**,
+/// not the channel's creation: kind 39000 is addressable/replaceable, so its
+/// `created_at` is overwritten on every metadata update and the channel's birth
+/// time is not recoverable from it. `updated_at` names this value honestly;
+/// `created_at` is a deprecated alias kept for one release so existing scripts
+/// do not break silently — prefer `updated_at`.
 fn extract_channel_metadata(e: &serde_json::Value) -> serde_json::Value {
+    let updated_at = e.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0);
     serde_json::json!({
         "channel_id": extract_d_tag(e),
         "name": extract_tag_value(e, "name"),
         "description": extract_tag_value(e, "about"),
-        "created_at": e.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0),
+        "updated_at": updated_at,
+        "created_at": updated_at,
     })
 }
 
@@ -1197,7 +1207,6 @@ pub async fn dispatch_canvas(cmd: crate::CanvasCmd, client: &BuzzClient) -> Resu
 mod tests {
     use super::{
         apply_cardinality_rule, build_template_report, cmd_set_add_policy,
-        extract_channel_metadata,
         finalize_roster_resolution, name_matches, resolve_roster_with_archive_filter,
         validate_ttl_seconds, validate_update_channel_fields, ArchivedExclusion, ChannelSummary,
         ResolvedAgent, RosterResolution, SkippedSlug,

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -533,6 +533,10 @@ pub enum MessagesCmd {
 #[derive(Subcommand)]
 pub enum ChannelsCmd {
     /// List channels visible to the current identity
+    ///
+    /// Each channel's `updated_at` is the time of its last channel-metadata
+    /// write (kind 39000 is replaceable), not its creation time. `created_at`
+    /// is a deprecated alias of `updated_at`.
     #[command(
         after_help = "Examples:\n  buzz channels list\n  buzz channels list --visibility open"
     )]


### PR DESCRIPTION
Fixes #6390.

## Problem

`buzz channels list` (and `channels get`) reports the kind 39000 channel-metadata event's `created_at` as the channel's `created_at`. Kind 39000 is addressable/replaceable, so that timestamp is overwritten on every metadata update. The field therefore reports the **last metadata write**, not the channel's creation. The channel's birth time is not recoverable from a replaceable event, so it cannot be fixed by finding a better source.

## Change

Name the field honestly instead of guessing a birth time:

- Add `updated_at`, carrying the same value under an accurate name.
- Keep `created_at` as a deprecated alias of `updated_at` for one release so existing scripts do not break silently.
- Document the semantics on `extract_channel_metadata` and in `buzz channels list --help`.

Both call sites (`channels list` at `channels.rs:103`, `channels get` at `:248`) go through `extract_channel_metadata`, so the change lands in one place by construction.

Removing `created_at` outright is out of scope for this PR — that is the follow-up once the deprecation window closes.

## Tests

Three tests were written first and watched fail, then the fix was applied (two commits, tests before fix):

- `updated_at_carries_kind_39000_created_at`
- `created_at_is_deprecated_alias_of_updated_at`
- `missing_created_at_yields_zero_for_both_fields`

All three call the real `extract_channel_metadata` the binary uses.

Deletion probes (both keep the code compiling and produce real failures):

- Remove the `updated_at` line → 3 failed.
- Remove the `created_at` alias line → 2 failed.

## Gates

At `f7ac2b5d0`, clean tree:

- `./scripts/run-tests.sh unit` (the `just test-unit` path when `cargo-nextest` is absent) → all 9 packages pass, 107s.
- `cargo clippy --workspace --all-targets -- -D warnings` → clean.
- `cargo fmt --all -- --check` → clean.

`just test-integration` / `just ci` need Docker and were not run.