### PR TITLE
fix(desktop): unify linked agent runtime review

### DIFF
--- a/Dockerfile.sprig
+++ b/Dockerfile.sprig
@@ -21,7 +21,11 @@ RUN cargo build --locked --profile sprig -p sprig \
 
 FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
 
-RUN apk add --no-cache bash ca-certificates curl git \
+RUN apk add --no-cache bash ca-certificates curl git nodejs npm \
+    && npm install --global --omit=dev \
+      @agentclientprotocol/codex-acp@1.4.0 \
+      @openai/codex@0.147.0 \
+    && npm cache clean --force \
     && adduser -D -h /home/agent agent \
     && install -d -o agent -g agent /workspace /home/agent \
     && git config --system gpg.format x509 \

--- a/VISION_REMOTE_AGENTS.md
+++ b/VISION_REMOTE_AGENTS.md
@@ -56,6 +56,8 @@ Remote agents solve it from the inside. Because the desktop retains no substrate
 
 **The body's state is mortal.** Files, checkouts, half-finished working trees — gone with the body unless the substrate persists them. The agent survives; its scratch space doesn't. Durable knowledge belongs on the relay, and agents are built to put it there.
 
+**Persistent workspace storage outlives compute — and its bill.** A Kubernetes workspace PVC deliberately survives clean exit, crash, pod deletion, and redeploy so the next body can resume the same checkout. The provider never garbage-collects it. Storage keeps accruing until the cluster operator explicitly deletes the claim or its namespace; choosing persistence also means choosing that cleanup duty.
+
 **Presence can lag the truth, but not for long.** If the substrate kills a body without ceremony, the presence dot can outlive the agent — by seconds if the connection drops cleanly, by at most about three minutes if it doesn't. Presence is a lease the agent renews, not a flag it sets: a dead agent stops renewing and the relay forgets it. A bounded wrong dot, never an indefinite one.
 
 **A running agent finishes on the configuration it started with.** New keys, new models, new settings take effect on the next body. And an instance that never got far enough to run — a body that failed to start — is the substrate operator's residue to clear, with the substrate's own tools. Editing an agent mid-sentence was never on the menu.

