### PR TITLE
fix(desktop): keep the huddle playout tick on schedule on Windows

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -63,7 +63,7 @@ user-idle = { version = "0.6", default-features = false }
 plist = "1"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Security", "Win32_Storage_FileSystem", "Win32_System_JobObjects", "Win32_System_Registry", "Win32_System_Threading", "Win32_Foundation"] }
+windows-sys = { version = "0.61", features = ["Win32_Security", "Win32_Storage_FileSystem", "Win32_System_JobObjects", "Win32_System_Registry", "Win32_System_Threading", "Win32_Foundation", "Win32_Media"] }
 keyring = { version = "3.6.3", default-features = false, features = ["windows-native", "vendored"], optional = true }
 user-idle = { version = "0.6", default-features = false }
 

--- a/desktop/src-tauri/src/huddle/playout.rs
+++ b/desktop/src-tauri/src/huddle/playout.rs
@@ -192,14 +192,35 @@ pub(crate) async fn run_playout_recv_loop(
     let mut speaker_level_tick =
         tokio::time::interval(std::time::Duration::from_millis(SPEAKER_LEVEL_TICK_MS));
     speaker_level_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Windows timers default to a 15.6 ms resolution, and tokio intervals
+    // fire ~14.6 ms late there on average (tokio-rs/tokio#5021). At that
+    // resolution the 10 ms playout tick below manages only ~62 of the 100
+    // required pulls per second (measured on Windows 11: 62.4 ticks/s
+    // without the raised resolution, 100.2 with it). Raise the resolution
+    // to 1 ms for the lifetime of the playout loop and hand it back on exit.
+    #[cfg(windows)]
+    let _timer_resolution = {
+        struct TimerResolutionGuard;
+        impl Drop for TimerResolutionGuard {
+            fn drop(&mut self) {
+                unsafe { windows_sys::Win32::Media::timeEndPeriod(1) };
+            }
+        }
+        unsafe { windows_sys::Win32::Media::timeBeginPeriod(1) };
+        TimerResolutionGuard
+    };
+
     let mut playout_tick = tokio::time::interval(std::time::Duration::from_millis(PLAYOUT_TICK_MS));
-    // `Delay` (not `Skip`) so a brief stall in another select arm — e.g. the
-    // ws_tx_for_pongs mutex contending with the encode-side task on a Ping —
-    // doesn't drop a playout tick outright. Dropped ticks would leave the
-    // per-peer Player queues empty for 10 ms and the device mixer would
-    // produce audible silence. `Delay` catches up immediately when the loop
-    // returns to the select.
-    playout_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // `Burst` rather than `Delay` or `Skip`. `Delay` never shortens the
+    // ticks that follow a missed one ("ticks are not shortened"), so once
+    // the timer resolves coarsely or the WebView loads the core, the mean
+    // pull rate stays below 100/s for good: the per-peer Player queues
+    // starve (audible gaps, dropped words) while NetEq stays full and
+    // time-compresses playback indefinitely (metallic, sped-up voices).
+    // `Burst` makes up missed ticks immediately and holds the mean rate;
+    // the short catch-up bursts are absorbed by the existing queue
+    // recovery (hysteresis 10→4, emergency trim at 30).
+    playout_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Burst);
 
     loop {
         tokio::select! {

--- a/desktop/src-tauri/src/huddle/playout.rs
+++ b/desktop/src-tauri/src/huddle/playout.rs
@@ -44,6 +44,10 @@ const SPEAKER_LEVEL_TICK_MS: u64 = 50;
 const FRAME_WINDOW: std::time::Duration = std::time::Duration::from_millis(500);
 /// Playout clock: NetEq emits 10 ms frames, so we tick at 10 ms.
 const PLAYOUT_TICK_MS: u64 = 10;
+/// Gap beyond which a `Burst` catch-up is pointless: NetEq holds at most
+/// 200 ms of audio, so a backlog older than this only replays silence and
+/// stalls the select loop. Detected gaps reset the interval instead.
+const PLAYOUT_STALE_RESET_MS: u64 = 300;
 
 /// How long after the last received packet we keep pulling frames out of a
 /// peer's NetEq into its rodio Player. NetEq always emits a frame on every
@@ -206,8 +210,11 @@ pub(crate) async fn run_playout_recv_loop(
                 unsafe { windows_sys::Win32::Media::timeEndPeriod(1) };
             }
         }
-        unsafe { windows_sys::Win32::Media::timeBeginPeriod(1) };
-        TimerResolutionGuard
+        // TIMERR_NOERROR == 0. Only pair a `timeEndPeriod` with a begin that
+        // actually succeeded; on failure we run at the default resolution and
+        // `Burst` below still recovers the mean rate.
+        (unsafe { windows_sys::Win32::Media::timeBeginPeriod(1) } == 0)
+            .then_some(TimerResolutionGuard)
     };
 
     let mut playout_tick = tokio::time::interval(std::time::Duration::from_millis(PLAYOUT_TICK_MS));
