### PR TITLE
feat(buzz-acp): lifecycle status reactions and long-runner posts

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -134,6 +134,24 @@ fn build_initialize_params() -> serde_json::Value {
     })
 }
 
+/// Tool-call lifecycle signal emitted from the ACP session-update stream to
+/// the per-turn status watcher in `pool::run_prompt_task`.
+///
+/// `Started` carries the tool title advertised by the agent so the watcher
+/// can name the tool in a long-runner status post. `Finished` fires when a
+/// `tool_call_update` reports a terminal status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolCallSignal {
+    /// A `tool_call` session update arrived — a tool call began.
+    Started {
+        /// Human-readable tool title from the update (`"unknown"` if absent).
+        title: String,
+    },
+    /// A `tool_call_update` reported a terminal status
+    /// (`completed`/`failed`/`cancelled`).
+    Finished,
+}
+
 /// ACP client that owns an agent subprocess and communicates over its stdio.
 ///
 /// One `AcpClient` per agent process. Multiple sessions can be created on the
@@ -214,6 +232,12 @@ pub struct AcpClient {
     standard_usage: StandardUsageTracker,
     /// Known adapter identity for prompt-response usage mapping.
     standard_adapter: Option<StandardAdapterKind>,
+    /// Per-turn sender for tool-call lifecycle signals, installed by
+    /// `pool::run_prompt_task` when status reactions are enabled. Sends are
+    /// best-effort: the watcher may already be gone (turn ended), in which
+    /// case the send error is ignored. Replaced (or cleared) at each turn
+    /// boundary via [`set_turn_status_tx`](Self::set_turn_status_tx).
+    turn_status_tx: Option<tokio::sync::mpsc::UnboundedSender<ToolCallSignal>>,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -563,6 +587,7 @@ impl AcpClient {
             goose_usage: UsageTracker::default(),
             standard_usage: StandardUsageTracker::default(),
             standard_adapter,
+            turn_status_tx: None,
         })
     }
 
@@ -575,6 +600,18 @@ impl AcpClient {
     /// Update metadata that will be attached to subsequent raw wire events.
     pub fn set_observer_context(&mut self, context: ObserverContext) {
         self.observer_context = context;
+    }
+
+    /// Install (or clear, with `None`) the per-turn tool-call status sender.
+    ///
+    /// Installed by `pool::run_prompt_task` before the prompt fires and
+    /// cleared by `send_prompt_result` at every turn exit, so a stale sender
+    /// never outlives the turn it served.
+    pub fn set_turn_status_tx(
+        &mut self,
+        tx: Option<tokio::sync::mpsc::UnboundedSender<ToolCallSignal>>,
+    ) {
+        self.turn_status_tx = tx;
     }
 
     /// Return a clone of the observer handle, if attached.
@@ -1769,6 +1806,11 @@ impl AcpClient {
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
                 tracing::info!(target: "acp::tool", "tool_call: {title} ({kind})");
+                if let Some(tx) = &self.turn_status_tx {
+                    let _ = tx.send(ToolCallSignal::Started {
+                        title: title.to_string(),
+                    });
+                }
                 true
             }
             "tool_call_update" => {
@@ -1778,6 +1820,11 @@ impl AcpClient {
                     .unwrap_or("?");
                 let status = update.get("status").and_then(|v| v.as_str()).unwrap_or("?");
                 tracing::info!(target: "acp::tool", "tool_call_update: {tool_id} → {status}");
+                if matches!(status, "completed" | "failed" | "cancelled") {
+                    if let Some(tx) = &self.turn_status_tx {
+                        let _ = tx.send(ToolCallSignal::Finished);
+                    }
+                }
                 false
             }
             "plan" => {
@@ -3747,6 +3794,80 @@ mod tests {
                 },
             }
         })