--- a/crates/buzz-backend-kubernetes/src/cluster.rs
+++ b/crates/buzz-backend-kubernetes/src/cluster.rs
@@ -567,6 +567,15 @@ mod tests {
     fn workspace_claim_verification_rejects_foreign_or_different_claims() {
         let desired = workspace_claim();
 
+        let mut legacy = desired.clone();
+        legacy.metadata.labels.as_mut().unwrap().insert(
+            crate::naming::LABEL_BINDING_VERSION.into(),
+            crate::naming::LEGACY_BINDING_VERSION.into(),
+        );
+        assert!(verify_workspace_claim(&legacy, &desired)
+            .unwrap_err()
+            .contains("not owned by this Buzz agent"));
+
         let mut foreign = desired.clone();
         foreign
             .metadata

--- a/crates/buzz-backend-kubernetes/src/cluster.rs
+++ b/crates/buzz-backend-kubernetes/src/cluster.rs
@@ -18,7 +18,7 @@
 use crate::classify::Fence;
 use crate::reconcile::{CreateOutcome, DeleteOutcome, Substrate};
 use chrono::{DateTime, Utc};
-use k8s_openapi::api::core::v1::{Namespace, Pod, Secret};
+use k8s_openapi::api::core::v1::{Namespace, PersistentVolumeClaim, Pod, Secret};
 use kube::api::{Api, DeleteParams, GetParams, ListParams, PostParams, Preconditions};
 use kube::core::ErrorResponse;
 use kube::{Client, Resource};
@@ -73,6 +73,10 @@ impl Cluster {
     }
 
     fn secrets(&self) -> Api<Secret> {
+        Api::namespaced(self.client.clone(), &self.namespace)
+    }
+
+    fn workspace_claims(&self) -> Api<PersistentVolumeClaim> {
         Api::namespaced(self.client.clone(), &self.namespace)
     }
 
@@ -170,6 +174,40 @@ impl Substrate for Cluster {
         }
     }
 
+    async fn ensure_workspace_claim(
+        &self,
+        claim: Option<&PersistentVolumeClaim>,
+    ) -> Result<(), String> {
+        let Some(desired) = claim else {
+            return Ok(());
+        };
+        let name = desired.metadata.name.as_deref().ok_or_else(|| {
+            "persistent workspace claim is missing its deterministic name".to_string()
+        })?;
+        let api = self.workspace_claims();
+
+        match api.get_opt(name).await {
+            Ok(Some(existing)) => verify_workspace_claim(&existing, desired),
+            Ok(None) => match api.create(&PostParams::default(), desired).await {
+                Ok(created) => verify_workspace_claim(&created, desired),
+                Err(error) if reason_is(&error, REASON_ALREADY_EXISTS) => {
+                    let existing = api.get(name).await.map_err(|read_error| {
+                        format!(
+                            "workspace claim {name} won a create race but could not be read: {read_error}"
+                        )
+                    })?;
+                    verify_workspace_claim(&existing, desired)
+                }
+                Err(error) => Err(format!(
+                    "could not create persistent workspace claim {name}: {error}"
+                )),
+            },
+            Err(error) => Err(format!(
+                "could not check persistent workspace claim {name}: {error}"
+            )),
+        }
+    }
+
     async fn list_pods(&self, selector: &str) -> Result<(Vec<Pod>, Option<DateTime<Utc>>), String> {
         self.list_with_date::<Pod>(selector).await
     }
@@ -255,6 +293,81 @@ impl Substrate for Cluster {
     fn elapsed(&self) -> Duration {
         self.started.elapsed()
     }
+}
+
+fn verify_workspace_claim(
+    existing: &PersistentVolumeClaim,
+    desired: &PersistentVolumeClaim,
+) -> Result<(), String> {
+    let name = desired.metadata.name.as_deref().unwrap_or("<unnamed>");
+    let desired_labels = desired
+        .metadata
+        .labels
+        .as_ref()
+        .ok_or_else(|| format!("persistent workspace claim {name} has no ownership labels"))?;
+    let existing_labels = existing.metadata.labels.as_ref();
+    if desired_labels
+        .iter()
+        .any(|(key, value)| existing_labels.and_then(|labels| labels.get(key)) != Some(value))
+    {
+        return Err(format!(
+            "persistent workspace claim {name} already exists but is not owned by this Buzz agent"
+        ));
+    }
+
+    let desired_annotations =
+        desired.metadata.annotations.as_ref().ok_or_else(|| {
+            format!("persistent workspace claim {name} has no identity annotation")
+        })?;
+    let existing_annotations = existing.metadata.annotations.as_ref();
+    if desired_annotations.iter().any(|(key, value)| {
+        existing_annotations.and_then(|annotations| annotations.get(key)) != Some(value)
+    }) {
+        return Err(format!(
+            "persistent workspace claim {name} belongs to a different agent identity"
+        ));
+    }
+
+    let desired_spec = desired.spec.as_ref().ok_or_else(|| {
+        format!("persistent workspace claim {name} is missing its requested shape")
+    })?;
+    let existing_spec = existing
+        .spec
+        .as_ref()
+        .ok_or_else(|| format!("persistent workspace claim {name} exists without a spec"))?;
+    let existing_storage = existing_spec
+        .resources
+        .as_ref()
+        .and_then(|resources| resources.requests.as_ref())
+        .and_then(|requests| requests.get("storage"));
+    let desired_storage = desired_spec
+        .resources
+        .as_ref()
+        .and_then(|resources| resources.requests.as_ref())
+        .and_then(|requests| requests.get("storage"));
+    if existing_storage != desired_storage {
+        return Err(format!(
+            "persistent workspace claim {name} already exists with a different storage request; resize or replace it with cluster tools before retrying"
+        ));
+    }
+    if let Some(desired_class) = desired_spec.storage_class_name.as_ref() {
+        if existing_spec.storage_class_name.as_ref() != Some(desired_class) {
+            return Err(format!(
+                "persistent workspace claim {name} already exists with a different storage class"
+            ));
+        }
+    }
+    if !existing_spec
+        .access_modes
+        .as_ref()
+        .is_some_and(|modes| modes.iter().any(|mode| mode == "ReadWriteOnce"))
+    {
+        return Err(format!(
+            "persistent workspace claim {name} does not allow ReadWriteOnce access"
+        ));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -423,5 +536,65 @@ mod tests {
         assert_eq!(REASON_CONFLICT, "Conflict");
         assert_eq!(REASON_NOT_FOUND, "NotFound");
         assert_eq!(REASON_FORBIDDEN, "Forbidden");
+    }
+
+    fn workspace_claim() -> PersistentVolumeClaim {
+        use nostr::nips::nip19::ToBech32;
+        let keys = nostr::Keys::generate();
+        let identity =
+            crate::naming::AgentIdentity::from_nsec(&keys.secret_key().to_bech32().unwrap())
+                .unwrap();
+        let cfg = crate::config::parse(&serde_json::json!({
+            "namespace": "buzz-agents-test",
+            "image": format!(
+                "ghcr.io/block/buzz-sprig@sha256:{}",
+                "a".repeat(64)
+            ),
+            "workspace_storage": "20Gi",
+            "workspace_storage_class": "fast-ssd"
+        }))
+        .unwrap();
+        crate::pod::build_workspace_claim(&identity, &cfg).unwrap()
+    }
+
+    #[test]
+    fn workspace_claim_verification_accepts_the_same_identity_and_shape() {
+        let desired = workspace_claim();
+        assert_eq!(verify_workspace_claim(&desired, &desired), Ok(()));
+    }
+
+    #[test]
+    fn workspace_claim_verification_rejects_foreign_or_different_claims() {
+        let desired = workspace_claim();
+
+        let mut foreign = desired.clone();
+        foreign
+            .metadata
+            .annotations
+            .as_mut()
+            .unwrap()
+            .insert(crate::naming::ANNOTATION_PUBKEY_FULL.into(), "0".repeat(64));
+        assert!(verify_workspace_claim(&foreign, &desired)
+            .unwrap_err()
+            .contains("different agent identity"));
+
+        let mut resized = desired.clone();
+        resized
+            .spec
+            .as_mut()
+            .unwrap()
+            .resources
+            .as_mut()
+            .unwrap()
+            .requests
+            .as_mut()
+            .unwrap()
+            .insert(
+                "storage".into(),
+                k8s_openapi::apimachinery::pkg::api::resource::Quantity("30Gi".into()),
+            );
+        assert!(verify_workspace_claim(&resized, &desired)
+            .unwrap_err()
+            .contains("different storage request"));
     }
 }

--- a/crates/buzz-backend-kubernetes/src/config.rs
+++ b/crates/buzz-backend-kubernetes/src/config.rs
@@ -1,7 +1,7 @@
 //! `provider_config` parsing and the `info` config schema
 //! (spec §`provider_config` v1 fields, `docs/remote-agents.md:1384-1389`).
 //!
-//! Nine fields, all optional except `image` (required at parse time; the
+//! Eleven fields, all optional except `image` (required at parse time; the
 //! schema offers the published sprig image as a prefill default — §Image).
 //! No credential field exists, by I2: cluster auth comes from ambient
 //! kubeconfig resolution and nothing else (`:196-198`).
@@ -71,6 +71,12 @@ pub struct ProviderConfig {
     /// `None` when `inactivity_seconds` was 0 — refused in v1, see [`parse`].
     pub inactivity_seconds: Option<u64>,
     pub service_account: Option<String>,
+    /// Requested capacity for an identity-owned persistent workspace claim.
+    /// `None` preserves the v1 `emptyDir` behavior.
+    pub workspace_storage: Option<String>,
+    /// Optional StorageClass for the persistent workspace claim. Rejected
+    /// unless [`workspace_storage`](Self::workspace_storage) is also set.
+    pub workspace_storage_class: Option<String>,
 }
 
 /// Read an optional non-empty string field. Rejects non-string scalars rather
@@ -165,6 +171,14 @@ pub fn parse(cfg: &serde_json::Value) -> Result<ProviderConfig, String> {
         Some(n) => Some(n),
     };
 
+    let workspace_storage = optional_string(cfg, "workspace_storage")?;
+    let workspace_storage_class = optional_string(cfg, "workspace_storage_class")?;
+    if workspace_storage.is_none() && workspace_storage_class.is_some() {
+        return Err(
+            "provider_config.workspace_storage_class requires workspace_storage".to_string(),
+        );
+    }
+
     Ok(ProviderConfig {
         context: optional_string(cfg, "context")?,
         namespace,
@@ -172,6 +186,8 @@ pub fn parse(cfg: &serde_json::Value) -> Result<ProviderConfig, String> {
         resources,
         inactivity_seconds,
         service_account: optional_string(cfg, "service_account")?,
+        workspace_storage,
+        workspace_storage_class,
     })
 }
 
@@ -236,6 +252,16 @@ pub fn config_schema() -> serde_json::Value {
                 "type": "string",
                 "title": "Service account",
                 "description": "Scheduling/RBAC identity only. No API token is mounted."
+            },
+            "workspace_storage": {
+                "type": "string",
+                "title": "Persistent workspace size",
+                "description": "Optional Kubernetes storage request such as 20Gi. When set, Buzz creates one identity-owned claim that survives pod replacement. Leave empty for an ephemeral workspace."
+            },
+            "workspace_storage_class": {
+                "type": "string",
+                "title": "Workspace storage class",
+                "description": "Optional StorageClass for the persistent workspace claim. Leave empty to use the cluster default."
             }
         },
         "required": ["namespace", "image"]
@@ -265,6 +291,8 @@ mod tests {
         assert_eq!(c.inactivity_seconds, Some(DEFAULT_INACTIVITY_SECONDS));
         assert_eq!(c.context, None);
         assert_eq!(c.service_account, None);
+        assert_eq!(c.workspace_storage, None);
+        assert_eq!(c.workspace_storage_class, None);
     }
 
     #[test]
@@ -386,6 +414,25 @@ mod tests {
     }
 
     #[test]
+    fn persistent_workspace_fields_are_parsed_together() {
+        let mut cfg = minimal();
+        cfg["workspace_storage"] = "20Gi".into();
+        cfg["workspace_storage_class"] = "fast-ssd".into();
+        let parsed = parse(&cfg).unwrap();
+        assert_eq!(parsed.workspace_storage.as_deref(), Some("20Gi"));
+        assert_eq!(parsed.workspace_storage_class.as_deref(), Some("fast-ssd"));
+    }
+
+    #[test]
+    fn workspace_storage_class_requires_a_storage_request() {
+        let mut cfg = minimal();
+        cfg["workspace_storage_class"] = "fast-ssd".into();
+        let error = parse(&cfg).unwrap_err();
+        assert!(error.contains("workspace_storage_class"), "got: {error}");
+        assert!(error.contains("workspace_storage"), "got: {error}");
+    }
+
+    #[test]
     fn generated_namespaces_are_fresh_and_valid() {
         let a = generated_namespace();
         let b = generated_namespace();
@@ -423,10 +470,10 @@ mod tests {
         );
     }
 
-    /// Nine fields exactly (§`provider_config` v1 fields). The cap is 20; the
+    /// Eleven fields exactly (§`provider_config` fields). The cap is 20; the
     /// count is pinned so a field added without a spec change is caught here.
     #[test]
-    fn schema_declares_exactly_the_nine_v1_fields() {
+    fn schema_declares_exactly_the_eleven_fields() {
         let schema = config_schema();
         let props = schema["properties"].as_object().unwrap();
         let mut keys: Vec<&str> = props.keys().map(String::as_str).collect();
@@ -442,7 +489,9 @@ mod tests {
                 "memory_limit",
                 "memory_request",
                 "namespace",
-                "service_account"
+                "service_account",
+                "workspace_storage",
+                "workspace_storage_class"
             ]
         );
         assert_eq!(

--- a/crates/buzz-backend-kubernetes/src/intent.rs
+++ b/crates/buzz-backend-kubernetes/src/intent.rs
@@ -81,12 +81,16 @@ pub struct IntentTemplate {
     /// Fixed placeholder for the per-attempt Secret in `envFrom`.
     pub env_from_secret: &'static str,
     pub workspace_mount_path: String,
+    /// `None` means the v1 ephemeral `emptyDir`; `Some` selects the
+    /// identity-owned persistent claim and records its requested capacity.
+    pub workspace_storage: Option<String>,
+    pub workspace_storage_class: Option<String>,
     pub run_as_user: i64,
     pub run_as_group: i64,
 }
 
 /// Current template schema version.
-pub const TEMPLATE_VERSION: u32 = 1;
+pub const TEMPLATE_VERSION: u32 = 2;
 
 impl IntentTemplate {
     /// Compute the fingerprint. `serde_json` on a struct with declared field
@@ -110,6 +114,8 @@ impl IntentTemplate {
         image: &ImageRef,
         resources: &crate::config::Resources,
         service_account: Option<&str>,
+        workspace_storage: Option<&str>,
+        workspace_storage_class: Option<&str>,
         env_keys: impl IntoIterator<Item = String>,
     ) -> Self {
         let mut env_keys: Vec<String> = env_keys.into_iter().collect();
@@ -128,6 +134,8 @@ impl IntentTemplate {
             env_keys,
             env_from_secret: SECRET_PLACEHOLDER,
             workspace_mount_path: crate::config::WORKSPACE_PATH.to_string(),
+            workspace_storage: workspace_storage.map(str::to_string),
+            workspace_storage_class: workspace_storage_class.map(str::to_string),
             run_as_user: crate::config::RUN_AS_UID,
             run_as_group: crate::config::RUN_AS_GID,
         }
@@ -152,6 +160,8 @@ mod tests {
             "buzz-agents",
             &image('a'),
             &Resources::default(),
+            None,
+            None,
             None,
             ["BUZZ_RELAY_URL".to_string(), "GOOSE_MODE".to_string()],
         )
@@ -178,12 +188,16 @@ mod tests {
             &image('a'),
             &Resources::default(),
             None,
+            None,
+            None,
             ["A".to_string(), "B".to_string(), "C".to_string()],
         );
         let b = IntentTemplate::new(
             "ns",
             &image('a'),
             &Resources::default(),
+            None,
+            None,
             None,
             ["C".to_string(), "A".to_string(), "B".to_string()],
         );
@@ -250,6 +264,16 @@ mod tests {
             (
                 "workspace_mount_path",
                 Box::new(|t: &mut IntentTemplate| t.workspace_mount_path = "/w".into()),
+            ),
+            (
+                "workspace_storage",
+                Box::new(|t: &mut IntentTemplate| t.workspace_storage = Some("20Gi".into())),
+            ),
+            (
+                "workspace_storage_class",
+                Box::new(|t: &mut IntentTemplate| {
+                    t.workspace_storage_class = Some("fast-ssd".into())
+                }),
             ),
             (
                 "run_as_user",

--- a/crates/buzz-backend-kubernetes/src/naming.rs
+++ b/crates/buzz-backend-kubernetes/src/naming.rs
@@ -15,9 +15,18 @@ pub const LABEL_MANAGED_BY: &str = "app.kubernetes.io/managed-by";
 /// Label key carrying [`BINDING_VERSION`] — the marker's schema half.
 pub const LABEL_BINDING_VERSION: &str = "buzz.block.xyz/binding-version";
 
-/// Schema version of the object layout this provider writes. Bumped when the
-/// pod/Secret shape changes in a way a older provider would mis-handle.
-pub const BINDING_VERSION: &str = "1";
+/// Legacy pod/Secret binding that the v2 reader still understands during an
+/// upgrade. It is never written by this provider.
+pub const LEGACY_BINDING_VERSION: &str = "1";
+
+/// Schema version of the object layout this provider writes. Bumped because a
+/// v1 provider would replace a terminal persistent generation with `emptyDir`.
+pub const BINDING_VERSION: &str = "2";
+
+/// Pod/Secret bindings this provider may safely observe, adopt, and collect.
+/// Persistent workspace claims are deliberately excluded from this legacy
+/// compatibility surface and must carry [`BINDING_VERSION`] exactly.
+pub const SUPPORTED_READ_BINDING_VERSIONS: &[&str] = &[LEGACY_BINDING_VERSION, BINDING_VERSION];
 
 /// Label key: truncated pubkey, the reconciliation and GC selector.
 pub const LABEL_AGENT_PUBKEY: &str = "buzz.block.xyz/agent-pubkey";

--- a/crates/buzz-backend-kubernetes/src/naming.rs
+++ b/crates/buzz-backend-kubernetes/src/naming.rs
@@ -76,6 +76,12 @@ impl AgentIdentity {
         format!("buzz-agent-{}", &self.pubkey_hex[..12])
     }
 
+    /// Deterministic persistent workspace claim. Unlike the per-attempt
+    /// Secret, this name deliberately survives every pod generation.
+    pub fn workspace_claim_name(&self) -> String {
+        format!("{}-workspace", self.pod_name())
+    }
+
     /// Per-attempt Secret name. `generation` is a fresh random token per
     /// create attempt — never reused — which is what makes payload and Secret
     /// atomic at the pod-spec boundary (§K8s Secrets).
@@ -186,6 +192,17 @@ mod tests {
             .pod_name()
             .chars()
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'));
+    }
+
+    #[test]
+    fn workspace_claim_name_is_identity_stable_and_dns_safe() {
+        let id = identity();
+        assert_eq!(id.workspace_claim_name(), id.workspace_claim_name());
+        assert_eq!(
+            id.workspace_claim_name(),
+            format!("{}-workspace", id.pod_name())
+        );
+        assert!(id.workspace_claim_name().len() <= 253);
     }
 
     /// Two attempts must never share a Secret name — that uniqueness is what

--- a/crates/buzz-backend-kubernetes/src/observe.rs
+++ b/crates/buzz-backend-kubernetes/src/observe.rs
@@ -13,8 +13,8 @@
 use crate::classify::{Fence, PullFailure, Startup, VerifiedPod};
 use crate::intent::Fingerprint;
 use crate::naming::{
-    AgentIdentity, ANNOTATION_CREATE_INTENT, ANNOTATION_PUBKEY_FULL, BINDING_VERSION,
-    LABEL_BINDING_VERSION, LABEL_MANAGED_BY, MANAGED_BY,
+    AgentIdentity, ANNOTATION_CREATE_INTENT, ANNOTATION_PUBKEY_FULL, LABEL_BINDING_VERSION,
+    LABEL_MANAGED_BY, MANAGED_BY, SUPPORTED_READ_BINDING_VERSIONS,
 };
 use k8s_openapi::api::core::v1::{Pod, Secret};
 
@@ -39,10 +39,22 @@ pub enum StartupObservation {
 ///
 /// Identity labels prove identity; the marker asserts protocol ownership.
 /// Without it an object that merely matches our schema fails closed.
-fn has_marker(labels: Option<&std::collections::BTreeMap<String, String>>) -> bool {
+fn has_marker_for_binding(
+    labels: Option<&std::collections::BTreeMap<String, String>>,
+    binding_version: &str,
+) -> bool {
     let Some(labels) = labels else { return false };
     labels.get(LABEL_MANAGED_BY).map(String::as_str) == Some(MANAGED_BY)
-        && labels.get(LABEL_BINDING_VERSION).map(String::as_str) == Some(BINDING_VERSION)
+        && labels.get(LABEL_BINDING_VERSION).map(String::as_str) == Some(binding_version)
+}
+
+/// New writers adopt v1 Pods and Secrets so an upgrade can converge them to a
+/// v2 generation on the next owner-driven replacement. Unknown and future
+/// bindings still fail closed.
+fn has_supported_marker(labels: Option<&std::collections::BTreeMap<String, String>>) -> bool {
+    SUPPORTED_READ_BINDING_VERSIONS
+        .iter()
+        .any(|version| has_marker_for_binding(labels, version))
 }
 
 /// Does the full-pubkey annotation equal the derived pubkey?
@@ -62,7 +74,7 @@ fn annotation_matches(
 /// Is this Secret ours and this identity's? The same fence GC applies before
 /// deleting anything.
 pub fn secret_is_ours(secret: &Secret, identity: &AgentIdentity) -> bool {
-    has_marker(secret.metadata.labels.as_ref())
+    has_supported_marker(secret.metadata.labels.as_ref())
         && annotation_matches(secret.metadata.annotations.as_ref(), identity)
 }
 
@@ -251,7 +263,7 @@ pub fn condition(pod: &Pod) -> Option<String> {
 /// `CreateContainerConfigError` needs a most-recent Secret read the pure layer
 /// must not perform.
 pub fn verify(pod: &Pod, identity: &AgentIdentity, startup: Startup) -> Option<VerifiedPod> {
-    if !has_marker(pod.metadata.labels.as_ref()) {
+    if !has_supported_marker(pod.metadata.labels.as_ref()) {
         return None;
     }
     if !annotation_matches(pod.metadata.annotations.as_ref(), identity) {
@@ -296,6 +308,24 @@ mod tests {
                 name: Some(id.pod_name()),
                 uid: Some("uid-1".into()),
                 resource_version: Some("100".into()),
+                labels: Some(id.labels()),
+                annotations: Some(
+                    [(
+                        ANNOTATION_PUBKEY_FULL.to_string(),
+                        id.pubkey_hex().to_string(),
+                    )]
+                    .into_iter()
+                    .collect::<BTreeMap<_, _>>(),
+                ),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn base_secret(id: &AgentIdentity) -> Secret {
+        Secret {
+            metadata: ObjectMeta {
                 labels: Some(id.labels()),
                 annotations: Some(
                     [(
@@ -517,6 +547,38 @@ mod tests {
         assert!(
             verify(&base_pod(&id), &id, Startup::Started).is_some(),
             "own pod rejected"
+        );
+    }
+
+    #[test]
+    fn current_reader_accepts_legacy_v1_pods_and_secrets() {
+        let id = identity();
+        let mut pod = base_pod(&id);
+        pod.metadata.labels.as_mut().unwrap().insert(
+            LABEL_BINDING_VERSION.to_string(),
+            crate::naming::LEGACY_BINDING_VERSION.to_string(),
+        );
+        assert!(verify(&pod, &id, Startup::Started).is_some());
+
+        let mut secret = base_secret(&id);
+        secret.metadata.labels.as_mut().unwrap().insert(
+            LABEL_BINDING_VERSION.to_string(),
+            crate::naming::LEGACY_BINDING_VERSION.to_string(),
+        );
+        assert!(secret_is_ours(&secret, &id));
+    }
+
+    #[test]
+    fn legacy_v1_reader_would_refuse_current_v2_state() {
+        let id = identity();
+        let pod = base_pod(&id);
+        assert!(has_supported_marker(pod.metadata.labels.as_ref()));
+        assert!(
+            !has_marker_for_binding(
+                pod.metadata.labels.as_ref(),
+                crate::naming::LEGACY_BINDING_VERSION,
+            ),
+            "a v1 reader must fail closed on a v2 deterministic-name collision"
         );
     }
 

--- a/crates/buzz-backend-kubernetes/src/pod.rs
+++ b/crates/buzz-backend-kubernetes/src/pod.rs
@@ -12,9 +12,10 @@ use crate::naming::{
     AgentIdentity, ANNOTATION_CREATE_INTENT, ANNOTATION_IMAGE, ANNOTATION_PUBKEY_FULL,
 };
 use k8s_openapi::api::core::v1::{
-    Capabilities, Container, EmptyDirVolumeSource, EnvFromSource, Pod, PodSecurityContext, PodSpec,
+    Capabilities, Container, EmptyDirVolumeSource, EnvFromSource, PersistentVolumeClaim,
+    PersistentVolumeClaimSpec, PersistentVolumeClaimVolumeSource, Pod, PodSecurityContext, PodSpec,
     ResourceRequirements, SeccompProfile, Secret, SecretEnvSource, SecurityContext, Volume,
-    VolumeMount,
+    VolumeMount, VolumeResourceRequirements,
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -25,6 +26,46 @@ const WORKSPACE_VOLUME: &str = "workspace";
 
 /// The container name. Fixed: log and exec tooling addresses it by name.
 const CONTAINER_NAME: &str = "agent";
+
+/// Build the identity-owned persistent workspace claim requested by this
+/// configuration. The deterministic name is intentionally generation-free:
+/// pods are disposable, the workspace is not.
+pub fn build_workspace_claim(
+    identity: &AgentIdentity,
+    cfg: &ProviderConfig,
+) -> Option<PersistentVolumeClaim> {
+    let storage = cfg.workspace_storage.as_ref()?;
+    let requests = [("storage".to_string(), Quantity(storage.clone()))]
+        .into_iter()
+        .collect();
+
+    Some(PersistentVolumeClaim {
+        metadata: ObjectMeta {
+            name: Some(identity.workspace_claim_name()),
+            namespace: Some(cfg.namespace.clone()),
+            labels: Some(identity.labels()),
+            annotations: Some(
+                [(
+                    ANNOTATION_PUBKEY_FULL.to_string(),
+                    identity.pubkey_hex().to_string(),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        },
+        spec: Some(PersistentVolumeClaimSpec {
+            access_modes: Some(vec!["ReadWriteOnce".to_string()]),
+            resources: Some(VolumeResourceRequirements {
+                requests: Some(requests),
+                ..Default::default()
+            }),
+            storage_class_name: cfg.workspace_storage_class.clone(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    })
+}
 
 /// Build the per-attempt Secret holding the resolved environment.
 ///
@@ -171,14 +212,29 @@ pub fn build_pod(
                 }),
                 ..Default::default()
             }),
-            volumes: Some(vec![Volume {
-                name: WORKSPACE_VOLUME.to_string(),
-                empty_dir: Some(EmptyDirVolumeSource::default()),
-                ..Default::default()
-            }]),
+            volumes: Some(vec![workspace_volume(identity, cfg)]),
             ..Default::default()
         }),
         ..Default::default()
+    }
+}
+
+fn workspace_volume(identity: &AgentIdentity, cfg: &ProviderConfig) -> Volume {
+    if cfg.workspace_storage.is_some() {
+        Volume {
+            name: WORKSPACE_VOLUME.to_string(),
+            persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource {
+                claim_name: identity.workspace_claim_name(),
+                read_only: Some(false),
+            }),
+            ..Default::default()
+        }
+    } else {
+        Volume {
+            name: WORKSPACE_VOLUME.to_string(),
+            empty_dir: Some(EmptyDirVolumeSource::default()),
+            ..Default::default()
+        }
     }
 }
 
@@ -192,6 +248,8 @@ pub fn intent_template(
         &cfg.image,
         &cfg.resources,
         cfg.service_account.as_deref(),
+        cfg.workspace_storage.as_deref(),
+        cfg.workspace_storage_class.as_deref(),
         env_keys,
     )
 }
@@ -307,7 +365,7 @@ mod tests {
     }
 
     #[test]
-    fn workspace_is_an_emptydir_mounted_at_home() {
+    fn workspace_defaults_to_an_emptydir_mounted_at_home() {
         let pod = pod();
         let spec = spec(&pod);
         let volume = &spec.volumes.as_ref().unwrap()[0];
@@ -316,6 +374,57 @@ mod tests {
         let mount = &spec.containers[0].volume_mounts.as_ref().unwrap()[0];
         assert_eq!(mount.name, volume.name);
         assert_eq!(mount.mount_path, WORKSPACE_PATH);
+    }
+
+    #[test]
+    fn persistent_workspace_claim_and_pod_share_the_identity_stable_name() {
+        let id = identity();
+        let mut cfg = provider_config();
+        cfg.workspace_storage = Some("20Gi".into());
+        cfg.workspace_storage_class = Some("fast-ssd".into());
+
+        let claim = build_workspace_claim(&id, &cfg).expect("persistent claim");
+        assert_eq!(
+            claim.metadata.name.as_deref(),
+            Some(id.workspace_claim_name().as_str())
+        );
+        assert_eq!(claim.metadata.labels.as_ref(), Some(&id.labels()));
+        assert_eq!(
+            claim.metadata.annotations.as_ref().unwrap()[ANNOTATION_PUBKEY_FULL],
+            id.pubkey_hex()
+        );
+        let claim_spec = claim.spec.as_ref().unwrap();
+        assert_eq!(
+            claim_spec.access_modes.as_deref(),
+            Some(["ReadWriteOnce".to_string()].as_slice())
+        );
+        assert_eq!(
+            claim_spec
+                .resources
+                .as_ref()
+                .unwrap()
+                .requests
+                .as_ref()
+                .unwrap()["storage"],
+            Quantity("20Gi".into())
+        );
+        assert_eq!(claim_spec.storage_class_name.as_deref(), Some("fast-ssd"));
+
+        let pod = build_pod(&id, &cfg, "g", &Fingerprint::from_annotation("f"));
+        let volume = &spec(&pod).volumes.as_ref().unwrap()[0];
+        assert!(volume.empty_dir.is_none());
+        let source = volume
+            .persistent_volume_claim
+            .as_ref()
+            .expect("persistent workspace volume");
+        assert_eq!(source.claim_name, id.workspace_claim_name());
+        assert_eq!(source.read_only, Some(false));
+    }
+
+    #[test]
+    fn ephemeral_workspace_does_not_create_a_claim() {
+        let id = identity();
+        assert!(build_workspace_claim(&id, &provider_config()).is_none());
     }
 
     #[test]

--- a/crates/buzz-backend-kubernetes/src/reconcile.rs
+++ b/crates/buzz-backend-kubernetes/src/reconcile.rs
@@ -23,7 +23,7 @@ use crate::gc;
 use crate::naming::AgentIdentity;
 use crate::observe::{self, StartupObservation};
 use chrono::{DateTime, Utc};
-use k8s_openapi::api::core::v1::{Pod, Secret};
+use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod, Secret};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
@@ -58,6 +58,13 @@ pub trait Substrate {
     /// literal `kubectl create namespace <name>` command and MUST NOT fall
     /// back to `default` (`:1002-1005`).
     async fn ensure_namespace(&self, namespace: &str) -> Result<(), String>;
+
+    /// Create or verify the identity-owned persistent workspace claim. `None`
+    /// keeps the legacy ephemeral workspace and performs no substrate write.
+    async fn ensure_workspace_claim(
+        &self,
+        claim: Option<&PersistentVolumeClaim>,
+    ) -> Result<(), String>;
 
     /// Most-recent read of the pods matching this identity's selector, plus
     /// the apiserver's clock from the same call's HTTP `Date` header. `None`
@@ -444,6 +451,13 @@ pub async fn deploy(
             }
 
             Action::Create => {
+                // A running v1 pod remains a strict zero-mutation no-op. Only
+                // the create edge may introduce or verify the durable claim.
+                let workspace_claim = crate::pod::build_workspace_claim(identity, cfg);
+                substrate
+                    .ensure_workspace_claim(workspace_claim.as_ref())
+                    .await?;
+
                 let generation = crate::naming::new_generation();
                 let secret_name = identity.secret_name(&generation);
 
@@ -568,6 +582,19 @@ mod tests {
             }
         }
 
+        async fn ensure_workspace_claim(
+            &self,
+            claim: Option<&PersistentVolumeClaim>,
+        ) -> Result<(), String> {
+            if let Some(claim) = claim {
+                self.log(format!(
+                    "ensure_workspace_claim {}",
+                    claim.metadata.name.as_deref().unwrap_or_default()
+                ));
+            }
+            Ok(())
+        }
+
         async fn list_pods(
             &self,
             _selector: &str,
@@ -684,6 +711,8 @@ mod tests {
             resources: Resources::default(),
             inactivity_seconds: Some(7200),
             service_account: None,
+            workspace_storage: None,
+            workspace_storage_class: None,
         }
     }
 
@@ -806,6 +835,46 @@ mod tests {
         );
     }
 
+    #[test]
+    fn persistent_workspace_is_ensured_before_the_pod_is_created() {
+        let id = identity();
+        let mut cfg = config();
+        cfg.workspace_storage = Some("20Gi".into());
+        let fake = Fake::default();
+        fake.on_poll.borrow_mut().push({
+            let name = id.pod_name();
+            Box::new(move |pods: &mut BTreeMap<String, Pod>| {
+                if let Some(pod) = pods.get_mut(&name) {
+                    pod.status = Some(PodStatus {
+                        phase: Some("Running".into()),
+                        container_statuses: Some(vec![ContainerStatus {
+                            name: crate::observe::CONTAINER_NAME.into(),
+                            state: Some(running()),
+                            ..Default::default()
+                        }]),
+                        ..Default::default()
+                    });
+                }
+            })
+        });
+
+        assert_eq!(run(&fake, &id, &cfg).unwrap(), id.pod_name());
+        let calls = fake.mutations();
+        let claim_at = calls
+            .iter()
+            .position(|call| call.starts_with("ensure_workspace_claim"))
+            .expect("workspace claim was not ensured");
+        let pod_at = calls
+            .iter()
+            .position(|call| call.starts_with("create_pod"))
+            .expect("pod was not created");
+        assert!(claim_at < pod_at, "pod preceded its claim: {calls:?}");
+        assert_eq!(
+            calls[claim_at],
+            format!("ensure_workspace_claim {}", id.workspace_claim_name())
+        );
+    }
+
     /// The strict no-op row: a started pod returns its id having mutated
     /// nothing at all. Asserted on the *call log*, not on final state — a
     /// delete-then-recreate would leave identical final state.
@@ -820,6 +889,26 @@ mod tests {
             fake.mutations(),
             [format!("ensure_namespace {}", cfg.namespace)],
             "the no-op row mutated something"
+        );
+    }
+
+    #[test]
+    fn started_ephemeral_pod_does_not_create_a_newly_requested_claim() {
+        let id = identity();
+        let running_cfg = config();
+        let fake = Fake::default().with_pod(our_pod(&id, &running_cfg, Some(running())));
+        let mut desired_cfg = running_cfg.clone();
+        desired_cfg.workspace_storage = Some("20Gi".into());
+
+        assert_eq!(
+            run(&fake, &id, &desired_cfg).unwrap(),
+            id.pod_name(),
+            "running v1 pod should remain the active generation"
+        );
+        assert_eq!(
+            fake.mutations(),
+            [format!("ensure_namespace {}", desired_cfg.namespace)],
+            "a running generation must not introduce its successor's claim"
         );
     }
 
@@ -1536,6 +1625,12 @@ mod tests {
         impl Substrate for GcDenied {
             async fn ensure_namespace(&self, ns: &str) -> Result<(), String> {
                 self.0.ensure_namespace(ns).await
+            }
+            async fn ensure_workspace_claim(
+                &self,
+                claim: Option<&PersistentVolumeClaim>,
+            ) -> Result<(), String> {
+                self.0.ensure_workspace_claim(claim).await
             }
             async fn list_pods(
                 &self,

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -22,7 +22,7 @@ use crate::{
         known_acp_runtime, load_global_agent_config, load_managed_agents, load_personas,
         managed_agent_avatar_url, missing_command_message, normalize_agent_args, resolve_command,
         save_managed_agents, sync_managed_agent_processes, try_regenerate_nest, AgentModelInfo,
-        AgentModelsResponse, ManagedAgentRecord, UpdateManagedAgentRequest,
+        AgentModelsResponse, BackendKind, ManagedAgentRecord, UpdateManagedAgentRequest,
         UpdateManagedAgentResponse, DEFAULT_ACP_COMMAND,
     },
     relay::{relay_ws_url_with_override, sync_managed_agent_profile},

--- a/desktop/src-tauri/src/commands/agent_models_update.rs
+++ b/desktop/src-tauri/src/commands/agent_models_update.rs
@@ -8,6 +8,22 @@ fn prepare_backend_update(requested: Option<&BackendKind>) -> Result<Option<Stri
     crate::managed_agents::resolve_provider_binary(id).map(|path| Some(path.display().to_string()))
 }
 
+fn legacy_runtime_pid_is_live_with(
+    record: &ManagedAgentRecord,
+    mut process_is_running: impl FnMut(u32) -> bool,
+    mut process_has_buzz_marker: impl FnMut(u32) -> bool,
+) -> bool {
+    record
+        .runtime_pid
+        .is_some_and(|pid| process_is_running(pid) && process_has_buzz_marker(pid))
+}
+
+fn legacy_runtime_pid_is_live(record: &ManagedAgentRecord, instance_id: &str) -> bool {
+    legacy_runtime_pid_is_live_with(record, crate::managed_agents::process_is_running, |pid| {
+        crate::managed_agents::process_has_buzz_marker(pid, instance_id)
+    })
+}
+
 fn apply_backend_update(
     record: &mut ManagedAgentRecord,
     requested: Option<&BackendKind>,
@@ -118,23 +134,39 @@ pub async fn update_managed_agent(
 
     // Phase 1: local save (synchronous, under lock)
     let (mut summary, sync_params, rollback, access_policy_changed, access_restart_relays) = {
+        // Runtime transitions always lock transition -> store -> processes.
+        // This prevents a manual start/stop or restore spawn from crossing the
+        // backend migration after its final restore-candidate revalidation.
+        let _transition_guard = state
+            .managed_agent_runtime_transition
+            .lock()
+            .map_err(|e| e.to_string())?;
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
             .map_err(|e| e.to_string())?;
         let mut records = load_managed_agents(&app)?;
+        let instance_id = current_instance_id(&app);
+        // Capture an owned legacy scalar runtime before lifecycle sync clears
+        // that deprecated field. A live marked process is still a real local
+        // runtime and must block migration even when it has no pair-map entry.
+        let legacy_runtime_active = records
+            .iter()
+            .find(|record| record.pubkey == input.pubkey)
+            .is_some_and(|record| legacy_runtime_pid_is_live(record, &instance_id));
         let mut runtimes = state
             .managed_agent_processes
             .lock()
             .map_err(|e| e.to_string())?;
         let (_, exited_pubkeys) =
-            sync_managed_agent_processes(&mut records, &mut runtimes, &current_instance_id(&app));
+            sync_managed_agent_processes(&mut records, &mut runtimes, &instance_id);
         for pubkey in &exited_pubkeys {
             state.clear_agent_session_caches(pubkey);
         }
 
-        let runtime_active =
-            !crate::managed_agents::managed_agent_runtime_keys(&runtimes, &input.pubkey).is_empty();
+        let runtime_active = legacy_runtime_active
+            || !crate::managed_agents::managed_agent_runtime_keys(&runtimes, &input.pubkey)
+                .is_empty();
         let record = find_managed_agent_mut(&mut records, &input.pubkey)?;
         let previous_record = record.clone();
 

--- a/desktop/src-tauri/src/commands/agent_models_update.rs
+++ b/desktop/src-tauri/src/commands/agent_models_update.rs
@@ -1,5 +1,54 @@
 use super::*;
 
+fn prepare_backend_update(requested: Option<&BackendKind>) -> Result<Option<String>, String> {
+    let Some(BackendKind::Provider { id, config }) = requested else {
+        return Ok(None);
+    };
+    crate::managed_agents::validate_provider_config(config)?;
+    crate::managed_agents::resolve_provider_binary(id).map(|path| Some(path.display().to_string()))
+}
+
+fn apply_backend_update(
+    record: &mut ManagedAgentRecord,
+    requested: Option<&BackendKind>,
+    provider_binary_path: Option<&str>,
+    runtime_active: bool,
+) -> Result<bool, String> {
+    let Some(requested) = requested else {
+        return Ok(false);
+    };
+    if requested == &record.backend {
+        return Ok(false);
+    }
+    match (&record.backend, requested) {
+        (BackendKind::Local, BackendKind::Provider { .. }) => {
+            if runtime_active || record.runtime_pid.is_some() {
+                return Err(
+                    "Stop this agent before changing where it runs; its local runtime is still active."
+                        .to_string(),
+                );
+            }
+            let provider_binary_path = provider_binary_path.ok_or_else(|| {
+                "provider binary was not resolved before backend migration".to_string()
+            })?;
+            record.backend = requested.clone();
+            record.backend_agent_id = None;
+            record.provider_binary_path = Some(provider_binary_path.to_string());
+            record.provider_policy_pending = false;
+            // A migration is saved but not deployed. Requiring the owner's
+            // explicit first Deploy keeps an app restart from crossing that
+            // lifecycle boundary automatically.
+            record.start_on_app_launch = false;
+            Ok(true)
+        }
+        (BackendKind::Provider { .. }, _) => Err(
+            "Changing an existing provider-backed agent's run location is not supported."
+                .to_string(),
+        ),
+        (BackendKind::Local, BackendKind::Local) => Ok(false),
+    }
+}
+
 pub(crate) fn managed_agent_access_policy_changed(
     current_mode: crate::managed_agents::RespondTo,
     current_allowlist: &[String],
@@ -63,6 +112,10 @@ pub async fn update_managed_agent(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<UpdateManagedAgentResponse, String> {
+    // Provider discovery executes a trusted external binary. Finish that
+    // validation before taking the store/process locks or mutating a record.
+    let prepared_provider_binary = prepare_backend_update(input.backend.as_ref())?;
+
     // Phase 1: local save (synchronous, under lock)
     let (mut summary, sync_params, rollback, access_policy_changed, access_restart_relays) = {
         let _store_guard = state
@@ -80,8 +133,30 @@ pub async fn update_managed_agent(
             state.clear_agent_session_caches(pubkey);
         }
 
+        let runtime_active =
+            !crate::managed_agents::managed_agent_runtime_keys(&runtimes, &input.pubkey).is_empty();
         let record = find_managed_agent_mut(&mut records, &input.pubkey)?;
         let previous_record = record.clone();
+
+        let backend_will_change = input
+            .backend
+            .as_ref()
+            .is_some_and(|backend| backend != &record.backend);
+        let name_will_change = input.name.as_ref().is_some_and(|name| {
+            let trimmed = name.trim();
+            !trimmed.is_empty() && trimmed != record.name
+        });
+        if backend_will_change && name_will_change {
+            return Err(
+                "Save the agent name separately before changing where it runs.".to_string(),
+            );
+        }
+        apply_backend_update(
+            record,
+            input.backend.as_ref(),
+            prepared_provider_binary.as_deref(),
+            runtime_active,
+        )?;
 
         let mut name_changed = false;
         if let Some(name_update) = input.name {

--- a/desktop/src-tauri/src/commands/agent_models_update_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_models_update_tests.rs
@@ -29,3 +29,64 @@ fn undeployed_provider_accepts_access_edits() {
     ensure_access_policy_change_supported(&provider_record(false), true)
         .expect("no running provider deployment can retain stale access");
 }
+
+#[test]
+fn stopped_local_agent_migrates_without_changing_identity() {
+    let mut record = provider_record(false);
+    record.backend = crate::managed_agents::BackendKind::Local;
+    record.private_key_nsec = "nsec1identity".to_string();
+    record.start_on_app_launch = true;
+    let pubkey = record.pubkey.clone();
+    let private_key = record.private_key_nsec.clone();
+    let requested = crate::managed_agents::BackendKind::Provider {
+        id: "kubernetes".to_string(),
+        config: serde_json::json!({"namespace": "buzz-agents"}),
+    };
+
+    assert!(apply_backend_update(
+        &mut record,
+        Some(&requested),
+        Some("/trusted/buzz-backend-kubernetes"),
+        false,
+    )
+    .expect("stopped local migration should succeed"));
+    assert_eq!(record.backend, requested);
+    assert_eq!(record.pubkey, pubkey);
+    assert_eq!(record.private_key_nsec, private_key);
+    assert_eq!(record.backend_agent_id, None);
+    assert_eq!(
+        record.provider_binary_path.as_deref(),
+        Some("/trusted/buzz-backend-kubernetes")
+    );
+    assert!(!record.provider_policy_pending);
+    assert!(!record.start_on_app_launch);
+}
+
+#[test]
+fn active_local_agent_cannot_migrate() {
+    let mut record = provider_record(false);
+    record.backend = crate::managed_agents::BackendKind::Local;
+    let requested = crate::managed_agents::BackendKind::Provider {
+        id: "kubernetes".to_string(),
+        config: serde_json::json!({}),
+    };
+
+    let error = apply_backend_update(
+        &mut record,
+        Some(&requested),
+        Some("/trusted/buzz-backend-kubernetes"),
+        true,
+    )
+    .expect_err("active local migration must fail closed");
+    assert!(error.contains("Stop this agent"));
+    assert_eq!(record.backend, crate::managed_agents::BackendKind::Local);
+}
+
+#[test]
+fn provider_backends_cannot_be_moved_by_generic_update() {
+    let mut record = provider_record(false);
+    let requested = crate::managed_agents::BackendKind::Local;
+    let error = apply_backend_update(&mut record, Some(&requested), None, false)
+        .expect_err("provider reversal needs an explicit lifecycle protocol");
+    assert!(error.contains("not supported"));
+}

--- a/desktop/src-tauri/src/commands/agent_models_update_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_models_update_tests.rs
@@ -83,6 +83,44 @@ fn active_local_agent_cannot_migrate() {
 }
 
 #[test]
+fn live_legacy_scalar_pid_blocks_migration_before_sync_cleanup() {
+    let mut record = provider_record(false);
+    record.backend = crate::managed_agents::BackendKind::Local;
+    record.runtime_pid = Some(4242);
+    let runtime_active = legacy_runtime_pid_is_live_with(&record, |pid| pid == 4242, |_| true);
+    assert!(
+        runtime_active,
+        "owned live scalar PID must survive the pre-sync guard"
+    );
+
+    let requested = crate::managed_agents::BackendKind::Provider {
+        id: "kubernetes".to_string(),
+        config: serde_json::json!({}),
+    };
+    let error = apply_backend_update(
+        &mut record,
+        Some(&requested),
+        Some("/trusted/buzz-backend-kubernetes"),
+        runtime_active,
+    )
+    .expect_err("legacy live runtime must block migration");
+    assert!(error.contains("Stop this agent"));
+    assert_eq!(record.backend, crate::managed_agents::BackendKind::Local);
+}
+
+#[test]
+fn unrelated_reused_scalar_pid_does_not_block_migration() {
+    let mut record = provider_record(false);
+    record.backend = crate::managed_agents::BackendKind::Local;
+    record.runtime_pid = Some(4242);
+    assert!(!legacy_runtime_pid_is_live_with(
+        &record,
+        |_| true,
+        |_| false
+    ));
+}
+
+#[test]
 fn provider_backends_cannot_be_moved_by_generic_update() {
     let mut record = provider_record(false);
     let requested = crate::managed_agents::BackendKind::Local;

--- a/desktop/src-tauri/src/managed_agents/restore.rs
+++ b/desktop/src-tauri/src/managed_agents/restore.rs
@@ -26,6 +26,16 @@ enum SpawnOutcome {
 }
 type AgentSpawnResult = (String, SpawnOutcome);
 
+fn restore_snapshot_is_current(
+    snapshot: &super::ManagedAgentRecord,
+    current: &super::ManagedAgentRecord,
+) -> bool {
+    current.pubkey == snapshot.pubkey
+        && current.backend == BackendKind::Local
+        && current.start_on_app_launch
+        && current.updated_at == snapshot.updated_at
+}
+
 /// Backfill the pinned persona snapshot for pre-existing agents created before
 /// the record became the spawn source of truth. Runs once at launch, before
 /// `restore_managed_agents_on_launch` spawns anything, so no agent boots from an
@@ -89,7 +99,7 @@ pub fn backfill_persona_snapshots(app: &tauri::AppHandle) -> Result<(), String> 
 ///
 /// Split into three phases to minimise lock contention with the frontend:
 ///   A (under lock): sync process state, cleanup, collect agents to start
-///   B (no locks):   resolve commands and spawn processes in parallel
+///   B (transition lock): revalidate, resolve commands, and spawn in parallel
 ///   C (re-lock):    write back PIDs and status to records on disk
 pub async fn restore_managed_agents_on_launch(
     app: &tauri::AppHandle,
@@ -241,7 +251,7 @@ pub async fn restore_managed_agents_on_launch(
         .map(|k| k.public_key().to_hex());
 
     #[cfg(feature = "mesh-llm")]
-    let agents_to_start = {
+    let mut agents_to_start = {
         // Preflight against the same resolution spawn uses — `resolve_effective_config`
         // (definition → global fallback). A linked instance's own `provider`/`model`/
         // `relay_mesh` bytes never contribute. See `start_local_agent_with_preflight`
@@ -285,6 +295,28 @@ pub async fn restore_managed_agents_on_launch(
         .lock()
         .map_err(|error| error.to_string())?;
     if shutdown_started.load(Ordering::SeqCst) {
+        return Ok(());
+    }
+
+    // Phase A deliberately releases the store lock before the transition lock
+    // is acquired. Revalidate every snapshot after entering the transition
+    // protocol so an edit in that window (especially Local -> Provider) cannot
+    // be followed by a stale local spawn. The transition lock now prevents any
+    // later backend update until registration finishes.
+    {
+        let _store_guard = state
+            .managed_agents_store_lock
+            .lock()
+            .map_err(|error| error.to_string())?;
+        let current_records = load_managed_agents(app)?;
+        agents_to_start.retain(|snapshot| {
+            current_records
+                .iter()
+                .find(|current| current.pubkey == snapshot.pubkey)
+                .is_some_and(|current| restore_snapshot_is_current(snapshot, current))
+        });
+    }
+    if agents_to_start.is_empty() {
         return Ok(());
     }
 
@@ -536,8 +568,23 @@ pub(crate) fn spawn_pending_profile_reconciliations(app: &tauri::AppHandle, work
 
 #[cfg(test)]
 mod profile_reconcile_tests {
-    use super::profile_reconcile_completed;
+    use super::{profile_reconcile_completed, restore_snapshot_is_current};
     use crate::commands::ProfileReconcileOutcome;
+
+    fn local_restore_record() -> super::super::ManagedAgentRecord {
+        let mut record: super::super::ManagedAgentRecord =
+            serde_json::from_value(serde_json::json!({
+                "pubkey": "agent", "name": "Agent", "relay_url": "", "acp_command": "",
+                "agent_command": "", "agent_args": [], "mcp_command": "",
+                "turn_timeout_seconds": 0, "system_prompt": null, "created_at": "",
+                "updated_at": "generation-a", "last_started_at": null,
+                "last_stopped_at": null, "last_exit_code": null, "last_error": null
+            }))
+            .unwrap();
+        record.backend = super::super::BackendKind::Local;
+        record.start_on_app_launch = true;
+        record
+    }
 
     #[test]
     fn skipped_reconciliation_never_retires_pending_work() {
@@ -547,6 +594,29 @@ mod profile_reconcile_tests {
         assert!(!profile_reconcile_completed(
             ProfileReconcileOutcome::SkippedDisabled
         ));
+    }
+
+    #[test]
+    fn migration_between_restore_snapshot_and_transition_fails_revalidation() {
+        let snapshot = local_restore_record();
+        let mut current = snapshot.clone();
+        assert!(restore_snapshot_is_current(&snapshot, &current));
+
+        current.backend = super::super::BackendKind::Provider {
+            id: "kubernetes".to_string(),
+            config: serde_json::json!({}),
+        };
+        current.start_on_app_launch = false;
+        current.updated_at = "generation-b".to_string();
+        assert!(!restore_snapshot_is_current(&snapshot, &current));
+    }
+
+    #[test]
+    fn edited_restore_generation_fails_revalidation() {
+        let snapshot = local_restore_record();
+        let mut current = snapshot.clone();
+        current.updated_at = "generation-b".to_string();
+        assert!(!restore_snapshot_is_current(&snapshot, &current));
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/types/requests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/requests.rs
@@ -200,6 +200,11 @@ pub struct CreateManagedAgentRequest {
 #[serde(rename_all = "camelCase")]
 pub struct UpdateManagedAgentRequest {
     pub pubkey: String,
+    /// Absent = don't touch. A stopped local agent may migrate to a provider.
+    /// Provider-to-local and provider-to-provider moves require an explicit
+    /// lifecycle protocol and are rejected by the update command.
+    #[serde(default)]
+    pub backend: Option<BackendKind>,
     /// Absent = don't touch. Present = rename the agent.
     #[serde(default)]
     pub name: Option<String>,

--- a/desktop/src-tauri/src/managed_agents/types/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/tests.rs
@@ -249,6 +249,31 @@ fn update_request_provider_tristate_value_means_set() {
     );
 }
 
+#[test]
+fn update_request_deserializes_provider_backend_migration() {
+    let request: super::UpdateManagedAgentRequest = serde_json::from_str(
+        r#"{
+            "pubkey": "abcd1234",
+            "backend": {
+                "type": "provider",
+                "id": "kubernetes",
+                "config": { "namespace": "buzz-agents", "workspace_gib": 5 }
+            }
+        }"#,
+    )
+    .expect("provider backend update should deserialize");
+    assert_eq!(
+        request.backend,
+        Some(super::BackendKind::Provider {
+            id: "kubernetes".to_string(),
+            config: serde_json::json!({
+                "namespace": "buzz-agents",
+                "workspace_gib": 5
+            }),
+        })
+    );
+}
+
 use super::{CreateManagedAgentRequest, RelayMeshConfig};
 
 /// Wire-shape test: the create request arrives from TS as camelCase

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -127,6 +127,10 @@ with a TypeScript lookup table or an id comparison in a component.
    Edit. In Edit,
    selecting Custom command keeps its required command field beside the harness
    picker rather than hiding it in Advanced.
+   A stopped local instance may also migrate once to a discovered provider from
+   Edit. Saving preserves its identity and settings, disables start on app
+   launch, and leaves it stopped until an explicit Deploy. Active local agents
+   and provider-backed agents keep a read-only `Run on` summary.
 10. **Catalog visibility is community-scoped relay state, never a global
     definition field.** `AgentDefinition.shared` is only the active
     relay+owner projection returned to the UI. Durable heads and pending

--- a/desktop/src/features/agents/lib/agentManagementUpdate.test.mjs
+++ b/desktop/src/features/agents/lib/agentManagementUpdate.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  agentManagementInstanceUpdate,
+  validateAgentManagementBackendEdit,
+} from "./agentManagementUpdate.ts";
+
+function agent(overrides = {}) {
+  return {
+    pubkey: "deadbeef".repeat(8),
+    name: "agentos",
+    personaId: "persona-1",
+    relayUrl: "ws://localhost:3000",
+    acpCommand: "buzz-acp",
+    agentCommand: "codex-acp",
+    agentArgs: [],
+    mcpCommand: "",
+    turnTimeoutSeconds: 320,
+    idleTimeoutSeconds: null,
+    maxTurnDurationSeconds: null,
+    parallelism: 1,
+    systemPrompt: "Old prompt",
+    avatarUrl: null,
+    model: "old-model",
+    envVars: {},
+    status: "stopped",
+    pid: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    lastStartedAt: null,
+    lastStoppedAt: null,
+    lastExitCode: null,
+    lastError: null,
+    logPath: null,
+    startOnAppLaunch: false,
+    backend: { type: "local" },
+    backendAgentId: null,
+    respondTo: "owner-only",
+    respondToAllowlist: [],
+    ...overrides,
+  };
+}
+
+function persona(overrides = {}) {
+  return {
+    id: "persona-1",
+    displayName: "agentos",
+    avatarUrl: null,
+    systemPrompt: "New prompt",
+    runtime: "codex-acp",
+    model: "gpt-5.6-sol",
+    provider: "openai",
+    namePool: [],
+    isBuiltIn: false,
+    isActive: true,
+    respondTo: "owner-only",
+    respondToAllowlist: [],
+    envVars: {},
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+test("combines linked profile synchronization and provider migration in one instance update", () => {
+  assert.deepEqual(
+    agentManagementInstanceUpdate({
+      backendIntent: {
+        type: "provider",
+        id: "kubernetes",
+        config: {
+          namespace: "buzz-agents-pilot",
+          workspace_storage: "5Gi",
+        },
+      },
+      managedAgent: agent(),
+      persona: persona(),
+      previousPersona: persona({
+        systemPrompt: "Old prompt",
+        model: "old-model",
+      }),
+      runtimes: [],
+    }),
+    {
+      pubkey: "deadbeef".repeat(8),
+      systemPrompt: "New prompt",
+      model: "gpt-5.6-sol",
+      backend: {
+        type: "provider",
+        id: "kubernetes",
+        config: {
+          namespace: "buzz-agents-pilot",
+          workspace_storage: "5Gi",
+        },
+      },
+    },
+  );
+});
+
+test("preserves an unchanged local instance when the review has no migration", () => {
+  const unchangedPersona = persona({
+    systemPrompt: "Old prompt",
+    model: "old-model",
+  });
+  assert.equal(
+    agentManagementInstanceUpdate({
+      backendIntent: null,
+      managedAgent: agent(),
+      persona: unchangedPersona,
+      previousPersona: unchangedPersona,
+      runtimes: [],
+    }),
+    null,
+  );
+});
+
+test("migration validation fails closed before a partial profile save", () => {
+  const backendIntent = {
+    type: "provider",
+    id: "kubernetes",
+    config: {},
+  };
+  assert.equal(
+    validateAgentManagementBackendEdit({
+      backendIntent,
+      managedAgent: agent({ status: "running", pid: 42 }),
+      nextName: "agentos",
+    }),
+    "Stop this agent before changing where it runs.",
+  );
+  assert.equal(
+    validateAgentManagementBackendEdit({
+      backendIntent,
+      managedAgent: agent(),
+      nextName: "agentos renamed",
+    }),
+    "Keep the current agent name during migration; rename it in a separate review.",
+  );
+});

--- a/desktop/src/features/agents/lib/agentManagementUpdate.ts
+++ b/desktop/src/features/agents/lib/agentManagementUpdate.ts
@@ -1,0 +1,72 @@
+import type { BackendIntent } from "./instanceInputForDefinition";
+import { personaManagedAgentUpdate } from "@/features/profile/ui/UserProfilePanelUtils";
+import type {
+  AcpRuntimeCatalogEntry,
+  AgentPersona,
+  ManagedAgent,
+  UpdateManagedAgentInput,
+} from "@/shared/api/types";
+import { isManagedAgentActive } from "./managedAgentControlActions";
+
+export function validateAgentManagementBackendEdit({
+  backendIntent,
+  managedAgent,
+  nextName,
+}: {
+  backendIntent: BackendIntent | null;
+  managedAgent: ManagedAgent | undefined;
+  nextName: string;
+}): string | null {
+  if (!backendIntent) return null;
+  if (!managedAgent) {
+    return "This agent does not have one unique instance to migrate.";
+  }
+  if (managedAgent.backend.type !== "local") {
+    return "Provider-backed agents cannot change run location yet.";
+  }
+  if (isManagedAgentActive(managedAgent)) {
+    return "Stop this agent before changing where it runs.";
+  }
+  if (nextName.trim() !== managedAgent.name) {
+    return "Keep the current agent name during migration; rename it in a separate review.";
+  }
+  return null;
+}
+
+/**
+ * Build the one instance update that follows an owner-reviewed definition edit.
+ * Identity/runtime synchronization and a stopped local→provider migration must
+ * land together so one review cannot silently discard either half.
+ */
+export function agentManagementInstanceUpdate({
+  backendIntent,
+  managedAgent,
+  persona,
+  previousPersona,
+  runtimes,
+}: {
+  backendIntent: BackendIntent | null;
+  managedAgent: ManagedAgent;
+  persona: AgentPersona;
+  previousPersona?: AgentPersona;
+  runtimes: readonly AcpRuntimeCatalogEntry[];
+}): UpdateManagedAgentInput | null {
+  const synced = personaManagedAgentUpdate(managedAgent, persona, {
+    previousPersona,
+    runtimes,
+  });
+  if (!synced && !backendIntent) return null;
+
+  return {
+    ...(synced ?? { pubkey: managedAgent.pubkey }),
+    ...(backendIntent
+      ? {
+          backend: {
+            type: "provider" as const,
+            id: backendIntent.id,
+            config: backendIntent.config,
+          },
+        }
+      : {}),
+  };
+}

--- a/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   getManagedAgentPrimaryActionLabel,
+  isManagedAgentLifecycleActionReady,
   isManagedAgentLive,
   startManagedAgentWithRules,
   respawnManagedAgentWithRules,
@@ -107,6 +108,18 @@ test("local liveness stays process-status based", () => {
     isManagedAgentLive(agent({ status: "stopped" }), "online"),
     false,
   );
+});
+
+test("provider lifecycle actions wait for presence while local actions do not", () => {
+  const remote = agent({
+    backend: { type: "provider", id: "kubernetes", config: {} },
+    backendAgentId: "buzz-agent-deadbeef",
+    status: "deployed",
+  });
+
+  assert.equal(isManagedAgentLifecycleActionReady(remote, false), false);
+  assert.equal(isManagedAgentLifecycleActionReady(remote, true), true);
+  assert.equal(isManagedAgentLifecycleActionReady(agent(), false), true);
 });
 
 // --- respawnManagedAgentWithRules: stop→clear→start boundary tests -----------

--- a/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  getManagedAgentPrimaryActionLabel,
+  isManagedAgentLive,
   startManagedAgentWithRules,
   respawnManagedAgentWithRules,
 } from "./managedAgentControlActions.ts";
@@ -79,6 +81,32 @@ test("ordinary local agents still start normally", async () => {
     },
   });
   assert.equal(calledWith, "deadbeef".repeat(8));
+});
+
+test("provider liveness and primary action follow relay presence", () => {
+  const remote = agent({
+    backend: { type: "provider", id: "kubernetes", config: {} },
+    backendAgentId: "buzz-agent-deadbeef",
+    status: "deployed",
+  });
+
+  assert.equal(isManagedAgentLive(remote, undefined), false);
+  assert.equal(isManagedAgentLive(remote, "offline"), false);
+  assert.equal(getManagedAgentPrimaryActionLabel(remote, "offline"), "Deploy");
+  assert.equal(isManagedAgentLive(remote, "online"), true);
+  assert.equal(getManagedAgentPrimaryActionLabel(remote, "online"), "Shutdown");
+  assert.equal(isManagedAgentLive(remote, "away"), true);
+});
+
+test("local liveness stays process-status based", () => {
+  assert.equal(
+    isManagedAgentLive(agent({ status: "running" }), "offline"),
+    true,
+  );
+  assert.equal(
+    isManagedAgentLive(agent({ status: "stopped" }), "online"),
+    false,
+  );
 });
 
 // --- respawnManagedAgentWithRules: stop→clear→start boundary tests -----------

--- a/desktop/src/features/agents/lib/managedAgentControlActions.ts
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.ts
@@ -3,6 +3,7 @@ import type {
   Channel,
   ManagedAgent,
   PresenceLookup,
+  PresenceStatus,
   RelayAgent,
 } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
@@ -35,9 +36,26 @@ export function isManagedAgentActive(agent: Pick<ManagedAgent, "status">) {
   return agent.status === "running" || agent.status === "deployed";
 }
 
-export function getManagedAgentPrimaryActionLabel(agent: ManagedAgent) {
+/**
+ * Conversational liveness. Provider deployment bookkeeping is deliberately
+ * not a health signal; relay presence is the only live axis for remote agents.
+ */
+export function isManagedAgentLive(
+  agent: ManagedAgent,
+  presenceStatus?: PresenceStatus | null,
+) {
   if (agent.backend.type === "provider") {
-    return isManagedAgentActive(agent) ? "Shutdown" : "Deploy";
+    return presenceStatus === "online" || presenceStatus === "away";
+  }
+  return isManagedAgentActive(agent);
+}
+
+export function getManagedAgentPrimaryActionLabel(
+  agent: ManagedAgent,
+  presenceStatus?: PresenceStatus | null,
+) {
+  if (agent.backend.type === "provider") {
+    return isManagedAgentLive(agent, presenceStatus) ? "Shutdown" : "Deploy";
   }
 
   if (isManagedAgentActive(agent)) {

--- a/desktop/src/features/agents/lib/managedAgentControlActions.ts
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.ts
@@ -50,6 +50,18 @@ export function isManagedAgentLive(
   return isManagedAgentActive(agent);
 }
 
+/**
+ * Provider lifecycle intent depends on relay presence. Until that query has
+ * settled, neither Deploy nor Shutdown is truthful enough to offer. Local
+ * agents continue to use their process status and do not need presence.
+ */
+export function isManagedAgentLifecycleActionReady(
+  agent: ManagedAgent,
+  presenceLoaded: boolean,
+) {
+  return agent.backend.type !== "provider" || presenceLoaded;
+}
+
 export function getManagedAgentPrimaryActionLabel(
   agent: ManagedAgent,
   presenceStatus?: PresenceStatus | null,

--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -113,6 +113,10 @@ type AgentDefinitionDialogProps = {
   createRunSection?: React.ReactNode;
   /** Extra create-mode submit gate (e.g. incomplete provider config). */
   createSubmitBlocked?: boolean;
+  /** Existing-instance run destination shown during owner-reviewed edits. */
+  editRunSection?: React.ReactNode;
+  /** Extra edit-mode submit gate (e.g. incomplete provider config). */
+  editSubmitBlocked?: boolean;
 };
 
 export type AgentDefinitionSubmitOptions = {
@@ -136,6 +140,8 @@ export function AgentDefinitionDialog({
   publishCatalogUpdatesOnSave = false,
   createRunSection,
   createSubmitBlocked = false,
+  editRunSection,
+  editSubmitBlocked = false,
 }: AgentDefinitionDialogProps) {
   const runtimesLoading = runtimeCatalogStatus === "loading";
   const [displayName, setDisplayName] = React.useState("");
@@ -499,6 +505,7 @@ export function AgentDefinitionDialog({
     (!isCreateMode || runtime.trim().length > 0) &&
     (!isCreateMode || selectedRuntimeIsAvailable) &&
     (!isCreateMode || !createSubmitBlocked) &&
+    (isCreateMode || !editSubmitBlocked) &&
     // Crash-loop guard, create AND edit: an empty allowlist would crash
     // every instance minted from this definition at startup.
     personaBehaviorDraftValid(behaviorDraft) &&
@@ -935,6 +942,8 @@ export function AgentDefinitionDialog({
           open={runtimeCanChooseLlmProvider && aiDefaultsOpen}
           returnFocusRef={aiDefaultsTriggerRef}
         />
+
+        {!isCreateMode ? editRunSection : null}
 
         <AddCustomHarnessDialog
           onOpenChange={setIsAddHarnessOpen}

--- a/desktop/src/features/agents/ui/AgentDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDialog.tsx
@@ -78,6 +78,8 @@ type AgentDialogDefinitionEditProps = {
     options: AgentDefinitionSubmitOptions,
   ) => Promise<unknown>;
   publishCatalogUpdatesOnSave?: boolean;
+  editRunSection?: React.ReactNode;
+  editSubmitBlocked?: boolean;
 };
 
 type AgentDialogProps =

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -65,10 +65,9 @@ import {
   type RuntimeModelProviderSelection,
 } from "./runtimeModelProviderSelection";
 import { AgentCreationPreview } from "./AgentCreationPreview";
-import { OwnerOnlyAccessField } from "./OwnerOnlyAccessField";
 import type { EnvVarsValue } from "./EnvVarsEditor";
 import { useRequiredCredentialState } from "./useRequiredCredentialState";
-import { RunOnSummarySection } from "./RunOnSummarySection";
+import { EditAgentRunOn, INITIAL_RUN_ON } from "./EditAgentRunOn";
 import { PersonaDropdownField } from "./PersonaDropdownField";
 import {
   MODEL_DISCOVERY_LOADING_VALUE,
@@ -161,20 +160,18 @@ export function AgentInstanceEditDialog({
   const [respondToAllowlist, setRespondToAllowlist] = React.useState<string[]>(
     agent.respondToAllowlist,
   );
+  const [runOnState, setRunOnState] = React.useState(INITIAL_RUN_ON);
   const [showAdvancedFields, setShowAdvancedFields] = React.useState(false);
   const [avatarUrl, setAvatarUrl] = React.useState(agent.avatarUrl ?? "");
   const [isAvatarUploadPending, setIsAvatarUploadPending] =
     React.useState(false);
   const [isAddHarnessOpen, setIsAddHarnessOpen] = React.useState(false);
   const shouldReduceMotion = useReducedMotion();
-
   // Runtime selector: defaults to "custom" until the dialog opens and the
   // catalog loads. The open-effect re-derives the correct id from the catalog.
   const [selectedRuntimeId, setSelectedRuntimeId] = React.useState("custom");
-
   // Tracks whether the user has made an in-dialog runtime selection.
   const runtimeTouched = React.useRef(false);
-
   // Reset form state only when the dialog opens or when switching to a different agent.
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — including agent fields would re-fire on every 5s poll and wipe edits
   React.useEffect(() => {
@@ -197,6 +194,7 @@ export function AgentInstanceEditDialog({
       setAutoRestartOnConfigChange(agent.autoRestartOnConfigChange);
       setRespondTo(agent.respondTo);
       setRespondToAllowlist(agent.respondToAllowlist);
+      setRunOnState(INITIAL_RUN_ON);
       setAvatarUrl(agent.avatarUrl ?? "");
       setShowAdvancedFields(false);
       setIsAvatarUploadPending(false);
@@ -209,7 +207,6 @@ export function AgentInstanceEditDialog({
       updateMutation.reset();
     }
   }, [open, agent.pubkey]);
-
   // Re-derive the runtime id when the catalog loads.
   React.useEffect(() => {
     if (!open || runtimeTouched.current || runtimes.length === 0) {
@@ -222,7 +219,6 @@ export function AgentInstanceEditDialog({
       setSelectedRuntimeId(matched.id);
     }
   }, [open, runtimes, agent.agentCommand]);
-
   // Build the sorted runtime catalog for the dropdown.
   const sortedRuntimes = React.useMemo(
     () => sortPersonaRuntimes(runtimes),
@@ -613,6 +609,7 @@ export function AgentInstanceEditDialog({
       requiredEnvKeyMissing,
     }) &&
     providerValid &&
+    runOnState.valid &&
     !updateMutation.isPending &&
     !isAvatarUploadPending;
 
@@ -658,6 +655,7 @@ export function AgentInstanceEditDialog({
       const submitEnvVars = inheritedSubmission.envVars;
       const input: UpdateManagedAgentInput = {
         pubkey: agent.pubkey,
+        backend: runOnState.backend,
         name: name.trim() !== agent.name ? name.trim() : undefined,
         // relayUrl deliberately never submitted: the legacy per-record pin is
         // ignored (#2122) and the stored value is preserved as-is.
@@ -934,15 +932,17 @@ export function AgentInstanceEditDialog({
                 />
               </div>
             </div>
-            <OwnerOnlyAccessField
+            <EditAgentRunOn
               accessLocked={agentAccessOwnerOnly === true}
+              agent={agent}
               allowlist={respondToAllowlist}
               disabled={updateMutation.isPending}
+              key={`${agent.pubkey}:${open}`}
               mode={respondTo}
               onAllowlistChange={setRespondToAllowlist}
               onModeChange={setRespondTo}
+              onRunOnStateChange={setRunOnState}
             />
-            <RunOnSummarySection backend={agent.backend} />
 
             {/* Provider (runtime) */}
             <div className="space-y-1.5">

--- a/desktop/src/features/agents/ui/AgentManagementDialogs.tsx
+++ b/desktop/src/features/agents/ui/AgentManagementDialogs.tsx
@@ -1,6 +1,16 @@
+import * as React from "react";
+
 import { useAgentManagement } from "@/features/agents/useAgentManagement";
+import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import { AgentCardDialogs } from "./AgentCardViewerDialog";
 import { AgentDialog } from "./AgentDialog";
+import { RunOnSummarySection } from "./RunOnSummarySection";
+import { WhereToRunSection } from "./WhereToRunSection";
+import {
+  canSubmitWhereToRun,
+  emptyWhereToRunDraft,
+  resolveBackendIntent,
+} from "./whereToRunIntent";
 
 /** Global review surfaces opened by owned agents through the Buzz harness. */
 export function AgentManagementDialogs() {
@@ -25,24 +35,73 @@ export function AgentManagementDialogs() {
         />
       ) : null}
       {management.request?.action === "update" ? (
-        <AgentDialog
-          description=""
-          error={management.editError ? new Error(management.editError) : null}
-          initialValues={management.editInitialValues}
-          isPending={management.isPending}
-          mode="definition-edit"
-          onOpenChange={(open) => {
-            if (!open) management.dismiss();
-          }}
-          onSubmit={management.submitUpdate}
-          open
-          runtimes={management.runtimes}
-          runtimeCatalogStatus={management.runtimeCatalogStatus}
-          submitLabel="Save changes"
-          title="Edit agent"
-        />
+        <AgentManagementUpdateDialog management={management} />
       ) : null}
       <AgentCardDialogs />
     </>
+  );
+}
+
+function AgentManagementUpdateDialog({
+  management,
+}: {
+  management: ReturnType<typeof useAgentManagement>;
+}) {
+  const [runDraft, setRunDraft] = React.useState(emptyWhereToRunDraft);
+
+  const managedAgent = management.currentManagedAgent;
+  const canMigrateBackend = Boolean(
+    managedAgent?.backend.type === "local" &&
+      !isManagedAgentActive(managedAgent),
+  );
+  const backendIntent = canMigrateBackend
+    ? resolveBackendIntent(runDraft)
+    : null;
+  const editRunSection = managedAgent ? (
+    canMigrateBackend ? (
+      <div className="space-y-2" data-testid="agent-management-run-on">
+        <WhereToRunSection
+          draft={runDraft}
+          isPending={management.isPending}
+          onDraftChange={setRunDraft}
+        />
+        {backendIntent ? (
+          <p className="text-xs text-muted-foreground">
+            Saving preserves this agent&apos;s identity and settings, but leaves
+            it stopped until you explicitly deploy it.
+          </p>
+        ) : null}
+      </div>
+    ) : (
+      <RunOnSummarySection
+        backend={managedAgent.backend}
+        migrationBlockedReason={
+          managedAgent.backend.type === "local"
+            ? "Stop this agent before changing where it runs."
+            : undefined
+        }
+      />
+    )
+  ) : null;
+
+  return (
+    <AgentDialog
+      description=""
+      error={management.editError ? new Error(management.editError) : null}
+      editRunSection={editRunSection}
+      editSubmitBlocked={canMigrateBackend && !canSubmitWhereToRun(runDraft)}
+      initialValues={management.editInitialValues}
+      isPending={management.isPending}
+      mode="definition-edit"
+      onOpenChange={(open) => {
+        if (!open) management.dismiss();
+      }}
+      onSubmit={(input) => management.submitUpdate(input, backendIntent)}
+      open
+      runtimes={management.runtimes}
+      runtimeCatalogStatus={management.runtimeCatalogStatus}
+      submitLabel="Save changes"
+      title="Edit agent"
+    />
   );
 }

--- a/desktop/src/features/agents/ui/AgentRuntimeAvatarControl.tsx
+++ b/desktop/src/features/agents/ui/AgentRuntimeAvatarControl.tsx
@@ -12,6 +12,7 @@ import { Spinner } from "@/shared/ui/spinner";
 import { IdentityInitialsAvatar } from "./IdentityInitialsAvatar";
 
 type AgentRuntimeAvatarControlProps = {
+  actionDisabled?: boolean;
   activeTestId: string;
   avatarUrl?: string | null;
   errorLabel?: string | null;
@@ -126,6 +127,7 @@ const MASK_TRANSITION = {
 } as const;
 
 export function AgentRuntimeAvatarControl({
+  actionDisabled = false,
   activeTestId,
   avatarUrl,
   errorLabel,
@@ -142,14 +144,20 @@ export function AgentRuntimeAvatarControl({
   const shouldReduceMotion = useReducedMotion();
   const trimmedAvatarUrl = avatarUrl?.trim() || null;
   const isRestartAction = requiresRestart || isRestarting;
-  const actionLabel = isRestarting
-    ? "Restarting Agent"
-    : isStarting
-      ? "Starting Agent"
-      : isRestartAction
-        ? "Restart Agent"
-        : "Start Agent";
-  const actionText = isRestartAction ? "Restart" : "Start";
+  const actionLabel = actionDisabled
+    ? "Checking Agent Status"
+    : isRestarting
+      ? "Restarting Agent"
+      : isStarting
+        ? "Starting Agent"
+        : isRestartAction
+          ? "Restart Agent"
+          : "Start Agent";
+  const actionText = actionDisabled
+    ? "Wait"
+    : isRestartAction
+      ? "Restart"
+      : "Start";
   const isPending = isStarting || isRestarting;
   const showRunningDot = isActive && !isRestartAction;
   const hasError = !isActive && !isPending && Boolean(errorLabel);
@@ -190,7 +198,7 @@ export function AgentRuntimeAvatarControl({
                     : "bg-primary text-primary-foreground hover:bg-primary/90",
               )}
               data-testid={hasError ? errorTestId : startTestId}
-              disabled={isPending}
+              disabled={isPending || (actionDisabled && !hasError)}
               onClick={(event) => {
                 event.stopPropagation();
                 if (hasError) {

--- a/desktop/src/features/agents/ui/AgentStatusBadge.tsx
+++ b/desktop/src/features/agents/ui/AgentStatusBadge.tsx
@@ -29,7 +29,10 @@ export function AgentStatusBadge({
     return () => clearTimeout(timer);
   }, []);
 
-  const isActive = status === "running" || status === "deployed";
+  const isRemote = status === "deployed" || status === "not_deployed";
+  const isActive = isRemote
+    ? presenceStatus === "online" || presenceStatus === "away"
+    : status === "running";
   const isStarting =
     !inGracePeriod &&
     presenceLoaded &&
@@ -44,11 +47,19 @@ export function AgentStatusBadge({
         ? "default"
         : "secondary";
 
+  const remoteLabel =
+    status === "not_deployed"
+      ? "not deployed"
+      : !presenceLoaded
+        ? "checking…"
+        : (presenceStatus ?? "offline");
   const rawLabel = isWorking
     ? "Working"
     : isStarting
       ? "Starting\u2026"
-      : status.replace(/_/g, " ");
+      : isRemote
+        ? remoteLabel
+        : status.replace(/_/g, " ");
   const label = sentenceCase
     ? `${rawLabel.charAt(0).toUpperCase()}${rawLabel.slice(1)}`
     : rawLabel;

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -25,7 +25,7 @@ import { usePersonaActions } from "./usePersonaActions";
 import { useTeamActions } from "./useTeamActions";
 import { useProfilePanel } from "@/shared/context/ProfilePanelContext";
 import { useBakedBuildEnvQuery } from "@/features/agents/hooks";
-import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
+import { isManagedAgentLive } from "@/features/agents/lib/managedAgentControlActions";
 import { useGlobalAgentConfig } from "@/features/agents/useGlobalAgentConfig";
 import { Button } from "@/shared/ui/button";
 import {
@@ -88,7 +88,10 @@ export function AgentsView() {
     teamActions.updateTeamMutation.isPending ||
     teamActions.deleteTeamMutation.isPending;
   const runningAgentCount = agents.managedAgents.filter((agent) =>
-    isManagedAgentActive(agent),
+    isManagedAgentLive(
+      agent,
+      agents.managedPresenceQuery.data?.[agent.pubkey.trim().toLowerCase()],
+    ),
   ).length;
   const hasSavedAgentDefaults = Boolean(
     globalConfig.preferred_runtime?.trim() ||
@@ -220,6 +223,7 @@ export function AgentsView() {
               }
               isActionPending={isActionPending}
               isAgentsLoading={agents.managedAgentsQuery.isLoading}
+              presenceLookup={agents.managedPresenceQuery.data ?? {}}
               startingAgentPubkey={agents.startingAgentPubkey}
               restartingAgentPubkey={agents.restartingAgentPubkey}
               startingPersonaIds={agents.startingPersonaIds}

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -223,6 +223,7 @@ export function AgentsView() {
               }
               isActionPending={isActionPending}
               isAgentsLoading={agents.managedAgentsQuery.isLoading}
+              presenceLoaded={agents.managedPresenceQuery.isSuccess}
               presenceLookup={agents.managedPresenceQuery.data ?? {}}
               startingAgentPubkey={agents.startingAgentPubkey}
               restartingAgentPubkey={agents.restartingAgentPubkey}

--- a/desktop/src/features/agents/ui/EditAgentRunOn.tsx
+++ b/desktop/src/features/agents/ui/EditAgentRunOn.tsx
@@ -1,0 +1,107 @@
+import * as React from "react";
+
+import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
+import type {
+  ManagedAgent,
+  ManagedAgentBackend,
+  RespondToMode,
+} from "@/shared/api/types";
+import {
+  runLocationForBackend,
+  runLocationForRunOn,
+} from "../lib/agentAccessWarning";
+import { AgentRunLocationProvider } from "./AgentRunLocationContext";
+import { OwnerOnlyAccessField } from "./OwnerOnlyAccessField";
+import { RunOnSummarySection } from "./RunOnSummarySection";
+import { WhereToRunSection } from "./WhereToRunSection";
+import {
+  canSubmitWhereToRun,
+  emptyWhereToRunDraft,
+  resolveBackendIntent,
+} from "./whereToRunIntent";
+
+export type EditAgentRunOnState = {
+  backend: ManagedAgentBackend | undefined;
+  valid: boolean;
+};
+export const INITIAL_RUN_ON: EditAgentRunOnState = {
+  backend: undefined,
+  valid: true,
+};
+
+export function EditAgentRunOn({
+  accessLocked,
+  agent,
+  allowlist,
+  disabled,
+  mode,
+  onAllowlistChange,
+  onModeChange,
+  onRunOnStateChange,
+}: {
+  accessLocked: boolean;
+  agent: ManagedAgent;
+  allowlist: string[];
+  disabled: boolean;
+  mode: RespondToMode;
+  onAllowlistChange: (allowlist: string[]) => void;
+  onModeChange: (mode: RespondToMode) => void;
+  onRunOnStateChange: (state: EditAgentRunOnState) => void;
+}) {
+  const [runDraft, setRunDraft] = React.useState(emptyWhereToRunDraft);
+  const canMigrateBackend =
+    agent.backend.type === "local" && !isManagedAgentActive(agent);
+  const backendIntent = React.useMemo(
+    () => (canMigrateBackend ? resolveBackendIntent(runDraft) : null),
+    [canMigrateBackend, runDraft],
+  );
+  const migrationRequested = backendIntent != null;
+  const valid = !canMigrateBackend || canSubmitWhereToRun(runDraft);
+
+  React.useEffect(() => {
+    onRunOnStateChange({ backend: backendIntent ?? undefined, valid });
+  }, [backendIntent, onRunOnStateChange, valid]);
+
+  return (
+    <AgentRunLocationProvider
+      runLocation={
+        canMigrateBackend
+          ? runLocationForRunOn(runDraft.runOn)
+          : runLocationForBackend(agent.backend)
+      }
+    >
+      <OwnerOnlyAccessField
+        accessLocked={accessLocked}
+        allowlist={allowlist}
+        disabled={disabled}
+        mode={mode}
+        onAllowlistChange={onAllowlistChange}
+        onModeChange={onModeChange}
+      />
+      {canMigrateBackend ? (
+        <div className="space-y-2" data-testid="edit-agent-run-on-migration">
+          <WhereToRunSection
+            draft={runDraft}
+            isPending={disabled}
+            onDraftChange={setRunDraft}
+          />
+          {migrationRequested ? (
+            <p className="text-xs text-muted-foreground">
+              Saving preserves this agent&apos;s identity and settings, but
+              leaves it stopped until you explicitly deploy it.
+            </p>
+          ) : null}
+        </div>
+      ) : (
+        <RunOnSummarySection
+          backend={agent.backend}
+          migrationBlockedReason={
+            agent.backend.type === "local"
+              ? "Stop this agent before changing where it runs."
+              : undefined
+          }
+        />
+      )}
+    </AgentRunLocationProvider>
+  );
+}

--- a/desktop/src/features/agents/ui/RunOnSummarySection.tsx
+++ b/desktop/src/features/agents/ui/RunOnSummarySection.tsx
@@ -5,9 +5,7 @@ import { summarizeRunOn } from "./runOnSummary";
 /**
  * Read-only "Run on" summary for the edit-agent dialog.
  *
- * Read-only on purpose: `UpdateManagedAgentRequest` has no backend field —
- * where an agent runs is fixed at creation (a provider-backed agent's
- * deployment holds its private key; there is no migrate operation). This
+ * Provider-backed agents and active local agents are read-only here. This
  * section shows the *saved* provider config from the record, without probing
  * the provider binary: an edit dialog must not do executable work as a side
  * effect, and a live probe would show today's schema defaults instead of
@@ -18,8 +16,10 @@ import { summarizeRunOn } from "./runOnSummary";
  */
 export function RunOnSummarySection({
   backend,
+  migrationBlockedReason,
 }: {
   backend: ManagedAgentBackend;
+  migrationBlockedReason?: string;
 }) {
   const summary = summarizeRunOn(backend);
 
@@ -64,9 +64,10 @@ export function RunOnSummarySection({
         </div>
       )}
       <p className="text-xs text-muted-foreground">
-        These are the settings saved when the agent was created. Where an agent
-        runs can&apos;t be changed afterwards — create a new agent to run
-        somewhere else.
+        {migrationBlockedReason ??
+          (summary.location === "provider"
+            ? "Provider-backed agents cannot change run location yet."
+            : "This agent runs on your computer.")}
       </p>
     </div>
   );

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -7,11 +7,16 @@ import {
 } from "@/features/agents/lib/agentCardAvatar";
 import { resolveAgentCardModelLabel } from "@/features/agents/lib/agentCardModelLabel";
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
-import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
+import { isManagedAgentLive } from "@/features/agents/lib/managedAgentControlActions";
 import { pickProfileAgent } from "@/features/agents/lib/pickProfileAgent";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useUserProfileQuery } from "@/features/profile/hooks";
-import type { AgentPersona, ManagedAgent } from "@/shared/api/types";
+import type {
+  AgentPersona,
+  ManagedAgent,
+  PresenceLookup,
+} from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 import type { ProfilePanelOpenOptions } from "@/shared/context/ProfilePanelContext";
 import { useFeedbackToasts } from "@/shared/hooks/useToastEffect";
 import { Badge } from "@/shared/ui/badge";
@@ -30,6 +35,7 @@ type UnifiedAgentsSectionProps = {
   agentsError: Error | null;
   isActionPending: boolean;
   isAgentsLoading: boolean;
+  presenceLookup?: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
   startingPersonaIds: ReadonlySet<string>;
@@ -73,6 +79,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
     agentsError,
     isActionPending,
     isAgentsLoading,
+    presenceLookup = {},
     restartingAgentPubkey,
     startingAgentPubkey,
     startingPersonaIds,
@@ -155,6 +162,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
                   defaultModel={defaultModel}
                   key={group.persona.id}
                   persona={group.persona}
+                  presenceLookup={presenceLookup}
                   restartingAgentPubkey={restartingAgentPubkey}
                   startingAgentPubkey={startingAgentPubkey}
                   startingPersonaIds={startingPersonaIds}
@@ -175,6 +183,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
               defaultModel={defaultModel}
               groupKey="__unknown__"
               label="Unknown agents"
+              presenceLookup={presenceLookup}
               restartingAgentPubkey={restartingAgentPubkey}
               startingAgentPubkey={startingAgentPubkey}
               onToggle={toggle}
@@ -190,6 +199,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
               defaultModel={defaultModel}
               groupKey="__ungrouped__"
               label="Custom agents"
+              presenceLookup={presenceLookup}
               restartingAgentPubkey={restartingAgentPubkey}
               startingAgentPubkey={startingAgentPubkey}
               onToggle={toggle}
@@ -224,6 +234,7 @@ function AgentPersonaCard({
   agent,
   defaultModel,
   persona,
+  presenceLookup,
   restartingAgentPubkey,
   startingAgentPubkey,
   startingPersonaIds,
@@ -240,6 +251,7 @@ function AgentPersonaCard({
   agent: ManagedAgent | undefined;
   defaultModel: string;
   persona: AgentPersona;
+  presenceLookup: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
   startingPersonaIds: ReadonlySet<string>;
@@ -259,7 +271,9 @@ function AgentPersonaCard({
     provider: persona.provider,
     defaultModel,
   });
-  const isActive = agent ? isManagedAgentActive(agent) : false;
+  const isActive = agent
+    ? isManagedAgentLive(agent, presenceLookup[normalizePubkey(agent.pubkey)])
+    : false;
   const profileQuery = useUserProfileQuery(agent?.pubkey);
   const avatarUrl = agent
     ? resolveAgentCardAvatarUrl(profileQuery.data?.avatarUrl, persona.avatarUrl)
@@ -340,6 +354,7 @@ function AgentPersonaCard({
 function StandaloneAgentCard({
   agent,
   defaultModel,
+  presenceLookup,
   restartingAgentPubkey,
   startingAgentPubkey,
   onOpenAgentProfile,
@@ -348,6 +363,7 @@ function StandaloneAgentCard({
 }: {
   agent: ManagedAgent;
   defaultModel: string;
+  presenceLookup: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
   onOpenAgentProfile: (
@@ -363,7 +379,10 @@ function StandaloneAgentCard({
     agent.lastError,
     agent.lastErrorCode,
   )?.copy;
-  const isActive = isManagedAgentActive(agent);
+  const isActive = isManagedAgentLive(
+    agent,
+    presenceLookup[normalizePubkey(agent.pubkey)],
+  );
   const opensRuntimeTab = Boolean(friendlyError && !isActive);
 
   return (
@@ -443,6 +462,7 @@ function CollapsibleAgentGroup({
   agents,
   collapsed,
   defaultModel,
+  presenceLookup,
   restartingAgentPubkey,
   startingAgentPubkey,
   onToggle,
@@ -455,6 +475,7 @@ function CollapsibleAgentGroup({
   agents: ManagedAgent[];
   collapsed: ReadonlySet<string>;
   defaultModel: string;
+  presenceLookup: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
   onToggle: (key: string) => void;
@@ -487,6 +508,7 @@ function CollapsibleAgentGroup({
             <StandaloneAgentCard
               agent={agent}
               defaultModel={defaultModel}
+              presenceLookup={presenceLookup}
               key={agent.pubkey}
               restartingAgentPubkey={restartingAgentPubkey}
               startingAgentPubkey={startingAgentPubkey}

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -7,7 +7,10 @@ import {
 } from "@/features/agents/lib/agentCardAvatar";
 import { resolveAgentCardModelLabel } from "@/features/agents/lib/agentCardModelLabel";
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
-import { isManagedAgentLive } from "@/features/agents/lib/managedAgentControlActions";
+import {
+  isManagedAgentLifecycleActionReady,
+  isManagedAgentLive,
+} from "@/features/agents/lib/managedAgentControlActions";
 import { pickProfileAgent } from "@/features/agents/lib/pickProfileAgent";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useUserProfileQuery } from "@/features/profile/hooks";
@@ -35,6 +38,7 @@ type UnifiedAgentsSectionProps = {
   agentsError: Error | null;
   isActionPending: boolean;
   isAgentsLoading: boolean;
+  presenceLoaded: boolean;
   presenceLookup?: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
@@ -79,6 +83,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
     agentsError,
     isActionPending,
     isAgentsLoading,
+    presenceLoaded,
     presenceLookup = {},
     restartingAgentPubkey,
     startingAgentPubkey,
@@ -162,6 +167,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
                   defaultModel={defaultModel}
                   key={group.persona.id}
                   persona={group.persona}
+                  presenceLoaded={presenceLoaded}
                   presenceLookup={presenceLookup}
                   restartingAgentPubkey={restartingAgentPubkey}
                   startingAgentPubkey={startingAgentPubkey}
@@ -183,6 +189,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
               defaultModel={defaultModel}
               groupKey="__unknown__"
               label="Unknown agents"
+              presenceLoaded={presenceLoaded}
               presenceLookup={presenceLookup}
               restartingAgentPubkey={restartingAgentPubkey}
               startingAgentPubkey={startingAgentPubkey}
@@ -199,6 +206,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
               defaultModel={defaultModel}
               groupKey="__ungrouped__"
               label="Custom agents"
+              presenceLoaded={presenceLoaded}
               presenceLookup={presenceLookup}
               restartingAgentPubkey={restartingAgentPubkey}
               startingAgentPubkey={startingAgentPubkey}
@@ -234,6 +242,7 @@ function AgentPersonaCard({
   agent,
   defaultModel,
   persona,
+  presenceLoaded,
   presenceLookup,
   restartingAgentPubkey,
   startingAgentPubkey,
@@ -251,6 +260,7 @@ function AgentPersonaCard({
   agent: ManagedAgent | undefined;
   defaultModel: string;
   persona: AgentPersona;
+  presenceLoaded: boolean;
   presenceLookup: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
@@ -292,6 +302,9 @@ function AgentPersonaCard({
       avatar={
         agent ? (
           <AgentRuntimeAvatarControl
+            actionDisabled={
+              !isManagedAgentLifecycleActionReady(agent, presenceLoaded)
+            }
             activeTestId={`agent-runtime-active-${agent.pubkey}`}
             avatarUrl={avatarUrl}
             errorLabel={friendlyError}
@@ -354,6 +367,7 @@ function AgentPersonaCard({
 function StandaloneAgentCard({
   agent,
   defaultModel,
+  presenceLoaded,
   presenceLookup,
   restartingAgentPubkey,
   startingAgentPubkey,
@@ -363,6 +377,7 @@ function StandaloneAgentCard({
 }: {
   agent: ManagedAgent;
   defaultModel: string;
+  presenceLoaded: boolean;
   presenceLookup: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
@@ -390,6 +405,9 @@ function StandaloneAgentCard({
       ariaLabel={`${title} agent profile`}
       avatar={
         <AgentRuntimeAvatarControl
+          actionDisabled={
+            !isManagedAgentLifecycleActionReady(agent, presenceLoaded)
+          }
           activeTestId={`agent-runtime-active-${agent.pubkey}`}
           avatarUrl={profileQuery.data?.avatarUrl}
           errorLabel={friendlyError}
@@ -462,6 +480,7 @@ function CollapsibleAgentGroup({
   agents,
   collapsed,
   defaultModel,
+  presenceLoaded,
   presenceLookup,
   restartingAgentPubkey,
   startingAgentPubkey,
@@ -475,6 +494,7 @@ function CollapsibleAgentGroup({
   agents: ManagedAgent[];
   collapsed: ReadonlySet<string>;
   defaultModel: string;
+  presenceLoaded: boolean;
   presenceLookup: PresenceLookup;
   restartingAgentPubkey: string | null;
   startingAgentPubkey: string | null;
@@ -508,6 +528,7 @@ function CollapsibleAgentGroup({
             <StandaloneAgentCard
               agent={agent}
               defaultModel={defaultModel}
+              presenceLoaded={presenceLoaded}
               presenceLookup={presenceLookup}
               key={agent.pubkey}
               restartingAgentPubkey={restartingAgentPubkey}

--- a/desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs
@@ -54,6 +54,7 @@ function agent(overrides = {}) {
     name: "Instance",
     personaId: "persona-1",
     status: "stopped",
+    backend: { type: "local" },
     model: null,
     modelSource: "global",
     lastError: null,

--- a/desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs
@@ -86,6 +86,7 @@ function baseProps(overrides = {}) {
     agentsError: null,
     isActionPending: false,
     isAgentsLoading: false,
+    presenceLoaded: true,
     restartingAgentPubkey: null,
     startingAgentPubkey: null,
     startingPersonaIds: new Set(),
@@ -226,6 +227,27 @@ test("persona card main click records a persona target, never an explicit pubkey
 
   assert.ok(recordedPersona, "the click must record a persona target");
   assert.equal(recordedPersona.id, "persona-1");
+});
+
+test("provider start action stays disabled until presence is known", async () => {
+  installFailOpenIpc();
+  const remote = agent({
+    backend: { type: "provider", id: "kubernetes", config: {} },
+    personaId: null,
+  });
+
+  await act(async () => {
+    renderSection(
+      baseProps({
+        agents: [remote],
+        presenceLoaded: false,
+      }),
+    );
+  });
+
+  const action = screen.getByTestId(`agent-runtime-start-${remote.pubkey}`);
+  assert.equal(action.disabled, true);
+  assert.equal(action.getAttribute("aria-label"), "Checking Agent Status");
 });
 
 test("persona card main click records a persona target even for a stopped errored agent", async () => {

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -21,6 +21,7 @@ import { removeChannelMember } from "@/shared/api/tauri";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import {
   deleteManagedAgentWithRules,
+  isManagedAgentLifecycleActionReady,
   isManagedAgentLive,
   respawnManagedAgentWithRules,
   startManagedAgentWithRules,
@@ -161,6 +162,14 @@ export function useManagedAgentActions() {
     try {
       const agent = managedAgents.find((c) => c.pubkey === pubkey);
       if (!agent) return;
+      if (
+        !isManagedAgentLifecycleActionReady(
+          agent,
+          managedPresenceQuery.isSuccess,
+        )
+      ) {
+        throw new Error("Agent status is still loading. Try again shortly.");
+      }
       await startManagedAgentWithRules({
         agent,
         startManagedAgent: startMutation.mutateAsync,
@@ -181,6 +190,14 @@ export function useManagedAgentActions() {
         (candidate) => candidate.pubkey === pubkey,
       );
       if (!agent) return;
+      if (
+        !isManagedAgentLifecycleActionReady(
+          agent,
+          managedPresenceQuery.isSuccess,
+        )
+      ) {
+        throw new Error("Agent status is still loading. Try again shortly.");
+      }
       await respawnManagedAgentWithRules({
         agent,
         startManagedAgent: startMutation.mutateAsync,

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -21,7 +21,7 @@ import { removeChannelMember } from "@/shared/api/tauri";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import {
   deleteManagedAgentWithRules,
-  isManagedAgentActive,
+  isManagedAgentLive,
   respawnManagedAgentWithRules,
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
@@ -389,7 +389,12 @@ export function useManagedAgentActions() {
 
   async function handleBulkStopRunning() {
     await runBulkAction(
-      managedAgents.filter((a) => isManagedAgentActive(a)),
+      managedAgents.filter((agent) =>
+        isManagedAgentLive(
+          agent,
+          managedPresenceQuery.data?.[normalizePubkey(agent.pubkey)],
+        ),
+      ),
       "Stop",
       "stop",
       async (a) => {

--- a/desktop/src/features/agents/ui/whereToRunIntent.test.mjs
+++ b/desktop/src/features/agents/ui/whereToRunIntent.test.mjs
@@ -61,6 +61,20 @@ test("provider draft resolves with coerced config values", () => {
   });
 });
 
+test("provider intent preserves the edit agent's provider configuration shape", () => {
+  const intent = resolveBackendIntent(
+    providerDraft({
+      runOn: "kubernetes",
+      providerConfig: { namespace: "pilot", size: "5" },
+    }),
+  );
+  assert.deepEqual(intent, {
+    type: "provider",
+    id: "kubernetes",
+    config: { namespace: "pilot", size: 5 },
+  });
+});
+
 // ── applyProbeResult: probe resolution must merge, not overwrite ─────────────
 //
 // Pins the seam that fixed the "Typewriter Eraser" (agent-create dialog's

--- a/desktop/src/features/agents/useAgentManagement.ts
+++ b/desktop/src/features/agents/useAgentManagement.ts
@@ -15,6 +15,7 @@ import {
   useCreatePersonaMutation,
   useManagedAgentsQuery,
   usePersonasQuery,
+  useUpdateManagedAgentMutation,
   useUpdatePersonaMutation,
 } from "./hooks";
 import {
@@ -32,6 +33,11 @@ import type {
   CreatePersonaInput,
   UpdatePersonaInput,
 } from "@/shared/api/types";
+import { validateLinkedAgentRuntimeEdit } from "@/features/profile/ui/UserProfilePanelPersonaSubmit";
+import {
+  agentManagementInstanceUpdate,
+  validateAgentManagementBackendEdit,
+} from "./lib/agentManagementUpdate";
 
 function updateInputFromRequest(
   request: Extract<AgentManagementRequest, { action: "update" }>,
@@ -65,6 +71,7 @@ export function useAgentManagement() {
   const runtimesQuery = useAcpRuntimesQuery({ enabled: true });
   const createPersonaMutation = useCreatePersonaMutation();
   const updatePersonaMutation = useUpdatePersonaMutation();
+  const updateManagedAgentMutation = useUpdateManagedAgentMutation();
   const createAgentMutation = useCreateManagedAgentMutation();
   const [request, setRequest] = React.useState<AgentManagementRequest | null>(
     null,
@@ -151,10 +158,22 @@ export function useAgentManagement() {
   }, [personasQuery.data, request]);
   const currentPersona =
     matchingPersonas.length === 1 ? matchingPersonas[0] : undefined;
+  const matchingManagedAgents = React.useMemo(
+    () =>
+      currentPersona
+        ? (managedAgentsQuery.data ?? []).filter(
+            (agent) => agent.personaId === currentPersona.id,
+          )
+        : [],
+    [currentPersona, managedAgentsQuery.data],
+  );
+  const currentManagedAgent =
+    matchingManagedAgents.length === 1 ? matchingManagedAgents[0] : undefined;
 
   const isPending =
     createPersonaMutation.isPending ||
     updatePersonaMutation.isPending ||
+    updateManagedAgentMutation.isPending ||
     createAgentMutation.isPending;
 
   function assertAgentCanActFromOrigin(channelId: string) {
@@ -237,14 +256,43 @@ export function useAgentManagement() {
     }
   }
 
-  async function submitUpdate(input: CreatePersonaInput | UpdatePersonaInput) {
+  async function submitUpdate(
+    input: CreatePersonaInput | UpdatePersonaInput,
+    backendIntent: BackendIntent | null = null,
+  ) {
     if (request?.action !== "update" || !("id" in input)) {
       return false;
     }
     setError(null);
     try {
       assertAgentCanActFromOrigin(request.request.channelId);
-      await updatePersonaMutation.mutateAsync(input);
+      const runtimeEditError = validateLinkedAgentRuntimeEdit({
+        input,
+        managedAgent: currentManagedAgent,
+        previousPersona: currentPersona,
+        runtimes: runtimesQuery.data ?? [],
+      });
+      if (runtimeEditError) throw new Error(runtimeEditError);
+      const backendEditError = validateAgentManagementBackendEdit({
+        backendIntent,
+        managedAgent: currentManagedAgent,
+        nextName: input.displayName,
+      });
+      if (backendEditError) throw new Error(backendEditError);
+
+      const persona = await updatePersonaMutation.mutateAsync(input);
+      if (currentManagedAgent) {
+        const instanceUpdate = agentManagementInstanceUpdate({
+          backendIntent,
+          managedAgent: currentManagedAgent,
+          persona,
+          previousPersona: currentPersona,
+          runtimes: runtimesQuery.data ?? [],
+        });
+        if (instanceUpdate) {
+          await updateManagedAgentMutation.mutateAsync(instanceUpdate);
+        }
+      }
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: personasQueryKey }),
         queryClient.invalidateQueries({ queryKey: managedAgentsQueryKey }),
@@ -297,6 +345,7 @@ export function useAgentManagement() {
     createInitialValues,
     editInitialValues,
     editError,
+    currentManagedAgent,
     error,
     ...createdAgentAttachment,
     isPending,

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -514,6 +514,7 @@ export function MembersSidebar({
     removableManagedBots,
     currentPubkey,
     onOpenChange,
+    presenceLookup: memberPresenceQuery.data ?? {},
     relayUrl,
   });
 

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -514,6 +514,7 @@ export function MembersSidebar({
     removableManagedBots,
     currentPubkey,
     onOpenChange,
+    presenceLoaded: memberPresenceQuery.isSuccess,
     presenceLookup: memberPresenceQuery.data ?? {},
     relayUrl,
   });
@@ -672,6 +673,7 @@ export function MembersSidebar({
               : undefined
           }
           pairAction={pairAction}
+          presenceLoaded={memberPresenceQuery.isSuccess}
           presenceStatus={
             memberPresenceQuery.data?.[member.pubkey.toLowerCase()] ?? null
           }

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -16,7 +16,7 @@ import {
 
 import {
   getManagedAgentPrimaryActionLabel,
-  isManagedAgentActive,
+  isManagedAgentLive,
 } from "@/features/agents/lib/managedAgentControlActions";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
@@ -215,14 +215,16 @@ export function MembersSidebarMemberCard({
                   ? agentCommunityAvailability(managedAgentRuntime) === "Here"
                     ? "default"
                     : "secondary"
-                  : managedAgent && isManagedAgentActive(managedAgent)
+                  : managedAgent &&
+                      isManagedAgentLive(managedAgent, presenceStatus)
                     ? "default"
                     : "secondary"
               }
             >
               {managedAgentRuntime
                 ? agentCommunityAvailability(managedAgentRuntime)
-                : managedAgent && isManagedAgentActive(managedAgent)
+                : managedAgent &&
+                    isManagedAgentLive(managedAgent, presenceStatus)
                   ? "Running"
                   : "Stopped"}
             </Badge>
@@ -282,6 +284,7 @@ export function MembersSidebarMemberCard({
           onUntimeout={onUntimeout}
           onViewActivity={onViewActivity}
           pairAction={pairAction}
+          presenceStatus={presenceStatus}
         />
       ) : null}
     </div>
@@ -310,6 +313,7 @@ function MemberActionsMenu({
   onUntimeout,
   onViewActivity,
   pairAction,
+  presenceStatus,
 }: {
   canChangeRole: boolean;
   canModerateMember: boolean;
@@ -330,6 +334,7 @@ function MemberActionsMenu({
   onUntimeout: (member: ChannelMember) => void;
   onViewActivity?: (pubkey: string) => void;
   pairAction?: ManagedAgentPairAction;
+  presenceStatus?: PresenceStatus | null;
 }) {
   const showChangeRole =
     canChangeRole && !memberIsBot && member.role !== "owner";
@@ -370,10 +375,13 @@ function MemberActionsMenu({
             >
               {pairAction
                 ? getPairActionIcon(pairAction)
-                : getManagedAgentActionIcon(managedAgent)}
+                : getManagedAgentActionIcon(managedAgent, presenceStatus)}
               {pairAction
                 ? MANAGED_AGENT_PAIR_ACTION_LABELS[pairAction]
-                : getManagedAgentPrimaryActionLabel(managedAgent)}
+                : getManagedAgentPrimaryActionLabel(
+                    managedAgent,
+                    presenceStatus,
+                  )}
             </DropdownMenuItem>
             {onEditRespondTo ? (
               <DropdownMenuItem
@@ -504,8 +512,11 @@ function getPairActionIcon(action: ManagedAgentPairAction) {
   return <Play className="h-4 w-4" />;
 }
 
-function getManagedAgentActionIcon(agent: ManagedAgent) {
-  if (isManagedAgentActive(agent)) {
+function getManagedAgentActionIcon(
+  agent: ManagedAgent,
+  presenceStatus?: PresenceStatus | null,
+) {
+  if (isManagedAgentLive(agent, presenceStatus)) {
     return <Square className="h-4 w-4" />;
   }
 

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -16,6 +16,7 @@ import {
 
 import {
   getManagedAgentPrimaryActionLabel,
+  isManagedAgentLifecycleActionReady,
   isManagedAgentLive,
 } from "@/features/agents/lib/managedAgentControlActions";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
@@ -71,6 +72,7 @@ type MembersSidebarMemberCardProps = {
   onUnban: (member: ChannelMember) => void;
   onUntimeout: (member: ChannelMember) => void;
   onViewActivity?: (pubkey: string) => void;
+  presenceLoaded: boolean;
   presenceStatus?: PresenceStatus | null;
   profileAvatarUrl?: string | null;
   viewerIsOwner: boolean;
@@ -139,12 +141,16 @@ export function MembersSidebarMemberCard({
   onUnban,
   onUntimeout,
   onViewActivity,
+  presenceLoaded,
   presenceStatus,
   profileAvatarUrl,
   viewerIsOwner,
 }: MembersSidebarMemberCardProps) {
   const roleLabel = formatRoleLabel(member, memberIsBot);
   const disabled = isActionPending || isArchived;
+  const lifecycleActionReady = managedAgent
+    ? isManagedAgentLifecycleActionReady(managedAgent, presenceLoaded)
+    : true;
   const canViewActivity =
     memberIsBot &&
     (viewerIsOwner || managedAgent?.backend.type === "local") &&
@@ -223,10 +229,13 @@ export function MembersSidebarMemberCard({
             >
               {managedAgentRuntime
                 ? agentCommunityAvailability(managedAgentRuntime)
-                : managedAgent &&
-                    isManagedAgentLive(managedAgent, presenceStatus)
-                  ? "Running"
-                  : "Stopped"}
+                : managedAgent?.backend.type === "provider" &&
+                    !lifecycleActionReady
+                  ? "Checking…"
+                  : managedAgent &&
+                      isManagedAgentLive(managedAgent, presenceStatus)
+                    ? "Running"
+                    : "Stopped"}
             </Badge>
             {managedAgent ? (
               <Badge
@@ -284,6 +293,7 @@ export function MembersSidebarMemberCard({
           onUntimeout={onUntimeout}
           onViewActivity={onViewActivity}
           pairAction={pairAction}
+          presenceLoaded={presenceLoaded}
           presenceStatus={presenceStatus}
         />
       ) : null}
@@ -313,6 +323,7 @@ function MemberActionsMenu({
   onUntimeout,
   onViewActivity,
   pairAction,
+  presenceLoaded,
   presenceStatus,
 }: {
   canChangeRole: boolean;
@@ -334,8 +345,12 @@ function MemberActionsMenu({
   onUntimeout: (member: ChannelMember) => void;
   onViewActivity?: (pubkey: string) => void;
   pairAction?: ManagedAgentPairAction;
+  presenceLoaded: boolean;
   presenceStatus?: PresenceStatus | null;
 }) {
+  const lifecycleActionReady = managedAgent
+    ? isManagedAgentLifecycleActionReady(managedAgent, presenceLoaded)
+    : true;
   const showChangeRole =
     canChangeRole && !memberIsBot && member.role !== "owner";
   const isBanned = moderationState?.banned ?? false;
@@ -370,7 +385,7 @@ function MemberActionsMenu({
             {canViewActivity ? <DropdownMenuSeparator /> : null}
             <DropdownMenuItem
               data-testid={`sidebar-agent-action-${member.pubkey}`}
-              disabled={disabled}
+              disabled={disabled || !lifecycleActionReady}
               onClick={() => onManagedAgentAction(managedAgent)}
             >
               {pairAction

--- a/desktop/src/features/channels/ui/useMembersSidebarActions.ts
+++ b/desktop/src/features/channels/ui/useMembersSidebarActions.ts
@@ -7,6 +7,7 @@ import {
 } from "@/features/agents/hooks";
 import {
   respawnManagedAgentWithRules,
+  isManagedAgentLifecycleActionReady,
   isManagedAgentLive,
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
@@ -34,6 +35,7 @@ type UseMembersSidebarActionsOptions = {
   removableManagedBots: readonly ManagedAgent[];
   currentPubkey?: string;
   onOpenChange: (open: boolean) => void;
+  presenceLoaded: boolean;
   presenceLookup: PresenceLookup;
   /** Active community relay. When set, local-agent lifecycle actions are
    * scoped to this agent+community pair instead of the whole agent. */
@@ -55,6 +57,7 @@ export function useMembersSidebarActions({
   removableManagedBots,
   currentPubkey,
   onOpenChange,
+  presenceLoaded,
   presenceLookup,
   relayUrl,
 }: UseMembersSidebarActionsOptions) {
@@ -157,6 +160,10 @@ export function useMembersSidebarActions({
     setActiveActionKey(`agent:${agent.pubkey}`);
 
     try {
+      if (!isManagedAgentLifecycleActionReady(agent, presenceLoaded)) {
+        throw new Error("Agent status is still loading. Try again shortly.");
+      }
+
       // Local agents run one harness per agent+community pair. Scope the
       // action to the active community so stopping the agent here never
       // touches its runtimes in other communities. Provider agents keep the

--- a/desktop/src/features/channels/ui/useMembersSidebarActions.ts
+++ b/desktop/src/features/channels/ui/useMembersSidebarActions.ts
@@ -7,7 +7,7 @@ import {
 } from "@/features/agents/hooks";
 import {
   respawnManagedAgentWithRules,
-  isManagedAgentActive,
+  isManagedAgentLive,
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
 } from "@/features/agents/lib/managedAgentControlActions";
@@ -25,6 +25,7 @@ import type {
   ChannelMember,
   ManagedAgent,
   ManagedAgentRuntimeStatus,
+  PresenceLookup,
 } from "@/shared/api/types";
 
 type UseMembersSidebarActionsOptions = {
@@ -33,6 +34,7 @@ type UseMembersSidebarActionsOptions = {
   removableManagedBots: readonly ManagedAgent[];
   currentPubkey?: string;
   onOpenChange: (open: boolean) => void;
+  presenceLookup: PresenceLookup;
   /** Active community relay. When set, local-agent lifecycle actions are
    * scoped to this agent+community pair instead of the whole agent. */
   relayUrl?: string;
@@ -53,6 +55,7 @@ export function useMembersSidebarActions({
   removableManagedBots,
   currentPubkey,
   onOpenChange,
+  presenceLookup,
   relayUrl,
 }: UseMembersSidebarActionsOptions) {
   const queryClient = useQueryClient();
@@ -72,8 +75,13 @@ export function useMembersSidebarActions({
 
   const stoppableManagedBots = React.useMemo(
     () =>
-      controllableManagedBots.filter((agent) => isManagedAgentActive(agent)),
-    [controllableManagedBots],
+      controllableManagedBots.filter((agent) =>
+        isManagedAgentLive(
+          agent,
+          presenceLookup[agent.pubkey.trim().toLowerCase()],
+        ),
+      ),
+    [controllableManagedBots, presenceLookup],
   );
 
   const isActionPending =
@@ -170,7 +178,12 @@ export function useMembersSidebarActions({
         return;
       }
 
-      if (isManagedAgentActive(agent)) {
+      if (
+        isManagedAgentLive(
+          agent,
+          presenceLookup[agent.pubkey.trim().toLowerCase()],
+        )
+      ) {
         await stopManagedAgentWithRules({
           agent,
           ...EMPTY_AGENT_CONTEXT,

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -455,6 +455,7 @@ export function UserProfilePanel({
     useAgentLifecycleActions({
       channels: channelsQuery.data,
       managedAgent,
+      presenceLoaded: presenceQuery.isSuccess,
       presenceStatus,
       relayAgents: relayAgentsQuery.data,
       startManagedAgent: startAgentMutation.mutateAsync,
@@ -839,6 +840,7 @@ export function UserProfilePanel({
           onOpenDiagnostics={() => setView("diagnostics")}
           onStickyChromeChange={handleStickyChromeChange}
           onTabChange={setTab}
+          presenceLoaded={presenceQuery.isSuccess}
           presenceStatus={presenceStatus}
           profile={profile}
           pubkey={effectivePubkey}

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -73,6 +73,7 @@ import {
   deriveProfileChannels,
   type ProfilePanelTab,
   type ProfilePanelView,
+  profileAgentEditTarget,
   profilePanelTargetKey,
   resolveAgentInstruction,
   resolvePanelProfile,
@@ -406,9 +407,21 @@ export function UserProfilePanel({
     return true;
   }, [managedAgent, resolvedPersona]);
   const handleEditAgent = React.useCallback(() => {
-    if (openResolvedPersonaEditor()) return;
-    setEditAgentOpen(true);
-  }, [openResolvedPersonaEditor, setEditAgentOpen]);
+    const editTarget = profileAgentEditTarget(
+      managedAgent !== undefined,
+      resolvedPersona !== undefined,
+    );
+    if (editTarget === "instance") {
+      setEditAgentOpen(true);
+      return;
+    }
+    if (editTarget === "definition") openResolvedPersonaEditor();
+  }, [
+    managedAgent,
+    openResolvedPersonaEditor,
+    resolvedPersona,
+    setEditAgentOpen,
+  ]);
   const { deleteManagedAgentRecord, deleteManagedAgentsForPersona } =
     useProfileAgentDeletion({
       channels: channelsQuery.data,

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -455,6 +455,7 @@ export function UserProfilePanel({
     useAgentLifecycleActions({
       channels: channelsQuery.data,
       managedAgent,
+      presenceStatus,
       relayAgents: relayAgentsQuery.data,
       startManagedAgent: startAgentMutation.mutateAsync,
       stopManagedAgent: stopAgentMutation.mutateAsync,

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -935,45 +935,43 @@ export function UserProfilePanel({
     />
   ) : null;
   const personaDialogs = (
-    <>
-      <UserProfilePersonaDialogs
-        cardMintTarget={cardMint.target}
-        createError={
-          createPersonaMutation.error instanceof Error
-            ? createPersonaMutation.error
-            : null
-        }
-        instanceCount={personaDeleteInstanceCount}
-        isPending={
-          createPersonaMutation.isPending ||
-          updatePersonaMutation.isPending ||
-          updateManagedAgentMutation.isPending ||
-          createAgentMutation.isPending
-        }
-        linkedAgentPubkey={managedAgent?.pubkey ?? null}
-        personaDialogState={personaDialogState}
-        personaToDelete={personaToDelete}
-        personaToExportSnapshot={personaToExportSnapshot}
-        resolvedPersona={resolvedPersona}
-        runtimes={acpRuntimesQuery.data ?? []}
-        runtimesError={acpRuntimesQuery.isError}
-        runtimesLoading={acpRuntimesQuery.isLoading}
-        updateError={
-          updatePersonaMutation.error instanceof Error
-            ? updatePersonaMutation.error
-            : null
-        }
-        onCloseCardMint={cardMint.close}
-        onCloseDelete={() => setPersonaToDelete(null)}
-        onCloseDialog={() => setPersonaDialogState(null)}
-        onCloseExportSnapshot={() => setPersonaToExportSnapshot(null)}
-        onConfirmDelete={(selectedPersona) => {
-          void handleConfirmDeletePersona(selectedPersona);
-        }}
-        onExportSnapshot={setPersonaToExportSnapshot}
-        onSubmit={handleSubmitPersona}
-      />
-    </>
+    <UserProfilePersonaDialogs
+      cardMintTarget={cardMint.target}
+      createError={
+        createPersonaMutation.error instanceof Error
+          ? createPersonaMutation.error
+          : null
+      }
+      instanceCount={personaDeleteInstanceCount}
+      isPending={
+        createPersonaMutation.isPending ||
+        updatePersonaMutation.isPending ||
+        updateManagedAgentMutation.isPending ||
+        createAgentMutation.isPending
+      }
+      linkedAgentPubkey={managedAgent?.pubkey ?? null}
+      personaDialogState={personaDialogState}
+      personaToDelete={personaToDelete}
+      personaToExportSnapshot={personaToExportSnapshot}
+      resolvedPersona={resolvedPersona}
+      runtimes={acpRuntimesQuery.data ?? []}
+      runtimesError={acpRuntimesQuery.isError}
+      runtimesLoading={acpRuntimesQuery.isLoading}
+      updateError={
+        updatePersonaMutation.error instanceof Error
+          ? updatePersonaMutation.error
+          : null
+      }
+      onCloseCardMint={cardMint.close}
+      onCloseDelete={() => setPersonaToDelete(null)}
+      onCloseDialog={() => setPersonaDialogState(null)}
+      onCloseExportSnapshot={() => setPersonaToExportSnapshot(null)}
+      onConfirmDelete={(selectedPersona) => {
+        void handleConfirmDeletePersona(selectedPersona);
+      }}
+      onExportSnapshot={setPersonaToExportSnapshot}
+      onSubmit={handleSubmitPersona}
+    />
   );
   return (
     <UserProfilePanelFrame

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -4,7 +4,7 @@ import { ChevronDown, ChevronUp, Pencil } from "lucide-react";
 import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
 import {
   getManagedAgentPrimaryActionLabel,
-  isManagedAgentActive,
+  isManagedAgentLive,
 } from "@/features/agents/lib/managedAgentControlActions";
 import { RestartDiffBadge } from "@/features/agents/ui/RestartDiffBadge";
 import { AgentConfigPanel } from "@/features/agents/ui/AgentConfigPanel";
@@ -191,7 +191,7 @@ export function ProfileSummaryView({
   const activeTurns = useAgentWorking(isBot ? pubkey : null).channels;
   const avatarStatus = isBot
     ? managedAgent
-      ? isManagedAgentActive(managedAgent)
+      ? isManagedAgentLive(managedAgent, presenceStatus)
         ? "online"
         : "offline"
       : (presenceStatus ?? "offline")
@@ -429,12 +429,13 @@ export function ProfileSummaryView({
           agentActionDisabled={isAgentActionPending}
           agentActionLabel={
             isOwner === true && managedAgent
-              ? getManagedAgentPrimaryActionLabel(managedAgent)
+              ? getManagedAgentPrimaryActionLabel(managedAgent, presenceStatus)
               : undefined
           }
           agentActionLive={
-            managedAgent?.status === "running" ||
-            managedAgent?.status === "deployed"
+            managedAgent
+              ? isManagedAgentLive(managedAgent, presenceStatus)
+              : false
           }
           onAgentPrimaryAction={
             isOwner === true && managedAgent

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronUp, Pencil } from "lucide-react";
 import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
 import {
   getManagedAgentPrimaryActionLabel,
+  isManagedAgentLifecycleActionReady,
   isManagedAgentLive,
 } from "@/features/agents/lib/managedAgentControlActions";
 import { RestartDiffBadge } from "@/features/agents/ui/RestartDiffBadge";
@@ -105,6 +106,7 @@ export type ProfileSummaryViewProps = {
   onOpenDiagnostics: () => void;
   onStickyChromeChange: (state: { active: boolean; height: number }) => void;
   onTabChange: (tab: ProfilePanelTab, options?: { replace?: boolean }) => void;
+  presenceLoaded: boolean;
   presenceStatus: "online" | "away" | "offline" | undefined;
   profile: ReturnType<typeof useUserProfileQuery>["data"];
   pubkey: string | null;
@@ -180,6 +182,7 @@ export function ProfileSummaryView({
   onOpenDiagnostics,
   onStickyChromeChange,
   onTabChange,
+  presenceLoaded,
   presenceStatus,
   profile,
   pubkey,
@@ -189,11 +192,16 @@ export function ProfileSummaryView({
   userStatus,
 }: ProfileSummaryViewProps) {
   const activeTurns = useAgentWorking(isBot ? pubkey : null).channels;
+  const lifecycleActionReady = managedAgent
+    ? isManagedAgentLifecycleActionReady(managedAgent, presenceLoaded)
+    : true;
   const avatarStatus = isBot
     ? managedAgent
-      ? isManagedAgentLive(managedAgent, presenceStatus)
-        ? "online"
-        : "offline"
+      ? !lifecycleActionReady
+        ? undefined
+        : isManagedAgentLive(managedAgent, presenceStatus)
+          ? "online"
+          : "offline"
       : (presenceStatus ?? "offline")
     : presenceStatus;
   const stickyLayoutRef = React.useRef<HTMLDivElement>(null);
@@ -426,7 +434,7 @@ export function ProfileSummaryView({
           className={primaryActionsMotionClassName}
           concealed={primaryActionsConcealed}
           followMutation={followMutation}
-          agentActionDisabled={isAgentActionPending}
+          agentActionDisabled={isAgentActionPending || !lifecycleActionReady}
           agentActionLabel={
             isOwner === true && managedAgent
               ? getManagedAgentPrimaryActionLabel(managedAgent, presenceStatus)

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
@@ -5,10 +5,18 @@ import {
   parseProfilePanelTab,
   parseProfilePanelView,
   personaManagedAgentUpdate,
+  profileAgentEditTarget,
   profilePanelTabFromSearch,
   profilePanelTargetKey,
   profilePanelViewFromSearch,
 } from "./UserProfilePanelUtils.ts";
+
+test("profile edit targets the deployed instance before its linked definition", () => {
+  assert.equal(profileAgentEditTarget(true, true), "instance");
+  assert.equal(profileAgentEditTarget(true, false), "instance");
+  assert.equal(profileAgentEditTarget(false, true), "definition");
+  assert.equal(profileAgentEditTarget(false, false), null);
+});
 
 function agent(overrides = {}) {
   return {

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
@@ -95,6 +95,15 @@ export function profilePanelTargetKey(
   return pubkey ?? `persona:${personaId ?? "unknown"}`;
 }
 
+export function profileAgentEditTarget(
+  hasManagedAgent: boolean,
+  hasResolvedPersona: boolean,
+): "instance" | "definition" | null {
+  if (hasManagedAgent) return "instance";
+  if (hasResolvedPersona) return "definition";
+  return null;
+}
+
 export type UserProfilePanelProps = {
   canResetWidth?: boolean;
   currentPubkey?: string;

--- a/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
+++ b/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import { toast } from "sonner";
 
 import {
+  isManagedAgentLifecycleActionReady,
   isManagedAgentLive,
   respawnManagedAgentWithRules,
   startManagedAgentWithRules,
@@ -14,6 +15,7 @@ import type { PresenceStatus } from "@/shared/api/types";
 export function useAgentLifecycleActions({
   channels,
   managedAgent,
+  presenceLoaded,
   presenceStatus,
   relayAgents,
   startManagedAgent,
@@ -21,6 +23,7 @@ export function useAgentLifecycleActions({
 }: {
   channels: readonly Channel[] | undefined;
   managedAgent: ManagedAgent | undefined;
+  presenceLoaded: boolean;
   presenceStatus?: PresenceStatus;
   relayAgents: readonly RelayAgent[] | undefined;
   startManagedAgent: (pubkey: string) => Promise<unknown>;
@@ -30,6 +33,10 @@ export function useAgentLifecycleActions({
     if (!managedAgent) return;
 
     try {
+      if (!isManagedAgentLifecycleActionReady(managedAgent, presenceLoaded)) {
+        throw new Error("Agent status is still loading. Try again shortly.");
+      }
+
       if (isManagedAgentLive(managedAgent, presenceStatus)) {
         const result = await stopManagedAgentWithRules({
           agent: managedAgent,
@@ -61,6 +68,7 @@ export function useAgentLifecycleActions({
   }, [
     channels,
     managedAgent,
+    presenceLoaded,
     presenceStatus,
     relayAgents,
     startManagedAgent,

--- a/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
+++ b/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
@@ -2,23 +2,26 @@ import * as React from "react";
 import { toast } from "sonner";
 
 import {
-  isManagedAgentActive,
+  isManagedAgentLive,
   respawnManagedAgentWithRules,
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
 } from "@/features/agents/lib/managedAgentControlActions";
 import { clearActiveTurnsForAgentOnStop } from "@/features/agents/managedAgentRuntimeHooks";
 import type { Channel, ManagedAgent, RelayAgent } from "@/shared/api/types";
+import type { PresenceStatus } from "@/shared/api/types";
 
 export function useAgentLifecycleActions({
   channels,
   managedAgent,
+  presenceStatus,
   relayAgents,
   startManagedAgent,
   stopManagedAgent,
 }: {
   channels: readonly Channel[] | undefined;
   managedAgent: ManagedAgent | undefined;
+  presenceStatus?: PresenceStatus;
   relayAgents: readonly RelayAgent[] | undefined;
   startManagedAgent: (pubkey: string) => Promise<unknown>;
   stopManagedAgent: (pubkey: string) => Promise<unknown>;
@@ -27,7 +30,7 @@ export function useAgentLifecycleActions({
     if (!managedAgent) return;
 
     try {
-      if (isManagedAgentActive(managedAgent)) {
+      if (isManagedAgentLive(managedAgent, presenceStatus)) {
         const result = await stopManagedAgentWithRules({
           agent: managedAgent,
           channels: channels ?? [],
@@ -58,6 +61,7 @@ export function useAgentLifecycleActions({
   }, [
     channels,
     managedAgent,
+    presenceStatus,
     relayAgents,
     startManagedAgent,
     stopManagedAgent,

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -672,9 +672,9 @@ export type RuntimeConfigSurface = {
   /** B5/I-7: adapter-advertised option values for the `thought_level` option — the picker renders these instead of hardcoded values. */
   effortOptions?: AcpConfigOptionValue[];
 };
-
 export type UpdateManagedAgentInput = {
   pubkey: string;
+  backend?: ManagedAgentBackend;
   name?: string;
   model?: string | null;
   provider?: string | null;

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -8950,6 +8950,7 @@ async function handleGetManagedAgentLog(args: {
 async function handleUpdateManagedAgent(args: {
   input: {
     pubkey: string;
+    backend?: RawManagedAgent["backend"];
     name?: string;
     model?: string | null;
     systemPrompt?: string | null;
@@ -8959,6 +8960,26 @@ async function handleUpdateManagedAgent(args: {
   };
 }): Promise<{ agent: RawManagedAgent; profile_sync_error: string | null }> {
   const agent = getMockManagedAgent(args.input.pubkey);
+  if (args.input.backend !== undefined) {
+    const backendChanged =
+      JSON.stringify(agent.backend) !== JSON.stringify(args.input.backend);
+    if (backendChanged && agent.backend.type === "provider") {
+      throw new Error(
+        "Changing an existing provider-backed agent's run location is not supported.",
+      );
+    }
+    if (
+      backendChanged &&
+      (agent.status === "running" || agent.status === "deployed")
+    ) {
+      throw new Error("Stop this agent before changing where it runs");
+    }
+    if (backendChanged) {
+      agent.backend = structuredClone(args.input.backend);
+      agent.backend_agent_id = null;
+      agent.start_on_app_launch = false;
+    }
+  }
   if (args.input.name !== undefined) {
     agent.name = args.input.name;
   }

--- a/desktop/tests/e2e/edit-agent-run-on.spec.ts
+++ b/desktop/tests/e2e/edit-agent-run-on.spec.ts
@@ -24,6 +24,26 @@ const KUBERNETES_CONFIG = {
   namespace: "buzz-agents-gfq7aq",
 };
 
+const KUBERNETES_PROVIDER = {
+  id: "kubernetes",
+  binaryPath: "/mock/buzz-backend-kubernetes",
+};
+
+const KUBERNETES_PROBE = {
+  ok: true,
+  config_schema: {
+    type: "object",
+    properties: {
+      namespace: {
+        type: "string",
+        title: "Namespace",
+        default: "buzz-agents-migration",
+      },
+    },
+    required: ["namespace"],
+  },
+};
+
 async function openEditDialog(
   page: import("@playwright/test").Page,
   agentName: string,
@@ -87,8 +107,9 @@ test("editing a kubernetes agent shows its saved run-on settings", async ({
     runOn.getByTestId("edit-agent-run-on-service_account"),
   ).toHaveCount(0);
 
-  // The section explains immutability instead of pretending to be a form.
-  await expect(runOn).toContainText("can't be changed afterwards");
+  await expect(runOn).toContainText(
+    "Provider-backed agents cannot change run location yet.",
+  );
 
   await runOn.scrollIntoViewIfNeeded();
   await waitForAnimations(page);
@@ -97,11 +118,13 @@ test("editing a kubernetes agent shows its saved run-on settings", async ({
     .screenshot({ path: `${SHOTS}/kubernetes-run-on.png` });
 });
 
-test("editing a local agent names this computer, with no config rows", async ({
+test("a stopped local agent migrates to a provider and keeps its profile", async ({
   page,
 }) => {
   const agent = TEST_IDENTITIES.tyler;
   await installMockBridge(page, {
+    backendProviders: [KUBERNETES_PROVIDER],
+    backendProviderProbeResult: KUBERNETES_PROBE,
     managedAgents: [
       {
         pubkey: agent.pubkey,
@@ -115,17 +138,67 @@ test("editing a local agent names this computer, with no config rows", async ({
   });
   await openEditDialog(page, "Local Helper");
 
+  const dialog = page.getByTestId("edit-agent-dialog");
+  const runOn = dialog.getByTestId("edit-agent-run-on-migration");
+  const trigger = runOn.locator("#agent-run-on");
+  await expect(trigger).toBeVisible();
+  await trigger.press("Enter");
+  await page
+    .getByRole("menuitemradio", { exact: true, name: "kubernetes" })
+    .press("Enter");
+  await expect(runOn.locator("#provider-cfg-namespace")).toHaveValue(
+    "buzz-agents-migration",
+  );
+  await expect(runOn).toContainText("preserves this agent's identity");
+  await dialog.getByTestId("edit-agent-dialog-submit").click();
+  await expect(dialog).toBeHidden();
+
+  await page.getByTestId("user-profile-edit-agent").click();
+  const savedRunOn = page.getByTestId("edit-agent-run-on");
+  await expect(savedRunOn.getByTestId("edit-agent-run-on-location")).toHaveText(
+    "kubernetes",
+  );
+  await expect(
+    savedRunOn.getByTestId("edit-agent-run-on-namespace"),
+  ).toContainText("buzz-agents-migration");
+  await expect(page.getByTestId("edit-agent-dialog")).toContainText(
+    "Edit Local Helper",
+  );
+
+  await savedRunOn.scrollIntoViewIfNeeded();
+  await waitForAnimations(page);
+  await page
+    .getByTestId("edit-agent-dialog")
+    .screenshot({ path: `${SHOTS}/migrated-run-on.png` });
+});
+
+test("an active local agent must be stopped before migration", async ({
+  page,
+}) => {
+  const agent = TEST_IDENTITIES.tyler;
+  await installMockBridge(page, {
+    backendProviders: [KUBERNETES_PROVIDER],
+    managedAgents: [
+      {
+        pubkey: agent.pubkey,
+        name: "Busy Local Helper",
+        status: "running",
+        channelNames: ["general"],
+        respondTo: "owner-only",
+        backend: { type: "local" },
+      },
+    ],
+  });
+  await openEditDialog(page, "Busy Local Helper");
+
   const runOn = page.getByTestId("edit-agent-run-on");
   await expect(runOn.getByTestId("edit-agent-run-on-location")).toHaveText(
     "This computer",
   );
-  await expect(runOn.getByTestId("edit-agent-run-on-namespace")).toHaveCount(0);
-
-  await runOn.scrollIntoViewIfNeeded();
-  await waitForAnimations(page);
-  await page
-    .getByTestId("edit-agent-dialog")
-    .screenshot({ path: `${SHOTS}/local-run-on.png` });
+  await expect(runOn).toContainText(
+    "Stop this agent before changing where it runs.",
+  );
+  await expect(page.locator("#agent-run-on")).toHaveCount(0);
 });
 
 test("a blox agent's single saved field renders with a humanized label", async ({

--- a/desktop/tests/e2e/edit-agent.spec.ts
+++ b/desktop/tests/e2e/edit-agent.spec.ts
@@ -352,16 +352,12 @@ test.describe("edit agent dialog", () => {
     ).toBeVisible();
   });
 
-  test("profile Edit routes persona-linked agents to the definition editor", async ({
+  test("profile Edit routes persona-linked agents to the instance editor", async ({
     page,
   }) => {
-    // Routing pin for handleEditAgent (UserProfilePanel): when the agent has
-    // a resolvable non-built-in persona, the Edit quick action opens the
-    // DEFINITION editor (persona dialog), not EditAgentDialog. The instance
-    // editor (and its inherit-runtime toggle) is reachable for persona-linked
-    // agents only via the requestOpenEditAgent event (ConfigNudgeCard) — no
-    // plain UI path — so its inherit-toggle behavior is covered by B3b's
-    // component-level pinning test, not e2e.
+    // A profile is an instance entry point even when that instance is linked
+    // to a persona. Definition editing remains available from the explicit
+    // template action inside the instance editor.
     await installMockBridge(page, {
       managedAgents: [
         {
@@ -396,14 +392,10 @@ test.describe("edit agent dialog", () => {
     });
     await page.getByTestId("user-profile-edit-agent").click();
 
-    // Definition editor opens; the instance editor does not.
-    await expect(page.getByTestId("persona-dialog")).toBeVisible({
+    await expect(page.getByTestId("edit-agent-dialog")).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByTestId("edit-agent-dialog")).not.toBeVisible();
-    // And it is the persona's record that's being edited.
-    await expect(page.locator("#persona-display-name")).toHaveValue(
-      "Edit E2E Persona",
-    );
+    await expect(page.getByTestId("persona-dialog")).not.toBeVisible();
+    await expect(page.locator("#edit-agent-name")).toHaveValue(AGENT_NAME);
   });
 });

--- a/docs/remote-agents.md
+++ b/docs/remote-agents.md
@@ -1016,6 +1016,12 @@ namespace does not exist the provider attempts to create it; on RBAC denial
 it MUST fail with the literal `kubectl create namespace <name>` command to
 run — it MUST NOT fall back to `default`.
 
+Persistent workspaces add one ambient permission boundary: the provider's
+cluster identity needs `get` and `create` on `persistentvolumeclaims` in the
+selected namespace, in addition to its existing namespace, Pod, and Secret
+permissions. Claim verification happens before any per-attempt Secret is
+written, so an RBAC refusal cannot leave a new identity Secret behind.
+
 ### Image
 
 `ghcr.io/block/buzz-sprig`: Alpine base + `bash` (required by the dev-MCP
@@ -1176,6 +1182,12 @@ regardless of `HOME`.
     destructive repair or GC action**. Identity labels/annotations prove
     identity; the marker asserts protocol ownership — without it, an object
     that merely matches our schema fails closed to the operator
+    - the current writer emits binding `2`. Its reader accepts legacy binding
+      `1` only for Pods and Secrets, allowing an in-place upgrade to observe
+      and collect old generations. PersistentVolumeClaims require binding `2`
+      plus the exact full-pubkey annotation; a v1 claim is never adopted. A v1
+      provider, in turn, refuses a v2 deterministic-name collision instead of
+      recreating the body with its old `emptyDir` pod shape
   - annotation `buzz.block.xyz/agent-pubkey-full: <full-64-hex>` —
     **load-bearing**: per §Deploy State Machine step 1, every label-selected
     object's annotation MUST equal the derived pubkey before the provider
@@ -1248,7 +1260,11 @@ regardless of `HOME`.
   claim. The claim carries the same management labels and full-pubkey
   annotation as the pod, and a same-named foreign claim is a hard refusal.
   Capacity or StorageClass drift is also refused rather than silently
-  pointing a new body at a different workspace. Agent memory remains
+  pointing a new body at a different workspace. The PVC has no Pod
+  owner-reference and is never deleted by provider GC: it survives clean exit,
+  crash, Pod deletion, and redeploy, and it continues to consume billable
+  storage until an operator explicitly deletes the PVC or its namespace.
+  Agent memory remains
   relay-persisted (NIP-AE) either way. [DECISION A — how remote pods get the nest workspace
   (AGENTS.md etc.) that local agents get from the desktop's `ensure_nest`;
   current recommendation is a desktop-stated protocol field, not

--- a/docs/remote-agents.md
+++ b/docs/remote-agents.md
@@ -1111,9 +1111,10 @@ paths. This is a harness interface limitation the binding inherits and
 matches, not one it introduces; a provider MUST NOT invent a private
 escaping scheme the harness would not decode.
 
-**Working directory.** `HOME` is set to a writable path backed by the
-workspace `emptyDir` (e.g. `/home/agent`), and the harness runs with cwd =
-`HOME` — mirroring the local spawn's agent-workdir convention. The baked
+**Working directory.** `HOME` is set to a writable workspace path (e.g.
+`/home/agent`) backed by `emptyDir` by default or by the identity-owned PVC
+when `provider_config.workspace_storage` is set, and the harness runs with
+cwd = `HOME` — mirroring the local spawn's agent-workdir convention. The baked
 system gitconfig references the nostr helpers by absolute path so it works
 regardless of `HOME`.
 
@@ -1161,6 +1162,9 @@ regardless of `HOME`.
   pubkey is 64 chars, one over):
   - pod name: `buzz-agent-<first-12-hex-of-pubkey>` — also the returned
     `agent_id`
+  - persistent workspace claim, when enabled:
+    `buzz-agent-<first-12-hex-of-pubkey>-workspace` — generation-free by
+    design so every replacement pod for the identity reattaches it
   - label `buzz.block.xyz/agent-pubkey: <first-32-hex>` — the selector key
     for reconciliation and GC. 128 bits is collision-*resistant*, not
     collision-free, which is why the annotation check below is normative,
@@ -1238,9 +1242,14 @@ regardless of `HOME`.
 - **Resources**: requests 1 cpu / 2Gi, limits 2 cpu / 4Gi, all four
   configurable (`cargo build` in an agent workspace makes 500m/1Gi requests
   unrealistic).
-- **Workspace**: `emptyDir`. Checkouts and scratch die with the pod; agent
-  memory is relay-persisted (NIP-AE) and unaffected. PVC support is a
-  deferred knob. [DECISION A — how remote pods get the nest workspace
+- **Workspace**: `emptyDir` by default. When `workspace_storage` is set, the
+  provider creates or verifies one deterministic `ReadWriteOnce` PVC per
+  agent identity and mounts it at `HOME`; pod/Secret GC never deletes that
+  claim. The claim carries the same management labels and full-pubkey
+  annotation as the pod, and a same-named foreign claim is a hard refusal.
+  Capacity or StorageClass drift is also refused rather than silently
+  pointing a new body at a different workspace. Agent memory remains
+  relay-persisted (NIP-AE) either way. [DECISION A — how remote pods get the nest workspace
   (AGENTS.md etc.) that local agents get from the desktop's `ensure_nest`;
   current recommendation is a desktop-stated protocol field, not
   image-side scaffolding — §Open Decisions.]
@@ -1393,12 +1402,15 @@ also self-heals the missing
 residue is one Completed pod that never restarts (I5) plus one Secret,
 removable with `kubectl delete`.
 
-### `provider_config` v1 fields
+### `provider_config` fields
 
 `context`, `namespace`, `image`, `cpu_request`, `memory_request`,
-`cpu_limit`, `memory_limit`, `inactivity_seconds`, `service_account` —
-9 of the 20-field validation cap. Node selectors, tolerations, and PVCs are
-deliberately baked out of v1 to preserve budget.
+`cpu_limit`, `memory_limit`, `inactivity_seconds`, `service_account`,
+`workspace_storage`, `workspace_storage_class` — 11 of the 20-field
+validation cap. `workspace_storage` is a Kubernetes quantity such as `20Gi`;
+`workspace_storage_class` is optional and invalid without a storage request.
+Node selectors and tolerations remain deliberately baked out to preserve
+budget.
 
 ### Distribution
 

--- a/scripts/test-k8s-sprig-image-live.sh
+++ b/scripts/test-k8s-sprig-image-live.sh
@@ -22,7 +22,7 @@ case "$PULL_POLICY" in
 esac
 
 MANAGED_BY="buzz-backend-kubernetes"
-BINDING_VERSION="v1"
+BINDING_VERSION="2"
 NAMESPACE="buzz-k8s-sprig-$(date +%s)-$RANDOM"
 CREATED=0
 
@@ -38,7 +38,7 @@ cleanup() {
         return 1
     fi
     foreign="$(kubectl --context "$CONTEXT" --namespace "$NAMESPACE" get pods -o json \
-        | jq '[.items[] | select(.metadata.labels["app.kubernetes.io/managed-by"] != "buzz-backend-kubernetes" or .metadata.labels["buzz.block.xyz/binding-version"] != "v1")] | length')"
+        | jq '[.items[] | select(.metadata.labels["app.kubernetes.io/managed-by"] != "buzz-backend-kubernetes" or .metadata.labels["buzz.block.xyz/binding-version"] != "2")] | length')"
     if [[ "$foreign" != 0 ]]; then
         echo "REFUSING cleanup: namespace contains an unowned pod: $NAMESPACE" >&2
         return 1

--- a/scripts/test-sprig-image.sh
+++ b/scripts/test-sprig-image.sh
@@ -11,7 +11,9 @@ assert_run() {
 }
 
 assert_run '
-  command -v bash git update-ca-certificates >/dev/null
+  command -v bash git update-ca-certificates codex codex-acp >/dev/null
+  test "$(codex --version)" = "codex-cli 0.147.0"
+  test "$(codex-acp --version)" = "@agentclientprotocol/codex-acp 1.4.0"
   test "$(readlink /usr/local/bin/buzz-acp)" = sprig
   for name in buzz-agent buzz-dev-mcp rg tree buzz git-credential-nostr git-sign-nostr; do
     test "$(readlink "/usr/local/bin/$name")" = sprig


### PR DESCRIPTION
## Summary
- expose the existing Run on/provider configuration inside owner-reviewed linked-agent edits
- preserve profile/runtime changes while applying a stopped local-to-provider migration
- fail closed before partial saves when the instance is active, ambiguous, provider-backed, or renamed during migration

## Verification
- `pnpm --dir desktop typecheck`
- focused Biome check for all six touched files
- `pnpm --dir desktop test` — 5,105 passed
- `pnpm --dir desktop build`

Repo-wide `pnpm --dir desktop check` still reports pre-existing lint findings in unrelated sidebar/terminal/e2e files; touched files are clean.