### PR TITLE
chore(desktop): drop unused ORIGINAL_CONTENT from empty-edit-delete spec

### DIFF
--- a/desktop/tests/e2e/empty-edit-delete.spec.ts
+++ b/desktop/tests/e2e/empty-edit-delete.spec.ts
@@ -6,7 +6,6 @@ import { installMockBridge } from "../helpers/bridge";
 // DEFAULT_MOCK_IDENTITY.pubkey in e2eBridge.ts). Editing/deleting one's own
 // message is exactly Sam's workflow: "delete a message by clearing its edit."
 const OWN_MESSAGE_ID = "mock-general-welcome";
-const ORIGINAL_CONTENT = "Welcome to #general";
 const RENDERED_ORIGINAL_CONTENT = "Welcome to general";
 
 // Open the more-actions menu for a message row and wait for the menu to mount.


### PR DESCRIPTION
`biome check` fails with `lint/correctness/noUnusedVariables` on `ORIGINAL_CONTENT` in `desktop/tests/e2e/empty-edit-delete.spec.ts`, which fails `pnpm check` (Desktop Core) for **every PR touching desktop paths** — e.g. it currently blocks #6460. It presumably landed while Desktop Core was path-skipped on the introducing PR.

One-line removal; the constant has no remaining references (the assertions use `RENDERED_ORIGINAL_CONTENT`).