+    }
+
+    /// Build a `session/update` notification carrying a `tool_call` update.
+    fn tool_call_msg(title: &str) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "test-session",
+                "update": {
+                    "sessionUpdate": "tool_call",
+                    "title": title,
+                    "kind": "execute",
+                },
+            }
+        })
+    }
+
+    /// Build a `session/update` notification carrying a `tool_call_update`
+    /// with the given status.
+    fn tool_call_update_msg(status: &str) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "test-session",
+                "update": {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": "tool-1",
+                    "status": status,
+                },
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn tool_call_updates_forward_turn_status_signals() {
+        let mut client = spawn_inert_client().await;
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        client.set_turn_status_tx(Some(tx));
+
+        let _ = client.handle_session_update(&tool_call_msg("cargo build"));
+        assert_eq!(
+            rx.try_recv().ok(),
+            Some(ToolCallSignal::Started {
+                title: "cargo build".into()
+            })
+        );
+
+        // Non-terminal statuses must not signal completion.
+        let _ = client.handle_session_update(&tool_call_update_msg("in_progress"));
+        assert!(rx.try_recv().is_err());
+
+        let _ = client.handle_session_update(&tool_call_update_msg("completed"));
+        assert_eq!(rx.try_recv().ok(), Some(ToolCallSignal::Finished));
+
+        let _ = client.handle_session_update(&tool_call_update_msg("failed"));
+        assert_eq!(rx.try_recv().ok(), Some(ToolCallSignal::Finished));
+    }
+
+    #[tokio::test]
+    async fn tool_call_updates_without_status_tx_are_ignored() {
+        // No sender installed (status reactions disabled / heartbeat turn):
+        // the updates must be handled without error.
+        let mut client = spawn_inert_client().await;
+        let _ = client.handle_session_update(&tool_call_msg("cargo build"));
+        let _ = client.handle_session_update(&tool_call_update_msg("completed"));
+
+        // Clearing an installed sender stops signal delivery mid-stream.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        client.set_turn_status_tx(Some(tx));
+        client.set_turn_status_tx(None);
+        let _ = client.handle_session_update(&tool_call_msg("cargo build"));
+        assert!(rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -387,6 +387,10 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_NO_TYPING")]
     pub no_typing: bool,
 
+    /// Disable lifecycle status reactions and long-runner status posts.
+    #[arg(long, env = "BUZZ_ACP_NO_STATUS_REACTIONS")]
+    pub no_status_reactions: bool,
+
     /// Enable NIP-AE agent core memory injection.
     ///
     /// Memory injection is on by default. When enabled, the harness
@@ -547,6 +551,10 @@ pub struct Config {
     pub max_turns_per_session: u32,
     pub presence_enabled: bool,
     pub typing_enabled: bool,
+    /// Whether lifecycle status reactions (on the triggering message) and
+    /// long-runner status posts are published. On by default; disabled via
+    /// `--no-status-reactions` / `BUZZ_ACP_NO_STATUS_REACTIONS`.
+    pub status_reactions_enabled: bool,
     /// Whether NIP-AE agent core memory injection is enabled. When false,
     /// the harness skips the per-session core engram fetch and renders no
     /// `[Agent Memory — core]` section. On by default; disabled via the
@@ -1123,6 +1131,7 @@ impl Config {
             max_turns_per_session: args.max_turns_per_session,
             presence_enabled: !args.no_presence,
             typing_enabled: !args.no_typing,
+            status_reactions_enabled: !args.no_status_reactions,
             memory_enabled: args.memory && !args.no_memory,
             model,
             effort_level: args.effort_level,
@@ -1164,7 +1173,7 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} status_reactions={} memory={} model={} permission_mode={} {}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
@@ -1182,6 +1191,7 @@ impl Config {
             self.max_turns_per_session,
             self.presence_enabled,
             self.typing_enabled,
+            self.status_reactions_enabled,
             self.memory_enabled,
             self.model.as_deref().unwrap_or("(agent default)"),
             self.permission_mode,
@@ -1499,6 +1509,7 @@ mod tests {
             max_turns_per_session: 0,
             presence_enabled: true,
             typing_enabled: true,
+            status_reactions_enabled: true,
             memory_enabled: true,
             model: None,
             effort_level: None,
@@ -2473,6 +2484,19 @@ channels = "ALL"
     #[test]
     fn idle_timeout_zero_from_deprecated_clamped_to_one() {
         assert_eq!(resolve_idle_timeout(None, Some(0)), 1);
+    }
+
+    #[test]
+    fn status_reactions_default_on_and_reported_in_summary() {
+        let mut config = test_config(SubscribeMode::Mentions);
+        assert!(config.status_reactions_enabled);
+        assert!(
+            config.summary().contains("status_reactions=true"),
+            "summary should report status_reactions: {}",
+            config.summary()
+        );
+        config.status_reactions_enabled = false;
+        assert!(config.summary().contains("status_reactions=false"));
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2205,6 +2205,7 @@ async fn tokio_main() -> Result<()> {
             .as_deref()
             .and_then(|hex| nostr::PublicKey::from_hex(hex).ok()),
         memory_enabled: config.memory_enabled,
+        status_reactions_enabled: config.status_reactions_enabled,
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
         relay_url: config.relay_url.clone(),
     });
@@ -2711,7 +2712,7 @@ async fn tokio_main() -> Result<()> {
                                     // 403 on non-open channels. Stale 👀 in that
                                     // case is a known limitation — fix belongs in
                                     // the relay (clean up bot reactions on removal).
-                                    if !drained_ids.is_empty() {
+                                    if !drained_ids.is_empty() && config.status_reactions_enabled {
                                         let rc = ctx.rest_client.clone();
                                         let ids = drained_ids.clone();
                                         tokio::spawn(async move {
@@ -2914,7 +2915,7 @@ async fn tokio_main() -> Result<()> {
                             // Fire-and-forget: on rare fast-failure paths the
                             // guard's cleanup may race with this add, leaving a
                             // cosmetic stale 👀. Acceptable — see ReactionGuard docs.
-                            if accepted {
+                            if accepted && config.status_reactions_enabled {
                                 let rc = ctx.rest_client.clone();
                                 let eid = event_id_hex.clone();
                                 tokio::spawn(async move {
@@ -3739,6 +3740,10 @@ fn dispatch_pending(
             DedupMode::Queue => Some(batch.clone()),
             DedupMode::Drop => None,
         };
+        // Captured for the terminal lifecycle reaction (✅/❌) published when
+        // this turn's PromptResult lands in handle_prompt_result.
+        let triggering_event_ids: Vec<String> =
+            batch.events.iter().map(|be| be.event.id.to_hex()).collect();
 
         let result_tx = pool.result_tx();
         let ctx_clone = Arc::clone(ctx);
@@ -3786,6 +3791,7 @@ fn dispatch_pending(
                 control_tx: Some(control_tx),
                 steer_tx,
                 successful_steer_deliveries: HashSet::new(),
+                triggering_event_ids,
             },
         );
         dispatched_channels.push((channel_id, typing_scope));
@@ -3846,7 +3852,7 @@ fn spawn_failure_notice(
         let rest = rest.clone();
         let channel_id = batch.channel_id;
         tokio::spawn(async move {
-            pool::post_failure_notice(&rest, channel_id, &thread_tags, &content).await;
+            pool::post_thread_notice(&rest, channel_id, &thread_tags, &content).await;
         });
     }
 }
@@ -3867,11 +3873,16 @@ fn handle_prompt_result(
 ) -> LoopAction {
     let before = pool.task_map().len();
     let agent_index = result.agent.index;
-    let successful_steer_deliveries = pool
+    let (successful_steer_deliveries, triggering_event_ids) = pool
         .task_map()
         .values()
         .find(|meta| meta.agent_index == agent_index)
-        .map(|meta| meta.successful_steer_deliveries.clone())
+        .map(|meta| {
+            (
+                meta.successful_steer_deliveries.clone(),
+                meta.triggering_event_ids.clone(),
+            )
+        })
         .unwrap_or_default();
     pool.task_map_mut()
         .retain(|_, meta| meta.agent_index != agent_index);
@@ -4019,6 +4030,23 @@ fn handle_prompt_result(
     // only touches idle agents.
     for ch in removed_channels {
         result.agent.state.invalidate_channel(ch);
+    }
+
+    // Terminal lifecycle reaction (✅/❌) on the triggering events. Spawned
+    // best-effort — a failed reaction must never affect turn handling. A
+    // requeued batch keeps its ❌ until the retry's turn either clears it on
+    // success or fails again.
+    if config.status_reactions_enabled && !triggering_event_ids.is_empty() {
+        if let (Some(rest), Some(emoji)) = (
+            rest_client,
+            pool::terminal_reaction_for_outcome(&result.outcome),
+        ) {
+            tokio::spawn(pool::react_terminal(
+                rest.clone(),
+                triggering_event_ids,
+                emoji,
+            ));
+        }
     }
 
     let outcome_label = match &result.outcome {
@@ -4422,6 +4450,7 @@ fn dispatch_heartbeat(
             control_tx: None,
             steer_tx: None,
             successful_steer_deliveries: HashSet::new(),
+            triggering_event_ids: Vec::new(),
         },
     );
     *heartbeat_in_flight = true;
@@ -5221,6 +5250,7 @@ mod owner_control_command_tests {
                 control_tx: Some(control_tx),
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
+                triggering_event_ids: vec![],
             },
         );
 
@@ -6770,6 +6800,7 @@ mod build_mcp_servers_tests {
             max_turns_per_session: 0,
             presence_enabled: true,
             typing_enabled: true,
+            status_reactions_enabled: true,
             memory_enabled: false,
             model: None,
             effort_level: None,
@@ -6994,6 +7025,7 @@ mod error_outcome_emission_tests {
             max_turns_per_session: 0,
             presence_enabled: true,
             typing_enabled: true,
+            status_reactions_enabled: true,
             memory_enabled: false,
             model: None,
             effort_level: None,
@@ -7085,6 +7117,7 @@ mod error_outcome_emission_tests {
                         session_id: "live-session".into(),
                     },
                 ]),
+                triggering_event_ids: vec![],
             },
         );
 
@@ -7157,6 +7190,7 @@ mod error_outcome_emission_tests {
                         session_id: "old-session".into(),
                     },
                 ]),
+                triggering_event_ids: vec![],
             },
         );
 
@@ -7272,6 +7306,7 @@ mod error_outcome_emission_tests {
                         session_id: "invalidated-session".into(),
                     },
                 ]),
+                triggering_event_ids: vec![],
             },
         );
         let mut queue = EventQueue::new(config::DedupMode::Queue);
@@ -7332,6 +7367,7 @@ mod error_outcome_emission_tests {
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
+                triggering_event_ids: vec![],
             },
         );
 
@@ -7409,6 +7445,7 @@ mod error_outcome_emission_tests {
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
+                triggering_event_ids: vec![],
             },
         );
         started_rx.await.unwrap();
@@ -7502,6 +7539,7 @@ mod error_outcome_emission_tests {
                     control_tx: None,
                     steer_tx: None,
                     successful_steer_deliveries: HashSet::new(),
+                    triggering_event_ids: vec![],
                 },
             );
             let mut queue = EventQueue::new(config::DedupMode::Queue);
@@ -7594,6 +7632,7 @@ mod error_outcome_emission_tests {
                     control_tx: None,
                     steer_tx: None,
                     successful_steer_deliveries: HashSet::new(),
+                    triggering_event_ids: vec![],
                 },
             );
             let mut queue = EventQueue::new(config::DedupMode::Queue);
