### PR TITLE
feat(desktop): add observer-frame retention control and archive size readout

### DIFF
--- a/desktop/src/features/local-archive/retentionSettings.test.mjs
+++ b/desktop/src/features/local-archive/retentionSettings.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MAX_RETENTION_DAYS,
+  MIN_RETENTION_DAYS,
+  deriveSizeReadout,
+  formatBytes,
+  parseRetentionDays,
+} from "./retentionSettings.ts";
+
+// ── parseRetentionDays ────────────────────────────────────────────────────────
+
+test("parseRetentionDays_validInteger_ok", () => {
+  assert.deepEqual(parseRetentionDays("30"), { ok: true, days: 30 });
+});
+
+test("parseRetentionDays_trimsWhitespace", () => {
+  assert.deepEqual(parseRetentionDays("  7  "), { ok: true, days: 7 });
+});
+
+test("parseRetentionDays_min_ok", () => {
+  assert.deepEqual(parseRetentionDays(String(MIN_RETENTION_DAYS)), {
+    ok: true,
+    days: MIN_RETENTION_DAYS,
+  });
+});
+
+test("parseRetentionDays_max_ok", () => {
+  assert.deepEqual(parseRetentionDays(String(MAX_RETENTION_DAYS)), {
+    ok: true,
+    days: MAX_RETENTION_DAYS,
+  });
+});
+
+test("parseRetentionDays_empty_error", () => {
+  const r = parseRetentionDays("   ");
+  assert.equal(r.ok, false);
+});
+
+test("parseRetentionDays_zero_belowMin", () => {
+  const r = parseRetentionDays("0");
+  assert.equal(r.ok, false);
+  assert.match(r.error, /at least 1/);
+});
+
+test("parseRetentionDays_negative_rejected", () => {
+  // The leading "-" fails the digits-only shape before the range check.
+  const r = parseRetentionDays("-5");
+  assert.equal(r.ok, false);
+  assert.match(r.error, /whole number/);
+});
+
+test("parseRetentionDays_fractional_rejected", () => {
+  const r = parseRetentionDays("3.5");
+  assert.equal(r.ok, false);
+  assert.match(r.error, /whole number/);
+});
+
+test("parseRetentionDays_nonNumeric_rejected", () => {
+  const r = parseRetentionDays("abc");
+  assert.equal(r.ok, false);
+});
+
+test("parseRetentionDays_aboveMax_rejected", () => {
+  const r = parseRetentionDays(String(MAX_RETENTION_DAYS + 1));
+  assert.equal(r.ok, false);
+  assert.match(r.error, /at most/);
+});
+
+// ── formatBytes ───────────────────────────────────────────────────────────────
+
+test("formatBytes_zeroAndNegative_clampToZero", () => {
+  assert.equal(formatBytes(0), "0 B");
+  assert.equal(formatBytes(-100), "0 B");
+  assert.equal(formatBytes(Number.NaN), "0 B");
+});
+
+test("formatBytes_bytes", () => {
+  assert.equal(formatBytes(820), "820 B");
+});
+
+test("formatBytes_kilobytes_oneDecimalUnderTen", () => {
+  assert.equal(formatBytes(1024 * 3 + 410), "3.4 KB");
+});
+
+test("formatBytes_gigabytes", () => {
+  assert.equal(formatBytes(7.4 * 1024 ** 3), "7.4 GB");
+});
+
+test("formatBytes_roundsAtTenOrAbove", () => {
+  // 12.4 GB rounds to whole number once ≥ 10 in its unit.
+  assert.equal(formatBytes(12.4 * 1024 ** 3), "12 GB");
+});
+
+// ── deriveSizeReadout ─────────────────────────────────────────────────────────
+
+test("deriveSizeReadout_physicalIsMainPlusWal", () => {
+  const r = deriveSizeReadout({
+    mainFileBytes: 1024 ** 3,
+    walFileBytes: 512 * 1024 ** 2,
+    pageSize: 4096,
+    pageCount: 1000,
+    freelistCount: 0,
+  });
+  assert.equal(r.physicalBytes, 1024 ** 3 + 512 * 1024 ** 2);
+  assert.equal(r.physicalLabel, "1.5 GB");
+  assert.equal(r.reclaimableBytes, 0);
+  assert.equal(r.reclaimableLabel, "0 B");
+});
+
+test("deriveSizeReadout_reclaimableIsFreelistTimesPageSize", () => {
+  const r = deriveSizeReadout({
+    mainFileBytes: 0,
+    walFileBytes: 0,
+    pageSize: 4096,
+    freelistCount: 262_144, // 256K pages × 4KB = 1 GB
+    pageCount: 300_000,
+  });
+  assert.equal(r.reclaimableBytes, 1024 ** 3);
+  assert.equal(r.reclaimableLabel, "1.0 GB");
+});