@@ -219,14 +226,25 @@ pub(crate) async fn run_playout_recv_loop(
     // time-compresses playback indefinitely (metallic, sped-up voices).
     // `Burst` makes up missed ticks immediately and holds the mean rate;
     // the short catch-up bursts are absorbed by the existing queue
-    // recovery (hysteresis 10→4, emergency trim at 30).
+    // recovery (hysteresis 10→4, emergency trim at 30). Catch-up is only
+    // useful within NetEq's reach though (200 ms): after a suspend or a
+    // stall longer than PLAYOUT_STALE_RESET_MS the backlog is stale, so we
+    // drop it and realign the cadence instead of replaying it.
     playout_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Burst);
+    let mut last_playout_tick = tokio::time::Instant::now();
 
     loop {
         tokio::select! {
             biased;
             _ = cancel.cancelled() => break,
             _ = playout_tick.tick() => {
+                let now = tokio::time::Instant::now();
+                if now.duration_since(last_playout_tick)
+                    > std::time::Duration::from_millis(PLAYOUT_STALE_RESET_MS)
+                {
+                    playout_tick.reset();
+                }
+                last_playout_tick = now;
                 // Drain one 10 ms frame from each *active* peer's NetEq into
                 // its Player. NetEq always emits a frame (Expand/silence when
                 // empty), so for peers that recently sent we keep the device


### PR DESCRIPTION
> Note: supersedes #5973 — same two commits, re-issued after the branch was force-pushed during an author-identity cleanup on my fork (GitHub does not allow reopening a PR after a force-push). Content is unchanged; review feedback from #5973 still applies.

Huddle audio on my Windows 11 box was constantly choppy — metallic voices, dropped words, every call, every peer. Sounded exactly like the reports in #2652. Network was my first suspect and it was a dead end: I measured the incoming frame stream over ten minutes and got p99 inter-frame gap of 22 ms with zero losses. So the frames arrive fine and something eats them locally.

Root cause is the 10 ms playout tick in `run_playout_recv_loop`. It uses `MissedTickBehavior::Delay`, and `Delay` never shortens the ticks that follow a missed one. Windows timers default to a 15.6 ms resolution, and tokio intervals fire ~14.6 ms late there on average (tokio-rs/tokio#5021). Put those together and the loop settles at ~62 pulls per second instead of 100. The per-peer rodio queues run dry and the mixer plays silence gaps, while NetEq sits at its 200 ms cap and time-compresses playback forever — that's the robot voice. #4281 later moved the drop threshold to speed recovery, but the tick rate itself never changed, which would be why the reports kept coming.

To verify I wrote a small standalone program with exactly this interval setup and ran it on Windows 11 (IoT LTSC 2024): 62.4 ticks/s with `Delay` at default resolution, 100.2 ticks/s with `timeBeginPeriod(1)` active and `Burst`. The machine dependence falls out of this too — any other process can raise the global timer resolution, so some machines never show the bug.

The fix does two things:

1. Raises the timer resolution to 1 ms for the lifetime of the playout loop, handed back through a drop guard (`timeEndPeriod`). Gated behind `#[cfg(windows)]`, so other platforms are untouched.
2. Switches the playout tick to `Burst`, so missed ticks are made up instead of silently lost. The short catch-up bursts stay bounded by the queue recovery that's already there (hysteresis 10→4, emergency trim at 30).

We've been running this in real calls since yesterday and the audio is clean — no gaps, no acceleration, and I couldn't hear any regression. I haven't exercised macOS or Linux beyond the fact that the resolution guard doesn't compile there and `Burst` only changes behavior when ticks are actually missed.

The `unsafe` blocks are the two `winmm` FFI calls; there was no way around them that I could find, and the desktop crate already does OS-level FFI the same way in `mouse_nav.rs` and `shutdown.rs`.

