### PR TITLE
fix(desktop): restore icon-only remote marker

### DIFF
--- a/desktop/src/features/agents/ui/OtherSetupAgentMarker.tsx
+++ b/desktop/src/features/agents/ui/OtherSetupAgentMarker.tsx
@@ -1,7 +1,6 @@
 import { Cloud } from "lucide-react";
 
 import { cn } from "@/shared/lib/cn";
-import { Badge } from "@/shared/ui/badge";
 
 const OTHER_SETUP_LABEL = "From another Buzz setup";
 
@@ -13,18 +12,14 @@ export function OtherSetupAgentMarker({
   testId?: string;
 }) {
   return (
-    <Badge
+    <span
       aria-label={OTHER_SETUP_LABEL}
-      className={cn(
-        "gap-1 px-1.5 py-0.5 font-medium normal-case tracking-normal",
-        className,
-      )}
+      className={cn("inline-flex shrink-0", className)}
       data-testid={testId}
+      role="img"
       title={OTHER_SETUP_LABEL}
-      variant="secondary"
     >
       <Cloud aria-hidden="true" className="h-3 w-3" />
-      Other setup
-    </Badge>
+    </span>
   );
 }

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -379,19 +379,25 @@ test("duplicate owned agents preserve provenance and exact pubkey selection", as
     0,
   );
   await expect(relayRow).toContainText("agent");
-  await expect(
-    relayRow.getByTestId("mention-agent-provenance"),
-  ).toHaveAttribute("aria-label", "From another Buzz setup");
-  await expect(
-    relayRow.getByText("Other setup", { exact: true }),
-  ).toBeVisible();
+  const relayProvenanceMarker = relayRow.getByTestId(
+    "mention-agent-provenance",
+  );
+  await expect(relayProvenanceMarker).toHaveAttribute(
+    "aria-label",
+    "From another Buzz setup",
+  );
+  await expect(relayProvenanceMarker).toHaveAttribute(
+    "title",
+    "From another Buzz setup",
+  );
+  await expect(relayProvenanceMarker).toBeVisible();
+  await expect(relayProvenanceMarker).toHaveText("");
+  await expect(relayProvenanceMarker.locator("svg")).toBeVisible();
   await expect(managedRow).not.toContainText("managed by you");
   await expect(relayRow).not.toContainText("managed by you");
 
   await page.setViewportSize({ width: 760, height: 640 });
-  await expect(
-    relayRow.getByText("Other setup", { exact: true }),
-  ).toBeVisible();
+  await expect(relayProvenanceMarker).toBeVisible();
   const rowBox = await relayRow.boundingBox();
   const dropdownBox = await dropdown.boundingBox();
   expect(rowBox).not.toBeNull();
@@ -470,7 +476,8 @@ test("duplicate owned agents preserve provenance and exact pubkey selection", as
     "aria-label",
     "From another Buzz setup",
   );
-  await expect(remoteSidebarMarker).toHaveText("Other setup");
+  await expect(remoteSidebarMarker).toHaveText("");
+  await expect(remoteSidebarMarker.locator("svg")).toBeVisible();
   const remoteSidebarRow = page.getByTestId(`sidebar-member-${relayPubkey}`);
   const localSidebarMarker = page.getByTestId(
     `sidebar-member-agent-provenance-${managedPubkey}`,


### PR DESCRIPTION
## Summary

- restore the agreed icon-only cloud marker for an agent from another setup
- retain the accessible `From another Buzz setup` label and native hover title
- keep the merged loading, hover/focus persistence, and exact-pubkey routing safeguards unchanged
- update the duplicate-agent E2E to require an icon with no visible marker text in both autocomplete and Channel members

## Why

PR #6401 accidentally changed the agreed compact icon treatment into a visible `Other setup` badge during review hardening. This is the smallest correction and is intended for the active release.

## Testing

- Desktop JS: 5,280/5,280 passed
- Desktop TypeScript typecheck passed
- E2E build passed
- focused duplicate-agent Playwright journey: 1/1 passed
- file-size gate passed
- changed-file Biome and `git diff --check` passed

Carl, an automated reviewer, opened this via Wes's GitHub account.