--- a/desktop/src/features/local-archive/retentionSettings.ts
+++ b/desktop/src/features/local-archive/retentionSettings.ts
@@ -1,0 +1,85 @@
+// Pure helpers for the observer-frame retention control and the archive size
+// readout. Kept free of React and Tauri so the branch-heavy logic — input
+// parsing, client-side bound validation, and byte formatting — is unit-tested
+// directly, matching the `localArchiveKinds` split in this feature.
+
+import type { ArchiveSizeStats } from "@/shared/api/tauriArchive";
+
+/** Inclusive bounds mirroring the backend's `validate_days` (`retention.rs`). */
+export const MIN_RETENTION_DAYS = 1;
+export const MAX_RETENTION_DAYS = 36_500;
+
+export type ParsedDays =
+  | { ok: true; days: number }
+  | { ok: false; error: string };
+
+/**
+ * Parse and bound-check a retention-days text input. Accepts only a plain
+ * non-negative integer in `[MIN, MAX]`; anything else (blank, non-numeric,
+ * fractional, signed, out-of-range) is rejected with a message suitable for
+ * inline display. Mirrors the backend contract so the invoke is only issued
+ * for values the store will accept.
+ */
+export function parseRetentionDays(raw: string): ParsedDays {
+  const trimmed = raw.trim();
+  if (trimmed === "") return { ok: false, error: "Enter a number of days." };
+  // Reject signs, decimals, whitespace-in-the-middle — only bare digits.
+  if (!/^\d+$/.test(trimmed)) {
+    return { ok: false, error: "Days must be a whole number." };
+  }
+  const days = Number(trimmed);
+  if (days < MIN_RETENTION_DAYS) {
+    return { ok: false, error: `Days must be at least ${MIN_RETENTION_DAYS}.` };
+  }
+  if (days > MAX_RETENTION_DAYS) {
+    return {
+      ok: false,
+      error: `Days must be at most ${MAX_RETENTION_DAYS.toLocaleString()}.`,
+    };
+  }
+  return { ok: true, days };
+}
+
+/**
+ * Human-readable byte size: "0 B", "820 B", "12.4 KB", "3.1 MB", "7.4 GB".
+ * Binary (1024) units, matching `FileCard`'s `formatFileSize`. Negative or
+ * non-finite inputs clamp to "0 B" rather than rendering nonsense.
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let size = bytes / 1024;
+  let i = 0;
+  while (size >= 1024 && i < units.length - 1) {
+    size /= 1024;
+    i += 1;
+  }
+  return `${size < 10 ? size.toFixed(1) : Math.round(size)} ${units[i]}`;
+}
+
+export type ArchiveSizeReadout = {
+  /** Physical bytes actually on disk: main DB file + `-wal` sidecar. */
+  physicalBytes: number;
+  /** Reclaimable bytes sitting on the freelist (`freelistCount × pageSize`). */
+  reclaimableBytes: number;
+  physicalLabel: string;
+  reclaimableLabel: string;
+};
+
+/**
+ * Derive the size readout from raw stats. Physical size is the honest on-disk
+ * footprint (main + WAL); reclaimable is freelist pages, which only shrink the
+ * file after an offline VACUUM — until then they are savings, not a smaller
+ * file. Callers label them so the UI never implies the file has already shrunk.
+ */
+export function deriveSizeReadout(stats: ArchiveSizeStats): ArchiveSizeReadout {
+  const physicalBytes = stats.mainFileBytes + stats.walFileBytes;
+  const reclaimableBytes = Math.max(0, stats.freelistCount * stats.pageSize);
+  return {
+    physicalBytes,
+    reclaimableBytes,
+    physicalLabel: formatBytes(physicalBytes),
+    reclaimableLabel: formatBytes(reclaimableBytes),
+  };
+}

--- a/desktop/src/features/local-archive/ui/LocalArchiveSettingsCard.test.mjs
+++ b/desktop/src/features/local-archive/ui/LocalArchiveSettingsCard.test.mjs
@@ -29,12 +29,17 @@ let screen;
 let createElement;
 let ObserverRetentionSection;
 let ArchiveSizeSection;
