### PR TITLE
Polish mobile channel navigation and message sends

### DIFF
--- a/mobile/lib/features/channels/channel_actions_sheet.dart
+++ b/mobile/lib/features/channels/channel_actions_sheet.dart
@@ -16,6 +16,8 @@ import '../../shared/widgets/buzz_action_tile.dart';
 import '../../shared/widgets/buzz_loading_indicator.dart';
 import '../../shared/widgets/frosted_app_bar.dart';
 import '../../shared/widgets/frosted_scaffold.dart';
+import '../../shared/widgets/ios_glass_navigation_button.dart';
+import '../../shared/widgets/lucide_star_icon.dart';
 import '../../shared/widgets/modal_presentation.dart';
 import '../../shared/widgets/sheet_divider.dart';
 import 'channel.dart';

--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -48,6 +48,8 @@ import 'ephemeral_channel_display.dart';
 import 'ime_metrics_settle_observer.dart';
 import 'jump_to_latest_button.dart';
 import 'jump_to_latest_switcher.dart';
+import 'local_message_send_animation_provider.dart';
+import 'local_message_send_transition.dart';
 import 'members_sheet.dart';
 import 'message_actions.dart';
 import 'message_action_backdrop_state.dart';

--- a/mobile/lib/features/channels/channel_detail_page/message_list.dart
+++ b/mobile/lib/features/channels/channel_detail_page/message_list.dart
@@ -69,9 +69,11 @@ class _MessageList extends HookConsumerWidget {
     );
     final isAutoScrolling = useRef(false);
     final latestNavigationRequest = useState(0);
+    final latestNavigationTargetId = useRef<String?>(null);
     final latestRealignmentQueued = useRef(false);
     final latestEntryId = entries.isEmpty ? null : entries.last.message.id;
     final previousLatestEntryId = useRef<String?>(null);
+    final observedLocalSendIds = useRef(localSendAnimations.keys.toSet());
     final didOpenInitialThread = useRef(false);
     final didJumpToInitialMessage = useRef(false);
     final isUnreadNavigationDismissed = useState(false);
@@ -341,14 +343,16 @@ class _MessageList extends HookConsumerWidget {
         return;
       }
       try {
+        final targetIndex =
+            reversedIndexOf(latestNavigationTargetId.value) ?? 0;
         await itemScrollController.scrollTo(
-          index: 0,
+          index: targetIndex,
           alignment: latestAlignment(),
           duration: jumpToLatestScrollDuration,
           curve: jumpToLatestScrollCurve,
         );
         if (context.mounted && !hasUserScrolled.value) {
-          isAtLatest.value = true;
+          isAtLatest.value = targetIndex == 0;
           isJumpToLatestVisible.value = false;
         }
       } finally {
@@ -356,12 +360,13 @@ class _MessageList extends HookConsumerWidget {
       }
     }
 