@@ -7700,6 +7739,7 @@ mod error_outcome_emission_tests {
                     control_tx: None,
                     steer_tx: None,
                     successful_steer_deliveries: HashSet::new(),
+                    triggering_event_ids: vec![],
                 },
             );
             let mut queue = EventQueue::new(config::DedupMode::Queue);
@@ -7777,6 +7817,7 @@ mod error_outcome_emission_tests {
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
+                triggering_event_ids: vec![],
             },
         );
         let mut queue = EventQueue::new(config::DedupMode::Queue);
@@ -7872,6 +7913,7 @@ mod error_outcome_emission_tests {
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
+                triggering_event_ids: vec![],
             },
         );
         let config = test_config();
@@ -7989,6 +8031,7 @@ mod error_outcome_emission_tests {
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
+                triggering_event_ids: vec![],
             },
         );
         let mut queue = EventQueue::new(config::DedupMode::Queue);
@@ -8129,6 +8172,7 @@ mod error_outcome_emission_tests {
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
+                triggering_event_ids: vec![],
             },
         );
         let mut queue = EventQueue::new(config::DedupMode::Queue);
@@ -8318,6 +8362,7 @@ mod error_outcome_emission_tests {
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
+                triggering_event_ids: vec![],
             },
         );
         let mut queue = EventQueue::new(config::DedupMode::Queue);
