### PR TITLE
test(desktop): survive early menu dismissals in the agent-voice spec

### DIFF
--- a/desktop/tests/e2e/huddle-transcription.spec.ts
+++ b/desktop/tests/e2e/huddle-transcription.spec.ts
@@ -811,17 +811,27 @@ test("assigns distinct agent voices and exposes compact per-agent controls", asy
   });
   expect(new Set(assignedVoices).size).toBe(2);
 
-  await page.getByRole("button", { name: "Voice settings for alice" }).click();
-  await waitForAnimations(page);
   const voiceMenu = page.locator(
     '[data-testid="huddle-agent-voice-menu-content"][data-state="open"]',
   );
-  await expect(voiceMenu).toBeVisible();
-  await expect(
-    voiceMenu.getByText("Agent text-to-speech", { exact: true }),
-  ).toBeVisible();
+  // Shortly after a cold load, background huddle-state settling re-renders
+  // the tiles and dismisses a just-opened Radix menu; in a fresh worker
+  // (which is also every CI retry) a single click fails deterministically.
+  // Retry the whole open-and-read unit until the menu holds through it.
   const ttsToggle = voiceMenu.getByTestId("huddle-agent-tts-toggle");
-  await expect(ttsToggle).toBeChecked();
+  await expect(async () => {
+    if (!(await voiceMenu.isVisible())) {
+      await page
+        .getByRole("button", { name: "Voice settings for alice" })
+        .click();
+    }
+    await expect(voiceMenu).toBeVisible({ timeout: 1_500 });
+    await expect(
+      voiceMenu.getByText("Agent text-to-speech", { exact: true }),
+    ).toBeVisible({ timeout: 1_500 });
+    await expect(ttsToggle).toBeChecked({ timeout: 1_500 });
+  }).toPass({ timeout: 20_000 });
+  await waitForAnimations(page);
   await expect(
     voiceMenu.getByTestId("huddle-agent-voice-selector"),
   ).toContainText("Vera");


### PR DESCRIPTION
`huddle-transcription.spec.ts` › *assigns distinct agent voices…* fails deterministically when run in a **fresh worker** (`--repeat-each` solo runs: 0/6 pass on pristine main): shortly after a cold load, background huddle-state settling re-renders the participant tiles and dismisses the just-opened Radix voice menu. Every CI retry runs in a fresh worker, so a first-attempt failure can never recover — this spec has been failing whole Smoke shards across unrelated PRs (e.g. #6455 twice today).

Fix: retry the open-and-read unit (open menu → title visible → TTS toggle checked) with `expect().toPass()` until the menu holds through it. After hardening: 10/10 sequential solo runs pass (0/6 before), full file 26/26.

**Product bug worth a follow-up look** (out of scope here): an open agent-voice popover can be dismissed by background state settling the user never initiated — trace shows the menu opening and closing with no user interaction. Repro: open the voice menu immediately after the huddle window cold-loads.