-    void scrollToLatest() {
+    void scrollToLatest({String? targetMessageId}) {
       if (!itemScrollController.isAttached || isAutoScrolling.value) return;
       isAutoScrolling.value = true;
       followsLatest.value = true;
       hasUserScrolled.value = false;
       hasUnseenLatestEntry.value = false;
+      latestNavigationTargetId.value = targetMessageId;
       latestNavigationRequest.value += 1;
     }
 
@@ -620,16 +625,26 @@ class _MessageList extends HookConsumerWidget {
     useEffect(() {
       final previous = previousLatestEntryId.value;
       previousLatestEntryId.value = latestEntryId;
-      if (previous == null ||
-          latestEntryId == null ||
-          previous == latestEntryId) {
+      final entryIds = entries.map((entry) => entry.message.id).toSet();
+      final newlyInsertedLocalSendIds = localSendAnimations.keys
+          .where(
+            (eventId) =>
+                !observedLocalSendIds.value.contains(eventId) &&
+                entryIds.contains(eventId),
+          )
+          .toList();
+      observedLocalSendIds.value
+        ..removeWhere((eventId) => !localSendAnimations.containsKey(eventId))
+        ..addAll(newlyInsertedLocalSendIds);
+      final localSendId = newlyInsertedLocalSendIds.firstOrNull;
+      final latestEntryChanged =
+          previous != null &&
+          latestEntryId != null &&
+          previous != latestEntryId;
+      if (!latestEntryChanged && localSendId == null) {
         return null;
       }
-      final isLocalSend = isRecentLocalMessageSendAnimation(
-        localSendAnimations,
-        latestEntryId,
-      );
-      if (isLocalSend) {
+      if (localSendId != null) {
         followsLatest.value = true;
         hasUserScrolled.value = false;
       }
@@ -639,7 +654,7 @@ class _MessageList extends HookConsumerWidget {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!context.mounted) return;
         if (followsLatest.value && !hasUserScrolled.value) {
-          scrollToLatest();
+          scrollToLatest(targetMessageId: localSendId);
           return;
         }
         final positions = itemPositionsListener.itemPositions.value;

--- a/mobile/lib/features/channels/channel_detail_page/message_list.dart
+++ b/mobile/lib/features/channels/channel_detail_page/message_list.dart
@@ -42,6 +42,9 @@ class _MessageList extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final appView = View.of(context);
+    final localSendAnimations = ref.watch(
+      localMessageSendAnimationProvider(channelId),
+    );
     final displayEntries = groupMembershipTimelineEntries(entries);
     final itemScrollController = useMemoized(ItemScrollController.new);
     final itemPositionsListener = useMemoized(ItemPositionsListener.create);
@@ -622,6 +625,14 @@ class _MessageList extends HookConsumerWidget {
           previous == latestEntryId) {
         return null;
       }
+      final isLocalSend = isRecentLocalMessageSendAnimation(
+        localSendAnimations,
+        latestEntryId,
+      );
+      if (isLocalSend) {
+        followsLatest.value = true;
+        hasUserScrolled.value = false;
+      }
       if (!followsLatest.value || hasUserScrolled.value) {
         hasUnseenLatestEntry.value = true;
       }
@@ -640,7 +651,7 @@ class _MessageList extends HookConsumerWidget {
         }
       });
       return null;
-    }, [latestEntryId]);
+    }, [latestEntryId, localSendAnimations]);
 
     if (entries.isEmpty) {
       return Center(
@@ -781,57 +792,67 @@ class _MessageList extends HookConsumerWidget {
                             message.pubkey.toLowerCase() ||
                         (message.createdAt - prevMessage.createdAt) > 300);
 
-                return Padding(
-                  key: ValueKey('channel-message-group-${message.id}'),
-                  padding: EdgeInsets.only(bottom: index == 0 ? Grid.xs : 0),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      if (showDayDivider)
-                        DayDivider(
-                          label: formatDayHeading(message.createdAt),
-                          dayTimestamp: message.createdAt,
-                          stickyDayTimestamp: stickyDayTimestamp,
-                        ),
-                      if (message.isSystem)
-                        _SystemMessageRow(
-                          message: message,
-                          groupedMessages: entryGroup.length > 1
-                              ? entryGroup
-                                    .map((entry) => entry.message)
-                                    .toList()
-                              : null,
-                          channelId: channelId,
-                          currentPubkey: currentPubkey,
-                          allMessages: null,
-                          isMember: isMember,
-                          isArchived: isArchived,
-                        )
-                      else ...[
-                        _MessageBubble(
-                          message: message,
-                          showAuthor: showAuthor,
-                          channelNames: channelNamesMap,
-                          currentChannelId: channelId,
-                          currentPubkey: currentPubkey,
-                          allMessages: allMessages,
-                          isMember: isMember,
-                          isArchived: isArchived,
-                          composerFocusNode: composerFocusNode,
-                          restoreComposerFocus: restoreComposerFocus,
-                        ),
-                        if (entry.summary != null)
-                          _ThreadSummaryRow(
-                            summary: entry.summary!,
+                return LocalMessageSendTransition(
+                  key: ValueKey('channel-message-send-${message.id}'),
+                  animate: isRecentLocalMessageSendAnimation(
+                    localSendAnimations,
+                    message.id,
+                  ),
+                  startOffsetFactor: showAuthor
+                      ? localMessageSendTransitionAvatarStartOffset
+                      : localMessageSendTransitionStartOffset,
+                  child: Padding(
+                    key: ValueKey('channel-message-group-${message.id}'),
+                    padding: EdgeInsets.only(bottom: index == 0 ? Grid.xs : 0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (showDayDivider)
+                          DayDivider(
+                            label: formatDayHeading(message.createdAt),
+                            dayTimestamp: message.createdAt,
+                            stickyDayTimestamp: stickyDayTimestamp,
+                          ),
+                        if (message.isSystem)
+                          _SystemMessageRow(
                             message: message,
-                            allMessages: allMessages,
+                            groupedMessages: entryGroup.length > 1
+                                ? entryGroup
+                                      .map((entry) => entry.message)
+                                      .toList()
+                                : null,
                             channelId: channelId,
                             currentPubkey: currentPubkey,
+                            allMessages: null,
                             isMember: isMember,
                             isArchived: isArchived,
+                          )
+                        else ...[
+                          _MessageBubble(
+                            message: message,
+                            showAuthor: showAuthor,
+                            channelNames: channelNamesMap,
+                            currentChannelId: channelId,
+                            currentPubkey: currentPubkey,
+                            allMessages: allMessages,
+                            isMember: isMember,
+                            isArchived: isArchived,
+                            composerFocusNode: composerFocusNode,
+                            restoreComposerFocus: restoreComposerFocus,
                           ),
+                          if (entry.summary != null)
+                            _ThreadSummaryRow(
+                              summary: entry.summary!,
+                              message: message,
+                              allMessages: allMessages,
+                              channelId: channelId,
+                              currentPubkey: currentPubkey,
+                              isMember: isMember,
+                              isArchived: isArchived,
+                            ),
+                        ],
                       ],
-                    ],
+                    ),
                   ),
                 );
               },

--- a/mobile/lib/features/channels/channel_details_page.dart
+++ b/mobile/lib/features/channels/channel_details_page.dart
@@ -249,11 +249,31 @@ class ChannelDetailsPage extends HookConsumerWidget {
     }
 
     final reducedMotion = MediaQuery.disableAnimationsOf(context);
+    final usesNativeIosGlassBackButton =
+        Navigator.canPop(context) &&
+        Theme.of(context).platform == TargetPlatform.iOS;
     return FrostedScaffold(
       backgroundColor: context.colors.surface,
       appBar: FrostedAppBar(
+        leading: usesNativeIosGlassBackButton
+            ? IosGlassNavigationButton(
+                key: const ValueKey('channel-details-ios-glass-back'),
+                icon: IosGlassNavigationIcon.back,
+                semanticLabel: 'Back',
+                onPressed: () => Navigator.of(context).maybePop(),
+                width: iosGlassChannelHeaderLeadingWidth,
+                buttonCenterX: iosGlassChannelHeaderButtonCenterX,
+              )
+            : null,
         iconColor: context.colors.primary,
-        actions: const [SizedBox.square(dimension: 48)],
+        actions: [
+          SizedBox(
+            width: usesNativeIosGlassBackButton
+                ? iosGlassChannelHeaderLeadingWidth
+                : 48,
+            height: 48,
+          ),
+        ],
         frosted: headerFrostProgress.value > 0,
         frostedSurfaceOpacity: 0.5 * headerFrostProgress.value,
         frostedBlurSigma:
@@ -302,8 +322,14 @@ class ChannelDetailsPage extends HookConsumerWidget {
                   Expanded(
                     child: BuzzActionTile(
                       key: const ValueKey('channel-details-star-action'),
-                      icon: isStarred ? LucideIcons.starOff : LucideIcons.star,
-                      label: isStarred ? 'Unstar' : 'Star channel',
+                      icon: null,
+                      iconWidget: LucideStarIcon(
+                        filled: isStarred,
+                        color: isStarred
+                            ? context.colors.primary
+                            : context.colors.onSurface,
+                      ),
+                      label: isStarred ? 'Unstar' : 'Star',
                       onTap: toggleStar,
                     ),
                   ),
@@ -312,7 +338,8 @@ class ChannelDetailsPage extends HookConsumerWidget {
                     child: BuzzActionTile(
                       key: const ValueKey('channel-details-mute-action'),
                       icon: isMuted ? LucideIcons.bell : LucideIcons.bellOff,
-                      label: isMuted ? 'Unmute' : 'Mute channel',
+                      iconColor: isMuted ? context.colors.primary : null,
+                      label: isMuted ? 'Unmute' : 'Mute',
                       onTap: toggleMute,
                     ),
                   ),

--- a/mobile/lib/features/channels/channel_mutes/channel_mutes_manager.dart
+++ b/mobile/lib/features/channels/channel_mutes/channel_mutes_manager.dart
@@ -100,6 +100,7 @@ class ChannelMutesManager {
     );
     _store = ChannelMuteStore(channels: {..._store.channels, channelId: entry});
     _persist();
+    _onChanged();
     markDirty();
   }
 
@@ -111,6 +112,7 @@ class ChannelMutesManager {
     );
     _store = ChannelMuteStore(channels: {..._store.channels, channelId: entry});
     _persist();
+    _onChanged();
     markDirty();
   }
 

--- a/mobile/lib/features/channels/channel_stars/channel_stars_manager.dart
+++ b/mobile/lib/features/channels/channel_stars/channel_stars_manager.dart
@@ -100,6 +100,7 @@ class ChannelStarsManager {
     );
     _store = ChannelStarStore(channels: {..._store.channels, channelId: entry});
     _persist();
+    _onChanged();
     markDirty();
   }
 
@@ -111,6 +112,7 @@ class ChannelStarsManager {
     );
     _store = ChannelStarStore(channels: {..._store.channels, channelId: entry});
     _persist();
+    _onChanged();
     markDirty();
   }
 

--- a/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
+++ b/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
@@ -501,29 +501,24 @@ class ComposeBar extends HookConsumerWidget {
       isSending.value = true;
       try {
         if (queuedAttachments.isEmpty) {
-          try {
-            await addMentionedNonMembers();
-            final payload = _ComposeDraftPayload.fromDraft(
+          if (!context.mounted) return;
+          await _sendTextOnlyDraft(
+            context: context,
+            controller: controller,
+            mentionMap: mentionMap,
+            draftRevision: draftRevision,
+            focusNode: focusNode,
+            clearComposer: clearComposer,
+            addMentionedNonMembers: addMentionedNonMembers,
+            payload: _ComposeDraftPayload.fromDraft(
               text: text,
               attachments: const [],
               customEmoji: customEmoji,
-            );
-            await onSend(
-              payload.content,
-              outgoing.pubkeys,
-              mediaTags: [...payload.mediaTags, ...outgoing.referenceTags],
-            );
-            if (context.mounted) clearComposer();
-          } on StateError {
-            _reportSendCancelledByCommunitySwitch(messenger);
-          } catch (error) {
-            // send() runs unawaited, so a relay rejection or publish timeout
-            // would otherwise vanish with the composer looking idle. The draft
-            // is kept (clearComposer never ran) so the user can retry.
-            messenger?.showSnackBar(
-              SnackBar(content: Text(_composeSendErrorMessage(error))),
-            );
-          }
+            ),
+            outgoing: outgoing,
+            onSend: onSend,
+            messenger: messenger,
+          );
           return;
         }
 

--- a/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
+++ b/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
@@ -456,6 +456,7 @@ class ComposeBar extends HookConsumerWidget {
           uploadingCount.value > 0) {
         return;
       }
+      final submittedDraftRevision = draftRevision.value;
       // Resolved before any await: see
       // `_reportSendCancelledByCommunitySwitch`.
       final messenger = ScaffoldMessenger.maybeOf(context);
@@ -507,6 +508,7 @@ class ComposeBar extends HookConsumerWidget {
             controller: controller,
             mentionMap: mentionMap,
             draftRevision: draftRevision,
+            submittedDraftRevision: submittedDraftRevision,
             focusNode: focusNode,
             clearComposer: clearComposer,
             addMentionedNonMembers: addMentionedNonMembers,

--- a/mobile/lib/features/channels/compose_bar/draft_lifecycle.dart
+++ b/mobile/lib/features/channels/compose_bar/draft_lifecycle.dart
@@ -1,5 +1,61 @@
 part of '../compose_bar.dart';
 
+Future<void> _sendTextOnlyDraft({
+  required BuildContext context,
+  required _MarkdownEditingController controller,
+  required ObjectRef<Map<String, MentionCandidate>> mentionMap,
+  required ObjectRef<int> draftRevision,
+  required FocusNode focusNode,
+  required VoidCallback clearComposer,
+  required Future<void> Function() addMentionedNonMembers,
+  required _ComposeDraftPayload payload,
+  required _OutgoingMentions outgoing,
+  required ComposeBarOnSend onSend,
+  required ScaffoldMessengerState? messenger,
+}) async {
+  final draftText = controller.value;
+  final draftMentions = Map<String, MentionCandidate>.of(mentionMap.value);
+  int? clearedDraftRevision;
+
+  void restoreClearedDraft() {
+    if (!context.mounted ||
+        clearedDraftRevision == null ||
+        draftRevision.value != clearedDraftRevision) {
+      return;
+    }
+    controller.value = draftText;
+    mentionMap.value
+      ..clear()
+      ..addAll(draftMentions);
+    focusNode.requestFocus();
+  }
+
+  try {
+    await addMentionedNonMembers();
+    // Clear before optimistic insertion so the outgoing row and draft never
+    // appear simultaneously during the send transition.
+    if (context.mounted) {
+      clearComposer();
+      clearedDraftRevision = draftRevision.value;
+    }
+    await onSend(
+      payload.content,
+      outgoing.pubkeys,
+      mediaTags: [...payload.mediaTags, ...outgoing.referenceTags],
+    );
+  } on StateError {
+    restoreClearedDraft();
+    _reportSendCancelledByCommunitySwitch(messenger);
+  } catch (error) {
+    // The caller runs unawaited, so surface publish failures and restore the
+    // sent draft unless the user has already started a new one.
+    restoreClearedDraft();
+    messenger?.showSnackBar(
+      SnackBar(content: Text(_composeSendErrorMessage(error))),
+    );
+  }
+}
+
 void _useComposeDraftLifecycle({
   required WidgetRef ref,
   required _MarkdownEditingController controller,

--- a/mobile/lib/features/channels/compose_bar/draft_lifecycle.dart
+++ b/mobile/lib/features/channels/compose_bar/draft_lifecycle.dart
@@ -5,6 +5,7 @@ Future<void> _sendTextOnlyDraft({
   required _MarkdownEditingController controller,
   required ObjectRef<Map<String, MentionCandidate>> mentionMap,
   required ObjectRef<int> draftRevision,
+  required int submittedDraftRevision,
   required FocusNode focusNode,
   required VoidCallback clearComposer,
   required Future<void> Function() addMentionedNonMembers,
@@ -13,28 +14,33 @@ Future<void> _sendTextOnlyDraft({
   required ComposeBarOnSend onSend,
   required ScaffoldMessengerState? messenger,
 }) async {
-  final draftText = controller.value;
-  final draftMentions = Map<String, MentionCandidate>.of(mentionMap.value);
+  TextEditingValue? clearedDraftText;
+  Map<String, MentionCandidate>? clearedDraftMentions;
   int? clearedDraftRevision;
 
   void restoreClearedDraft() {
     if (!context.mounted ||
+        clearedDraftText == null ||
+        clearedDraftMentions == null ||
         clearedDraftRevision == null ||
         draftRevision.value != clearedDraftRevision) {
       return;
     }
-    controller.value = draftText;
+    controller.value = clearedDraftText;
     mentionMap.value
       ..clear()
-      ..addAll(draftMentions);
+      ..addAll(clearedDraftMentions);
     focusNode.requestFocus();
   }
 
   try {
     await addMentionedNonMembers();
     // Clear before optimistic insertion so the outgoing row and draft never
-    // appear simultaneously during the send transition.
-    if (context.mounted) {
+    // appear simultaneously during the send transition. If the user edited
+    // while membership changes were pending, preserve that newer draft.
+    if (context.mounted && draftRevision.value == submittedDraftRevision) {
+      clearedDraftText = controller.value;
+      clearedDraftMentions = Map<String, MentionCandidate>.of(mentionMap.value);
       clearComposer();
       clearedDraftRevision = draftRevision.value;
     }

--- a/mobile/lib/features/channels/local_message_send_animation_provider.dart
+++ b/mobile/lib/features/channels/local_message_send_animation_provider.dart
@@ -8,13 +8,16 @@ const _localMessageSendAnimationClaimWindow = Duration(seconds: 1);
 /// example after opening its channel) from looking newly sent.
 class LocalMessageSendAnimationNotifier
     extends Notifier<Map<String, DateTime>> {
+  /// The channel whose outgoing messages are tracked by this notifier.
   final String channelId;
 
+  /// Creates animation state scoped to [channelId].
   LocalMessageSendAnimationNotifier(this.channelId);
 
   @override
   Map<String, DateTime> build() => const {};
 
+  /// Marks [eventId] as a newly signed local message eligible for animation.
   void mark(String eventId) {
     final now = DateTime.now();
     state = {
@@ -27,6 +30,7 @@ class LocalMessageSendAnimationNotifier
   }
 }
 
+/// Whether [eventId] was marked recently enough to animate as a local send.
 bool isRecentLocalMessageSendAnimation(
   Map<String, DateTime> animations,
   String eventId, {
@@ -38,6 +42,7 @@ bool isRecentLocalMessageSendAnimation(
       _localMessageSendAnimationClaimWindow;
 }
 
+/// Recent local-send animation claims keyed by channel and event ID.
 final localMessageSendAnimationProvider =
     NotifierProvider.family<
       LocalMessageSendAnimationNotifier,

--- a/mobile/lib/features/channels/local_message_send_animation_provider.dart
+++ b/mobile/lib/features/channels/local_message_send_animation_provider.dart
@@ -1,0 +1,46 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+const _localMessageSendAnimationClaimWindow = Duration(seconds: 1);
+
+/// Recently signed local messages that may play the send entrance animation.
+///
+/// The short claim window prevents a message first rendered much later (for
+/// example after opening its channel) from looking newly sent.
+class LocalMessageSendAnimationNotifier
+    extends Notifier<Map<String, DateTime>> {
+  final String channelId;
+
+  LocalMessageSendAnimationNotifier(this.channelId);
+
+  @override
+  Map<String, DateTime> build() => const {};
+
+  void mark(String eventId) {
+    final now = DateTime.now();
+    state = {
+      for (final entry in state.entries)
+        if (now.difference(entry.value) <=
+            _localMessageSendAnimationClaimWindow)
+          entry.key: entry.value,
+      eventId: now,
+    };
+  }
+}
+
+bool isRecentLocalMessageSendAnimation(
+  Map<String, DateTime> animations,
+  String eventId, {
+  DateTime? now,
+}) {
+  final markedAt = animations[eventId];
+  if (markedAt == null) return false;
+  return (now ?? DateTime.now()).difference(markedAt) <=
+      _localMessageSendAnimationClaimWindow;
+}
+
+final localMessageSendAnimationProvider =
+    NotifierProvider.family<
+      LocalMessageSendAnimationNotifier,
+      Map<String, DateTime>,
+      String
+    >(LocalMessageSendAnimationNotifier.new);

--- a/mobile/lib/features/channels/local_message_send_transition.dart
+++ b/mobile/lib/features/channels/local_message_send_transition.dart
@@ -3,12 +3,18 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
+/// Duration of a local message's entrance transition.
 const localMessageSendTransitionDuration = Duration(milliseconds: 300);
+
+/// Default vertical offset, in child heights, for a message entrance.
 const localMessageSendTransitionStartOffset = 1.5;
+
+/// Vertical offset, in child heights, used for an avatar entrance.
 const localMessageSendTransitionAvatarStartOffset = 2.5;
 
 /// Slides a newly sent local message upward from beneath the composer.
 class LocalMessageSendTransition extends HookWidget {
+  /// Creates a local send transition around [child].
   const LocalMessageSendTransition({
     super.key,
     required this.animate,
@@ -16,8 +22,13 @@ class LocalMessageSendTransition extends HookWidget {
     required this.child,
   });
 
+  /// Whether to play the entrance transition.
   final bool animate;
+
+  /// Initial vertical offset expressed as a multiple of the child's height.
   final double startOffsetFactor;
+
+  /// Message content translated by the transition.
   final Widget child;
 
   @override

--- a/mobile/lib/features/channels/local_message_send_transition.dart
+++ b/mobile/lib/features/channels/local_message_send_transition.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+const localMessageSendTransitionDuration = Duration(milliseconds: 300);
+const localMessageSendTransitionStartOffset = 1.5;
+const localMessageSendTransitionAvatarStartOffset = 2.5;
+
+/// Slides a newly sent local message upward from beneath the composer.
+class LocalMessageSendTransition extends HookWidget {
+  const LocalMessageSendTransition({
+    super.key,
+    required this.animate,
+    this.startOffsetFactor = localMessageSendTransitionStartOffset,
+    required this.child,
+  });
+
+  final bool animate;
+  final double startOffsetFactor;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final reduceMotion = MediaQuery.disableAnimationsOf(context);
+    final controller = useAnimationController(
+      duration: localMessageSendTransitionDuration,
+      initialValue: animate && !reduceMotion ? 0 : 1,
+    );
+    final easedAnimation = useMemoized(
+      () => CurvedAnimation(parent: controller, curve: Curves.easeOutCubic),
+      [controller],
+    );
+    useEffect(() => easedAnimation.dispose, [easedAnimation]);
+
+    useEffect(() {
+      if (animate && !reduceMotion) {
+        unawaited(
+          controller.animateTo(
+            1,
+            duration: localMessageSendTransitionDuration,
+            curve: Curves.linear,
+          ),
+        );
+      } else {
+        controller.value = 1;
+      }
+      return null;
+    }, [animate, controller, reduceMotion]);
+
+    return AnimatedBuilder(
+      animation: easedAnimation,
+      child: child,
+      builder: (context, child) => FractionalTranslation(
+        translation: Offset(0, startOffsetFactor * (1 - easedAnimation.value)),
+        transformHitTests: false,
+        child: child,
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -7,6 +7,7 @@ import '../../shared/profile/user_profile.dart';
 import 'channel.dart';
 import 'channel_messages_provider.dart';
 import 'message_mention_pubkeys.dart';
+import 'local_message_send_animation_provider.dart';
 
 /// Sends messages by signing an event with the user's nsec and publishing it
 /// over the relay's NIP-42-authenticated WebSocket session.
@@ -15,6 +16,8 @@ class SendMessage {
   final Future<List<ChannelMember>> Function(String channelId) _fetchMembers;
   final Map<String, UserProfile> Function() _readUserCache;
   final void Function(String channelId, NostrEvent event) _addLocalMessage;
+  final void Function(String channelId, String eventId)
+  _markLocalMessageForAnimation;
   final void Function(String channelId, String eventId) _completeLocalMessage;
   final void Function(String channelId, String eventId) _removeLocalMessage;
   final bool Function()? _isDeliveryValid;
@@ -25,6 +28,8 @@ class SendMessage {
     fetchMembers,
     required Map<String, UserProfile> Function() readUserCache,
     required void Function(String channelId, NostrEvent event) addLocalMessage,
+    void Function(String channelId, String eventId)?
+    markLocalMessageForAnimation,
     required void Function(String channelId, String eventId)
     completeLocalMessage,
     required void Function(String channelId, String eventId) removeLocalMessage,
@@ -33,6 +38,8 @@ class SendMessage {
        _fetchMembers = fetchMembers,
        _readUserCache = readUserCache,
        _addLocalMessage = addLocalMessage,
+       _markLocalMessageForAnimation =
+           markLocalMessageForAnimation ?? ((_, _) {}),
        _completeLocalMessage = completeLocalMessage,
        _removeLocalMessage = removeLocalMessage,
        _isDeliveryValid = isDeliveryValid;
@@ -96,6 +103,7 @@ class SendMessage {
         tags: tags,
         onSigned: (event) {
           localMessage = event;
+          _markLocalMessageForAnimation(channelId, event.id);
           _addLocalMessage(channelId, event);
         },
       );
@@ -230,6 +238,9 @@ final sendMessageProvider = Provider<SendMessage>((ref) {
     addLocalMessage: (channelId, event) => ref
         .read(channelMessagesProvider(channelId).notifier)
         .addLocalMessage(event),
+    markLocalMessageForAnimation: (channelId, eventId) => ref
+        .read(localMessageSendAnimationProvider(channelId).notifier)
+        .mark(eventId),
     completeLocalMessage: (channelId, eventId) => ref
         .read(channelMessagesProvider(channelId).notifier)
         .completeLocalMessage(eventId),

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -33,6 +33,8 @@ import 'initial_thread_tail_settle.dart';
 import 'laid_out_viewport.dart';
 import 'jump_to_latest_button.dart';
 import 'jump_to_latest_switcher.dart';
+import 'local_message_send_animation_provider.dart';
+import 'local_message_send_transition.dart';
 import '../profile/user_profile_sheet.dart';
 import 'message_actions.dart';
 import 'message_action_backdrop_state.dart';
@@ -104,6 +106,9 @@ class ThreadDetailPage extends HookConsumerWidget {
       return session.registerVisibleChannel(channelId);
     }, [channelId]);
     final sendMessage = ref.read(sendMessageProvider);
+    final localSendAnimations = ref.watch(
+      localMessageSendAnimationProvider(channelId),
+    );
     // Relay thread queries are keyed by the outermost root, even when this
     // page displays a nested branch. Query that root, then select this head's
     // direct children from the returned subtree below.
@@ -893,6 +898,7 @@ class ThreadDetailPage extends HookConsumerWidget {
                   itemPositionsListener: itemPositionsListener,
                   bottomInset: timelineBottomInset,
                   replies: replies,
+                  localSendAnimations: localSendAnimations,
                   trackActiveScrollPosition: trackActiveScrollPosition,
                   headIsDeleted: liveDeletionHidesHead,
                   head: liveHead,

--- a/mobile/lib/features/channels/thread_detail_page/message_list.dart
+++ b/mobile/lib/features/channels/thread_detail_page/message_list.dart
@@ -9,6 +9,7 @@ class _ThreadMessageList extends StatelessWidget {
   final ItemPositionsListener itemPositionsListener;
   final double bottomInset;
   final List<TimelineMessage> replies;
+  final Map<String, DateTime> localSendAnimations;
   final Widget Function(Widget child) trackActiveScrollPosition;
   final bool headIsDeleted;
   final TimelineMessage head;
@@ -33,6 +34,7 @@ class _ThreadMessageList extends StatelessWidget {
     required this.itemPositionsListener,
     required this.bottomInset,
     required this.replies,
+    required this.localSendAnimations,
     required this.trackActiveScrollPosition,
     required this.headIsDeleted,
     required this.head,
@@ -183,45 +185,55 @@ class _ThreadMessageList extends StatelessWidget {
                     : null;
 
                 return trackActiveScrollPosition(
-                  Padding(
-                    key: ValueKey('thread-message-group-${reply.id}'),
-                    // Tail spacing comes from the list's own bottom padding now
-                    // that the list runs top-down; the reversed list used to
-                    // need it here because item 0 sat against the composer.
-                    padding: EdgeInsets.zero,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        if (showDayDivider)
-                          DayDivider(
-                            label: formatDayHeading(reply.createdAt),
-                            dayTimestamp: reply.createdAt,
-                            stickyDayTimestamp: stickyDayTimestamp,
-                          ),
-                        _ThreadMessage(
-                          message: reply,
-                          channelNames: channelNames,
-                          channelId: channelId,
-                          currentPubkey: currentPubkey,
-                          showAuthor: showAuthor,
-                          isHighlighted: reply.id == highlightedMessageId,
-                          allMessages: allMessages,
-                          isMember: isMember,
-                          isArchived: isArchived,
-                          composerFocusNode: composerFocusNode,
-                          restoreComposerFocus: restoreComposerFocus,
-                        ),
-                        if (nestedSummary != null)
-                          _NestedThreadSummaryRow(
-                            summary: nestedSummary,
-                            replyMessage: reply,
-                            allMessages: allMessages,
+                  LocalMessageSendTransition(
+                    key: ValueKey('thread-message-send-${reply.id}'),
+                    animate: isRecentLocalMessageSendAnimation(
+                      localSendAnimations,
+                      reply.id,
+                    ),
+                    startOffsetFactor: showAuthor
+                        ? localMessageSendTransitionAvatarStartOffset
+                        : localMessageSendTransitionStartOffset,
+                    child: Padding(
+                      key: ValueKey('thread-message-group-${reply.id}'),
+                      // Tail spacing comes from the list's own bottom padding now
+                      // that the list runs top-down; the reversed list used to
+                      // need it here because item 0 sat against the composer.
+                      padding: EdgeInsets.zero,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          if (showDayDivider)
+                            DayDivider(
+                              label: formatDayHeading(reply.createdAt),
+                              dayTimestamp: reply.createdAt,
+                              stickyDayTimestamp: stickyDayTimestamp,
+                            ),
+                          _ThreadMessage(
+                            message: reply,
+                            channelNames: channelNames,
                             channelId: channelId,
                             currentPubkey: currentPubkey,
+                            showAuthor: showAuthor,
+                            isHighlighted: reply.id == highlightedMessageId,
+                            allMessages: allMessages,
                             isMember: isMember,
                             isArchived: isArchived,
+                            composerFocusNode: composerFocusNode,
+                            restoreComposerFocus: restoreComposerFocus,
                           ),
-                      ],
+                          if (nestedSummary != null)
+                            _NestedThreadSummaryRow(
+                              summary: nestedSummary,
+                              replyMessage: reply,
+                              allMessages: allMessages,
+                              channelId: channelId,
+                              currentPubkey: currentPubkey,
+                              isMember: isMember,
+                              isArchived: isArchived,
+                            ),
+                        ],
+                      ),
                     ),
                   ),
                 );

--- a/mobile/lib/features/pairing/pairing_page.dart
+++ b/mobile/lib/features/pairing/pairing_page.dart
@@ -95,14 +95,21 @@ class PairingPage extends HookConsumerWidget {
         ? AppBar(
             foregroundColor: _onboardingInk,
             systemOverlayStyle: onboardingSystemOverlayStyle,
+            leadingWidth: Theme.of(context).platform == TargetPlatform.iOS
+                ? Grid.quarter + iosGlassChannelHeaderLeadingWidth
+                : null,
             leading: Theme.of(context).platform == TargetPlatform.iOS
-                ? IosGlassNavigationButton(
-                    key: const ValueKey('pairing-ios-glass-back'),
-                    icon: IosGlassNavigationIcon.back,
-                    semanticLabel: 'Back',
-                    onPressed: () => Navigator.of(context).maybePop(),
-                    width: 56,
-                    foregroundColor: _onboardingInk,
+                ? Padding(
+                    padding: const EdgeInsets.only(left: Grid.quarter),
+                    child: IosGlassNavigationButton(
+                      key: const ValueKey('pairing-ios-glass-back'),
+                      icon: IosGlassNavigationIcon.back,
+                      semanticLabel: 'Back',
+                      onPressed: () => Navigator.of(context).maybePop(),
+                      width: iosGlassChannelHeaderLeadingWidth,
+                      buttonCenterX: iosGlassChannelHeaderButtonCenterX,
+                      foregroundColor: _onboardingInk,
+                    ),
                   )
                 : IconButton(
                     icon: const Icon(LucideIcons.arrowLeft),

--- a/mobile/lib/shared/widgets/buzz_action_tile.dart
+++ b/mobile/lib/shared/widgets/buzz_action_tile.dart
@@ -14,13 +14,18 @@ class BuzzActionTile extends StatelessWidget {
     required this.icon,
     required this.label,
     required this.onTap,
+    this.iconWidget,
     this.isEnabled = true,
     this.isLoading = false,
     this.loadingSemanticLabel,
+    this.iconColor,
   });
 
   /// Icon shown when the tile is not loading.
   final IconData? icon;
+
+  /// Optional custom icon widget shown instead of [icon].
+  final Widget? iconWidget;
 
   /// Label shown below the icon.
   final String label;
@@ -36,6 +41,9 @@ class BuzzActionTile extends StatelessWidget {
 
   /// Accessibility label for the loading indicator.
   final String? loadingSemanticLabel;
+
+  /// Optional icon tint used to communicate a selected action state.
+  final Color? iconColor;
 
   @override
   Widget build(BuildContext context) {
@@ -75,7 +83,12 @@ class BuzzActionTile extends StatelessWidget {
                     semanticLabel: loadingSemanticLabel ?? label,
                   )
                 else
-                  Icon(icon, size: 22, color: context.colors.onSurface),
+                  iconWidget ??
+                      Icon(
+                        icon,
+                        size: 22,
+                        color: iconColor ?? context.colors.onSurface,
+                      ),
                 const SizedBox(height: Grid.xxs),
                 Text(
                   label,

--- a/mobile/lib/shared/widgets/frosted_app_bar.dart
+++ b/mobile/lib/shared/widgets/frosted_app_bar.dart
@@ -171,15 +171,22 @@ class FrostedAppBar extends StatelessWidget {
       titleStyle,
       titleContentHeight,
     );
+    final usesAutomaticIosGlassBackButton =
+        leading == null &&
+        automaticallyImplyLeading &&
+        canPop &&
+        Theme.of(context).platform == TargetPlatform.iOS;
 
     final effectiveLeading =
         leading ??
         (automaticallyImplyLeading && canPop
-            ? Theme.of(context).platform == TargetPlatform.iOS
+            ? usesAutomaticIosGlassBackButton
                   ? IosGlassNavigationButton(
                       icon: IosGlassNavigationIcon.back,
                       semanticLabel: 'Back',
                       onPressed: () => Navigator.of(context).maybePop(),
+                      width: iosGlassChannelHeaderLeadingWidth,
+                      buttonCenterX: iosGlassChannelHeaderButtonCenterX,
                       foregroundColor: iconColor,
                     )
                   : SizedBox(
@@ -208,7 +215,9 @@ class FrostedAppBar extends StatelessWidget {
                   child: Padding(
                     padding: EdgeInsets.only(
                       left: effectiveLeading != null
-                          ? 0
+                          ? usesAutomaticIosGlassBackButton
+                                ? iosGlassChannelHeaderTitleSpacing
+                                : 0
                           : horizontalInset < Grid.gutter
                           ? Grid.gutter - horizontalInset
                           : 0,

--- a/mobile/lib/shared/widgets/lucide_star_icon.dart
+++ b/mobile/lib/shared/widgets/lucide_star_icon.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 /// A Lucide-shaped star that can fill without changing its geometry.
 class LucideStarIcon extends StatelessWidget {
+  /// Creates a Lucide star using [color], optionally filled.
   const LucideStarIcon({
     super.key,
     required this.color,
@@ -11,8 +12,13 @@ class LucideStarIcon extends StatelessWidget {
     this.size = 22,
   });
 
+  /// Color of the star's stroke or fill.
   final Color color;
+
+  /// Whether to paint the star filled instead of outlined.
   final bool filled;
+
+  /// Width and height of the square icon canvas.
   final double size;
 
   @override

--- a/mobile/lib/shared/widgets/lucide_star_icon.dart
+++ b/mobile/lib/shared/widgets/lucide_star_icon.dart
@@ -1,0 +1,61 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// A Lucide-shaped star that can fill without changing its geometry.
+class LucideStarIcon extends StatelessWidget {
+  const LucideStarIcon({
+    super.key,
+    required this.color,
+    this.filled = false,
+    this.size = 22,
+  });
+
+  final Color color;
+  final bool filled;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) => CustomPaint(
+    size: Size.square(size),
+    painter: _LucideStarPainter(color: color, filled: filled),
+  );
+}
+
+class _LucideStarPainter extends CustomPainter {
+  const _LucideStarPainter({required this.color, required this.filled});
+
+  final Color color;
+  final bool filled;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final scale = math.min(size.width, size.height) / 24;
+    final path = Path()
+      ..moveTo(12 * scale, 2 * scale)
+      ..lineTo(15.09 * scale, 8.26 * scale)
+      ..lineTo(22 * scale, 9.27 * scale)
+      ..lineTo(17 * scale, 14.14 * scale)
+      ..lineTo(18.18 * scale, 21.02 * scale)
+      ..lineTo(12 * scale, 17.77 * scale)
+      ..lineTo(5.82 * scale, 21.02 * scale)
+      ..lineTo(7 * scale, 14.14 * scale)
+      ..lineTo(2 * scale, 9.27 * scale)
+      ..lineTo(8.91 * scale, 8.26 * scale)
+      ..close();
+
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = color
+        ..style = filled ? PaintingStyle.fill : PaintingStyle.stroke
+        ..strokeWidth = 2 * scale
+        ..strokeCap = StrokeCap.round
+        ..strokeJoin = StrokeJoin.round,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_LucideStarPainter oldDelegate) =>
+      color != oldDelegate.color || filled != oldDelegate.filled;
+}

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -27,6 +27,7 @@ import 'package:buzz/features/channels/date_formatters.dart';
 import 'package:buzz/features/channels/day_divider.dart';
 import 'package:buzz/features/channels/emoji_picker.dart';
 import 'package:buzz/features/channels/ime_metrics_settle_observer.dart';
+import 'package:buzz/features/channels/local_message_send_animation_provider.dart';
 import 'package:buzz/features/channels/message_action_backdrop_state.dart';
 import 'package:buzz/features/channels/message_actions.dart';
 import 'package:buzz/features/channels/reaction_row.dart';
@@ -3522,6 +3523,70 @@ void main() {
         findsNothing,
       );
     });
+
+    testWidgets(
+      'a same-second local send follows its inserted row when the tail ID stays unchanged',
+      (tester) async {
+        tester.view.physicalSize = const Size(400, 600);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+
+        final initialMessages = [
+          for (var i = 0; i < 39; i++)
+            _textMsg(
+              id: 'msg$i',
+              pubkey: 'alice',
+              content: 'Message $i',
+              createdAt: 1000 + i,
+            ),
+          _textMsg(
+            id: 'z-final',
+            pubkey: 'alice',
+            content: List.filled(20, 'Tall final message').join('\n'),
+            createdAt: 2000,
+          ),
+        ];
+        final messagesNotifier = _FakeMessagesNotifier(initialMessages);
+
+        await tester.pumpWidget(
+          _buildTestable(
+            messages: const [],
+            messagesNotifier: messagesNotifier,
+            users: const {
+              'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+              'self': UserProfile(pubkey: 'self', displayName: 'Self'),
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final messageList = find.byKey(const ValueKey('channel-message-list'));
+        await tester.drag(messageList, const Offset(0, 300));
+        await tester.pumpAndSettle();
+        expect(findRichText('My same-second send'), findsNothing);
+
+        final localSend = _textMsg(
+          id: 'a-local',
+          pubkey: 'self',
+          content: 'My same-second send',
+          createdAt: 2000,
+        );
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(ChannelDetailPage)),
+        );
+        container
+            .read(localMessageSendAnimationProvider(_channelId).notifier)
+            .mark(localSend.id);
+        messagesNotifier.setMessages([...initialMessages, localSend]);
+        await tester.pumpAndSettle();
+
+        expect(findRichText('My same-second send'), findsOneWidget);
+        expect(
+          find.byKey(const ValueKey('channel-jump-to-latest')),
+          findsNothing,
+        );
+      },
+    );
 
     testWidgets(
       'Latest reveals the channel tail while the Android keyboard stays open',

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -16,6 +16,10 @@ import 'package:buzz/features/channels/channel.dart';
 import 'package:buzz/features/channels/channel_detail_page.dart';
 import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/features/channels/channel_messages_provider.dart';
+import 'package:buzz/features/channels/channel_mutes/channel_mutes_provider.dart';
+import 'package:buzz/features/channels/channel_mutes/channel_mutes_storage.dart';
+import 'package:buzz/features/channels/channel_stars/channel_stars_provider.dart';
+import 'package:buzz/features/channels/channel_stars/channel_stars_storage.dart';
 import 'package:buzz/features/channels/channel_typing_provider.dart';
 import 'package:buzz/features/channels/members_sheet.dart';
 import 'package:buzz/features/channels/composer_dock_size_reporter.dart';
@@ -46,6 +50,7 @@ import 'package:buzz/shared/widgets/frosted_app_bar.dart';
 import 'package:buzz/shared/widgets/frosted_scaffold.dart';
 import 'package:buzz/shared/widgets/keyboard_dismiss_on_drag.dart';
 import 'package:buzz/shared/widgets/ios_glass_navigation_button.dart';
+import 'package:buzz/shared/widgets/lucide_star_icon.dart';
 import 'package:buzz/shared/widgets/masked_avatar_badge.dart';
 import 'package:buzz/shared/widgets/skeleton.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -229,6 +234,8 @@ Widget _buildTestable({
       ),
       profileProvider.overrideWith(() => _FakeProfileNotifier()),
       channelsProvider.overrideWith(() => fakeChannelsNotifier),
+      channelStarsProvider.overrideWith(_FakeChannelStarsNotifier.new),
+      channelMutesProvider.overrideWith(_FakeChannelMutesNotifier.new),
       channelDetailsProvider(_channelId).overrideWith(
         (ref) async => ChannelDetails.fromChannel(resolvedChannel),
       ),
@@ -1062,7 +1069,7 @@ void main() {
       final starSemantics = tester.getSemantics(
         find.byKey(const ValueKey('channel-details-star-action')),
       );
-      expect(starSemantics.label, 'Star channel');
+      expect(starSemantics.label, 'Star');
       expect(starSemantics.flagsCollection.isButton, isTrue);
       expect(
         starSemantics.flagsCollection.isEnabled.toString(),
@@ -1087,6 +1094,56 @@ void main() {
         isFalse,
       );
     });
+
+    testWidgets(
+      'star and mute actions update their visible state immediately',
+      (tester) async {
+        await tester.pumpWidget(_buildTestable(messages: const []));
+        await tester.pumpAndSettle();
+
+        await tester.tap(
+          find.byKey(const ValueKey('channel-header-settings-trigger')),
+        );
+        await tester.pumpAndSettle();
+
+        final starAction = find.byKey(
+          const ValueKey('channel-details-star-action'),
+        );
+        final muteAction = find.byKey(
+          const ValueKey('channel-details-mute-action'),
+        );
+        expect(find.text('Star'), findsOneWidget);
+        var star = tester.widget<LucideStarIcon>(find.byType(LucideStarIcon));
+        expect(star.filled, isFalse);
+        expect(find.text('Mute'), findsOneWidget);
+        expect(find.byIcon(LucideIcons.bellOff), findsOneWidget);
+
+        await tester.tap(starAction);
+        await tester.pump();
+
+        expect(find.text('Unstar'), findsOneWidget);
+        star = tester.widget<LucideStarIcon>(find.byType(LucideStarIcon));
+        expect(star.filled, isTrue);
+        expect(star.color, AppTheme.light().colorScheme.primary);
+
+        await tester.tap(muteAction);
+        await tester.pump();
+
+        expect(find.text('Unmute'), findsOneWidget);
+        final activeBell = tester.widget<Icon>(find.byIcon(LucideIcons.bell));
+        expect(activeBell.color, AppTheme.light().colorScheme.primary);
+
+        await tester.tap(starAction);
+        await tester.tap(muteAction);
+        await tester.pump();
+
+        expect(find.text('Star'), findsOneWidget);
+        expect(find.text('Mute'), findsOneWidget);
+        star = tester.widget<LucideStarIcon>(find.byType(LucideStarIcon));
+        expect(star.filled, isFalse);
+        expect(find.byIcon(LucideIcons.bellOff), findsOneWidget);
+      },
+    );
 
     testWidgets('action tiles grow together for large text on a narrow page', (
       tester,
@@ -1118,8 +1175,8 @@ void main() {
       final editAction = find.byKey(
         const ValueKey('channel-details-edit-action'),
       );
-      expect(find.text('Star channel'), findsOneWidget);
-      expect(find.text('Mute channel'), findsOneWidget);
+      expect(find.text('Star'), findsOneWidget);
+      expect(find.text('Mute'), findsOneWidget);
       expect(find.text('Edit'), findsOneWidget);
       expect(tester.getSize(starAction).height, greaterThan(84));
       expect(
@@ -1651,7 +1708,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Mute channel'), findsOneWidget);
+      expect(find.text('Mute'), findsOneWidget);
       expect(find.text('Leave channel'), findsNothing);
       expect(find.text('Topic'), findsNothing);
       expect(find.text('Purpose'), findsNothing);
@@ -5197,6 +5254,79 @@ void main() {
   });
 
   group('App bar', () {
+    testWidgets('aligns the Channel Details iOS back control with channels', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: const [],
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: TextButton(
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => ChannelDetailPage(channel: _testChannel),
+                  ),
+                ),
+                child: const Text('Open channel'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Open channel'));
+      await tester.pumpAndSettle();
+
+      final channelBack = find.byKey(const ValueKey('channel-ios-glass-back'));
+      final channelNativeView = tester.widget<UiKitView>(
+        find.descendant(of: channelBack, matching: find.byType(UiKitView)),
+      );
+      final channelParams =
+          channelNativeView.creationParams as Map<String, Object>;
+      final channelButtonCenter =
+          tester.getTopLeft(channelBack).dx +
+          (channelParams['buttonCenterX']! as double);
+
+      await tester.tap(
+        find.byKey(const ValueKey('channel-header-settings-trigger')),
+      );
+      await tester.pumpAndSettle();
+
+      final detailsBack = find.byKey(
+        const ValueKey('channel-details-ios-glass-back'),
+      );
+      final detailsNativeView = tester.widget<UiKitView>(
+        find.descendant(of: detailsBack, matching: find.byType(UiKitView)),
+      );
+      final detailsParams =
+          detailsNativeView.creationParams as Map<String, Object>;
+      final detailsButtonCenter =
+          tester.getTopLeft(detailsBack).dx +
+          (detailsParams['buttonCenterX']! as double);
+      debugDefaultTargetPlatformOverride = null;
+
+      expect(detailsBack, findsOneWidget);
+      expect(
+        detailsParams['buttonCenterX'],
+        iosGlassChannelHeaderButtonCenterX,
+      );
+      expect(
+        detailsParams['hitTargetWidth'],
+        iosGlassChannelHeaderLeadingWidth,
+      );
+      expect(detailsButtonCenter, moreOrLessEquals(channelButtonCenter));
+      expect(
+        tester.getRect(detailsBack).width,
+        iosGlassChannelHeaderLeadingWidth,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('matches the channel header placement on iOS', (tester) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
       addTearDown(() => debugDefaultTargetPlatformOverride = null);
@@ -5566,8 +5696,8 @@ void main() {
       expect(find.text('General discussion'), findsOneWidget);
       expect(find.text('5 members'), findsOneWidget);
       expect(find.text('Preferences'), findsNothing);
-      expect(find.text('Star channel'), findsOneWidget);
-      expect(find.text('Mute channel'), findsOneWidget);
+      expect(find.text('Star'), findsOneWidget);
+      expect(find.text('Mute'), findsOneWidget);
       expect(find.text('Edit'), findsOneWidget);
       expect(find.text('Actions'), findsNothing);
       expect(find.byTooltip('Back'), findsOneWidget);
@@ -9746,6 +9876,54 @@ class _FakeProfileNotifier extends ProfileNotifier {
   @override
   Future<UserProfile?> build() async =>
       const UserProfile(pubkey: 'self', displayName: 'Self');
+}
+
+class _FakeChannelStarsNotifier extends ChannelStarsNotifier {
+  @override
+  ChannelStarsState build() => const ChannelStarsState(isReady: true);
+
+  @override
+  void starChannel(String channelId) => _setStarred(channelId, true);
+
+  @override
+  void unstarChannel(String channelId) => _setStarred(channelId, false);
+
+  void _setStarred(String channelId, bool starred) {
+    state = ChannelStarsState(
+      isReady: true,
+      store: ChannelStarStore(
+        channels: {
+          ...state.store.channels,
+          channelId: ChannelStarEntry(starred: starred, updatedAt: 1),
+        },
+      ),
+      version: state.version + 1,
+    );
+  }
+}
+
+class _FakeChannelMutesNotifier extends ChannelMutesNotifier {
+  @override
+  ChannelMutesState build() => const ChannelMutesState(isReady: true);
+
+  @override
+  void muteChannel(String channelId) => _setMuted(channelId, true);
+
+  @override
+  void unmuteChannel(String channelId) => _setMuted(channelId, false);
+
+  void _setMuted(String channelId, bool muted) {
+    state = ChannelMutesState(
+      isReady: true,
+      store: ChannelMuteStore(
+        channels: {
+          ...state.store.channels,
+          channelId: ChannelMuteEntry(muted: muted, updatedAt: 1),
+        },
+      ),
+      version: state.version + 1,
+    );
+  }
 }
 
 class _FakeUserCacheNotifier extends UserCacheNotifier {

--- a/mobile/test/features/channels/channel_preferences_manager_test.dart
+++ b/mobile/test/features/channels/channel_preferences_manager_test.dart
@@ -1,0 +1,57 @@
+import 'package:buzz/features/channels/channel_mutes/channel_mutes_manager.dart';
+import 'package:buzz/features/channels/channel_stars/channel_stars_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr/nostr.dart' as nostr;
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('local star changes notify listeners immediately', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final keys = nostr.Keys.generate();
+    var changes = 0;
+    final manager = ChannelStarsManager(
+      pubkey: keys.public,
+      prefs: prefs,
+      crypto: ChannelStarsCrypto(keys.nsec, keys.public),
+      relaySession: null,
+      signedEventRelay: null,
+      remoteEnabled: false,
+      onChanged: () => changes += 1,
+    );
+    addTearDown(manager.dispose);
+
+    manager.starChannel('general');
+    expect(manager.store.channels['general']?.starred, isTrue);
+    expect(changes, 1);
+
+    manager.unstarChannel('general');
+    expect(manager.store.channels['general']?.starred, isFalse);
+    expect(changes, 2);
+  });
+
+  test('local mute changes notify listeners immediately', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final keys = nostr.Keys.generate();
+    var changes = 0;
+    final manager = ChannelMutesManager(
+      pubkey: keys.public,
+      prefs: prefs,
+      crypto: ChannelMutesCrypto(keys.nsec, keys.public),
+      relaySession: null,
+      signedEventRelay: null,
+      remoteEnabled: false,
+      onChanged: () => changes += 1,
+    );
+    addTearDown(manager.dispose);
+
+    manager.muteChannel('general');
+    expect(manager.store.channels['general']?.muted, isTrue);
+    expect(changes, 1);
+
+    manager.unmuteChannel('general');
+    expect(manager.store.channels['general']?.muted, isFalse);
+    expect(changes, 2);
+  });
+}

--- a/mobile/test/features/channels/compose_bar_test.dart
+++ b/mobile/test/features/channels/compose_bar_test.dart
@@ -378,6 +378,10 @@ class _RecordingRelaySocket extends RelaySocket {
   final List<Map<String, dynamic>> events;
   final void Function(List<dynamic> message) handleMessage;
 
+  /// Invoked after an event is handed to the socket but before its relay
+  /// acknowledgement is delivered. Tests may defer that acknowledgement.
+  final Future<void> Function(Map<String, dynamic> event)? beforeAcknowledged;
+
   /// Invoked after an event has been recorded and acknowledged, before the
   /// caller's `await` resumes. Lets a test interleave state changes (such as
   /// a community switch) between two relay round trips.
@@ -386,6 +390,7 @@ class _RecordingRelaySocket extends RelaySocket {
   _RecordingRelaySocket(
     this.events,
     this.handleMessage, {
+    this.beforeAcknowledged,
     this.onEventAcknowledged,
   }) : super(
          wsUrl: 'ws://localhost',
@@ -403,8 +408,18 @@ class _RecordingRelaySocket extends RelaySocket {
     if (payload case ['EVENT', final Map<String, dynamic> event]) {
       events.add(event);
       final id = event['id'] as String;
-      super.debugHandleOkForTest(['OK', id, true, '']);
-      onEventAcknowledged?.call(event);
+      final pending = beforeAcknowledged?.call(event);
+      if (pending == null) {
+        super.debugHandleOkForTest(['OK', id, true, '']);
+        onEventAcknowledged?.call(event);
+      } else {
+        unawaited(
+          pending.then((_) {
+            super.debugHandleOkForTest(['OK', id, true, '']);
+            onEventAcknowledged?.call(event);
+          }),
+        );
+      }
     }
   }
 
@@ -3850,6 +3865,78 @@ void main() {
         ['p', agentPubkey],
         ['role', 'bot'],
       ]);
+    });
+
+    testWidgets('preserves edits made while a mentioned agent is being added', (
+      tester,
+    ) async {
+      final agentPubkey = 'c' * 64;
+      final signer = nostr.Keys.generate();
+      final publishedEvents = <Map<String, dynamic>>[];
+      final addMemberAcknowledgement = Completer<void>();
+      String? sentContent;
+
+      await tester.pumpWidget(
+        _buildComposeBar(
+          uploadService: _testUploadService(signer.nsec),
+          currentPubkey: signer.public,
+          relayAgents: [
+            AgentDirectoryEntry(
+              pubkey: agentPubkey,
+              displayName: 'Helper Bot',
+              respondTo: 'anyone',
+              channelIds: const ['shared-channel'],
+            ),
+          ],
+          channels: [_makeCurrentChannel(), _makeSharedMemberChannel()],
+          onSend:
+              (
+                content,
+                mentionPubkeys, {
+                mediaTags = const <List<String>>[],
+              }) async {
+                sentContent = content;
+              },
+        ),
+      );
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ComposeBar)),
+      );
+      final session = container.read(relaySessionProvider.notifier);
+      session.debugAttachSocketForTest(
+        _RecordingRelaySocket(
+          publishedEvents,
+          session.debugHandleSocketMessageForTest,
+          beforeAcknowledged: (event) async {
+            if (event['kind'] == 9000) await addMemberAcknowledgement.future;
+          },
+        ),
+      );
+
+      await _expandComposer(tester);
+      await tester.enterText(find.byType(TextField), '@hel');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Helper Bot'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), 'hello @Helper Bot');
+      await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      await tester.pump();
+
+      expect(
+        publishedEvents.where((event) => event['kind'] == 9000),
+        hasLength(1),
+      );
+
+      await tester.enterText(find.byType(TextField), 'newer draft');
+      addMemberAcknowledgement.complete();
+      await tester.pumpAndSettle();
+
+      expect(sentContent, 'hello @Helper Bot');
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        'newer draft',
+      );
     });
 
     testWidgets(

--- a/mobile/test/features/channels/compose_bar_test.dart
+++ b/mobile/test/features/channels/compose_bar_test.dart
@@ -913,6 +913,124 @@ void main() {
       expect(sentContent, 'First line\nSecond line');
     });
 
+    testWidgets('clears text before the optimistic send completes', (
+      tester,
+    ) async {
+      final delivery = Completer<void>();
+      await tester.pumpWidget(
+        _buildComposeBar(
+          uploadService: _testUploadService(nostr.Keys.generate().nsec),
+          onSend:
+              (content, mentionPubkeys, {mediaTags = const <List<String>>[]}) =>
+                  delivery.future,
+        ),
+      );
+
+      await _expandComposer(tester);
+      await tester.enterText(find.byType(TextField), 'hello');
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 20));
+        if (tester
+            .widget<TextField>(find.byType(TextField))
+            .controller!
+            .text
+            .isEmpty) {
+          break;
+        }
+      }
+
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        '',
+      );
+
+      delivery.complete();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('a failed send restores an untouched cleared draft', (
+      tester,
+    ) async {
+      final delivery = Completer<void>();
+      await tester.pumpWidget(
+        _buildComposeBar(
+          uploadService: _testUploadService(nostr.Keys.generate().nsec),
+          onSend:
+              (content, mentionPubkeys, {mediaTags = const <List<String>>[]}) =>
+                  delivery.future,
+        ),
+      );
+
+      await _expandComposer(tester);
+      await tester.enterText(find.byType(TextField), 'retry me');
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 20));
+        if (tester
+            .widget<TextField>(find.byType(TextField))
+            .controller!
+            .text
+            .isEmpty) {
+          break;
+        }
+      }
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        '',
+      );
+
+      delivery.completeError(Exception('relay rejected'));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        'retry me',
+      );
+    });
+
+    testWidgets('a failed send does not overwrite a new draft', (tester) async {
+      final delivery = Completer<void>();
+      await tester.pumpWidget(
+        _buildComposeBar(
+          uploadService: _testUploadService(nostr.Keys.generate().nsec),
+          onSend:
+              (content, mentionPubkeys, {mediaTags = const <List<String>>[]}) =>
+                  delivery.future,
+        ),
+      );
+
+      await _expandComposer(tester);
+      await tester.enterText(find.byType(TextField), 'first draft');
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(LucideIcons.arrowUp));
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 20));
+        if (tester
+            .widget<TextField>(find.byType(TextField))
+            .controller!
+            .text
+            .isEmpty) {
+          break;
+        }
+      }
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        '',
+      );
+
+      await tester.enterText(find.byType(TextField), 'new draft');
+      delivery.completeError(StateError('relay rejected'));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        'new draft',
+      );
+    });
+
     testWidgets('smoothly resizes the text field when a new line is added', (
       tester,
     ) async {

--- a/mobile/test/features/channels/local_message_send_transition_test.dart
+++ b/mobile/test/features/channels/local_message_send_transition_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:buzz/features/channels/local_message_send_animation_provider.dart';
+import 'package:buzz/features/channels/local_message_send_transition.dart';
+
+Widget _testable({
+  bool animate = true,
+  bool reduceMotion = false,
+  double startOffsetFactor = localMessageSendTransitionStartOffset,
+}) => MaterialApp(
+  home: MediaQuery(
+    data: MediaQueryData(disableAnimations: reduceMotion),
+    child: Scaffold(
+      body: LocalMessageSendTransition(
+        animate: animate,
+        startOffsetFactor: startOffsetFactor,
+        child: const SizedBox(key: ValueKey('message'), width: 100, height: 40),
+      ),
+    ),
+  ),
+);
+
+void main() {
+  Finder sendTranslation() => find.descendant(
+    of: find.byType(LocalMessageSendTransition),
+    matching: find.byType(FractionalTranslation),
+  );
+
+  test('local send claims expire before a later navigation', () {
+    final markedAt = DateTime(2026);
+    final animations = {'event': markedAt};
+
+    expect(
+      isRecentLocalMessageSendAnimation(
+        animations,
+        'event',
+        now: markedAt.add(const Duration(milliseconds: 999)),
+      ),
+      isTrue,
+    );
+    expect(
+      isRecentLocalMessageSendAnimation(
+        animations,
+        'event',
+        now: markedAt.add(const Duration(seconds: 2)),
+      ),
+      isFalse,
+    );
+  });
+
+  testWidgets('local send rises from behind the composer', (tester) async {
+    await tester.pumpWidget(_testable());
+
+    var transition = tester.widget<FractionalTranslation>(sendTranslation());
+    expect(
+      transition.translation,
+      const Offset(0, localMessageSendTransitionStartOffset),
+    );
+    expect(
+      find.descendant(
+        of: find.byType(LocalMessageSendTransition),
+        matching: find.byType(FadeTransition),
+      ),
+      findsNothing,
+    );
+
+    await tester.pump(localMessageSendTransitionDuration ~/ 2);
+    transition = tester.widget<FractionalTranslation>(sendTranslation());
+    expect(transition.translation.dy, greaterThan(0));
+    expect(
+      transition.translation.dy,
+      lessThan(localMessageSendTransitionStartOffset),
+    );
+
+    await tester.pump(localMessageSendTransitionDuration);
+    transition = tester.widget<FractionalTranslation>(sendTranslation());
+    expect(transition.translation, Offset.zero);
+  });
+
+  testWidgets('an avatar row starts deeper behind the composer', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _testable(startOffsetFactor: localMessageSendTransitionAvatarStartOffset),
+    );
+
+    final transition = tester.widget<FractionalTranslation>(sendTranslation());
+    expect(
+      transition.translation,
+      const Offset(0, localMessageSendTransitionAvatarStartOffset),
+    );
+  });
+
+  testWidgets('ordinary messages do not animate', (tester) async {
+    await tester.pumpWidget(_testable(animate: false));
+
+    final transition = tester.widget<FractionalTranslation>(sendTranslation());
+    expect(transition.translation, Offset.zero);
+  });
+
+  testWidgets('reduced motion skips the send translation', (tester) async {
+    await tester.pumpWidget(_testable(reduceMotion: true));
+
+    final transition = tester.widget<FractionalTranslation>(sendTranslation());
+    expect(transition.translation, Offset.zero);
+  });
+}

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -16,6 +16,7 @@ void main() {
       final localMessages = <NostrEvent>[];
       final removedIds = <String>[];
       final completedIds = <String>[];
+      final animatedIds = <String>[];
       final send = SendMessage(
         signedEventRelay: SignedEventRelay(
           session: session,
@@ -24,6 +25,7 @@ void main() {
         fetchMembers: (_) async => const [],
         readUserCache: () => const {},
         addLocalMessage: (_, event) => localMessages.add(event),
+        markLocalMessageForAnimation: (_, eventId) => animatedIds.add(eventId),
         completeLocalMessage: (_, eventId) => completedIds.add(eventId),
         removeLocalMessage: (_, eventId) => removedIds.add(eventId),
       );
@@ -35,6 +37,7 @@ void main() {
       expect(localMessages.single.id, session.event.id);
       expect(localMessages.single.content, 'hello');
       expect(localMessages.single.channelId, _channelId);
+      expect(animatedIds, [localMessages.single.id]);
       expect(removedIds, isEmpty);
 
       session.accept();

--- a/mobile/test/features/pairing/pairing_page_test.dart
+++ b/mobile/test/features/pairing/pairing_page_test.dart
@@ -11,6 +11,7 @@ import 'package:buzz/shared/community/community.dart';
 import 'package:buzz/shared/security/sensitive_action_authorizer.dart';
 import 'package:buzz/shared/theme/theme.dart';
 import 'package:buzz/shared/widgets/buzz_loading_indicator.dart';
+import 'package:buzz/shared/widgets/ios_glass_navigation_button.dart';
 import 'package:buzz/shared/widgets/tappable_flapping_bee.dart';
 
 import '../../helpers/widget_helpers.dart';
@@ -150,6 +151,21 @@ void main() {
       final nativeBack = tester.widget<UiKitView>(find.byType(UiKitView));
       expect(nativeBack.viewType, 'buzz/navigation_glass');
       expect(nativeBack.creationParams, containsPair('icon', 'back'));
+      expect(
+        nativeBack.creationParams,
+        containsPair('buttonCenterX', iosGlassChannelHeaderButtonCenterX),
+      );
+      expect(
+        nativeBack.creationParams,
+        containsPair('hitTargetWidth', iosGlassChannelHeaderLeadingWidth),
+      );
+      final backRect = tester.getRect(
+        find.byKey(const ValueKey('pairing-ios-glass-back')),
+      );
+      expect(
+        backRect.left + iosGlassChannelHeaderButtonCenterX,
+        Grid.quarter + iosGlassChannelHeaderButtonCenterX,
+      );
       expect(find.byTooltip('Back'), findsOneWidget);
       debugDefaultTargetPlatformOverride = null;
     });

--- a/mobile/test/shared/widgets/frosted_app_bar_test.dart
+++ b/mobile/test/shared/widgets/frosted_app_bar_test.dart
@@ -99,7 +99,14 @@ void main() {
             onPressed: () => Navigator.of(context).push(
               MaterialPageRoute<void>(
                 builder: (_) => const Stack(
-                  children: [FrostedAppBar(title: Text('Destination'))],
+                  children: [
+                    FrostedAppBar(
+                      title: Text(
+                        'Destination',
+                        key: ValueKey('destination-title'),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),
@@ -119,8 +126,20 @@ void main() {
       nativeBack.creationParams,
       containsPair('accessibilityLabel', 'Back'),
     );
-    expect(nativeBack.creationParams, containsPair('hitTargetWidth', 48.0));
+    expect(
+      nativeBack.creationParams,
+      containsPair('buttonCenterX', iosGlassChannelHeaderButtonCenterX),
+    );
+    expect(
+      nativeBack.creationParams,
+      containsPair('hitTargetWidth', iosGlassChannelHeaderLeadingWidth),
+    );
     expect(nativeBack.creationParams, containsPair('hitTargetHeight', 48.0));
+    final backRect = tester.getRect(find.byType(IosGlassNavigationButton));
+    final titleRect = tester.getRect(
+      find.byKey(const ValueKey('destination-title')),
+    );
+    expect(titleRect.left - backRect.right, iosGlassChannelHeaderTitleSpacing);
     expect(find.byTooltip('Back'), findsOneWidget);
     expect(
       tester.widget<Tooltip>(find.byTooltip('Back')).excludeFromSemantics,


### PR DESCRIPTION
## Summary
- align iOS back controls and affected titles across channel details, settings, and pairing
- make channel star and mute actions reflect their state immediately
- animate locally sent channel, thread, and DM messages from behind the composer with a 300ms ease-out

## Testing
- `just mobile-check`
- full mobile test suite (1,573 tests)