### PR TITLE
fix(buzz-acp): treat settled turns as activity for the idle-pool clock

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1638,7 +1638,7 @@ fn inactivity_expired(
 /// arms before their trailing `dispatch_pending`, so the clock reflects the
 /// most recent turn completion — not only the last dispatch.
 fn note_turn_settled(last_activity: &mut tokio::time::Instant) {
-    let _ = last_activity;
+    *last_activity = tokio::time::Instant::now();
 }
 
 /// Whether a woken lazy pool may be torn back down to the empty-slot state.

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1632,6 +1632,15 @@ fn inactivity_expired(
     !bound.is_zero() && !turn_in_flight && now.duration_since(last_activity) >= bound
 }
 
+/// Re-anchor point for the idle-reaper clock when a pool turn settles.
+///
+/// Called unconditionally by the `PoolEvent::Result` and `PoolEvent::Panic`
+/// arms before their trailing `dispatch_pending`, so the clock reflects the
+/// most recent turn completion — not only the last dispatch.
+fn note_turn_settled(last_activity: &mut tokio::time::Instant) {
+    let _ = last_activity;
+}
+
 /// Whether a woken lazy pool may be torn back down to the empty-slot state.
 ///
 /// True only when the pool is ready, the idle bound has elapsed with no
@@ -1720,6 +1729,41 @@ mod idle_pool_sleep_tests {
 
     #[test]
     fn sleeps_when_ready_idle_and_quiet() {
+        let (last, now, bound) = ready_after_bound();
+        assert!(idle_pool_sleep_due(
+            true, last, now, bound, false, false, false, false
+        ));
+    }
+
+    // Decision-level pin for block/buzz#6378: a turn that ran from T to
+    // T + 2B and has just settled (empty queue, nothing in flight) must
+    // re-anchor the clock at completion, so the pool is not sleep-due at
+    // T + 2B even though the dispatch-time anchor is long stale.
+    #[tokio::test(start_paused = true)]
+    async fn completed_long_turn_reanchors_clock_not_sleep_due() {
+        let bound = Duration::from_secs(30);
+        let turn_start = tokio::time::Instant::now();
+        tokio::time::advance(2 * bound).await;
+
+        let mut last_activity = turn_start;
+        note_turn_settled(&mut last_activity);
+
+        assert!(!idle_pool_sleep_due(
+            true,
+            last_activity,
+            tokio::time::Instant::now(),
+            bound,
+            false,
+            false,
+            false,
+            false
+        ));
+    }
+
+    // The bump must not defeat teardown: with no completed turn since the
+    // anchor T, an idle pool is still sleep-due once the bound elapses.
+    #[test]
+    fn idle_pool_without_completion_still_sleep_due_after_bound() {
         let (last, now, bound) = ready_after_bound();
         assert!(idle_pool_sleep_due(
             true, last, now, bound, false, false, false, false
@@ -3130,6 +3174,7 @@ async fn tokio_main() -> Result<()> {
 
         match pool_event {
             Some(PoolEvent::Result(result)) => {
+                note_turn_settled(&mut last_activity);
                 // Stop typing indicator for the completed channel.
                 if let PromptSource::Channel(ch) = &result.source {
                     typing_channels.remove(ch);
@@ -3172,6 +3217,7 @@ async fn tokio_main() -> Result<()> {
                 }
             }
             Some(PoolEvent::Panic(join_error)) => {
+                note_turn_settled(&mut last_activity);
                 tracing::error!("agent task panicked: {join_error}");
                 recover_panicked_agent(
                     &mut pool,


### PR DESCRIPTION
## Problem

`buzz-acp`'s idle-pool reaper anchors on `last_activity`, which is only advanced when a prompt is **dispatched**. It is never advanced when a turn **settles**.

So a turn that runs longer than the idle bound is torn down on the first reaper tick after it completes — the pool did useful work for the entire window, and the clock still reads as if it had been idle the whole time. The longer a turn runs, the more certain the teardown.

Fixes #6378.

## Change

Adds a `note_turn_settled` seam and calls it unconditionally from both settle paths in the event loop — `PoolEvent::Result` (`lib.rs:3177`) and `PoolEvent::Panic` (`lib.rs:3220`) — before their trailing `dispatch_pending`.

The existing `dispatch_pending` call already bumps `last_activity`, but only when it actually dispatches something. In the exact case this bug is about — a long turn finishing with an empty queue — it dispatches nothing and the clock stays stale. Hence a separate bump at settle time.

Two commits, test first:

- `0956a58f5` adds the seam and pins the contract. The re-anchor test fails at this commit.
- `a09fd9fe5` supplies the bump.

## Verification

All commands run on a clean tree at `a09fd9fe5` (`git status --short` empty, confirmed before and after each run).

```text
cargo fmt --all -- --check                              exit 0
cargo clippy --workspace --all-targets -- -D warnings   exit 0, 0 diagnostics
cargo test -p buzz-acp                                  lib 806 passed / 0 failed
                                                        pool_lifecycle_state 9 passed / 0 failed
```

`buzz-acp` is not one of the nine packages in `scripts/run-tests.sh unit`, so the package test above is run separately and is the gate that actually executes these tests.

**Behavioural probe.** Checked out the test-only commit `0956a58f5` in a separate detached worktree — the seam and both call sites are present there, only the bump is absent, so the crate still compiles and the wiring is unchanged:

```text
failures:
    idle_pool_sleep_tests::completed_long_turn_reanchors_clock_not_sleep_due

test result: FAILED. 805 passed; 1 failed
```

Exactly the decision test, and nothing else. Removing the behaviour while keeping the wiring fails the test.

## Known limitation

The test is decision-level: it calls `note_turn_settled` and then asserts `idle_pool_sleep_due`. It does **not** drive the real `tokio::select!` loop, so it cannot catch someone deleting one of the two arm call sites individually — the unit tests cannot reach inside those arms without a refactor well beyond this fix.

What it does cover: both arms call the same single-statement helper, so removing the shared bump disables both at once, which is what the probe above exercises. Stating the gap rather than claiming coverage the test does not have.


## Test coverage limitation — stated deliberately

The two new tests call `note_turn_settled` directly and then assert `idle_pool_sleep_due`. They pin the
decision rule, not the wiring: `tokio_main`'s event loop is not reachable from a unit test, so deleting
either call site leaves the suite green. The bump lives in one shared one-line function called
unconditionally by both settle arms, so the two arms cannot diverge, but reviewers should read the two
call sites rather than trust the tests to cover them. Flagging this rather than implying coverage the
tests do not provide.
