### PR TITLE
docs(bridge): document /query filter array request body

### DIFF
--- a/docs/bridge-channel-window.md
+++ b/docs/bridge-channel-window.md
@@ -27,19 +27,23 @@ full-event query; they never see a wrong-but-plausible timeline.
 
 ## Request
 
-A standard bridge filter plus extension fields:
+A standard bridge filter plus extension fields. The HTTP bridge accepts a JSON
+**array of filters**, so send the following complete request body to `POST
+/query` (not the inner filter object by itself):
 
 ```json
-{
-  "kinds": [9],
-  "#h": ["<channel-uuid>"],
-  "limit": 50,
-  "top_level": true,
-  "include_summaries": true,
-  "include_aux": true,
-  "until": 1751500000,
-  "before_id": "<64-hex event id>"
-}
+[
+  {
+    "kinds": [9],
+    "#h": ["<channel-uuid>"],
+    "limit": 50,
+    "top_level": true,
+    "include_summaries": true,
+    "include_aux": true,
+    "until": 1751500000,
+    "before_id": "<64-hex event id>"
+  }
+]
 ```
 
 - `top_level: true` — routes this filter to the top-level SQL view.

--- a/docs/nips/NIP-CW.md
+++ b/docs/nips/NIP-CW.md
@@ -47,19 +47,21 @@ This document uses MUST, MUST NOT, SHOULD, MAY, and RECOMMENDED as defined in RF
 
 ## Request
 
-A window request is a standard filter plus extension fields, submitted wherever the relay accepts filters (for Buzz: the NIP-98-authenticated HTTP bridge `POST /query`):
+A window request is a standard filter plus extension fields, submitted wherever the relay accepts filters (for Buzz: the NIP-98-authenticated HTTP bridge `POST /query`). The request body is a JSON **array of filters**, as on a NIP-01 filter surface; the window filter below is one element of that array:
 
 ```jsonc
-{
-  "kinds": [9],                  // optional row-kind restriction
-  "#h": ["<channel-id>"],        // REQUIRED: exactly one channel
-  "limit": 50,                   // row budget (rows only, never overlays)
-  "top_level": true,             // selects the window path
-  "include_summaries": true,     // optional: kind:39005 overlays
-  "include_aux": true,           // optional: aux closure
-  "until": 1751500000,           // ┐ composite request cursor —
-  "before_id": "<64-hex id>"     // ┘ both or neither
-}
+[
+  {
+    "kinds": [9],                  // optional row-kind restriction
+    "#h": ["<channel-id>"],        // REQUIRED: exactly one channel
+    "limit": 50,                   // row budget (rows only, never overlays)
+    "top_level": true,             // selects the window path
+    "include_summaries": true,     // optional: kind:39005 overlays
+    "include_aux": true,           // optional: aux closure
+    "until": 1751500000,           // ┐ composite request cursor —
+    "before_id": "<64-hex id>"     // ┘ both or neither
+  }
+]
 ```
 
 - `top_level` — MUST be boolean `true` to select the window path. Any other value (absent, `false`, string, number) means the filter is served as a normal filter.


### PR DESCRIPTION
## Summary

- Document that the HTTP bridge `POST /query` accepts a JSON array of filters
- Show complete copyable request bodies in NIP-CW and bridge-channel-window
- Clarify that sending the inner filter object by itself is invalid

Closes #6477.

## Testing

- `git diff --check`
- Parsed both documented request examples as JSON (stripping JSONC comments in the NIP example)