### PR TITLE
feat(workflow): operator CIDR allowlist for webhook SSRF check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -249,4 +249,7 @@ RUST_LOG=buzz_relay=debug,buzz_datastore=info,buzz_db=debug,buzz_auth=debug,buzz
 # attestation are optional; configuring any one enables policy acceptance.
 # BUZZ_TERMS_OF_SERVICE_MARKDOWN="# Terms of Service\n\nFull terms here."
 # BUZZ_PRIVACY_POLICY_MARKDOWN="# Privacy Policy\n\nFull policy here."
+# Comma-separated CIDR allowlist for workflow webhook SSRF check. Empty (default) blocks all private/reserved ranges.
+# BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS=100.64.0.0/10,fd00::/8
+
 # BUZZ_AGE_ATTESTATION_REQUIRED=true

--- a/crates/buzz-core/src/network.rs
+++ b/crates/buzz-core/src/network.rs
@@ -43,6 +43,8 @@ fn embedded_ipv4(v6: &std::net::Ipv6Addr, prefix: &[u8; 12]) -> Option<std::net:
 /// - NAT64 local-use     64:ff9b:1::/48 (RFC 8215)
 /// - Teredo              2001::/32 (RFC 4380)
 /// - 6to4                2002::/16 (RFC 3056)
+///
+/// Returns `true` if the IP address is in a private, reserved, or loopback range.
 pub fn is_private_ip(ip: &std::net::IpAddr) -> bool {
     match ip {
         std::net::IpAddr::V4(v4) => {
@@ -92,6 +94,108 @@ pub fn is_private_ip(ip: &std::net::IpAddr) -> bool {
                 || (segments[0] == 0x2001 && segments[1] == 0x0db8)
         }
     }
+}
+
+/// CIDR range for allowlist matching (hand-rolled, no extra dependency).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IpCidr {
+    /// Base address of the CIDR range.
+    pub base: std::net::IpAddr,
+    /// Prefix length (0-32 for IPv4, 0-128 for IPv6).
+    pub prefix_len: u8,
+}
+
+impl IpCidr {
+    /// Returns true if `ip` is within this CIDR range. Family mismatch returns false.
+    pub fn contains(&self, ip: &std::net::IpAddr) -> bool {
+        match (&self.base, ip) {
+            (std::net::IpAddr::V4(b), std::net::IpAddr::V4(i)) => {
+                if self.prefix_len == 0 {
+                    return true;
+                }
+                if self.prefix_len > 32 {
+                    return false;
+                }
+                let mask = if self.prefix_len == 32 {
+                    u32::MAX
+                } else {
+                    u32::MAX << (32 - self.prefix_len)
+                };
+                (u32::from(*b) & mask) == (u32::from(*i) & mask)
+            }
+            (std::net::IpAddr::V6(b), std::net::IpAddr::V6(i)) => {
+                if self.prefix_len == 0 {
+                    return true;
+                }
+                if self.prefix_len > 128 {
+                    return false;
+                }
+                let b = b.octets();
+                let i = i.octets();
+                let full = (self.prefix_len / 8) as usize;
+                if b[..full] != i[..full] {
+                    return false;
+                }
+                let rem = self.prefix_len % 8;
+                if rem == 0 {
+                    return true;
+                }
+                let mask: u8 = 0xFF << (8 - rem);
+                (b[full] & mask) == (i[full] & mask)
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Parse comma-separated CIDR spec into valid entries. Malformed entries are dropped with a warning.
+pub fn parse_allowed_cidrs(spec: &str) -> Vec<IpCidr> {
+    let mut out = Vec::new();
+    for part in spec.split(',') {
+        let s = part.trim();
+        if s.is_empty() {
+            continue;
+        }
+        let Some((addr_str, prefix_str)) = s.split_once('/') else {
+            eprintln!(
+                "BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS: dropping malformed entry '{}'",
+                s
+            );
+            continue;
+        };
+        let Ok(prefix_len) = prefix_str.trim().parse::<u8>() else {
+            eprintln!(
+                "BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS: dropping malformed entry '{}'",
+                s
+            );
+            continue;
+        };
+        let Ok(base) = addr_str.trim().parse::<std::net::IpAddr>() else {
+            eprintln!(
+                "BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS: dropping malformed entry '{}'",
+                s
+            );
+            continue;
+        };
+        let max = match base {
+            std::net::IpAddr::V4(_) => 32,
+            std::net::IpAddr::V6(_) => 128,
+        };
+        if prefix_len > max {
+            eprintln!(
+                "BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS: dropping malformed entry '{}'",
+                s
+            );
+            continue;
+        }
+        out.push(IpCidr { base, prefix_len });
+    }
+    out
+}
+
+/// Returns true if `ip` is private/reserved and not covered by `allowed`.
+pub fn is_blocked_ip(ip: &std::net::IpAddr, allowed: &[IpCidr]) -> bool {
+    is_private_ip(ip) && !allowed.iter().any(|c| c.contains(ip))
 }
 
 #[cfg(test)]
@@ -358,5 +462,81 @@ mod tests {
     fn test_ipv6_not_multicast() {
         // fe00:: — just below ff00::/8 (not multicast, not link-local, not ULA)
         assert!(!is_private_ip(&"fe00::1".parse::<IpAddr>().unwrap()));
+    }
+
+    #[test]
+    fn test_allowlist_cgnat() {
+        let ip: IpAddr = "100.64.1.5".parse().unwrap();
+        assert!(is_blocked_ip(&ip, &[]));
+        let allowed = parse_allowed_cidrs("100.64.0.0/10");
+        assert!(!is_blocked_ip(&ip, &allowed));
+        let near = parse_allowed_cidrs("100.65.0.0/16");
+        assert!(is_blocked_ip(&ip, &near));
+    }
+
+    #[test]
+    fn test_allowlist_public_never_blocked() {
+        let ip: IpAddr = "93.184.216.34".parse().unwrap();
+        assert!(!is_blocked_ip(&ip, &[]));
+        assert!(!is_blocked_ip(&ip, &parse_allowed_cidrs("100.64.0.0/10")));
+    }
+
+    #[test]
+    fn test_allowlist_one_range_does_not_open_others() {
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        let allowed = parse_allowed_cidrs("100.64.0.0/10");
+        assert!(is_blocked_ip(&ip, &allowed));
+    }
+
+    #[test]
+    fn test_allowlist_ipv6_ula() {
+        let ip: IpAddr = "fd00::1".parse().unwrap();
+        assert!(is_blocked_ip(&ip, &[]));
+        assert!(!is_blocked_ip(&ip, &parse_allowed_cidrs("fd00::/8")));
+    }
+
+    #[test]
+    fn test_allowlist_family_mismatch() {
+        let v4: IpAddr = "10.0.0.1".parse().unwrap();
+        let v6: IpAddr = "fd00::1".parse().unwrap();
+        assert!(is_blocked_ip(&v4, &parse_allowed_cidrs("fd00::/8")));
+        assert!(is_blocked_ip(&v6, &parse_allowed_cidrs("10.0.0.0/8")));
+    }
+
+    #[test]
+    fn test_allowlist_single_host() {
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        let neigh: IpAddr = "10.0.0.2".parse().unwrap();
+        let allowed = parse_allowed_cidrs("10.0.0.1/32");
+        assert!(!is_blocked_ip(&ip, &allowed));
+        assert!(is_blocked_ip(&neigh, &allowed));
+        let v6: IpAddr = "fd00::1".parse().unwrap();
+        let v6n: IpAddr = "fd00::2".parse().unwrap();
+        let allowed6 = parse_allowed_cidrs("fd00::1/128");
+        assert!(!is_blocked_ip(&v6, &allowed6));
+        assert!(is_blocked_ip(&v6n, &allowed6));
+    }
+
+    #[test]
+    fn test_parse_drops_malformed() {
+        let v = parse_allowed_cidrs("10.0.0.0/8, garbage, 100.64.0.0/99, 100.64.0.0/10");
+        assert_eq!(v.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_empty() {
+        assert!(parse_allowed_cidrs("").is_empty());
+        assert!(parse_allowed_cidrs("   ").is_empty());
+        // empty allowlist behaves like is_private_ip
+        for s in [
+            "10.0.0.1",
+            "8.8.8.8",
+            "100.64.1.5",
+            "fd00::1",
+            "2606:4700::1",
+        ] {
+            let ip: IpAddr = s.parse().unwrap();
+            assert_eq!(is_blocked_ip(&ip, &[]), is_private_ip(&ip));
+        }
     }
 }

--- a/crates/buzz-core/src/network.rs
+++ b/crates/buzz-core/src/network.rs
@@ -148,33 +148,26 @@ impl IpCidr {
     }
 }
 
-/// Parse comma-separated CIDR spec into valid entries. Malformed entries are dropped with a warning.
-pub fn parse_allowed_cidrs(spec: &str) -> Vec<IpCidr> {
+/// Parse comma-separated CIDR spec into valid entries. Malformed entries are dropped.
+/// Returns the valid ranges and the dropped entry strings.
+pub fn parse_allowed_cidrs(spec: &str) -> (Vec<IpCidr>, Vec<String>) {
     let mut out = Vec::new();
+    let mut dropped = Vec::new();
     for part in spec.split(',') {
         let s = part.trim();
         if s.is_empty() {
             continue;
         }
         let Some((addr_str, prefix_str)) = s.split_once('/') else {
-            eprintln!(
-                "BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS: dropping malformed entry '{}'",
-                s
-            );
+            dropped.push(s.to_string());
             continue;
         };
         let Ok(prefix_len) = prefix_str.trim().parse::<u8>() else {
-            eprintln!(
-                "BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS: dropping malformed entry '{}'",
-                s
-            );
+            dropped.push(s.to_string());
             continue;
         };
         let Ok(base) = addr_str.trim().parse::<std::net::IpAddr>() else {
-            eprintln!(
-                "BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS: dropping malformed entry '{}'",
-                s
-            );
+            dropped.push(s.to_string());
             continue;
         };
         let max = match base {
@@ -182,15 +175,12 @@ pub fn parse_allowed_cidrs(spec: &str) -> Vec<IpCidr> {
             std::net::IpAddr::V6(_) => 128,
         };
         if prefix_len > max {
-            eprintln!(
-                "BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS: dropping malformed entry '{}'",
-                s
-            );
+            dropped.push(s.to_string());
             continue;
         }
         out.push(IpCidr { base, prefix_len });
     }
-    out
+    (out, dropped)
 }
 
 /// Returns true if `ip` is private/reserved and not covered by `allowed`.
@@ -468,9 +458,9 @@ mod tests {
     fn test_allowlist_cgnat() {
         let ip: IpAddr = "100.64.1.5".parse().unwrap();
         assert!(is_blocked_ip(&ip, &[]));
-        let allowed = parse_allowed_cidrs("100.64.0.0/10");
+        let (allowed, _) = parse_allowed_cidrs("100.64.0.0/10");
         assert!(!is_blocked_ip(&ip, &allowed));
-        let near = parse_allowed_cidrs("100.65.0.0/16");
+        let (near, _) = parse_allowed_cidrs("100.65.0.0/16");
         assert!(is_blocked_ip(&ip, &near));
     }
 
@@ -478,13 +468,14 @@ mod tests {
     fn test_allowlist_public_never_blocked() {
         let ip: IpAddr = "93.184.216.34".parse().unwrap();
         assert!(!is_blocked_ip(&ip, &[]));
-        assert!(!is_blocked_ip(&ip, &parse_allowed_cidrs("100.64.0.0/10")));
+        let (allowed, _) = parse_allowed_cidrs("100.64.0.0/10");
+        assert!(!is_blocked_ip(&ip, &allowed));
     }
 
     #[test]
     fn test_allowlist_one_range_does_not_open_others() {
         let ip: IpAddr = "10.0.0.1".parse().unwrap();
-        let allowed = parse_allowed_cidrs("100.64.0.0/10");
+        let (allowed, _) = parse_allowed_cidrs("100.64.0.0/10");
         assert!(is_blocked_ip(&ip, &allowed));
     }
 
@@ -492,41 +483,45 @@ mod tests {
     fn test_allowlist_ipv6_ula() {
         let ip: IpAddr = "fd00::1".parse().unwrap();
         assert!(is_blocked_ip(&ip, &[]));
-        assert!(!is_blocked_ip(&ip, &parse_allowed_cidrs("fd00::/8")));
+        let (allowed, _) = parse_allowed_cidrs("fd00::/8");
+        assert!(!is_blocked_ip(&ip, &allowed));
     }
 
     #[test]
     fn test_allowlist_family_mismatch() {
         let v4: IpAddr = "10.0.0.1".parse().unwrap();
         let v6: IpAddr = "fd00::1".parse().unwrap();
-        assert!(is_blocked_ip(&v4, &parse_allowed_cidrs("fd00::/8")));
-        assert!(is_blocked_ip(&v6, &parse_allowed_cidrs("10.0.0.0/8")));
+        let (a1, _) = parse_allowed_cidrs("fd00::/8");
+        assert!(is_blocked_ip(&v4, &a1));
+        let (a2, _) = parse_allowed_cidrs("10.0.0.0/8");
+        assert!(is_blocked_ip(&v6, &a2));
     }
 
     #[test]
     fn test_allowlist_single_host() {
         let ip: IpAddr = "10.0.0.1".parse().unwrap();
         let neigh: IpAddr = "10.0.0.2".parse().unwrap();
-        let allowed = parse_allowed_cidrs("10.0.0.1/32");
+        let (allowed, _) = parse_allowed_cidrs("10.0.0.1/32");
         assert!(!is_blocked_ip(&ip, &allowed));
         assert!(is_blocked_ip(&neigh, &allowed));
         let v6: IpAddr = "fd00::1".parse().unwrap();
         let v6n: IpAddr = "fd00::2".parse().unwrap();
-        let allowed6 = parse_allowed_cidrs("fd00::1/128");
+        let (allowed6, _) = parse_allowed_cidrs("fd00::1/128");
         assert!(!is_blocked_ip(&v6, &allowed6));
         assert!(is_blocked_ip(&v6n, &allowed6));
     }
 
     #[test]
     fn test_parse_drops_malformed() {
-        let v = parse_allowed_cidrs("10.0.0.0/8, garbage, 100.64.0.0/99, 100.64.0.0/10");
+        let (v, dropped) = parse_allowed_cidrs("10.0.0.0/8, garbage, 100.64.0.0/99, 100.64.0.0/10");
         assert_eq!(v.len(), 2);
+        assert_eq!(dropped, vec!["garbage", "100.64.0.0/99"]);
     }
 
     #[test]
     fn test_parse_empty() {
-        assert!(parse_allowed_cidrs("").is_empty());
-        assert!(parse_allowed_cidrs("   ").is_empty());
+        assert!(parse_allowed_cidrs("").0.is_empty());
+        assert!(parse_allowed_cidrs("   ").0.is_empty());
         // empty allowlist behaves like is_private_ip
         for s in [
             "10.0.0.1",

--- a/crates/buzz-workflow/src/executor.rs
+++ b/crates/buzz-workflow/src/executor.rs
@@ -843,10 +843,13 @@ async fn check_ssrf(host: &str, port: u16) -> Result<std::net::IpAddr, WorkflowE
 
     debug!("Resolved webhook host '{}' → {:?}", host, addrs);
 
+    let allowed = buzz_core::network::parse_allowed_cidrs(
+        &std::env::var("BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS").unwrap_or_default(),
+    );
     for ip in &addrs {
-        if buzz_core::network::is_private_ip(ip) {
+        if buzz_core::network::is_blocked_ip(ip, &allowed) {
             return Err(WorkflowError::WebhookError(format!(
-                "SSRF blocked: '{host}' resolved to private/reserved address {ip}"
+                "SSRF blocked: '{host}' resolved to private/reserved address {ip} (allow it with BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS)"
             )));
         }
     }

--- a/crates/buzz-workflow/src/executor.rs
+++ b/crates/buzz-workflow/src/executor.rs
@@ -2015,6 +2015,19 @@ mod tests {
         assert!(ssrf_verdict("example.com", &[], "").is_err());
     }
 
+    #[cfg(feature = "reqwest")]
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn check_ssrf_reads_allowlist_env_var() {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS");
+        assert!(check_ssrf("127.0.0.1", 80).await.is_err());
+        std::env::set_var("BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS", "127.0.0.0/8");
+        assert!(check_ssrf("127.0.0.1", 80).await.is_ok());
+        std::env::remove_var("BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS");
+    }
+
     #[test]
     fn send_message_canonicalizes_valid_explicit_override_for_global_workflow() {
         let override_channel_id = Uuid::new_v4();

--- a/crates/buzz-workflow/src/executor.rs
+++ b/crates/buzz-workflow/src/executor.rs
@@ -2016,15 +2016,18 @@ mod tests {
     }
 
     #[cfg(feature = "reqwest")]
-    #[tokio::test]
-    #[allow(clippy::await_holding_lock)]
-    async fn check_ssrf_reads_allowlist_env_var() {
+    #[test]
+    fn check_ssrf_reads_allowlist_env_var() {
         static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
         std::env::remove_var("BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS");
-        assert!(check_ssrf("127.0.0.1", 80).await.is_err());
+        assert!(rt.block_on(check_ssrf("127.0.0.1", 80)).is_err());
         std::env::set_var("BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS", "127.0.0.0/8");
-        assert!(check_ssrf("127.0.0.1", 80).await.is_ok());
+        assert!(rt.block_on(check_ssrf("127.0.0.1", 80)).is_ok());
         std::env::remove_var("BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS");
     }
 

--- a/crates/buzz-workflow/src/executor.rs
+++ b/crates/buzz-workflow/src/executor.rs
@@ -850,12 +850,19 @@ async fn check_ssrf(host: &str, port: u16) -> Result<std::net::IpAddr, WorkflowE
     )
 }
 
+#[cfg(feature = "reqwest")]
 fn ssrf_verdict(
     host: &str,
     addrs: &[std::net::IpAddr],
     allowed_spec: &str,
 ) -> Result<std::net::IpAddr, WorkflowError> {
-    let allowed = buzz_core::network::parse_allowed_cidrs(allowed_spec);
+    let (allowed, dropped) = buzz_core::network::parse_allowed_cidrs(allowed_spec);
+    if !dropped.is_empty() {
+        tracing::warn!(
+            "BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS: dropping malformed entries {:?}",
+            dropped
+        );
+    }
     for ip in addrs {
         if buzz_core::network::is_blocked_ip(ip, &allowed) {
             return Err(WorkflowError::WebhookError(format!(
@@ -1974,28 +1981,38 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "reqwest")]
     fn ssrf_verdict_empty_blocks_cgnat() {
         let ip: std::net::IpAddr = "100.64.1.5".parse().unwrap();
         assert!(ssrf_verdict("example.com", &[ip], "").is_err());
     }
 
     #[test]
+    #[cfg(feature = "reqwest")]
     fn ssrf_verdict_allows_cgnat_with_spec() {
         let ip: std::net::IpAddr = "100.64.1.5".parse().unwrap();
         assert!(ssrf_verdict("example.com", &[ip], "100.64.0.0/10").is_ok());
     }
 
     #[test]
+    #[cfg(feature = "reqwest")]
     fn ssrf_verdict_still_blocks_other_private() {
         let ip: std::net::IpAddr = "10.0.0.1".parse().unwrap();
         assert!(ssrf_verdict("example.com", &[ip], "100.64.0.0/10").is_err());
     }
 
     #[test]
+    #[cfg(feature = "reqwest")]
     fn ssrf_verdict_public_passes() {
         let ip: std::net::IpAddr = "93.184.216.34".parse().unwrap();
         assert!(ssrf_verdict("example.com", &[ip], "").is_ok());
         assert!(ssrf_verdict("example.com", &[ip], "100.64.0.0/10").is_ok());
+    }
+
+    #[test]
+    #[cfg(feature = "reqwest")]
+    fn ssrf_verdict_empty_addrs_is_err() {
+        assert!(ssrf_verdict("example.com", &[], "").is_err());
     }
 
     #[test]

--- a/crates/buzz-workflow/src/executor.rs
+++ b/crates/buzz-workflow/src/executor.rs
@@ -843,18 +843,30 @@ async fn check_ssrf(host: &str, port: u16) -> Result<std::net::IpAddr, WorkflowE
 
     debug!("Resolved webhook host '{}' → {:?}", host, addrs);
 
-    let allowed = buzz_core::network::parse_allowed_cidrs(
+    ssrf_verdict(
+        host,
+        &addrs,
         &std::env::var("BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS").unwrap_or_default(),
-    );
-    for ip in &addrs {
+    )
+}
+
+fn ssrf_verdict(
+    host: &str,
+    addrs: &[std::net::IpAddr],
+    allowed_spec: &str,
+) -> Result<std::net::IpAddr, WorkflowError> {
+    let allowed = buzz_core::network::parse_allowed_cidrs(allowed_spec);
+    for ip in addrs {
         if buzz_core::network::is_blocked_ip(ip, &allowed) {
             return Err(WorkflowError::WebhookError(format!(
                 "SSRF blocked: '{host}' resolved to private/reserved address {ip} (allow it with BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS)"
             )));
         }
     }
-
-    Ok(addrs[0])
+    addrs
+        .first()
+        .copied()
+        .ok_or_else(|| WorkflowError::WebhookError("DNS resolution returned no addresses".into()))
 }
 
 /// Maximum response body size for webhook calls (1 MiB).
@@ -1959,6 +1971,31 @@ mod tests {
             err.to_string().contains("channel override must match"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn ssrf_verdict_empty_blocks_cgnat() {
+        let ip: std::net::IpAddr = "100.64.1.5".parse().unwrap();
+        assert!(ssrf_verdict("example.com", &[ip], "").is_err());
+    }
+
+    #[test]
+    fn ssrf_verdict_allows_cgnat_with_spec() {
+        let ip: std::net::IpAddr = "100.64.1.5".parse().unwrap();
+        assert!(ssrf_verdict("example.com", &[ip], "100.64.0.0/10").is_ok());
+    }
+
+    #[test]
+    fn ssrf_verdict_still_blocks_other_private() {
+        let ip: std::net::IpAddr = "10.0.0.1".parse().unwrap();
+        assert!(ssrf_verdict("example.com", &[ip], "100.64.0.0/10").is_err());
+    }
+
+    #[test]
+    fn ssrf_verdict_public_passes() {
+        let ip: std::net::IpAddr = "93.184.216.34".parse().unwrap();
+        assert!(ssrf_verdict("example.com", &[ip], "").is_ok());
+        assert!(ssrf_verdict("example.com", &[ip], "100.64.0.0/10").is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Closes #6500.

`call_webhook`'s SSRF check rejects every private/reserved range, including `100.64.0.0/10`. On a Tailscale deployment that range *is* the operator's internal network, so `call_webhook` cannot reach anything they run. This adds an opt-in, operator-controlled CIDR allowlist. The default is empty, so behaviour is byte-for-byte unchanged for anyone who does not set the variable.

## What changed

- `buzz-core::network` gains `IpCidr` (with `contains`), `parse_allowed_cidrs`, and `is_blocked_ip(ip, allowed) == is_private_ip(ip) && !allowed.contains(ip)`. Hand-rolled masking, no new dependency.
- `buzz-workflow::executor` gains `ssrf_verdict(host, addrs, allowed_spec)`. `check_ssrf` is now resolve-then-delegate, reading `BUZZ_WORKFLOW_WEBHOOK_ALLOWED_CIDRS`.
- The SSRF error now names the variable, so a blocked destination points at its own remedy.
- Malformed entries are dropped and the dropped list is returned to the caller, which logs one `tracing::warn!` naming the variable. `buzz-core` has no `tracing` dependency and does no logging itself.
- `.env.example` documents the variable.

`parse_allowed_cidrs` fails closed: an unparseable or over-wide entry is dropped rather than widened, and a bare address with no `/prefix` is dropped rather than treated as a host route.

## Scope

This is option 1 of the two the issue asks for. Option 2 — surfacing blocked destinations as an explicit step error instead of a silent non-delivery — is #5122 and is not addressed here. The issue says option 1 alone unblocks the reported case.

## Verification

`ssrf_verdict` and its five tests are behind `#[cfg(feature = "reqwest")]`, matching every other item in that block. Two things follow, and both matter when reading a green pipeline:

- **`./scripts/run-tests.sh unit` does not run `buzz-workflow` at all.** Its suites are buzz-core, buzz-auth, buzz-voice, buzz-cli, buzz-db, buzz-conformance, buzz-push-gateway, buzz-backend-kubernetes, buzz-agent. Only the `buzz-core` half of this change is covered there.
- **`cargo clippy --workspace` cannot see a cfg mismatch on this function**, because feature unification turns `reqwest` on. An earlier revision of this branch was missing the `#[cfg]` and passed workspace clippy while `cargo clippy -p buzz-workflow --all-targets -- -D warnings` failed on dead code. Reviewers should run the per-crate form.

Run `cargo test -p buzz-workflow --features reqwest` to exercise the workflow-side tests; without the feature they are filtered out (measured: 5 run with it, 0 without).

Gates run on the branch and again on the branch merged with `main`:

```
cargo fmt --all --check                                             exit 0
cargo clippy --workspace --all-targets -- -D warnings               clean
cargo clippy -p buzz-workflow --all-targets -- -D warnings          clean
cargo clippy -p buzz-workflow --all-targets --features reqwest ...  clean
cargo test -p buzz-core                                             270 passed, 0 failed
cargo test -p buzz-workflow --features reqwest                      175 passed, 0 failed
./scripts/run-tests.sh unit                                         All tests passed
```

Mutation probes, with the baseline restored and re-confirmed green between each:

| Change | Result |
|---|---|
| `is_blocked_ip` drops the allowlist term | 3 failed |
| `parse_allowed_cidrs` returns an empty dropped list | 1 failed |
| `IpCidr::contains` always returns true | 4 failed |
| Delete the `ssrf_verdict` call from `check_ssrf` | 1 failed, plus clippy dead-code error |
| Replace the `env::var` argument with a literal `""` | 1 failed |

The last row is the one worth calling out. Deleting the call site is caught by the dead-code lint, but silently disabling the feature by breaking the variable name is not — that is what `check_ssrf_reads_allowlist_env_var` exists to catch. It drives `check_ssrf` through a current-thread runtime under a mutex, and needs no network: `"127.0.0.1:80".to_socket_addrs()` is a pure parse.
