### PR TITLE
fix(cli): use NIP-09 for self-deletes

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -121,6 +121,55 @@ async fn resolve_channel_id(client: &BuzzClient, event_id: &str) -> Result<Uuid,
     channel_id_from_event(event_id, &event)
 }
 
+fn normalized_event_pubkey(event: &serde_json::Value) -> Option<String> {
+    event
+        .get("pubkey")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|pubkey| PublicKey::from_hex(pubkey).ok())
+        .map(|pubkey| pubkey.to_hex())
+}
+
+fn effective_target_author(event: &serde_json::Value, relay_self: &str) -> Option<String> {
+    let signer = normalized_event_pubkey(event)?;
+    if signer != relay_self {
+        return Some(signer);
+    }
+
+    for tag_name in ["actor", "p"] {
+        let attributed = event
+            .get("tags")
+            .and_then(serde_json::Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(serde_json::Value::as_array)
+            .find(|tag| tag.first().and_then(serde_json::Value::as_str) == Some(tag_name))
+            .and_then(|tag| tag.get(1))
+            .and_then(serde_json::Value::as_str)
+            .and_then(|pubkey| PublicKey::from_hex(pubkey).ok())
+            .map(|pubkey| pubkey.to_hex());
+        if attributed.is_some() {
+            return attributed;
+        }
+    }
+
+    Some(signer)
+}
+
+async fn relay_self_pubkey(client: &BuzzClient) -> Result<String, CliError> {
+    let raw = client
+        .get_public("/")
+        .await
+        .map_err(|error| CliError::Other(format!("failed to fetch relay info: {error}")))?;
+    let document: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|error| CliError::Other(format!("invalid relay info document: {error}")))?;
+    document
+        .get("self")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|pubkey| PublicKey::from_hex(pubkey).ok())
+        .map(|pubkey| pubkey.to_hex())
+        .ok_or_else(|| CliError::Other("relay info document missing valid 'self' pubkey".into()))
+}
+
 fn resolve_names_to_pubkeys(
     names: &[String],
     name_to_pubkeys: &std::collections::HashMap<String, Vec<String>>,
@@ -831,10 +880,21 @@ pub async fn cmd_delete_message(
     let target_event = fetch_event(client, event_id).await?;
     let channel_uuid = channel_id_from_event(event_id, &target_event)?;
     let target_eid = parse_event_id(event_id)?;
-    let is_self_authored = target_event
-        .get("pubkey")
-        .and_then(serde_json::Value::as_str)
-        .is_some_and(|pubkey| pubkey.eq_ignore_ascii_case(&client.keys().public_key().to_hex()));
+    let signer = client.keys().public_key().to_hex();
+    let target_signer = normalized_event_pubkey(&target_event)
+        .ok_or_else(|| CliError::Other("target event missing valid 'pubkey'".into()))?;
+    let target_author = if target_signer == signer {
+        target_signer
+    } else {
+        // If relay identity is unavailable, retain the existing audited
+        // moderation path instead of making deletes depend on NIP-11 uptime.
+        relay_self_pubkey(client)
+            .await
+            .ok()
+            .and_then(|relay_self| effective_target_author(&target_event, &relay_self))
+            .unwrap_or(target_signer)
+    };
+    let is_self_authored = target_author == signer;
 
     let builder = build_cli_delete_message(
         channel_uuid,
@@ -1083,11 +1143,11 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_cli_delete_message, channel_id_from_event, cmd_get_thread, event_mention_pubkeys,
-        find_root_from_tags, match_profiles_by_name, merge_message_mentions, missing_members,
-        normalize_explicit_mentions, parse_member_pubkeys, resolve_names_to_pubkeys,
-        resolve_thread_target, thread_ref_from_event, thread_ref_from_parent_tags, BuzzClient,
-        CliError, Uuid,
+        build_cli_delete_message, channel_id_from_event, cmd_get_thread, effective_target_author,
+        event_mention_pubkeys, find_root_from_tags, match_profiles_by_name, merge_message_mentions,
+        missing_members, normalize_explicit_mentions, parse_member_pubkeys,
+        resolve_names_to_pubkeys, resolve_thread_target, thread_ref_from_event,
+        thread_ref_from_parent_tags, BuzzClient, CliError, Uuid,
     };
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
@@ -1155,6 +1215,27 @@ mod tests {
         let event = builder.sign_with_keys(&Keys::generate()).unwrap();
 
         assert_eq!(event.kind.as_u16(), 9005);
+    }
+
+    #[test]
+    fn relay_signed_target_uses_trusted_effective_author() {
+        let event = json!({
+            "pubkey": PK_VALID_A,
+            "tags": [
+                ["actor", PK_VALID_B],
+                ["p", PK_VALID_C],
+            ],
+        });
+
+        assert_eq!(
+            effective_target_author(&event, PK_VALID_A).as_deref(),
+            Some(PK_VALID_B),
+        );
+        assert_eq!(
+            effective_target_author(&event, PK_VALID_C).as_deref(),
+            Some(PK_VALID_A),
+            "attribution tags on a non-relay signer must be ignored",
+        );
     }
 
     #[tokio::test]

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -826,13 +826,20 @@ pub async fn cmd_delete_message(
 ) -> Result<(), CliError> {
     validate_hex64(event_id)?;
 
-    // Resolve channel_id from the event's h-tag
-    let channel_uuid = resolve_channel_id(client, event_id).await?;
+    // Resolve the target once so self-delete and moderation routing use the
+    // same event snapshot.
+    let target_event = fetch_event(client, event_id).await?;
+    let channel_uuid = channel_id_from_event(event_id, &target_event)?;
     let target_eid = parse_event_id(event_id)?;
+    let is_self_authored = target_event
+        .get("pubkey")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|pubkey| pubkey.eq_ignore_ascii_case(&client.keys().public_key().to_hex()));
 
     let builder = build_cli_delete_message(
         channel_uuid,
         target_eid,
+        is_self_authored,
         DeleteMessageOptions {
             action_id,
             reason_code,
@@ -851,12 +858,14 @@ pub async fn cmd_delete_message(
 fn build_cli_delete_message(
     channel_id: Uuid,
     target_event_id: nostr::EventId,
+    is_self_authored: bool,
     options: DeleteMessageOptions<'_>,
 ) -> Result<nostr::EventBuilder, buzz_sdk::SdkError> {
-    // Keep ordinary agent/member deletes aligned with Desktop's NIP-09 path.
-    // Any moderation metadata is an explicit opt-in to the audited kind:9005
-    // command and its visible room-facing tombstone.
-    if options.action_id.is_none()
+    // Keep proven self-deletes aligned with Desktop's NIP-09 path. Foreign
+    // targets and any moderation metadata retain the audited kind:9005 command
+    // and its visible room-facing tombstone.
+    if is_self_authored
+        && options.action_id.is_none()
         && options.reason_code.is_none()
         && options.public_reason.is_none()
     {
@@ -1101,6 +1110,7 @@ mod tests {
         let builder = build_cli_delete_message(
             Uuid::nil(),
             nostr::EventId::all_zeros(),
+            true,
             buzz_sdk::DeleteMessageOptions::default(),
         )
         .unwrap();
@@ -1114,6 +1124,7 @@ mod tests {
         let builder = build_cli_delete_message(
             Uuid::nil(),
             nostr::EventId::all_zeros(),
+            true,
             buzz_sdk::DeleteMessageOptions {
                 action_id: Some(Uuid::nil()),
                 reason_code: Some("spam"),
@@ -1130,6 +1141,20 @@ mod tests {
                 .iter()
                 .any(|tag| tag.kind().to_string() == tag_name));
         }
+    }
+
+    #[test]
+    fn foreign_plain_delete_keeps_moderation_kind() {
+        let builder = build_cli_delete_message(
+            Uuid::nil(),
+            nostr::EventId::all_zeros(),
+            false,
+            buzz_sdk::DeleteMessageOptions::default(),
+        )
+        .unwrap();
+        let event = builder.sign_with_keys(&Keys::generate()).unwrap();
+
+        assert_eq!(event.kind.as_u16(), 9005);
     }
 
     #[tokio::test]

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -830,7 +830,7 @@ pub async fn cmd_delete_message(
     let channel_uuid = resolve_channel_id(client, event_id).await?;
     let target_eid = parse_event_id(event_id)?;
 
-    let builder = buzz_sdk::build_delete_message_with_options(
+    let builder = build_cli_delete_message(
         channel_uuid,
         target_eid,
         DeleteMessageOptions {
@@ -846,6 +846,24 @@ pub async fn cmd_delete_message(
     let resp = client.submit_event(event).await?;
     println!("{}", normalize_write_response(&resp));
     Ok(())
+}
+
+fn build_cli_delete_message(
+    channel_id: Uuid,
+    target_event_id: nostr::EventId,
+    options: DeleteMessageOptions<'_>,
+) -> Result<nostr::EventBuilder, buzz_sdk::SdkError> {
+    // Keep ordinary agent/member deletes aligned with Desktop's NIP-09 path.
+    // Any moderation metadata is an explicit opt-in to the audited kind:9005
+    // command and its visible room-facing tombstone.
+    if options.action_id.is_none()
+        && options.reason_code.is_none()
+        && options.public_reason.is_none()
+    {
+        buzz_sdk::build_delete_compat(channel_id, target_event_id)
+    } else {
+        buzz_sdk::build_delete_message_with_options(channel_id, target_event_id, options)
+    }
 }
 
 /// Edit a message you previously sent.
@@ -1056,8 +1074,8 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::{
-        channel_id_from_event, cmd_get_thread, event_mention_pubkeys, find_root_from_tags,
-        match_profiles_by_name, merge_message_mentions, missing_members,
+        build_cli_delete_message, channel_id_from_event, cmd_get_thread, event_mention_pubkeys,
+        find_root_from_tags, match_profiles_by_name, merge_message_mentions, missing_members,
         normalize_explicit_mentions, parse_member_pubkeys, resolve_names_to_pubkeys,
         resolve_thread_target, thread_ref_from_event, thread_ref_from_parent_tags, BuzzClient,
         CliError, Uuid,
@@ -1077,6 +1095,42 @@ mod tests {
     const PK_VALID_A: &str = "35c18ae273fccfaf80d629e20e7f8721b90499379addff533054acc2504c12b4";
     const PK_VALID_B: &str = "c6237ef84fa537c78dcee78efd2d4e59f728859c7f194da42ac51ededfa0be05";
     const PK_VALID_C: &str = "f4a42a97e594b77bdbd8ee35191c8b28a94a4cb871d96f32921558275421fb68";
+
+    #[test]
+    fn plain_cli_delete_uses_nip09_self_delete() {
+        let builder = build_cli_delete_message(
+            Uuid::nil(),
+            nostr::EventId::all_zeros(),
+            buzz_sdk::DeleteMessageOptions::default(),
+        )
+        .unwrap();
+        let event = builder.sign_with_keys(&Keys::generate()).unwrap();
+
+        assert_eq!(event.kind.as_u16(), 5);
+    }
+
+    #[test]
+    fn delete_with_moderation_metadata_keeps_audited_kind() {
+        let builder = build_cli_delete_message(
+            Uuid::nil(),
+            nostr::EventId::all_zeros(),
+            buzz_sdk::DeleteMessageOptions {
+                action_id: Some(Uuid::nil()),
+                reason_code: Some("spam"),
+                public_reason: Some("Removed as spam"),
+            },
+        )
+        .unwrap();
+        let event = builder.sign_with_keys(&Keys::generate()).unwrap();
+
+        assert_eq!(event.kind.as_u16(), 9005);
+        for tag_name in ["action_id", "reason_code", "public_reason"] {
+            assert!(event
+                .tags
+                .iter()
+                .any(|tag| tag.kind().to_string() == tag_name));
+        }
+    }
 
     #[tokio::test]
     async fn malformed_channel_is_rejected_before_thread_fetch() {

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -444,7 +444,10 @@ pub enum MessagesCmd {
         #[arg(long)]
         content: String,
     },
-    /// Delete a message by event ID
+    /// Delete a message by event ID.
+    ///
+    /// Plain deletes are NIP-09 self-deletes. Supplying moderation metadata
+    /// uses Buzz's audited moderation delete path instead.
     Delete {
         /// Event ID to delete (64-char hex)
         #[arg(long)]

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -446,8 +446,8 @@ pub enum MessagesCmd {
     },
     /// Delete a message by event ID.
     ///
-    /// Plain deletes are NIP-09 self-deletes. Supplying moderation metadata
-    /// uses Buzz's audited moderation delete path instead.
+    /// Self-authored targets use NIP-09. Foreign targets or supplied moderation
+    /// metadata use Buzz's audited moderation delete path instead.
     Delete {
         /// Event ID to delete (64-char hex)
         #[arg(long)]


### PR DESCRIPTION
## Summary

This fixes a CLI/Desktop inconsistency in message deletion. `buzz messages delete` now publishes a NIP-09 kind 5 event for a plain self-delete, matching Buzz Desktop and avoiding the visible kind 40099 moderation tombstone. Foreign targets and deletes carrying moderation metadata continue through kind 9005 so the relay preserves its moderation audit behavior.

Relay-signed messages use their trusted `actor` or `p` attribution only when the signer matches the relay identity advertised by NIP-11. If relay identity cannot be verified, the CLI falls back to the audited moderation path.

Existing plain kind 40099 tombstones remain visible. Their payloads do not prove that the deleted target was self-authored, so hiding them client-side could suppress legitimate moderation markers. Client-side hiding would not delete relay history.

### Related issue

None found.

### Testing

- Added focused coverage proving plain self-deletes emit kind 5 while foreign targets and moderation metadata retain kind 9005.
- Added coverage for trusted relay attribution and rejection of attribution tags from non-relay signers.
- Validated the exact commit on Blox with all 367 `buzz-cli` tests, strict clippy, formatting, and the repository file-size gate.

No existing Buzz messages were deleted or mutated during verification.
