### PR TITLE
fix(desktop): accept ACP config option name labels

### DIFF
--- a/desktop/src-tauri/src/commands/agent_config.rs
+++ b/desktop/src-tauri/src/commands/agent_config.rs
@@ -414,6 +414,7 @@ fn parse_config_options(raw: Option<&serde_json::Value>) -> Vec<AcpConfigOptionE
                     .map(str::to_string),
                 display_name: opt
                     .get("displayName")
+                    .or_else(|| opt.get("name"))
                     .and_then(|v| v.as_str())
                     .map(str::to_string),
                 current_value: opt
@@ -439,6 +440,7 @@ fn parse_option_values(raw: Option<&serde_json::Value>) -> Vec<AcpConfigOptionVa
                 value,
                 display_name: o
                     .get("displayName")
+                    .or_else(|| o.get("name"))
                     .and_then(|v| v.as_str())
                     .map(str::to_string),
             })

--- a/desktop/src-tauri/src/commands/agent_config_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_config_tests.rs
@@ -710,3 +710,25 @@ fn live_switch_null_models_parses_to_no_current_model() {
     );
     assert!(available.is_empty());
 }
+
+#[test]
+fn config_options_accept_acp_name_labels() {
+    let raw = serde_json::json!([{
+        "id": "model",
+        "name": "Model",
+        "currentValue": "default[]",
+        "options": [
+            {"value": "default[]", "name": "Auto"},
+            {"value": "legacy", "displayName": "Legacy label", "name": "ACP label"}
+        ]
+    }]);
+
+    let parsed = parse_config_options(Some(&raw));
+
+    assert_eq!(parsed[0].display_name.as_deref(), Some("Model"));
+    assert_eq!(parsed[0].options[0].display_name.as_deref(), Some("Auto"));
+    assert_eq!(
+        parsed[0].options[1].display_name.as_deref(),
+        Some("Legacy label")
+    );
+}

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -739,6 +739,7 @@ pub(super) fn normalize_agent_models(
                                 id: value.to_string(),
                                 name: o
                                     .get("displayName")
+                                    .or_else(|| o.get("name"))
                                     .and_then(|v| v.as_str())
                                     .map(str::to_string),
                                 description: None,

--- a/desktop/src-tauri/src/commands/agent_models_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_models_tests.rs
@@ -962,3 +962,29 @@ fn databricks_static_token_error_redacts_echoed_token() {
         "error lost its remediation: {error}"
     );
 }
+
+#[test]
+fn agent_model_normalization_accepts_acp_name_field() {
+    let raw = serde_json::json!({
+        "agent": {"name": "Cursor", "version": "1"},
+        "stable": {
+            "configOptions": [{
+                "category": "model",
+                "options": [
+                    {"value": "default[]", "name": "Auto"},
+                    {"value": "z-ai/glm-5", "displayName": "GLM 5"}
+                ]
+            }]
+        },
+        "unstable": {
+            "currentModelId": "default[]",
+            "availableModels": [{"modelId": "default[]", "name": "Duplicate"}]
+        }
+    });
+
+    let result = normalize_agent_models(&raw, None);
+
+    assert_eq!(result.models.len(), 2);
+    assert_eq!(result.models[0].name.as_deref(), Some("Auto"));
+    assert_eq!(result.models[1].name.as_deref(), Some("GLM 5"));
+}


### PR DESCRIPTION
## Summary

- Accept the ACP-standard `name` field for config-option and select-value labels.
- Preserve the existing `displayName` field as the first choice for backward compatibility.
- Apply the same fallback when normalizing model options for the Desktop model picker.

ACP v1 defines `name` as the required human-readable label for both `ConfigOption` and `ConfigOptionValue`: https://github.com/agentclientprotocol/agent-client-protocol/blob/main/docs/protocol/v1/session-config-options.mdx

Buzz previously read only the non-standard `displayName` field. Agents that follow the spec, including Cursor ACP, therefore exposed raw values such as `default[]` instead of their advertised label (`Auto`).

### Related issue

N/A — no matching open issue or PR found.

### Testing

- `just desktop-tauri-test`
- `just desktop-tauri-clippy`
- `just desktop-tauri-fmt-check`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml config_options_accept_acp_name_labels --lib`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml agent_model_normalization_accepts_acp_name_field --lib`
- `git diff --check`

### Before / after

| Before | After |
|---|---|
| Cursor's advertised `default[]` value is shown raw. | The same value uses its ACP `name`, `Auto`. |
| ![Before: raw default model id](https://raw.githubusercontent.com/unclejobs-ai/buzz/pr-assets/.github/pr-assets/acp-name-before.png) | ![After: ACP model label](https://raw.githubusercontent.com/unclejobs-ai/buzz/pr-assets/.github/pr-assets/acp-name-after.png) |
