### PR TITLE
fix(acp): name the command in agent spawn errors and flag PATH absence

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -82,6 +82,12 @@ pub enum AcpError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
+    #[error("failed to spawn agent command: {source}")]
+    Spawn {
+        command: String,
+        source: std::io::Error,
+    },
+
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
 
@@ -534,7 +540,10 @@ impl AcpClient {
                 "codex" | "codex-acp" => Some(StandardAdapterKind::Codex),
                 _ => None,
             };
-        let mut child = cmd.spawn()?;
+        let mut child = cmd.spawn().map_err(|source| AcpError::Spawn {
+            command: command.to_string(),
+            source,
+        })?;
 
         let stdin = child
             .stdin
@@ -5026,5 +5035,73 @@ mod tests {
             msg.contains("sandbox_workspace_write"),
             "error must mention sandbox_workspace_write"
         );
+    }
+}
+
+#[cfg(test)]
+mod spawn_error_tests {
+    use super::{AcpClient, AcpError};
+
+    const MISSING_BINARY: &str = "buzz-acp-nonexistent-binary-6473";
+
+    // #6473: a failed spawn must name the command and, when the binary is
+    // simply absent, say so in PATH terms an operator recognises.
+    #[tokio::test]
+    async fn spawn_error_names_missing_command_and_says_not_on_path() {
+        let err = AcpClient::spawn(MISSING_BINARY, &[], &[], false)
+            .await
+            .err()
+            .expect("spawn of a nonexistent binary must fail");
+        match &err {
+            AcpError::Spawn { command, .. } => {
+                assert_eq!(command, MISSING_BINARY);
+            }
+            other => panic!("expected AcpError::Spawn, got {other}"),
+        }
+        let msg = err.to_string();
+        assert!(
+            msg.contains(MISSING_BINARY),
+            "message must contain the command name, got: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("not found") && msg.to_lowercase().contains("path"),
+            "message must identify the binary as not found on PATH, got: {msg}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_error_names_command_on_non_notfound_failure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // A path that exists but is not executable: io::ErrorKind::PermissionDenied.
+        let dir = std::env::temp_dir().join(format!(
+            "buzz-acp-notexec-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let path = dir.join("not-executable-script");
+        std::fs::write(&path, "#!/usr/bin/env bash\necho hi\n").expect("write file");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("set permissions");
+
+        let err = AcpClient::spawn(path.to_str().expect("utf8 path"), &[], &[], false)
+            .await
+            .err()
+            .expect("spawn of a non-executable file must fail");
+        match &err {
+            AcpError::Spawn { command, .. } => {
+                assert_eq!(command, path.to_str().expect("utf8 path"));
+            }
+            other => panic!("expected AcpError::Spawn, got {other}"),
+        }
+        let msg = err.to_string();
+        assert!(
+            msg.contains(path.to_str().expect("utf8 path")),
+            "non-NotFound spawn failures must also name the command, got: {msg}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -82,10 +82,13 @@ pub enum AcpError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
-    #[error("failed to spawn agent command: {source}")]
+    #[error("failed to spawn agent command {command:?}: {source}{missing}")]
     Spawn {
         command: String,
         source: std::io::Error,
+        /// Set when `source` is NotFound, so operators read "not found on
+        /// PATH" instead of a bare errno that reads like a missing directory.
+        missing: String,
     },
 
     #[error("JSON error: {0}")]
@@ -540,9 +543,19 @@ impl AcpClient {
                 "codex" | "codex-acp" => Some(StandardAdapterKind::Codex),
                 _ => None,
             };
-        let mut child = cmd.spawn().map_err(|source| AcpError::Spawn {
-            command: command.to_string(),
-            source,
+        let mut child = cmd.spawn().map_err(|source| {
+            // #6473: "No such file or directory" alone reads like a missing
+            // working directory; name the command and say PATH explicitly.
+            let missing = if source.kind() == std::io::ErrorKind::NotFound {
+                " — binary not found on PATH".to_string()
+            } else {
+                String::new()
+            };
+            AcpError::Spawn {
+                command: command.to_string(),
+                source,
+                missing,
+            }
         })?;
 
         let stdin = child


### PR DESCRIPTION
Fixes #6473.

When `buzz-acp` fails to launch an agent, the error surfaced as a bare
`IO error: No such file or directory (os error 2)`. That reads like a missing
working directory, so operators look in the wrong place. The command name is
never printed, and neither is the fact that the binary was not on `PATH`.

## Change

`AcpClient::spawn` now maps the `Command::spawn` failure into a new
`AcpError::Spawn { command, source, missing }` variant instead of letting it
fall through to the blanket `#[from] std::io::Error` arm. The message names the
command, and when the underlying kind is `NotFound` it appends
`— binary not found on PATH`.

Before:

```
IO error: No such file or directory (os error 2)
```

After:

```
failed to spawn agent command "claude-code-acp": No such file or directory (os error 2) — binary not found on PATH
```

Non-`NotFound` failures (e.g. a file that exists but is not executable) keep the
plain `source` text but still name the command.

## Tests

Two tests in `crates/buzz-acp/src/acp.rs`, added in a commit that precedes the
fix. Both drive the real `AcpClient::spawn`, not a synthetic error value:

- `spawn_error_names_missing_command_and_says_not_on_path` — spawns a binary
  name that does not exist and asserts the variant, the command name, and the
  `not found` / `path` wording.
- `spawn_error_names_command_on_non_notfound_failure` (unix) — writes a `0644`
  file and spawns it, producing `PermissionDenied`, and asserts the command is
  still named.

Deletion probes, both compiling and both failing:

- Force `missing` to `String::new()` → the `NotFound` test fails on the PATH
  assertion (1 passed, 1 failed).
- Revert `cmd.spawn().map_err(...)` back to `cmd.spawn()?` → both tests fail on
  the `AcpError::Spawn` match (0 passed, 2 failed).

## Verification

Run in a detached worktree pinned at the branch head, clean tree before and
after:

```
cargo fmt --all -- --check                        exit 0
cargo clippy --workspace --all-targets -- -D warnings   exit 0
./scripts/run-tests.sh unit                       All tests passed
cargo test -p buzz-acp                            805 passed; 0 failed
```

Note for maintainers: `scripts/run-tests.sh unit` does not include `buzz-acp`,
so `cargo test -p buzz-acp` was run separately. Two pre-existing tests in
`crates/buzz-acp/src/config.rs` (`lazy_pool_defaults_off`,
`idle_pool_sleep_defaults_disabled_and_accepts_cli_value`) fail if
`BUZZ_ACP_LAZY_POOL` / `BUZZ_ACP_IDLE_POOL_SLEEP` are exported in the shell,
because they assert parser defaults while `clap` reads the env. Unrelated to
this change, but it may be worth clearing those vars inside the tests.

## Out of scope

Error text for any other spawn site, and the `desktop` surfacing of this error.