@@ -8404,6 +8449,7 @@ mod error_outcome_emission_tests {
                 control_tx: None,
                 steer_tx: None,
                 successful_steer_deliveries: HashSet::new(),
+                triggering_event_ids: vec![],
             },
         );
         let mut queue = EventQueue::new(config::DedupMode::Queue);

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -32,7 +32,7 @@ use uuid::Uuid;
 use crate::acp::{
     extract_model_config_options, extract_model_state, extract_thought_level_config_id,
     model_in_catalog, resolve_model_switch_method, AcpClient, AcpError, EnvVar, McpServer,
-    ModelSwitchMethod, StopReason, SystemPromptTransport,
+    ModelSwitchMethod, StopReason, SystemPromptTransport, ToolCallSignal,
 };
 use crate::config::{compose_session_title, DedupMode, PermissionMode};
 use crate::observer;
@@ -77,6 +77,10 @@ pub struct TaskMeta {
     /// live session. The session ID prevents a late ack from contaminating a
     /// replacement session after task return.
     pub successful_steer_deliveries: HashSet<SuccessfulSteerDelivery>,
+    /// Event IDs of the batch that triggered this turn. Read by the main
+    /// loop when the turn completes to publish the terminal lifecycle
+    /// reaction (✅/❌). Empty for heartbeat tasks.
+    pub triggering_event_ids: Vec<String>,
 }
 
 /// Agent-level model capabilities. Populated on first session creation.