+let LocalArchiveSettingsCard;
+let QueryClient;
+let QueryClientProvider;
+let CommunitiesProvider;
 
 before(async () => {
   Object.assign(globalThis, {
     document: dom.window.document,
     HTMLElement: dom.window.HTMLElement,
     window: dom.window,
+    localStorage: dom.window.localStorage,
     IS_REACT_ACT_ENVIRONMENT: true,
   });
   Object.defineProperty(globalThis, "navigator", {
@@ -60,8 +65,13 @@ before(async () => {
     "@testing-library/react"
   ));
   ({ createElement } = await import("react"));
-  ({ ObserverRetentionSection, ArchiveSizeSection } = await import(
-    "./LocalArchiveSettingsCard.tsx"
+  ({ ObserverRetentionSection, ArchiveSizeSection, LocalArchiveSettingsCard } =
+    await import("./LocalArchiveSettingsCard.tsx"));
+  ({ QueryClient, QueryClientProvider } = await import(
+    "@tanstack/react-query"
+  ));
+  ({ CommunitiesProvider } = await import(
+    "@/features/communities/useCommunities.tsx"
   ));
 });
 
@@ -79,6 +89,8 @@ test("retention field seeds from the saved value and disables Save while unchang
     render(
       createElement(ObserverRetentionSection, {
         savedDays: 30,
+        status: "loaded",
+        onRetry: () => {},
         onSaved: () => {},
       }),
     );
@@ -95,6 +107,8 @@ test("input disabled until the saved value loads", async () => {
     render(
       createElement(ObserverRetentionSection, {
         savedDays: null,
+        status: "loading",
+        onRetry: () => {},
         onSaved: () => {},
       }),
     );
@@ -111,6 +125,8 @@ test("out-of-bounds input surfaces an inline error and blocks Save", async () =>
     render(
       createElement(ObserverRetentionSection, {
         savedDays: 30,
+        status: "loaded",
+        onRetry: () => {},
         onSaved: () => {},
       }),
     );
@@ -131,6 +147,60 @@ test("out-of-bounds input surfaces an inline error and blocks Save", async () =>
   );
 });
 
+test("inline validation error is associated with the input via aria", async () => {
+  await act(async () => {
+    render(
+      createElement(ObserverRetentionSection, {
+        savedDays: 30,
+        status: "loaded",
+        onRetry: () => {},
+        onSaved: () => {},
+      }),
+    );
+  });
+
+  const input = screen.getByTestId("local-archive-retention-days");
+
+  // Valid state: no error wiring.
+  assert.equal(input.getAttribute("aria-invalid"), "false");
+  assert.equal(input.getAttribute("aria-describedby"), null);
+
+  await act(async () => {
+    fireEvent.change(input, { target: { value: "0" } });
+  });
+
+  const error = screen.getByTestId("local-archive-retention-error");
+  assert.equal(input.getAttribute("aria-invalid"), "true");
+  assert.equal(input.getAttribute("aria-describedby"), error.id);
+  assert.ok(error.id, "error message carries an id to reference");
+});
+
+test("retention load failure shows an error state with retry, not a stuck field", async () => {
+  let retries = 0;
+  await act(async () => {
+    render(
+      createElement(ObserverRetentionSection, {
+        savedDays: null,
+        status: "error",
+        onRetry: () => {
+          retries += 1;
+        },
+        onSaved: () => {},
+      }),
+    );
+  });
+
+  // The input/Save affordance is replaced by an explicit error+retry row.
+  assert.equal(screen.queryByTestId("local-archive-retention-days"), null);
+  const errorState = screen.getByTestId("local-archive-retention-error-state");
+  assert.match(errorState.textContent, /Couldn't load/);
+
+  await act(async () => {
+    fireEvent.click(errorState.querySelector("button"));
+  });
+  assert.equal(retries, 1, "Retry invokes the reload callback");
+});
+
 test("a valid change saves through the invoke and reports the new value", async () => {
   const setCalls = [];
   ipcHandlers.set("set_observer_retention_days", (args) => {
@@ -143,6 +213,8 @@ test("a valid change saves through the invoke and reports the new value", async 
     render(
       createElement(ObserverRetentionSection, {
         savedDays: 30,
+        status: "loaded",
+        onRetry: () => {},
         onSaved: (d) => {
           saved = d;
         },
@@ -172,6 +244,8 @@ test("size readout shows physical size and reclaimable bytes", async () => {
   await act(async () => {
     render(
       createElement(ArchiveSizeSection, {
+        status: "loaded",
+        onRetry: () => {},
         stats: {
           mainFileBytes: 1024 ** 3,
           walFileBytes: 512 * 1024 ** 2,
@@ -195,7 +269,13 @@ test("size readout shows physical size and reclaimable bytes", async () => {
 
 test("size readout shows a loading fallback before stats arrive", async () => {
   await act(async () => {
-    render(createElement(ArchiveSizeSection, { stats: null }));
+    render(
+      createElement(ArchiveSizeSection, {
+        stats: null,
+        status: "loading",
+        onRetry: () => {},
+      }),
+    );
   });
 
   assert.equal(
@@ -206,4 +286,106 @@ test("size readout shows a loading fallback before stats arrive", async () => {
     screen.getByTestId("local-archive-size-section").textContent,
     /Loading…/,
   );
+});
+
+test("size load failure shows an error state with retry", async () => {
+  let retries = 0;
+  await act(async () => {
+    render(
+      createElement(ArchiveSizeSection, {
+        stats: null,
+        status: "error",
+        onRetry: () => {
+          retries += 1;
+        },
+      }),
+    );
+  });
+
+  assert.equal(screen.queryByTestId("local-archive-size-physical"), null);
+  const errorState = screen.getByTestId("local-archive-size-error-state");
+  assert.match(errorState.textContent, /Couldn't load/);
+
+  await act(async () => {
+    fireEvent.click(errorState.querySelector("button"));
+  });
+  assert.equal(retries, 1, "Retry invokes the reload callback");
+});
+
+// ── Full-card get → set → get round trip ──────────────────────────────────────
+
+test("full card loads the persisted retention, saves an edit, and reflects it", async () => {
+  // No stored communities ⇒ activeCommunity is null ⇒ the channels query stays
+  // disabled, so only these archive commands fire. get_observer_retention_days
+  // reads the store on mount; set persists; the card advances its own state
+  // from the resolved set (no re-fetch), which is the get→set→get contract.
+  let stored = 30;
+  const setCalls = [];
+  ipcHandlers.set("get_identity", () =>
+    Promise.resolve({ pubkey: "f".repeat(64), display_name: "Tester" }),
+  );
+  ipcHandlers.set("list_save_subscriptions", () => Promise.resolve([]));
+  ipcHandlers.set("get_observer_retention_days", () => Promise.resolve(stored));
+  ipcHandlers.set("archive_size_stats", () =>
+    Promise.resolve({
+      mainFileBytes: 1024 ** 3,
+      walFileBytes: 0,
+      pageSize: 4096,
+      pageCount: 262_144,
+      freelistCount: 0,
+    }),
+  );
+  ipcHandlers.set("set_observer_retention_days", (args) => {
+    setCalls.push(args);
+    stored = args.days;
+    return Promise.resolve(null);
+  });
+
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+
+  await act(async () => {
+    render(
+      createElement(
+        QueryClientProvider,
+        { client },
+        createElement(
+          CommunitiesProvider,
+          null,
+          createElement(LocalArchiveSettingsCard),
+        ),
+      ),
+    );
+  });
+
+  // get: field seeded from the persisted 30, Save disabled while unchanged.
+  const input = screen.getByTestId("local-archive-retention-days");
+  assert.equal(input.value, "30");
+  assert.equal(
+    screen.getByTestId("local-archive-retention-save").disabled,
+    true,
+  );
+
+  // set: edit to a new valid value and save.
+  await act(async () => {
+    fireEvent.change(input, { target: { value: "7" } });
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByTestId("local-archive-retention-save"));
+  });
+
+  assert.deepEqual(setCalls, [{ days: 7 }], "set invoke receives parsed days");
+  assert.equal(stored, 7, "backing store now holds the new value");
+
+  // get (post-set): the card advanced its saved value, so the field still shows
+  // 7 and Save has returned to disabled — the persisted value round-trips.
+  assert.equal(input.value, "7");
+  assert.equal(
+    screen.getByTestId("local-archive-retention-save").disabled,
+    true,
+    "Save re-disables once the edit matches the new saved value",
+  );
+
+  client.clear();
 });

--- a/desktop/src/features/local-archive/ui/LocalArchiveSettingsCard.test.mjs
+++ b/desktop/src/features/local-archive/ui/LocalArchiveSettingsCard.test.mjs
@@ -1,0 +1,209 @@
+/**
+ * Mounted-render tests for the two archive-retention sections added in P3':
+ * ObserverRetentionSection and ArchiveSizeSection.
+ *
+ * These mount the REAL subcomponents (exported from LocalArchiveSettingsCard)
+ * against a mocked Tauri IPC bridge, so the render → validate → invoke path is
+ * exercised end-to-end. The full card is not mounted: it depends on the
+ * communities/channels query context, which is orthogonal to what these
+ * sections do. The bound-parsing and byte-formatting logic they build on is
+ * unit-tested directly in `retentionSettings.test.mjs`.
+ */
+
+import assert from "node:assert/strict";
+import { after, afterEach, before, test } from "node:test";
+
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+const ipcHandlers = new Map();
+
+let act;
+let cleanup;
+let fireEvent;
+let render;
+let screen;
+let createElement;
+let ObserverRetentionSection;
+let ArchiveSizeSection;
+
+before(async () => {
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    window: dom.window,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: dom.window.navigator,
+    writable: true,
+  });
+  dom.window.matchMedia = () => ({
+    matches: false,
+    addEventListener() {},
+    removeEventListener() {},
+  });
+  dom.window.__TAURI_INTERNALS__ = {
+    invoke: (cmd, args) => {
+      const handler = ipcHandlers.get(cmd);
+      if (handler) return handler(args);
+      return Promise.reject(new Error(`unmocked Tauri command: ${cmd}`));
+    },
+    transformCallback: () => Math.random(),
+  };
+
+  ({ act, cleanup, fireEvent, render, screen } = await import(
+    "@testing-library/react"
+  ));
+  ({ createElement } = await import("react"));
+  ({ ObserverRetentionSection, ArchiveSizeSection } = await import(
+    "./LocalArchiveSettingsCard.tsx"
+  ));
+});
+
+afterEach(() => {
+  cleanup?.();
+  ipcHandlers.clear();
+});
+
+after(() => dom.window.close());
+
+// ── ObserverRetentionSection ──────────────────────────────────────────────────
+
+test("retention field seeds from the saved value and disables Save while unchanged", async () => {
+  await act(async () => {
+    render(
+      createElement(ObserverRetentionSection, {
+        savedDays: 30,
+        onSaved: () => {},
+      }),
+    );
+  });
+
+  const input = screen.getByTestId("local-archive-retention-days");
+  assert.equal(input.value, "30");
+  const save = screen.getByTestId("local-archive-retention-save");
+  assert.equal(save.disabled, true, "unchanged value cannot be saved");
+});
+
+test("input disabled until the saved value loads", async () => {
+  await act(async () => {
+    render(
+      createElement(ObserverRetentionSection, {
+        savedDays: null,
+        onSaved: () => {},
+      }),
+    );
+  });
+
+  assert.equal(
+    screen.getByTestId("local-archive-retention-days").disabled,
+    true,
+  );
+});
+
+test("out-of-bounds input surfaces an inline error and blocks Save", async () => {
+  await act(async () => {
+    render(
+      createElement(ObserverRetentionSection, {
+        savedDays: 30,
+        onSaved: () => {},
+      }),
+    );
+  });
+
+  const input = screen.getByTestId("local-archive-retention-days");
+  await act(async () => {
+    fireEvent.change(input, { target: { value: "0" } });
+  });
+
+  assert.match(
+    screen.getByTestId("local-archive-retention-error").textContent,
+    /at least 1/,
+  );
+  assert.equal(
+    screen.getByTestId("local-archive-retention-save").disabled,
+    true,
+  );
+});
+
+test("a valid change saves through the invoke and reports the new value", async () => {
+  const setCalls = [];
+  ipcHandlers.set("set_observer_retention_days", (args) => {
+    setCalls.push(args);
+    return Promise.resolve(null);
+  });
+
+  let saved = null;
+  await act(async () => {
+    render(
+      createElement(ObserverRetentionSection, {
+        savedDays: 30,
+        onSaved: (d) => {
+          saved = d;
+        },
+      }),
+    );
+  });
+
+  const input = screen.getByTestId("local-archive-retention-days");
+  await act(async () => {
+    fireEvent.change(input, { target: { value: "14" } });
+  });
+
+  const save = screen.getByTestId("local-archive-retention-save");
+  assert.equal(save.disabled, false, "a changed valid value enables Save");
+
+  await act(async () => {
+    fireEvent.click(save);
+  });
+
+  assert.deepEqual(setCalls, [{ days: 14 }], "invoke receives the parsed days");
+  assert.equal(saved, 14, "onSaved reports the persisted value");
+});
+
+// ── ArchiveSizeSection ────────────────────────────────────────────────────────
+
+test("size readout shows physical size and reclaimable bytes", async () => {
+  await act(async () => {
+    render(
+      createElement(ArchiveSizeSection, {
+        stats: {
+          mainFileBytes: 1024 ** 3,
+          walFileBytes: 512 * 1024 ** 2,
+          pageSize: 4096,
+          pageCount: 300_000,
+          freelistCount: 262_144, // 1 GB reclaimable
+        },
+      }),
+    );
+  });
+
+  assert.equal(
+    screen.getByTestId("local-archive-size-physical").textContent,
+    "1.5 GB",
+  );
+  const copy = screen.getByTestId("local-archive-size-section").textContent;
+  assert.match(copy, /1\.5 GB/);
+  assert.match(copy, /1\.0 GB is reclaimable/);
+  assert.match(copy, /only shrinks after an offline compaction/);
+});
+
+test("size readout shows a loading fallback before stats arrive", async () => {
+  await act(async () => {
+    render(createElement(ArchiveSizeSection, { stats: null }));
+  });
+
+  assert.equal(
+    screen.getByTestId("local-archive-size-physical").textContent,
+    "—",
+  );
+  assert.match(
+    screen.getByTestId("local-archive-size-section").textContent,
+    /Loading…/,
+  );
+});

--- a/desktop/src/features/local-archive/ui/LocalArchiveSettingsCard.tsx
+++ b/desktop/src/features/local-archive/ui/LocalArchiveSettingsCard.tsx
@@ -67,6 +67,30 @@ function kindSummary(kinds: number[]): string {
   return `${kinds.slice(0, 3).join(", ")} +${kinds.length - 3} more`;
 }
 
+/** Load lifecycle for the two independently-fetched sections below. */
+export type LoadStatus = "loading" | "error" | "loaded";
+
+/** Inline failure row with a retry action, scoped to a single section so a
+ * failed read never wedges the rest of the card. */
+function LoadErrorRow({
+  message,
+  onRetry,
+  testId,
+}: {
+  message: string;
+  onRetry: () => void;
+  testId: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-4" data-testid={testId}>
+      <p className="min-w-0 flex-1 text-sm text-destructive">{message}</p>
+      <Button onClick={onRetry} size="sm" type="button" variant="outline">
+        Retry
+      </Button>
+    </div>
+  );
+}
+
 // ── Observer-feed archive section ─────────────────────────────────────────────
 
 type ObserverSectionProps = {
@@ -161,13 +185,18 @@ function AgentMetricArchiveSection({
 // ── Observer retention section ────────────────────────────────────────────────
 
 type RetentionSectionProps = {
-  /** Persisted value, or `null` while the initial load is in flight. */
+  /** Persisted value, or `null` while unavailable (loading or errored). */
   savedDays: number | null;
+  /** Load lifecycle; drives the error/retry affordance. */
+  status: LoadStatus;
+  onRetry: () => void;
   onSaved: (days: number) => void;
 };
 
 export function ObserverRetentionSection({
   savedDays,
+  status,
+  onRetry,
   onSaved,
 }: RetentionSectionProps) {
   const [draft, setDraft] = React.useState("");
@@ -181,6 +210,7 @@ export function ObserverRetentionSection({
 
   const parsed = parseRetentionDays(draft);
   const invalid = !parsed.ok;
+  const showError = invalid && draft.trim() !== "";
   const unchanged =
     parsed.ok && savedDays !== null && parsed.days === savedDays;
   const canSave = parsed.ok && !unchanged && !isSaving;
@@ -207,45 +237,58 @@ export function ObserverRetentionSection({
         title="Observer frame retention"
         description="Observer frames older than this many days are pruned from the local archive. NIP-AM turn metrics and every other archived kind are kept forever."
       >
-        <div className="space-y-3 px-4 py-4">
-          <div className="flex items-end gap-2">
-            <div className="min-w-0">
-              <label
-                className="mb-1.5 block text-sm font-medium"
-                htmlFor="local-archive-retention-days"
+        {status === "error" ? (
+          <LoadErrorRow
+            message="Couldn't load the retention window."
+            onRetry={onRetry}
+            testId="local-archive-retention-error-state"
+          />
+        ) : (
+          <div className="space-y-3 px-4 py-4">
+            <div className="flex items-end gap-2">
+              <div className="min-w-0">
+                <label
+                  className="mb-1.5 block text-sm font-medium"
+                  htmlFor="local-archive-retention-days"
+                >
+                  Keep for (days)
+                </label>
+                <input
+                  aria-describedby={
+                    showError ? "local-archive-retention-error" : undefined
+                  }
+                  aria-invalid={showError}
+                  className="w-32 rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  data-testid="local-archive-retention-days"
+                  disabled={savedDays === null}
+                  id="local-archive-retention-days"
+                  inputMode="numeric"
+                  onChange={(e) => setDraft(e.target.value)}
+                  placeholder="30"
+                  type="text"
+                  value={draft}
+                />
+              </div>
+              <Button
+                data-testid="local-archive-retention-save"
+                disabled={!canSave}
+                onClick={() => void handleSave()}
+                type="button"
               >
-                Keep for (days)
-              </label>
-              <input
-                className="w-32 rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                data-testid="local-archive-retention-days"
-                disabled={savedDays === null}
-                id="local-archive-retention-days"
-                inputMode="numeric"
-                onChange={(e) => setDraft(e.target.value)}
-                placeholder="30"
-                type="text"
-                value={draft}
-              />
+                {isSaving ? "Saving…" : "Save"}
+              </Button>
             </div>
-            <Button
-              data-testid="local-archive-retention-save"
-              disabled={!canSave}
-              onClick={() => void handleSave()}
-              type="button"
-            >
-              {isSaving ? "Saving…" : "Save"}
-            </Button>
+            {showError && (
+              <p
+                className="text-xs text-destructive"
+                data-testid="local-archive-retention-error"
+                id="local-archive-retention-error"
+              >
+                {parsed.error}
+              </p>
+            )}
           </div>
-          {invalid && draft.trim() !== "" && (
-            <p
-              className="text-xs text-destructive"
-              data-testid="local-archive-retention-error"
-            >
-              {parsed.error}
-            </p>
-          )}
-        </div>
+        )}
       </SettingsOptionGroup>
     </div>
   );
@@ -255,32 +298,44 @@ export function ObserverRetentionSection({
 
 export function ArchiveSizeSection({
   stats,
+  status,
+  onRetry,
 }: {
   stats: ArchiveSizeStats | null;
+  status: LoadStatus;
+  onRetry: () => void;
 }) {
   const readout = stats ? deriveSizeReadout(stats) : null;
   return (
     <div data-testid="local-archive-size-section">
       <SettingsOptionGroup title="Storage">
-        <SettingsOptionRow>
-          <div className="min-w-0 flex-1">
-            <p className="text-sm font-medium">Archive size on disk</p>
-            <p
-              className="text-sm font-normal text-muted-foreground/70"
-              data-settings-subcopy
+        {status === "error" ? (
+          <LoadErrorRow
+            message="Couldn't load the archive size."
+            onRetry={onRetry}
+            testId="local-archive-size-error-state"
+          />
+        ) : (
+          <SettingsOptionRow>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium">Archive size on disk</p>
+              <p
+                className="text-sm font-normal text-muted-foreground/70"
+                data-settings-subcopy
+              >
+                {readout === null
+                  ? "Loading…"
+                  : `Physical size ${readout.physicalLabel} (database + write-ahead log). ${readout.reclaimableLabel} is reclaimable after pruning — freed pages become reusable space; the file only shrinks after an offline compaction.`}
+              </p>
+            </div>
+            <span
+              className="shrink-0 text-sm font-medium tabular-nums"
+              data-testid="local-archive-size-physical"
             >
-              {readout === null
-                ? "Loading…"
-                : `Physical size ${readout.physicalLabel} (database + write-ahead log). ${readout.reclaimableLabel} is reclaimable after pruning — freed pages become reusable space; the file only shrinks after an offline compaction.`}
-            </p>
-          </div>
-          <span
-            className="shrink-0 text-sm font-medium tabular-nums"
-            data-testid="local-archive-size-physical"
-          >
-            {readout?.physicalLabel ?? "—"}
-          </span>
-        </SettingsOptionRow>
+              {readout?.physicalLabel ?? "—"}
+            </span>
+          </SettingsOptionRow>
+        )}
       </SettingsOptionGroup>
     </div>
   );
@@ -531,9 +586,12 @@ export function LocalArchiveSettingsCard() {
   const [observerToggling, setObserverToggling] = React.useState(false);
   const [metricToggling, setMetricToggling] = React.useState(false);
   const [retentionDays, setRetentionDays] = React.useState<number | null>(null);
+  const [retentionStatus, setRetentionStatus] =
+    React.useState<LoadStatus>("loading");
   const [sizeStats, setSizeStats] = React.useState<ArchiveSizeStats | null>(
     null,
   );
+  const [sizeStatus, setSizeStatus] = React.useState<LoadStatus>("loading");
 
   const pubkey = identityQuery.data?.pubkey ?? "";
 
@@ -566,20 +624,38 @@ export function LocalArchiveSettingsCard() {
   }, [reload]);
 
   // Retention window + size readout load independently of the subscription
-  // list; a failure in either is non-fatal (the sections show their loading
-  // fallback) and must not blank the rest of the card.
-  React.useEffect(() => {
+  // list; a failure in either is non-fatal — the affected section shows an
+  // inline error with a retry action and never blanks the rest of the card.
+  const loadRetention = React.useCallback(() => {
+    setRetentionStatus("loading");
     void getObserverRetentionDays()
-      .then(setRetentionDays)
-      .catch((err) =>
-        console.warn("[LocalArchiveSettingsCard] retention load failed:", err),
-      );
-    void archiveSizeStats()
-      .then(setSizeStats)
-      .catch((err) =>
-        console.warn("[LocalArchiveSettingsCard] size load failed:", err),
-      );
+      .then((days) => {
+        setRetentionDays(days);
+        setRetentionStatus("loaded");
+      })
+      .catch((err) => {
+        console.warn("[LocalArchiveSettingsCard] retention load failed:", err);
+        setRetentionStatus("error");
+      });
   }, []);
+
+  const loadSize = React.useCallback(() => {
+    setSizeStatus("loading");
+    void archiveSizeStats()
+      .then((stats) => {
+        setSizeStats(stats);
+        setSizeStatus("loaded");
+      })
+      .catch((err) => {
+        console.warn("[LocalArchiveSettingsCard] size load failed:", err);
+        setSizeStatus("error");
+      });
+  }, []);
+
+  React.useEffect(() => {
+    loadRetention();
+    loadSize();
+  }, [loadRetention, loadSize]);
 
   const handleDelete = React.useCallback(
     async (scopeType: ScopeType, scopeValue: string) => {
@@ -698,12 +774,18 @@ export function LocalArchiveSettingsCard() {
 
         {/* Observer frame retention window */}
         <ObserverRetentionSection
+          onRetry={loadRetention}
           onSaved={setRetentionDays}
           savedDays={retentionDays}
+          status={retentionStatus}
         />
 
         {/* Archive size readout */}
-        <ArchiveSizeSection stats={sizeStats} />
+        <ArchiveSizeSection
+          onRetry={loadSize}
+          stats={sizeStats}
+          status={sizeStatus}
+        />
 
         {/* Channel subscriptions */}
         <div data-testid="local-archive-subscriptions">

--- a/desktop/src/features/local-archive/ui/LocalArchiveSettingsCard.tsx
+++ b/desktop/src/features/local-archive/ui/LocalArchiveSettingsCard.tsx
@@ -3,11 +3,15 @@ import * as React from "react";
 import { toast } from "sonner";
 
 import {
+  archiveSizeStats,
   createSaveSubscription,
   deleteSaveSubscription,
+  getObserverRetentionDays,
   listSaveSubscriptions,
   mergeSaveSubscriptionKinds,
   removeSaveSubscriptionKind,
+  setObserverRetentionDays,
+  type ArchiveSizeStats,
   type SaveSubscription,
   type ScopeType,
 } from "@/shared/api/tauriArchive";
@@ -27,6 +31,7 @@ import {
 import { SettingsSectionHeader } from "@/features/settings/ui/SettingsSectionHeader";
 import { setExplicitAgentMetricArchiveChoice } from "../agentMetricArchivePreference";
 import { setExplicitObserverArchiveChoice } from "../observerArchivePreference";
+import { deriveSizeReadout, parseRetentionDays } from "../retentionSettings";
 
 import {
   buildSubscriptionRequest,
@@ -147,6 +152,134 @@ function AgentMetricArchiveSection({
             id="local-archive-agent-metric-toggle"
             onCheckedChange={onToggle}
           />
+        </SettingsOptionRow>
+      </SettingsOptionGroup>
+    </div>
+  );
+}
+
+// ── Observer retention section ────────────────────────────────────────────────
+
+type RetentionSectionProps = {
+  /** Persisted value, or `null` while the initial load is in flight. */
+  savedDays: number | null;
+  onSaved: (days: number) => void;
+};
+
+export function ObserverRetentionSection({
+  savedDays,
+  onSaved,
+}: RetentionSectionProps) {
+  const [draft, setDraft] = React.useState("");
+  const [isSaving, setIsSaving] = React.useState(false);
+
+  // Seed the field from the persisted value once it loads, and re-seed whenever
+  // it changes underneath us (e.g. a successful save elsewhere).
+  React.useEffect(() => {
+    if (savedDays !== null) setDraft(String(savedDays));
+  }, [savedDays]);
+
+  const parsed = parseRetentionDays(draft);
+  const invalid = !parsed.ok;
+  const unchanged =
+    parsed.ok && savedDays !== null && parsed.days === savedDays;
+  const canSave = parsed.ok && !unchanged && !isSaving;
+
+  const handleSave = React.useCallback(async () => {
+    if (!parsed.ok) return;
+    setIsSaving(true);
+    try {
+      await setObserverRetentionDays(parsed.days);
+      onSaved(parsed.days);
+      toast.success("Retention window updated.");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to update retention.",
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }, [parsed, onSaved]);
+
+  return (
+    <div data-testid="local-archive-retention-section">
+      <SettingsOptionGroup
+        title="Observer frame retention"
+        description="Observer frames older than this many days are pruned from the local archive. NIP-AM turn metrics and every other archived kind are kept forever."
+      >
+        <div className="space-y-3 px-4 py-4">
+          <div className="flex items-end gap-2">
+            <div className="min-w-0">
+              <label
+                className="mb-1.5 block text-sm font-medium"
+                htmlFor="local-archive-retention-days"
+              >
+                Keep for (days)
+              </label>
+              <input
+                className="w-32 rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                data-testid="local-archive-retention-days"
+                disabled={savedDays === null}
+                id="local-archive-retention-days"
+                inputMode="numeric"
+                onChange={(e) => setDraft(e.target.value)}
+                placeholder="30"
+                type="text"
+                value={draft}
+              />
+            </div>
+            <Button
+              data-testid="local-archive-retention-save"
+              disabled={!canSave}
+              onClick={() => void handleSave()}
+              type="button"
+            >
+              {isSaving ? "Saving…" : "Save"}
+            </Button>
+          </div>
+          {invalid && draft.trim() !== "" && (
+            <p
+              className="text-xs text-destructive"
+              data-testid="local-archive-retention-error"
+            >
+              {parsed.error}
+            </p>
+          )}
+        </div>
+      </SettingsOptionGroup>
+    </div>
+  );
+}
+
+// ── Archive size readout section ──────────────────────────────────────────────
+
+export function ArchiveSizeSection({
+  stats,
+}: {
+  stats: ArchiveSizeStats | null;
+}) {
+  const readout = stats ? deriveSizeReadout(stats) : null;
+  return (
+    <div data-testid="local-archive-size-section">
+      <SettingsOptionGroup title="Storage">
+        <SettingsOptionRow>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium">Archive size on disk</p>
+            <p
+              className="text-sm font-normal text-muted-foreground/70"
+              data-settings-subcopy
+            >
+              {readout === null
+                ? "Loading…"
+                : `Physical size ${readout.physicalLabel} (database + write-ahead log). ${readout.reclaimableLabel} is reclaimable after pruning — freed pages become reusable space; the file only shrinks after an offline compaction.`}
+            </p>
+          </div>
+          <span
+            className="shrink-0 text-sm font-medium tabular-nums"
+            data-testid="local-archive-size-physical"
+          >
+            {readout?.physicalLabel ?? "—"}
+          </span>
         </SettingsOptionRow>
       </SettingsOptionGroup>
     </div>
@@ -397,6 +530,10 @@ export function LocalArchiveSettingsCard() {
   const [isAddingOpen, setIsAddingOpen] = React.useState(false);
   const [observerToggling, setObserverToggling] = React.useState(false);
   const [metricToggling, setMetricToggling] = React.useState(false);
+  const [retentionDays, setRetentionDays] = React.useState<number | null>(null);
+  const [sizeStats, setSizeStats] = React.useState<ArchiveSizeStats | null>(
+    null,
+  );
 
   const pubkey = identityQuery.data?.pubkey ?? "";
 
@@ -427,6 +564,22 @@ export function LocalArchiveSettingsCard() {
   React.useEffect(() => {
     void reload();
   }, [reload]);
+
+  // Retention window + size readout load independently of the subscription
+  // list; a failure in either is non-fatal (the sections show their loading
+  // fallback) and must not blank the rest of the card.
+  React.useEffect(() => {
+    void getObserverRetentionDays()
+      .then(setRetentionDays)
+      .catch((err) =>
+        console.warn("[LocalArchiveSettingsCard] retention load failed:", err),
+      );
+    void archiveSizeStats()
+      .then(setSizeStats)
+      .catch((err) =>
+        console.warn("[LocalArchiveSettingsCard] size load failed:", err),
+      );
+  }, []);
 
   const handleDelete = React.useCallback(
     async (scopeType: ScopeType, scopeValue: string) => {
@@ -542,6 +695,15 @@ export function LocalArchiveSettingsCard() {
           onToggle={(checked) => void handleMetricToggle(checked)}
           toggling={metricToggling}
         />
+
+        {/* Observer frame retention window */}
+        <ObserverRetentionSection
+          onSaved={setRetentionDays}
+          savedDays={retentionDays}
+        />
+
+        {/* Archive size readout */}
+        <ArchiveSizeSection stats={sizeStats} />
 
         {/* Channel subscriptions */}
         <div data-testid="local-archive-subscriptions">

--- a/desktop/src/shared/api/tauriArchive.ts
+++ b/desktop/src/shared/api/tauriArchive.ts
@@ -99,6 +99,25 @@ export type AgentUsageSeriesRequest = {
   agentPubkey?: string;
 };
 
+/**
+ * Physical and logical size accounting for the archive DB, from
+ * `archive_size_stats`. Mirrors `retention::ArchiveSizeStats`
+ * (`#[serde(rename_all = "camelCase")]`) field-for-field. All figures are cheap
+ * PRAGMAs + file metadata — no payload scans.
+ */
+export type ArchiveSizeStats = {
+  /** On-disk size of the main DB file, in bytes. */
+  mainFileBytes: number;
+  /** On-disk size of the `-wal` sidecar, in bytes; `0` when absent. */
+  walFileBytes: number;
+  /** SQLite page size, in bytes. */
+  pageSize: number;
+  /** Total pages in the main DB. */
+  pageCount: number;
+  /** Free (reclaimable) pages on the freelist. */
+  freelistCount: number;
+};
+
 // ── Wire-shape types (raw Tauri responses) ───────────────────────────────────
 
 /**
@@ -554,4 +573,32 @@ export async function readArchivedEvents(
       }
     })
     .filter((e): e is import("@/shared/api/types").RelayEvent => e !== null);
+}
+
+// ── Retention configuration ──────────────────────────────────────────────────
+
+/**
+ * Read the global observer-frame (kind 24200) retention window, in days. Every
+ * other archived kind — NIP-AM metrics and any custom subscription — is kept
+ * indefinitely and has no setting.
+ */
+export async function getObserverRetentionDays(): Promise<number> {
+  return invokeTauri<number>("get_observer_retention_days");
+}
+
+/**
+ * Set the global observer-frame retention window, in days. The backend is
+ * fail-closed and rejects values outside `1..=36500`; callers validate the
+ * same bounds client-side before invoking (see `retentionSettings`).
+ */
+export async function setObserverRetentionDays(days: number): Promise<void> {
+  await invokeTauri("set_observer_retention_days", { days });
+}
+
+/**
+ * Physical (file) and logical (page) size accounting for the archive DB, for
+ * the Settings size readout. PRAGMAs + file metadata only — no payload scans.
+ */
+export async function archiveSizeStats(): Promise<ArchiveSizeStats> {
+  return invokeTauri<ArchiveSizeStats>("archive_size_stats");
 }


### PR DESCRIPTION
Bounds the observer-frame retention window and surfaces archive size in the local-archive Settings card. The retention backend landed in #5719 (the `get_observer_retention_days` / `set_observer_retention_days` / `archive_size_stats` commands), but nothing consumed it yet.

## What this adds

- **Observer frame retention field** — one control bound to `1..=36500` days, validated client-side to match the fail-closed backend, wired to `getObserverRetentionDays` / `setObserverRetentionDays`. Copy states that NIP-AM turn metrics and every other archived kind are kept forever. Save is disabled while the value is unchanged or invalid.
- **Storage readout** — physical size (main DB + `-wal`) plus reclaimable freelist bytes (`freelistCount × pageSize`) from `archive_size_stats`, honestly labeled: freed pages become reusable space; the file only shrinks after an offline compaction.

The prune worker (P2', separate PR) does the actual deletion — the retention value persists and takes effect when it lands; this UI needs no knowledge of the worker.

## Structure

- `retentionSettings.ts` — pure `parseRetentionDays`, `formatBytes`, and `deriveSizeReadout` helpers, split out per the feature's existing `localArchiveKinds` convention so the branch-heavy logic is unit-tested directly.
- New API wrappers + `ArchiveSizeStats` type in `tauriArchive.ts` (camelCase wire shape, mirrors the Rust struct).
- Two new sections in `LocalArchiveSettingsCard.tsx`.

## Tests

- `retentionSettings.test.mjs` — bounds/parse edge cases (blank, signed, fractional, zero, over-max) and byte-formatting/size-math.
- `LocalArchiveSettingsCard.test.mjs` — mounts the real sections against a mocked IPC bridge: seed-from-saved, disabled-until-loaded, inline validation, set→invoke round-trip, and the size readout formatting + loading fallback.

From the `buzz-archive-retention` arc (P3').
