### PR TITLE
Clarify huddle message destination

### DIFF
--- a/desktop/src-tauri/src/huddle/agents.rs
+++ b/desktop/src-tauri/src/huddle/agents.rs
@@ -37,11 +37,11 @@ use super::{pipeline::start_auto_enabled_transcription, HuddlePhase};
 pub fn voice_mode_guidelines(parent_channel_id: &str) -> String {
     format!(
         "\
-You are in a live voice huddle attached to channel {parent_channel_id}.
-Only messages sent with `buzz messages send` to this huddle channel are spoken aloud, in the order sent; everything else you produce is silent.
-When a user addresses you, your FIRST tool call must send a brief spoken reply to this channel, before any file read, search, or other tool call. The usual rule against bare acknowledgments does not apply here; the pickup is the feedback that you heard them.
+You are in a live voice huddle. Its attached main channel is {parent_channel_id}; that is not the live huddle channel.
+The channel UUID in the current `[Context]` block is the live huddle channel. Only messages sent with `buzz messages send` to that current Context channel are spoken aloud, in the order sent; everything else you produce is silent.
+When a user addresses you, your FIRST tool call must send a brief spoken reply to the current Context channel, before any file read, search, or other tool call. The usual rule against bare acknowledgments does not apply here; the pickup is the feedback that you heard them.
 Then work, sending each useful sentence as its own message the moment it is ready—a few sentences per answer, not a monologue.
-Speak plainly without markdown; post code or long detail to the attached channel instead.
+Speak plainly without markdown; post code or long detail to the attached main channel instead.
 If you are not addressed, stay silent."
     )
 }
@@ -303,11 +303,13 @@ mod tests {
     fn voice_mode_guidelines_pin_spoken_reply_as_first_tool_call() {
         let guidelines = voice_mode_guidelines("parent-channel");
         assert_eq!(guidelines.lines().count(), 6);
-        assert!(guidelines.contains("Only messages sent with `buzz messages send`"));
+        assert!(guidelines.contains("Its attached main channel is parent-channel"));
+        assert!(guidelines.contains("that is not the live huddle channel"));
+        assert!(guidelines.contains("current `[Context]` block is the live huddle channel"));
+        assert!(guidelines.contains("buzz messages send` to that current Context channel"));
         assert!(guidelines.contains("your FIRST tool call must send a brief spoken reply"));
         assert!(guidelines.contains("before any file read, search, or other tool call"));
         assert!(guidelines.contains("rule against bare acknowledgments does not apply here"));
-        assert!(guidelines.contains("parent-channel"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- identify the injected channel ID as the attached main channel, not the live huddle channel
- direct spoken replies to the channel UUID in the current Context block
- pin the distinction with regression assertions

## Testing
- `just desktop-tauri-test`
- pre-push desktop Tauri checks