@@ -511,6 +515,7 @@ pub enum TimeoutKind {
 
 /// Outcome of a prompt task.
 #[allow(dead_code)]
+#[derive(Debug)]
 pub enum PromptOutcome {
     Ok(StopReason),
     Error(AcpError),
@@ -634,6 +639,11 @@ pub struct PromptContext {
     /// `[Agent Memory — core]` section. On by default; disabled via
     /// `--no-memory` / `BUZZ_ACP_NO_MEMORY`.
     pub memory_enabled: bool,
+    /// Whether lifecycle status reactions (👀/💬/⚙️ on the triggering message)
+    /// and long-runner status posts are published. Terminal ✅/❌ reactions are
+    /// gated separately in the main loop from `Config`. Disabled via
+    /// `--no-status-reactions` / `BUZZ_ACP_NO_STATUS_REACTIONS`.
+    pub status_reactions_enabled: bool,
     /// Harness identity string for NIP-AM `harness` field. Derived from the
     /// configured `agent_command` at startup (e.g. `"goose"`, `"buzz-agent"`).
     pub harness_name: String,
@@ -1745,6 +1755,7 @@ fn send_prompt_result(
     batch: Option<FlushBatch>,
 ) {
     agent.acp.clear_steer_rx();
+    agent.acp.set_turn_status_tx(None);
     let _ = result_tx.send(PromptResult {
         agent,
         source,
@@ -1846,13 +1857,46 @@ pub async fn run_prompt_task(
     let liveness_guard = LivenessGuard::new(liveness_handle, liveness_state);
 
     // Collects event IDs up front. On drop (any exit path — normal, early
-    // return, or panic), spawns best-effort cleanup of both 👀 and 💬.
+    // return, or panic), spawns best-effort cleanup of 👀, 💬, and ⚙️.
     // See `ReactionGuard` docs for ordering guarantees and known edge cases.
-    let reaction_ids: Vec<String> = batch
-        .as_ref()
-        .map(|b| b.events.iter().map(|be| be.event.id.to_hex()).collect())
-        .unwrap_or_default();
+    // With status reactions disabled the guard gets no IDs, so every
+    // reaction path below (and the cleanup) is a no-op.
+    let reaction_ids: Vec<String> = if ctx.status_reactions_enabled {
+        batch
+            .as_ref()
+            .map(|b| b.events.iter().map(|be| be.event.id.to_hex()).collect())
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
     let _reaction_guard = ReactionGuard::new(ctx.rest_client.clone(), reaction_ids.clone());
+
+    // Per-turn tool-call status watcher: ⚙️ on the first tool call, one
+    // long-runner thread post per turn. The sender rides on the AcpClient
+    // (cleared by `send_prompt_result` at every exit); the guard aborts the
+    // watcher when this task ends. Declared after `_reaction_guard` so drop
+    // order (reverse of declaration) stops the watcher before cleanup runs.
+    let _turn_status_guard = match (&batch, reaction_ids.is_empty()) {
+        (Some(b), false) => {
+            let (status_tx, status_rx) = mpsc::unbounded_channel();
+            agent.acp.set_turn_status_tx(Some(status_tx));
+            let thread_tags = b
+                .events
+                .last()
+                .map(|be| crate::queue::parse_thread_tags(&be.event))
+                .unwrap_or_default();
+            Some(TurnStatusWatcherGuard(tokio::spawn(
+                run_turn_status_watcher(
+                    ctx.rest_client.clone(),
+                    reaction_ids.clone(),
+                    b.channel_id,
+                    thread_tags,
+                    status_rx,
+                ),
+            )))
+        }
+        _ => None,
+    };
 
     //
     // Core memory is delivered inside the system prompt the harness already
@@ -4479,6 +4523,13 @@ async fn publish_agent_turn_metric(
 
 const REACTION_SEEN: &str = "👀";
 const REACTION_WORKING: &str = "💬";
+const REACTION_TOOLING: &str = "⚙️";
+const REACTION_DONE: &str = "✅";
+const REACTION_FAILED: &str = "❌";
+
+/// How long a single tool call may run before the turn's one long-runner
+/// status post fires.
+const LONG_RUNNER_THRESHOLD: Duration = Duration::from_secs(60);
 
 /// Best-effort timeout for a single reaction REST call.
 const REACTION_TIMEOUT: Duration = Duration::from_millis(500);
@@ -4535,11 +4586,12 @@ pub(crate) async fn reaction_add(rest: &crate::relay::RestClient, event_id: &str
     }
 }
 
-/// Best-effort: post a visible failure notice (kind:9) to a channel after a
-/// batch is dead-lettered. Replies into the thread of `thread_tags` when the
-/// triggering event was threaded. Errors are logged and swallowed — the
-/// notice must never take down the main loop.
-pub(crate) async fn post_failure_notice(
+/// Best-effort: post a visible notice (kind:9) to a channel — dead-letter
+/// failure notices and long-runner status posts share this path. Replies into
+/// the thread of `thread_tags` when the triggering event was threaded. Errors
+/// are logged and swallowed — the notice must never take down the main loop
+/// or a turn.
+pub(crate) async fn post_thread_notice(
     rest: &crate::relay::RestClient,
     channel_id: Uuid,
     thread_tags: &ThreadTags,
@@ -4561,21 +4613,21 @@ pub(crate) async fn post_failure_notice(
         match buzz_sdk::build_message(channel_id, content, thread_ref.as_ref(), &[], false, &[]) {
             Ok(b) => b,
             Err(e) => {
-                tracing::warn!(channel = %channel_id, "failure notice: build failed: {e}");
+                tracing::warn!(channel = %channel_id, "thread notice: build failed: {e}");
                 return;
             }
         };
     let event = match builder.sign_with_keys(&rest.keys) {
         Ok(e) => e,
         Err(e) => {
-            tracing::warn!(channel = %channel_id, "failure notice: sign failed: {e}");
+            tracing::warn!(channel = %channel_id, "thread notice: sign failed: {e}");
             return;
         }
     };
     match tokio::time::timeout(Duration::from_secs(5), rest.submit_event(&event)).await {
         Ok(Ok(_)) => {}
-        Ok(Err(e)) => tracing::warn!(channel = %channel_id, "failure notice failed: {e}"),
-        Err(_) => tracing::warn!(channel = %channel_id, "failure notice timed out"),
+        Ok(Err(e)) => tracing::warn!(channel = %channel_id, "thread notice failed: {e}"),
+        Err(_) => tracing::warn!(channel = %channel_id, "thread notice timed out"),
     }
 }
 
@@ -4677,18 +4729,157 @@ async fn react_working(rest: &crate::relay::RestClient, event_ids: &[String]) {
     }
 }
 
-/// Fire-and-forget: remove both 👀 and 💬 from all events. Spawned on turn complete.
-/// Capped at `REACTION_CONCURRENCY` concurrent requests per chunk to avoid
-/// unbounded HTTP fan-out on large batches.
+/// Fire-and-forget: remove 👀, 💬, and ⚙️ from all events. Spawned on turn
+/// complete. Capped at `REACTION_CONCURRENCY` concurrent requests per chunk to
+/// avoid unbounded HTTP fan-out on large batches. Deliberately leaves the
+/// terminal ✅/❌ (added by the main loop after the turn returns) untouched —
+/// removing ❌ here would race the main loop adding it.
 async fn clear_reactions(rest: crate::relay::RestClient, event_ids: Vec<String>) {
-    // Each event needs two removals (👀 and 💬); pair them and chunk by
-    // REACTION_CONCURRENCY pairs so the total concurrent requests stay bounded.
+    // Each event needs three removals (👀, 💬, ⚙️); group them and chunk by
+    // REACTION_CONCURRENCY events so the total concurrent requests stay bounded.
     for chunk in event_ids.chunks(REACTION_CONCURRENCY) {
         futures_util::future::join_all(chunk.iter().flat_map(|eid| {
             [
                 reaction_remove(&rest, eid, REACTION_SEEN),
                 reaction_remove(&rest, eid, REACTION_WORKING),
+                reaction_remove(&rest, eid, REACTION_TOOLING),
             ]
+        }))
+        .await;
+    }
+}
+
+/// Aborts the per-turn tool-call status watcher when the turn's task exits.
+///
+/// Held by `run_prompt_task` for the lifetime of the turn; dropping it (any
+/// exit path, including panic unwind) stops the watcher so a long-runner post
+/// can never fire after the turn has ended.
+struct TurnStatusWatcherGuard(JoinHandle<()>);
+
+impl Drop for TurnStatusWatcherGuard {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// Render the one-per-turn long-runner status post body.
+fn long_runner_notice(title: &str, elapsed: Duration) -> String {
+    // Floor at 1 minute: the post can only fire at or after the 60s threshold.
+    let minutes = (elapsed.as_secs() / 60).max(1);
+    format!("⚙️ still working — {title} ({minutes}m)")
+}
+
+/// Per-turn tool-call status watcher.
+///
+/// Driven by [`ToolCallSignal`]s forwarded from the ACP session-update stream:
+///
+/// * first `Started` → adds ⚙️ to every triggering event;
+/// * a single tool call running past [`LONG_RUNNER_THRESHOLD`] → posts one
+///   kind:9 thread reply for the whole turn ("⚙️ still working — …"), even
+///   when the tool never emits a `tool_call_update` (the deadline is armed at
+///   `Started`, not polled from updates).
+///
+/// Ends when the sender is dropped or the owning [`TurnStatusWatcherGuard`]
+/// aborts it. Everything here is best-effort — failures are logged by the
+/// underlying publish helpers and never affect the turn.
+async fn run_turn_status_watcher(
+    rest: crate::relay::RestClient,
+    event_ids: Vec<String>,
+    channel_id: Uuid,
+    thread_tags: ThreadTags,
+    mut rx: mpsc::UnboundedReceiver<ToolCallSignal>,
+) {
+    let mut first_tool_seen = false;
+    let mut long_post_sent = false;
+    // Number of tool calls currently running, plus the title and start time
+    // of the one whose long-runner deadline is armed. Signals carry no tool
+    // id, so overlapping calls are tracked as a count: the armed deadline
+    // belongs to the call that started while none were running.
+    let mut running: usize = 0;
+    let mut current: Option<(String, tokio::time::Instant)> = None;
+
+    loop {
+        let deadline = match (&current, long_post_sent) {
+            (Some((_, started)), false) => Some(*started + LONG_RUNNER_THRESHOLD),
+            _ => None,
+        };
+        let long_runner_due = async {
+            match deadline {
+                Some(at) => tokio::time::sleep_until(at).await,
+                None => std::future::pending().await,
+            }
+        };
+        tokio::select! {
+            signal = rx.recv() => match signal {
+                None => break,
+                Some(ToolCallSignal::Started { title }) => {
+                    if !first_tool_seen {
+                        first_tool_seen = true;
+                        for chunk in event_ids.chunks(REACTION_CONCURRENCY) {
+                            futures_util::future::join_all(
+                                chunk.iter().map(|eid| reaction_add(&rest, eid, REACTION_TOOLING)),
+                            )
+                            .await;
+                        }
+                    }
+                    running += 1;
+                    if current.is_none() {
+                        current = Some((title, tokio::time::Instant::now()));
+                    }
+                }
+                Some(ToolCallSignal::Finished) => {
+                    running = running.saturating_sub(1);
+                    if running == 0 {
+                        current = None;
+                    }
+                }
+            },
+            _ = long_runner_due => {
+                if let Some((title, started)) = &current {
+                    let content = long_runner_notice(title, started.elapsed());
+                    post_thread_notice(&rest, channel_id, &thread_tags, &content).await;
+                    long_post_sent = true;
+                }
+            }
+        }
+    }
+}
+
+/// Map a completed turn's outcome to its terminal lifecycle reaction.
+///
+/// `None` means "no terminal reaction": cancelled turns (including an
+/// agent-reported `cancelled` stop reason) re-deliver their batch into the
+/// next turn (steer/interrupt merge), so neither ✅ nor ❌ would be truthful
+/// yet. A refusal completes the ACP turn but posts no reply, so it counts as
+/// ❌ alongside errors, exits, and timeouts.
+pub(crate) fn terminal_reaction_for_outcome(outcome: &PromptOutcome) -> Option<&'static str> {
+    match outcome {
+        PromptOutcome::Ok(StopReason::Refusal) => Some(REACTION_FAILED),
+        PromptOutcome::Ok(StopReason::Cancelled) => None,
+        PromptOutcome::Ok(_) => Some(REACTION_DONE),
+        PromptOutcome::Cancelled | PromptOutcome::CancelDrainTimeout(_) => None,
+        PromptOutcome::Error(_) | PromptOutcome::AgentExited | PromptOutcome::Timeout(_) => {
+            Some(REACTION_FAILED)
+        }
+    }
+}
+
+/// Best-effort: publish the terminal lifecycle reaction (✅/❌) on all
+/// triggering events. A ✅ first removes any ❌ left by an earlier failed
+/// attempt of the same events, so a retried batch that eventually succeeds
+/// does not display both. Capped at `REACTION_CONCURRENCY` concurrent
+/// requests per chunk.
+pub(crate) async fn react_terminal(
+    rest: crate::relay::RestClient,
+    event_ids: Vec<String>,
+    emoji: &'static str,
+) {
+    for chunk in event_ids.chunks(REACTION_CONCURRENCY) {
+        futures_util::future::join_all(chunk.iter().map(|eid| async {
+            if emoji == REACTION_DONE {
+                reaction_remove(&rest, eid, REACTION_FAILED).await;
+            }
+            reaction_add(&rest, eid, emoji).await;
         }))
         .await;
     }
@@ -4699,6 +4890,102 @@ mod tests {
     use super::*;
     use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
     use serde_json::json;
+
+    // ── Lifecycle status reactions ──────────────────────────────────────
+
+    /// Shape contract for every status reaction published by `reaction_add`:
+    /// NIP-25 kind 7, content = emoji, a single `e` tag naming the target.
+    /// No `h` tag — the relay derives a reaction's channel from its target
+    /// event (`derive_reaction_channel`), matching the CLI/desktop shape.
+    #[test]
+    fn status_reaction_event_is_kind_7_with_target_e_tag() {
+        let keys = Keys::generate();
+        let target = EventBuilder::new(Kind::Custom(1), "x")
+            .tags([])
+            .sign_with_keys(&keys)
+            .expect("sign target")
+            .id;
+        let event = buzz_sdk::build_reaction(target, REACTION_TOOLING)
+            .expect("build reaction")
+            .sign_with_keys(&keys)
+            .expect("sign reaction");
+
+        assert_eq!(event.kind, Kind::Custom(7));
+        assert_eq!(event.content, REACTION_TOOLING);
+        let e_tags: Vec<_> = event
+            .tags
+            .iter()
+            .filter(|t| t.kind().to_string() == "e")
+            .collect();
+        assert_eq!(e_tags.len(), 1, "exactly one e tag");
+        assert_eq!(e_tags[0].content(), Some(target.to_hex().as_str()));
+        assert!(
+            !event.tags.iter().any(|t| t.kind().to_string() == "h"),
+            "reactions carry no h tag — channel is derived from the target"
+        );
+    }
+
+    #[test]
+    fn terminal_reaction_ok_outcomes_map_to_done() {
+        for stop in [
+            StopReason::EndTurn,
+            StopReason::MaxTokens,
+            StopReason::MaxTurnRequests,
+        ] {
+            assert_eq!(
+                terminal_reaction_for_outcome(&PromptOutcome::Ok(stop)),
+                Some(REACTION_DONE)
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_reaction_failures_map_to_failed() {
+        let failures = [
+            PromptOutcome::Ok(StopReason::Refusal),
+            PromptOutcome::Error(AcpError::Protocol("boom".into())),
+            PromptOutcome::AgentExited,
+            PromptOutcome::Timeout(TimeoutKind::Idle),
+            PromptOutcome::Timeout(TimeoutKind::Hard {
+                recently_active: true,
+            }),
+            PromptOutcome::Timeout(TimeoutKind::Hard {
+                recently_active: false,
+            }),
+        ];
+        for outcome in &failures {
+            assert_eq!(
+                terminal_reaction_for_outcome(outcome),
+                Some(REACTION_FAILED),
+                "{outcome:?} must map to ❌"
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_reaction_cancels_map_to_none() {
+        // Cancelled batches are re-delivered into the next turn, so neither
+        // terminal reaction would be truthful yet.
+        for outcome in [
+            PromptOutcome::Ok(StopReason::Cancelled),
+            PromptOutcome::Cancelled,
+            PromptOutcome::CancelDrainTimeout(Duration::from_secs(5)),
+        ] {
+            assert_eq!(terminal_reaction_for_outcome(&outcome), None);
+        }
+    }
+
+    #[test]
+    fn long_runner_notice_floors_at_one_minute() {
+        assert_eq!(
+            long_runner_notice("shell", Duration::from_secs(60)),
+            "⚙️ still working — shell (1m)"
+        );
+        assert_eq!(
+            long_runner_notice("web_search", Duration::from_secs(150)),
+            "⚙️ still working — web_search (2m)"
+        );
+    }
 
     fn test_mcp_server() -> McpServer {
         McpServer {
@@ -7957,6 +8244,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             agent_keys: agent_keys.clone(),
             agent_owner_pubkey: owner_pubkey,
             memory_enabled: false,
+            status_reactions_enabled: true,
             harness_name: "goose".to_string(),
             relay_url: "ws://127.0.0.1:3000".to_string(),
         }


### PR DESCRIPTION
## What

Agent turns are invisible from inside a channel: a user who mentions an agent cannot tell "thinking" from "dead" without reading harness logs. This adds deterministic, harness-level status signals:

- **Lifecycle reactions** on the triggering message: ⚙️ when the first `tool_call` session update arrives, ✅ when the turn completes with output, ❌ on error/timeout/agent-exit/refusal. (👀 at queue-accept and 💬 pre-prompt already existed; this completes the lifecycle.) A ✅ removes a stale ❌ left by an earlier failed attempt of the same batch, so retries converge on the truth.
- **Long-runner post**: if a single tool call runs >60s, one throttled kind:9 thread reply — "⚙️ still working — <tool title> (2m)" — via the existing thread-notice path (correct root/reply/h tags). Fires from a timer, so a tool call that never sends updates still reports.

Both are on by default and disabled with `--no-status-reactions` / `BUZZ_ACP_NO_STATUS_REACTIONS`, mirroring the `no_typing` pattern end to end (CLI, config, startup summary line).

## Design notes

- Reactions use the existing `pool::reaction_add`/`reaction_remove` REST path and the canonical Buzz reaction shape (single `e` tag; the relay derives the channel via `derive_reaction_channel`). Best-effort: a failed reaction never fails a turn.
- Terminal reactions publish from `handle_prompt_result` — the single choke point where every turn outcome lands. Cancelled turns get no terminal emoji: cancelled batches re-deliver into the next turn, so neither ✅ nor ❌ would be truthful.
- Tool-call signals flow from the ACP session-update handler to a per-turn watcher task via an `UnboundedSender<ToolCallSignal>`; a guard aborts the watcher on any turn exit.

## Testing

- `cargo test -p buzz-acp`: 811 + 9 pass. New coverage: reaction event shape, outcome→emoji mapping, long-runner notice formatting, signal forwarding + no-sender safety, config default and summary.
- `cargo fmt --check`, `cargo clippy -p buzz-acp --all-targets -- -D warnings` clean on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wQgGmhkhqkmpRLfwPu3aX