### PR TITLE
fix(desktop): drop punctuation-only STT transcripts in huddles

### DIFF
--- a/desktop/src-tauri/src/huddle/stt.rs
+++ b/desktop/src-tauri/src/huddle/stt.rs
@@ -719,10 +719,15 @@ fn decode_speech(recognizer: &sherpa_onnx::OfflineRecognizer, speech_buf: &[f32]
 }
 
 fn send_transcript(text: String, text_tx: &tokio_mpsc::Sender<String>) {
-    if !text.is_empty() {
-        if let Err(e) = text_tx.blocking_send(text) {
-            eprintln!("buzz-desktop: STT text channel closed: {e}");
-        }
+    // Parakeet hallucinates bare punctuation (".", "?") on non-speech audio
+    // that clears the VAD's minimum-voiced-frames gate. A transcript with no
+    // alphanumeric characters carries no speech content — drop it here so it
+    // never reaches the posting task and becomes a channel message.
+    if !text.chars().any(char::is_alphanumeric) {
+        return;
+    }
+    if let Err(e) = text_tx.blocking_send(text) {
+        eprintln!("buzz-desktop: STT text channel closed: {e}");
     }
 }
 

--- a/desktop/src-tauri/src/huddle/stt_tests.rs
+++ b/desktop/src-tauri/src/huddle/stt_tests.rs
@@ -253,3 +253,26 @@ fn held_push_to_talk_never_silence_flushes() {
     // Manually open mic with the shortcut up: normal VAD behavior.
     assert!(vad_flush_allowed(true, true, false));
 }
+
+#[test]
+fn punctuation_only_transcripts_are_dropped() {
+    // Capacity exceeds total sends so the pre-fix code fails on the assertion
+    // below (hallucinations received) instead of deadlocking blocking_send.
+    let (text_tx, mut text_rx) = tokio::sync::mpsc::channel::<String>(16);
+
+    // Parakeet hallucinations on non-speech audio: no alphanumeric content.
+    for hallucinated in [".", "?", "!", ",", "...", ". .", "—"] {
+        super::send_transcript(hallucinated.to_string(), &text_tx);
+    }
+    // Real speech survives, including single-word and non-ASCII replies.
+    for speech in ["yes", "ok.", "привет", "第九"] {
+        super::send_transcript(speech.to_string(), &text_tx);
+    }
+    drop(text_tx);
+
+    let mut received = Vec::new();
+    while let Ok(text) = text_rx.try_recv() {
+        received.push(text);
+    }
+    assert_eq!(received, ["yes", "ok.", "привет", "第九"]);
+}


### PR DESCRIPTION
## Problem

Stray `.` messages appear in huddle channels (reported by Tyler in the tyler-agent-stuff huddle, 2026-08-21). Each one notifies every tagged agent for zero content.

**Chain:**
1. The VAD endpoint's minimum-voiced-audio gate is deliberately permissive (`MIN_VOICED_FRAMES = 12`, ~192 ms) to preserve short replies like "yes" — so brief noise blips (breath, keyboard) can clear it.
2. Parakeet hallucinates bare punctuation on non-speech audio — a known failure mode for punctuated-output ASR.
3. Every downstream filter only checked emptiness: `decode_speech` trims whitespace, `send_transcript` checked `!text.is_empty()`, and the posting task in `pipeline.rs` checks `t.is_empty()`. A lone `.` survives all three and is signed and posted as a kind:9 message.

## Fix

Drop transcripts containing no alphanumeric characters in `send_transcript`, before they leave the STT worker. One guard clause + a comment. Real speech — including single-word ("yes") and non-ASCII ("привет", "第九") replies — is unaffected (`char::is_alphanumeric` is Unicode-aware).

## Verification

- New test `punctuation_only_transcripts_are_dropped` FAILS at pre-fix code (assertion shows `.` `?` `!` etc. flowing through) and passes with the fix — the instrument detects the bug it claims to fix.
- Full `desktop/src-tauri` suite at HEAD c3b84b9: **2725 passed / 0 failed** (+7 +3 in other targets).

Root-cause analysis and discussion in the tyler-agent-stuff huddle channel.