### PR TITLE
feat: preview exact release runs in messages

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -65,6 +65,7 @@ export default defineConfig({
         "**/spoiler.spec.ts",
         "**/composer-link-shortcut.spec.ts",
         "**/entity-link-recipient-cards.spec.ts",
+        "**/release-run-preview.spec.ts",
         "**/composer-selection-formatting.spec.ts",
         "**/composer-tooltip-dismiss.spec.ts",
         "**/mentions.spec.ts",

--- a/desktop/src/shared/lib/releaseRunLink.test.mjs
+++ b/desktop/src/shared/lib/releaseRunLink.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildReleaseRunLink,
+  parseReleaseRunLink,
+  releaseRunViewState,
+} from "./releaseRunLink.ts";
+
+const payload = {
+  version: 1,
+  runId: "deezer-2026-08-22T06:00:33.651Z",
+  runName: "Deezer release re-identification",
+  status: "completed",
+  checked: 40,
+  released: 3,
+  held: 37,
+  sourceHealth: "Deezer healthy",
+  finishedAt: "2026-08-22T06:00:33.651Z",
+  tracks: [
+    {
+      id: "track-1",
+      artist: "D Stone",
+      title: "Total Unison",
+      version: "Original Mix",
+      label: "Heist Recordings",
+      releaseDate: "2026-08-22",
+      artworkUrl: "https://cdn.example.com/total-unison.jpg",
+      source: "Deezer",
+      sourceUrl: "https://www.deezer.com/track/123",
+      detailsUrl: "https://team.trakthat.app/releases?track=track-1",
+    },
+    {
+      id: "track-2",
+      artist: "Fleur Shore",
+      title: "Higher",
+      label: "Cuttin' Headz",
+      releaseDate: "2026-08-22",
+      source: "Deezer",
+    },
+    {
+      id: "track-3",
+      artist: "M-High",
+      title: "The Answer",
+      releaseDate: "2026-08-22",
+      source: "Deezer",
+    },
+  ],
+};
+
+test("release run link round-trips a complete bounded payload", () => {
+  const href = buildReleaseRunLink(payload);
+  assert.match(href, /^buzz:\/\/release-run\?data=[A-Za-z0-9_-]+$/);
+  assert.deepEqual(parseReleaseRunLink(href), payload);
+  assert.equal(releaseRunViewState(payload), "ready");
+});
+
+test("release run parser rejects a mismatched released count", () => {
+  const href = buildReleaseRunLink({ ...payload, released: 2 });
+  assert.equal(parseReleaseRunLink(href), null);
+});
+
+test("release run parser rejects insecure artwork and destinations", () => {
+  const href = buildReleaseRunLink({
+    ...payload,
+    tracks: [
+      { ...payload.tracks[0], artworkUrl: "http://cdn.example.com/cover.jpg" },
+      ...payload.tracks.slice(1),
+    ],
+  });
+  assert.equal(parseReleaseRunLink(href), null);
+});
+
+test("release run parser rejects duplicate and unknown query parameters", () => {
+  const href = buildReleaseRunLink(payload);
+  const data = new URL(href).searchParams.get("data");
+  assert.equal(
+    parseReleaseRunLink(`${href}&data=${data}`),
+    null,
+    "duplicate data parameter",
+  );
+  assert.equal(parseReleaseRunLink(`${href}&open=external`), null);
+});
+
+test("release run view state distinguishes live, empty, and failed runs", () => {
+  const empty = { ...payload, released: 0, tracks: [] };
+  assert.equal(releaseRunViewState({ ...empty, status: "running" }), "loading");
+  assert.equal(releaseRunViewState({ ...empty, status: "completed" }), "empty");
+  assert.equal(releaseRunViewState({ ...empty, status: "failed" }), "failed");
+});

--- a/desktop/src/shared/lib/releaseRunLink.ts
+++ b/desktop/src/shared/lib/releaseRunLink.ts
@@ -1,0 +1,246 @@
+export type ReleaseRunTrack = {
+  id: string;
+  artist: string;
+  title: string;
+  version?: string;
+  label?: string;
+  releaseDate: string;
+  artworkUrl?: string;
+  source: string;
+  sourceUrl?: string;
+  detailsUrl?: string;
+};
+
+export type ReleaseRunPayload = {
+  version: 1;
+  runId: string;
+  runName: string;
+  status: string;
+  checked: number;
+  released: number;
+  held: number;
+  sourceHealth: string;
+  finishedAt: string;
+  tracks: ReleaseRunTrack[];
+};
+
+export type ReleaseRunViewState = "loading" | "empty" | "failed" | "ready";
+
+const MAX_ENCODED_PAYLOAD_LENGTH = 48_000;
+const MAX_TRACKS = 50;
+const RUN_ID_PATTERN = /^[A-Za-z0-9._:-]{1,120}$/;
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function boundedString(value: unknown, maximumLength: number): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > maximumLength) return null;
+  return trimmed;
+}
+
+function optionalBoundedString(
+  value: unknown,
+  maximumLength: number,
+): string | undefined | null {
+  if (value == null || value === "") return undefined;
+  return boundedString(value, maximumLength);
+}
+
+function count(value: unknown): number | null {
+  return typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value <= 1_000_000
+    ? value
+    : null;
+}
+
+function httpsUrl(value: unknown): string | undefined | null {
+  const candidate = optionalBoundedString(value, 2_000);
+  if (candidate == null) return candidate;
+  try {
+    const parsed = new URL(candidate);
+    return parsed.protocol === "https:" &&
+      !parsed.username &&
+      !parsed.password &&
+      parsed.hostname
+      ? parsed.href
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function decodeBase64Url(value: string): string | null {
+  if (
+    !value ||
+    value.length > MAX_ENCODED_PAYLOAD_LENGTH ||
+    !BASE64URL_PATTERN.test(value)
+  ) {
+    return null;
+  }
+
+  try {
+    const padded = value.replace(/-/g, "+").replace(/_/g, "/");
+    const padding = "=".repeat((4 - (padded.length % 4)) % 4);
+    const binary = atob(`${padded}${padding}`);
+    const bytes = Uint8Array.from(binary, (character) =>
+      character.charCodeAt(0),
+    );
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+function parseTrack(value: unknown): ReleaseRunTrack | null {
+  if (!isRecord(value)) return null;
+
+  const id = boundedString(value.id, 160);
+  const artist = boundedString(value.artist, 200);
+  const title = boundedString(value.title, 240);
+  const version = optionalBoundedString(value.version, 160);
+  const label = optionalBoundedString(value.label, 200);
+  const releaseDate = boundedString(value.releaseDate, 40);
+  const artworkUrl = httpsUrl(value.artworkUrl);
+  const source = boundedString(value.source, 100);
+  const sourceUrl = httpsUrl(value.sourceUrl);
+  const detailsUrl = httpsUrl(value.detailsUrl);
+
+  if (
+    !id ||
+    !artist ||
+    !title ||
+    !releaseDate ||
+    !source ||
+    version === null ||
+    label === null ||
+    artworkUrl === null ||
+    sourceUrl === null ||
+    detailsUrl === null
+  ) {
+    return null;
+  }
+
+  return {
+    id,
+    artist,
+    title,
+    ...(version ? { version } : {}),
+    ...(label ? { label } : {}),
+    releaseDate,
+    ...(artworkUrl ? { artworkUrl } : {}),
+    source,
+    ...(sourceUrl ? { sourceUrl } : {}),
+    ...(detailsUrl ? { detailsUrl } : {}),
+  };
+}
+
+export function parseReleaseRunLink(href: string): ReleaseRunPayload | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(href);
+  } catch {
+    return null;
+  }
+
+  if (
+    parsed.protocol !== "buzz:" ||
+    parsed.hostname !== "release-run" ||
+    (parsed.pathname !== "" && parsed.pathname !== "/") ||
+    parsed.hash ||
+    parsed.username ||
+    parsed.password ||
+    parsed.port
+  ) {
+    return null;
+  }
+
+  if (
+    [...parsed.searchParams.keys()].some((key) => key !== "data") ||
+    parsed.searchParams.getAll("data").length !== 1
+  ) {
+    return null;
+  }
+
+  const decoded = decodeBase64Url(parsed.searchParams.get("data") ?? "");
+  if (!decoded) return null;
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(decoded);
+  } catch {
+    return null;
+  }
+  if (!isRecord(raw) || raw.version !== 1) return null;
+
+  const runId = boundedString(raw.runId, 120);
+  const runName = boundedString(raw.runName, 200);
+  const status = boundedString(raw.status, 80);
+  const checked = count(raw.checked);
+  const released = count(raw.released);
+  const held = count(raw.held);
+  const sourceHealth = boundedString(raw.sourceHealth, 500);
+  const finishedAt = boundedString(raw.finishedAt, 80);
+
+  if (
+    !runId ||
+    !RUN_ID_PATTERN.test(runId) ||
+    !runName ||
+    !status ||
+    checked === null ||
+    released === null ||
+    held === null ||
+    !sourceHealth ||
+    !finishedAt ||
+    Number.isNaN(Date.parse(finishedAt)) ||
+    !Array.isArray(raw.tracks) ||
+    raw.tracks.length > MAX_TRACKS
+  ) {
+    return null;
+  }
+
+  const tracks = raw.tracks.map(parseTrack);
+  if (tracks.some((track) => track === null)) return null;
+  if (released !== tracks.length) return null;
+
+  return {
+    version: 1,
+    runId,
+    runName,
+    status,
+    checked,
+    released,
+    held,
+    sourceHealth,
+    finishedAt,
+    tracks: tracks as ReleaseRunTrack[],
+  };
+}
+
+export function releaseRunViewState(
+  payload: ReleaseRunPayload,
+): ReleaseRunViewState {
+  const status = payload.status.toLowerCase();
+  if (/running|pending|queued|started/.test(status)) return "loading";
+  if (/failed|error|critical/.test(status) && payload.tracks.length === 0) {
+    return "failed";
+  }
+  return payload.tracks.length === 0 ? "empty" : "ready";
+}
+
+export function buildReleaseRunLink(payload: ReleaseRunPayload): string {
+  const json = JSON.stringify(payload);
+  const bytes = new TextEncoder().encode(json);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  const data = btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+  return `buzz://release-run?data=${data}`;
+}

--- a/desktop/src/shared/styles/globals/components.css
+++ b/desktop/src/shared/styles/globals/components.css
@@ -784,3 +784,36 @@
     }
   }
 }
+
+@layer components {
+  .buzz-release-run-surface {
+    background: hsl(var(--background) / 0.82);
+    border: 1px solid hsl(var(--border) / 0.58);
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / 0.22),
+      inset 0 -1px 0 rgb(0 0 0 / 0.08),
+      0 28px 72px -36px rgb(0 0 0 / 0.58),
+      0 10px 28px -20px rgb(0 0 0 / 0.28);
+    -webkit-backdrop-filter: blur(28px) saturate(150%);
+    backdrop-filter: blur(28px) saturate(150%);
+  }
+
+  .dark .buzz-release-run-surface {
+    background: hsl(var(--background) / 0.72);
+    border-color: rgb(255 255 255 / 0.16);
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / 0.14),
+      inset 0 -1px 0 rgb(0 0 0 / 0.14),
+      0 30px 76px -34px rgb(0 0 0 / 0.78),
+      0 12px 30px -20px rgb(0 0 0 / 0.54);
+  }
+
+  @media (prefers-reduced-transparency: reduce), (prefers-contrast: more) {
+    .buzz-release-run-surface,
+    .dark .buzz-release-run-surface {
+      background: hsl(var(--background));
+      -webkit-backdrop-filter: none;
+      backdrop-filter: none;
+    }
+  }
+}

--- a/desktop/src/shared/ui/markdown.test.mjs
+++ b/desktop/src/shared/ui/markdown.test.mjs
@@ -537,6 +537,10 @@ import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import { isChannelLink } from "../../features/messages/lib/channelLink.ts";
 import { isMessageLink } from "../../features/messages/lib/messageLink.ts";
 import { parseEntityLink } from "../lib/entityLink.ts";
+import {
+  buildReleaseRunLink,
+  parseReleaseRunLink,
+} from "../lib/releaseRunLink.ts";
 import remarkSpoilers from "../lib/remarkSpoilers.ts";
 
 const OWNER_HEX =
@@ -548,6 +552,7 @@ function buzzDeepLinkUrlTransform(value, key) {
   if (key !== "href") return defaultUrlTransform(value);
   if (isMessageLink(value) || isChannelLink(value)) return value;
   if (parseEntityLink(value).ok) return value;
+  if (parseReleaseRunLink(value)) return value;
   return defaultUrlTransform(value);
 }
 
@@ -623,6 +628,43 @@ test("messageLinkUrlTransform: leaves non-entity buzz:// schemes to default", ()
   // defaultUrlTransform (which strips it) since it's not clickable in-app.
   const html = renderMarkdown(
     "[connect](buzz://connect?relay=wss://relay.example)",
+  );
+  assert.match(html, /href=""/);
+});
+
+test("buzzDeepLinkUrlTransform: preserves a valid release-run payload", () => {
+  const releaseRunLink = buildReleaseRunLink({
+    version: 1,
+    runId: "deezer-2026-08-22",
+    runName: "Deezer release re-identification",
+    status: "completed",
+    checked: 40,
+    released: 1,
+    held: 39,
+    sourceHealth: "Deezer healthy",
+    finishedAt: "2026-08-22T06:00:33.651Z",
+    tracks: [
+      {
+        id: "track-1",
+        artist: "D Stone",
+        title: "Total Unison",
+        version: "Original Mix",
+        label: "Heist Recordings",
+        releaseDate: "2026-08-22",
+        artworkUrl: "https://cdn.example.com/total-unison.jpg",
+        source: "Deezer",
+        detailsUrl: "https://team.trakthat.app/releases?track=track-1",
+      },
+    ],
+  });
+  const html = renderMarkdown(`[Open 1 release](${releaseRunLink})`);
+  assert.match(html, /href="buzz:\/\/release-run\?data=/);
+  assert.doesNotMatch(html, /href=""/);
+});
+
+test("buzzDeepLinkUrlTransform: strips a malformed release-run payload", () => {
+  const html = renderMarkdown(
+    "[Open releases](buzz://release-run?data=not-valid-json)",
   );
   assert.match(html, /href=""/);
 });

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -25,6 +25,7 @@ import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext"
 import { cn } from "@/shared/lib/cn";
 import { parseEntityLink } from "@/shared/lib/entityLink";
 import { parseSupportedLinkPreview } from "@/shared/lib/linkPreview";
+import { parseReleaseRunLink } from "@/shared/lib/releaseRunLink";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import { useRelayOrigin } from "@/shared/lib/useRelayOrigin";
 import { AttachmentGroup } from "@/shared/ui/attachment";
@@ -120,6 +121,7 @@ import { MarkdownTable } from "./markdown/MarkdownTable";
 import { ProgressiveImage } from "./markdown/ProgressiveImage";
 import { BuzzInlineLink } from "./markdown/BuzzLinkChip";
 import { MessageLinkPill } from "./markdown/MessageLinkPill";
+import { ReleaseRunLink } from "./markdown/ReleaseRunLink";
 import { renderCachedMarkdown } from "./markdown/nodeCache";
 import { useMessageLinkPreviews } from "./markdown/useMessageLinkPreviews";
 import {
@@ -1291,8 +1293,7 @@ export function createMarkdownComponents(
 
     const label = getReactNodeText(children);
 
-    // Snapshot attachment (agent or team): classify before generic FileCard.
-    // resolveSnapshotCard checks the filename suffix + SHA-256 field.
+    // Classify snapshots before generic files using the filename + SHA-256.
     const snapshotCard = resolveSnapshotCard(
       href ? imetaByUrl?.get(href) : undefined,
       href,
@@ -1320,9 +1321,7 @@ export function createMarkdownComponents(
       );
     }
 
-    // Generic file attachment: a `[filename](url)` link whose href matches an
-    // imeta entry with a non-image, non-video MIME. Render a download card
-    // instead of a plain link. (Media uses the `img` renderer, not this path.)
+    // Non-media `[filename](url)` imeta entries render as download cards.
     const card = resolveFileCard(
       href ? imetaByUrl?.get(href) : undefined,
       href,
@@ -1334,9 +1333,11 @@ export function createMarkdownComponents(
       );
     }
 
-    // Intercept `buzz://channel/<uuid>` and `buzz://message?...` links so
-    // clicks navigate in-app instead of opening the URL in the OS browser.
     if (href) {
+      const releaseRun = parseReleaseRunLink(href);
+      if (releaseRun) {
+        return <ReleaseRunLink payload={releaseRun}>{children}</ReleaseRunLink>;
+      }
       if (parseChannelLink(href).ok) {
         return (
           <ChannelDeepLinkAnchor
@@ -1378,8 +1379,7 @@ export function createMarkdownComponents(
       // anchor (renders as a normal external link).
     }
 
-    // `buzz://pr|issue|repo?…` entity links navigate in-app; malformed ones
-    // fall through to the default anchor.
+    // Valid entity links navigate in-app; malformed ones fall through.
     const entityAnchor = renderEntityLinkAnchor({
       children,
       href,

--- a/desktop/src/shared/ui/markdown/ReleaseRunLink.tsx
+++ b/desktop/src/shared/ui/markdown/ReleaseRunLink.tsx
@@ -1,0 +1,304 @@
+import * as React from "react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import {
+  AlertCircle,
+  ArrowUpRight,
+  Check,
+  Clock3,
+  Disc3,
+  ImageOff,
+  Music2,
+  RefreshCw,
+  ShieldCheck,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { useIsMobile } from "@/shared/hooks/use-mobile";
+import {
+  releaseRunViewState,
+  type ReleaseRunPayload,
+  type ReleaseRunTrack,
+} from "@/shared/lib/releaseRunLink";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
+import { Sheet, SheetContent, SheetTrigger } from "@/shared/ui/sheet";
+
+function formatFinishedAt(value: string): string {
+  const date = new Date(value);
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function trackDestination(track: ReleaseRunTrack): string | undefined {
+  return track.detailsUrl ?? track.sourceUrl;
+}
+
+function ReleaseArtwork({ track }: { track: ReleaseRunTrack }) {
+  const [failed, setFailed] = React.useState(false);
+  if (!track.artworkUrl || failed) {
+    return (
+      <div className="flex size-13 shrink-0 items-center justify-center rounded-xl bg-foreground/[0.055] text-muted-foreground ring-1 ring-border/45 dark:bg-white/[0.055]">
+        {track.artworkUrl ? (
+          <ImageOff aria-hidden="true" className="size-4" />
+        ) : (
+          <Music2 aria-hidden="true" className="size-4" />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      alt=""
+      className="size-13 shrink-0 rounded-xl object-cover ring-1 ring-black/10 dark:ring-white/15"
+      loading="lazy"
+      onError={() => setFailed(true)}
+      src={track.artworkUrl}
+    />
+  );
+}
+
+function ReleaseTrackRow({
+  onOpen,
+  track,
+}: {
+  onOpen: (href: string) => void;
+  track: ReleaseRunTrack;
+}) {
+  const destination = trackDestination(track);
+  const content = (
+    <>
+      <ReleaseArtwork track={track} />
+      <div className="min-w-0 flex-1 self-center">
+        <p className="truncate text-xs font-medium text-muted-foreground">
+          {track.artist}
+        </p>
+        <p className="mt-0.5 truncate text-sm font-semibold leading-5 text-foreground">
+          {track.title}
+          {track.version ? (
+            <span className="font-normal text-muted-foreground">
+              {` · ${track.version}`}
+            </span>
+          ) : null}
+        </p>
+        <p className="mt-1 truncate text-2xs leading-4 text-muted-foreground/80">
+          {[track.label, track.releaseDate, track.source]
+            .filter(Boolean)
+            .join(" · ")}
+        </p>
+      </div>
+      {destination ? (
+        <ArrowUpRight
+          aria-hidden="true"
+          className="size-4 shrink-0 self-center text-muted-foreground/65 transition-colors duration-150 ease-out group-hover/release-track:text-foreground motion-reduce:transition-none"
+        />
+      ) : (
+        <Check
+          aria-hidden="true"
+          className="size-4 shrink-0 self-center text-emerald-500"
+        />
+      )}
+    </>
+  );
+
+  if (!destination) {
+    return (
+      <div
+        className="flex min-h-19 items-start gap-3 px-4 py-3"
+        data-release-track={track.id}
+      >
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      aria-label={`Open ${track.artist} — ${track.title} in Trakd`}
+      className="group/release-track flex min-h-19 w-full items-start gap-3 px-4 py-3 text-left transition-colors duration-150 ease-out hover:bg-foreground/[0.045] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70 active:bg-foreground/[0.075] motion-reduce:transition-none dark:hover:bg-white/[0.055] dark:active:bg-white/[0.08]"
+      data-release-track={track.id}
+      onClick={() => onOpen(destination)}
+      type="button"
+    >
+      {content}
+    </button>
+  );
+}
+
+function ReleaseRunState({ payload }: { payload: ReleaseRunPayload }) {
+  const state = releaseRunViewState(payload);
+  if (state === "ready") return null;
+
+  const stateContent = {
+    empty: {
+      icon: Disc3,
+      title: "No tracks released",
+      description: `${payload.checked} checks completed; ${payload.held} stayed held.`,
+    },
+    failed: {
+      icon: AlertCircle,
+      title: "Run needs attention",
+      description: payload.sourceHealth,
+    },
+    loading: {
+      icon: RefreshCw,
+      title: "Release check in progress",
+      description:
+        "This preview will be populated by the completed run report.",
+    },
+  }[state];
+  const StateIcon = stateContent.icon;
+
+  return (
+    <div className="flex min-h-44 flex-col items-center justify-center px-8 py-10 text-center">
+      <span className="flex size-10 items-center justify-center rounded-full bg-foreground/[0.055] text-muted-foreground ring-1 ring-border/45 dark:bg-white/[0.055]">
+        <StateIcon
+          aria-hidden="true"
+          className={`size-4 ${state === "loading" ? "animate-spin motion-reduce:animate-none" : ""}`}
+        />
+      </span>
+      <p className="mt-3 text-sm font-semibold text-foreground">
+        {stateContent.title}
+      </p>
+      <p className="mt-1 max-w-72 text-xs leading-5 text-muted-foreground">
+        {stateContent.description}
+      </p>
+    </div>
+  );
+}
+
+function ReleaseRunSurface({
+  onClose,
+  payload,
+}: {
+  onClose: () => void;
+  payload: ReleaseRunPayload;
+}) {
+  const openTrack = React.useCallback(
+    (href: string) => {
+      onClose();
+      void openUrl(href).catch(() => toast.error("Could not open track"));
+    },
+    [onClose],
+  );
+  const state = releaseRunViewState(payload);
+
+  return (
+    <section
+      aria-label={`${payload.runName} release results`}
+      className="buzz-release-run-surface overflow-hidden rounded-[1.375rem] text-foreground"
+      data-release-run-preview=""
+      data-release-run-state={state}
+    >
+      <header className="relative border-b border-border/45 px-4 pb-3.5 pt-4 pr-12">
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-xl bg-[oklch(0.64_0.23_18)] text-white shadow-[inset_0_1px_0_rgb(255_255_255/0.24),0_8px_18px_-10px_oklch(0.64_0.23_18/0.8)]">
+            <Disc3 aria-hidden="true" className="size-4" />
+          </span>
+          <div className="min-w-0">
+            <h2 className="truncate text-base font-semibold tracking-tight">
+              {payload.released === 0
+                ? "Release run"
+                : `Released · ${payload.released} ${payload.released === 1 ? "track" : "tracks"}`}
+            </h2>
+            <div className="mt-1 flex min-w-0 items-center gap-1.5 text-2xs text-muted-foreground">
+              <Clock3 aria-hidden="true" className="size-3 shrink-0" />
+              <span className="truncate">
+                {formatFinishedAt(payload.finishedAt)}
+              </span>
+              <span aria-hidden="true">·</span>
+              <span className="truncate">{payload.runName}</span>
+            </div>
+          </div>
+        </div>
+        <button
+          aria-label="Close release preview"
+          className="absolute right-3 top-3 flex size-8 items-center justify-center rounded-lg text-muted-foreground transition-[background-color,color,scale] duration-150 ease-out hover:bg-foreground/[0.06] hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/70 active:scale-[0.96] motion-reduce:transition-none dark:hover:bg-white/[0.07]"
+          data-testid="release-run-close"
+          onClick={onClose}
+          type="button"
+        >
+          <X aria-hidden="true" className="size-4" />
+        </button>
+      </header>
+
+      <div className="max-h-[min(31rem,calc(100vh-12rem))] overflow-y-auto overscroll-contain">
+        {state === "ready" ? (
+          <div className="divide-y divide-border/45" data-release-run-tracks="">
+            {payload.tracks.map((track) => (
+              <ReleaseTrackRow
+                key={track.id}
+                onOpen={openTrack}
+                track={track}
+              />
+            ))}
+          </div>
+        ) : (
+          <ReleaseRunState payload={payload} />
+        )}
+      </div>
+
+      <footer className="flex items-center gap-2 border-t border-border/45 bg-foreground/[0.025] px-4 py-3 text-2xs leading-4 text-muted-foreground dark:bg-white/[0.025]">
+        <ShieldCheck
+          aria-hidden="true"
+          className="size-3.5 shrink-0 text-emerald-500"
+        />
+        <span className="min-w-0 truncate">{payload.sourceHealth}</span>
+      </footer>
+    </section>
+  );
+}
+
+export function ReleaseRunLink({
+  children,
+  payload,
+}: {
+  children: React.ReactNode;
+  payload: ReleaseRunPayload;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const isMobile = useIsMobile();
+  const trigger = (
+    <button
+      className="font-medium text-primary underline underline-offset-4 transition-[color,scale] duration-150 ease-out hover:text-primary/80 focus-visible:rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/70 active:scale-[0.98] motion-reduce:transition-none"
+      data-release-run-trigger=""
+      type="button"
+    >
+      {children}
+    </button>
+  );
+
+  if (isMobile) {
+    return (
+      <Sheet onOpenChange={setOpen} open={open}>
+        <SheetTrigger asChild>{trigger}</SheetTrigger>
+        <SheetContent
+          className="border-0 bg-transparent p-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] shadow-none data-[state=closed]:duration-150 data-[state=open]:duration-200 [&>button]:hidden"
+          data-testid="release-run-sheet"
+          side="bottom"
+        >
+          <ReleaseRunSurface onClose={() => setOpen(false)} payload={payload} />
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[30rem] max-w-[calc(100vw-2rem)] border-0 bg-transparent p-0 shadow-none"
+        data-testid="release-run-popover"
+        side="bottom"
+        sideOffset={8}
+      >
+        <ReleaseRunSurface onClose={() => setOpen(false)} payload={payload} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/desktop/src/shared/ui/markdown/utils.ts
+++ b/desktop/src/shared/ui/markdown/utils.ts
@@ -4,6 +4,7 @@ import { defaultUrlTransform } from "react-markdown";
 import { isChannelLink } from "@/features/messages/lib/channelLink";
 import { isMessageLink } from "@/features/messages/lib/messageLink";
 import { parseEntityLink } from "@/shared/lib/entityLink";
+import { parseReleaseRunLink } from "@/shared/lib/releaseRunLink";
 
 export function useStableArray<T>(arr: T[]): T[] {
   const ref = React.useRef(arr);
@@ -179,12 +180,15 @@ export function isInsideHiddenSpoiler(element: Element): boolean {
  *   message-link pill renderer).
  * - `buzz://pr|issue|repo` hrefs — preserved only when `parseEntityLink`
  *   succeeds, keeping the sanitizer active against arbitrary `buzz://` URIs.
+ * - `buzz://release-run` hrefs — preserved only when their bounded embedded
+ *   payload passes the release-run parser.
  * - Everything else delegates to `defaultUrlTransform`.
  */
 export function buzzDeepLinkUrlTransform(value: string, key: string): string {
   if (key !== "href") return defaultUrlTransform(value);
   if (isMessageLink(value) || isChannelLink(value)) return value;
   if (parseEntityLink(value).ok) return value;
+  if (parseReleaseRunLink(value)) return value;
   return defaultUrlTransform(value);
 }
 

--- a/desktop/tests/e2e/release-run-preview.spec.ts
+++ b/desktop/tests/e2e/release-run-preview.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+const SHOTS = "test-results/release-run-preview";
+const ARTWORKS = [
+  "https://assets.trakd.test/total-unison.svg",
+  "https://assets.trakd.test/assumptions.svg",
+  "https://assets.trakd.test/love-trance.svg",
+] as const;
+
+const releaseRun = {
+  version: 1,
+  runId: "deezer-reidentify:2026-08-22T09:30:00.000Z",
+  runName: "Daily release check",
+  status: "completed",
+  checked: 41,
+  released: 3,
+  held: 38,
+  sourceHealth: "Deezer verified all 3 tracks",
+  finishedAt: "2026-08-22T09:30:00.000Z",
+  tracks: [
+    {
+      id: "d-stone-total-unison",
+      artist: "D Stone",
+      title: "Total Unison",
+      version: "Original Mix",
+      label: "Heist Recordings",
+      releaseDate: "Aug 22, 2026",
+      artworkUrl: ARTWORKS[0],
+      source: "Deezer",
+      sourceUrl: "https://www.deezer.com/track/1",
+      detailsUrl: "https://trakd.app/releases/d-stone-total-unison",
+    },
+    {
+      id: "jamback-assumptions",
+      artist: "Jamback",
+      title: "Assumptions",
+      version: "Extended Mix",
+      label: "PIV",
+      releaseDate: "Aug 22, 2026",
+      artworkUrl: ARTWORKS[1],
+      source: "Deezer",
+      sourceUrl: "https://www.deezer.com/track/2",
+      detailsUrl: "https://trakd.app/releases/jamback-assumptions",
+    },
+    {
+      id: "silva-bumpa-love-trance",
+      artist: "Silva Bumpa",
+      title: "Love Trance",
+      label: "Hardline Sounds",
+      releaseDate: "Aug 22, 2026",
+      artworkUrl: ARTWORKS[2],
+      source: "Deezer",
+      sourceUrl: "https://www.deezer.com/track/3",
+      detailsUrl: "https://trakd.app/releases/silva-bumpa-love-trance",
+    },
+  ],
+} as const;
+
+const releaseLink = `buzz://release-run?data=${Buffer.from(
+  JSON.stringify(releaseRun),
+).toString("base64url")}`;
+
+async function openChannelWithReleaseReport(page: Page) {
+  await page.route("https://assets.trakd.test/**", async (route) => {
+    const index = ARTWORKS.indexOf(
+      route.request().url() as (typeof ARTWORKS)[number],
+    );
+    const palettes = [
+      ["#FE6A86", "#3D101A"],
+      ["#F3BB52", "#522E0B"],
+      ["#70D6C7", "#103B3A"],
+    ];
+    const [start, end] = palettes[Math.max(index, 0)];
+    await route.fulfill({
+      body: `<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160"><defs><linearGradient id="g" x2="1" y2="1"><stop stop-color="${start}"/><stop offset="1" stop-color="${end}"/></linearGradient></defs><rect width="160" height="160" fill="url(#g)"/><circle cx="80" cy="80" r="48" fill="none" stroke="white" stroke-opacity=".66" stroke-width="2"/><circle cx="80" cy="80" r="8" fill="white" fill-opacity=".82"/><path d="M18 122C48 93 94 139 145 72" fill="none" stroke="white" stroke-opacity=".5" stroke-width="5"/></svg>`,
+      contentType: "image/svg+xml",
+    });
+  });
+  await installMockBridge(page);
+  await page.setViewportSize({ width: 1120, height: 820 });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.getByTestId("channel-general").click();
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function",
+  );
+  await page.evaluate(
+    ({ content, pubkey }) => {
+      window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "general",
+        pubkey,
+        content,
+      });
+    },
+    {
+      content: [
+        "**Release run update**",
+        "Checked 41 · Released 3 · Held 38",
+        "",
+        `[Open 3 releases](${releaseLink})`,
+      ].join("\n"),
+      pubkey: TEST_IDENTITIES.alice.pubkey,
+    },
+  );
+  const row = page
+    .getByTestId("message-row")
+    .filter({ hasText: "Release run update" })
+    .last();
+  await expect(row).toBeVisible();
+  return row;
+}
+
+test("release report opens its exact run in an anchored glass preview", async ({
+  page,
+}) => {
+  const row = await openChannelWithReleaseReport(page);
+  await row.locator("[data-release-run-trigger]").click();
+
+  const preview = page.getByTestId("release-run-popover");
+  await expect(preview).toBeVisible();
+  await expect(preview).toContainText("Released · 3 tracks");
+  await expect(preview.locator("[data-release-track]")).toHaveCount(3);
+  await expect(preview).toContainText("Total Unison");
+  await expect(preview).toContainText("Assumptions");
+  await expect(preview).toContainText("Love Trance");
+  await expect(preview).toContainText("Deezer verified all 3 tracks");
+
+  await waitForAnimations(page);
+  await page.screenshot({
+    animations: "disabled",
+    path: `${SHOTS}/desktop.png`,
+  });
+});
+
+test("the same release report becomes a bottom sheet on a narrow window", async ({
+  page,
+}) => {
+  const row = await openChannelWithReleaseReport(page);
+  await page.setViewportSize({ width: 620, height: 820 });
+  await row.locator("[data-release-run-trigger]").click();
+
+  const preview = page.getByTestId("release-run-sheet");
+  await expect(preview).toBeVisible();
+  await expect(preview.locator("[data-release-track]")).toHaveCount(3);
+
+  await waitForAnimations(page);
+  await page.screenshot({
+    animations: "disabled",
+    path: `${SHOTS}/narrow.png`,
+  });
+});

--- a/mobile/lib/features/channels/message_content.dart
+++ b/mobile/lib/features/channels/message_content.dart
@@ -20,6 +20,7 @@ import '../../shared/deeplink/pending_deep_link_provider.dart';
 import '../../shared/relay/relay.dart';
 import '../../shared/syntax_highlight.dart';
 import '../../shared/theme/theme.dart';
+import '../../shared/widgets/release_run_sheet.dart';
 import '../../shared/custom_emoji/custom_emoji.dart';
 import '../../shared/custom_emoji/custom_emoji_provider.dart';
 import '../../shared/custom_emoji/custom_emoji_render.dart';
@@ -361,6 +362,7 @@ class MessageContent extends HookConsumerWidget {
     final isBuzzLink =
         buzzLink is ChannelDeepLink ||
         buzzLink is MessageDeepLink ||
+        buzzLink is ReleaseRunDeepLink ||
         buzzLink is EntityDeepLink;
     final isCanonicalBuzzLabel = isBuzzLink && text == url;
     final buzzPresentation = switch (buzzLink) {
@@ -379,6 +381,14 @@ class MessageContent extends HookConsumerWidget {
             '${_channelNameForId(resolvedChannelNames, channelId) ?? channelId.substring(0, math.min(8, channelId.length))} · ${messageId.substring(0, math.min(8, messageId.length))}',
         semanticLabel:
             'Open message ${messageId.substring(0, math.min(8, messageId.length))} in channel ${_channelNameForId(resolvedChannelNames, channelId) ?? channelId.substring(0, math.min(8, channelId.length))}',
+        interactive: true,
+      ),
+      ReleaseRunDeepLink(:final released) => (
+        icon: LucideIcons.disc3,
+        label: released == 1 ? 'Open 1 release' : 'Open $released releases',
+        semanticLabel: released == 1
+            ? 'Open 1 released track'
+            : 'Open $released released tracks',
         interactive: true,
       ),
       EntityDeepLink(:final type, :final repository, :final eventId) => (
@@ -446,6 +456,8 @@ class MessageContent extends HookConsumerWidget {
           final deepLink = parseBuzzDeepLink(uri);
           if (deepLink case ChannelDeepLink(:final channelId)) {
             resolvedChannelTap(channelId);
+          } else if (deepLink case ReleaseRunDeepLink()) {
+            await showReleaseRunSheet(context, deepLink);
           } else if (deepLink is MessageDeepLink ||
               deepLink is InviteDeepLink) {
             ref.read(pendingDeepLinkProvider.notifier).open(uri);

--- a/mobile/lib/shared/deeplink/deep_link.dart
+++ b/mobile/lib/shared/deeplink/deep_link.dart
@@ -7,6 +7,8 @@
 /// half-formed target.
 library;
 
+import 'dart:convert';
+
 import '../relay/relay_validation.dart';
 
 /// A parsed deep link supported by the app.
@@ -101,6 +103,206 @@ class MessageDeepLink extends BuzzDeepLink {
   String toString() =>
       'MessageDeepLink(channel: $channelId, id: $messageId, '
       'thread: $threadRootId)';
+}
+
+/// One released track embedded in a signed release-run message link.
+class ReleaseRunTrack {
+  final String id;
+  final String artist;
+  final String title;
+  final String? version;
+  final String? label;
+  final String releaseDate;
+  final String? artworkUrl;
+  final String source;
+  final String? sourceUrl;
+  final String? detailsUrl;
+
+  const ReleaseRunTrack({
+    required this.id,
+    required this.artist,
+    required this.title,
+    required this.releaseDate,
+    required this.source,
+    this.version,
+    this.label,
+    this.artworkUrl,
+    this.sourceUrl,
+    this.detailsUrl,
+  });
+}
+
+/// A bounded, self-contained release result carried by `buzz://release-run`.
+class ReleaseRunDeepLink extends BuzzDeepLink {
+  final String runId;
+  final String runName;
+  final String status;
+  final int checked;
+  final int released;
+  final int held;
+  final String sourceHealth;
+  final DateTime finishedAt;
+  final List<ReleaseRunTrack> tracks;
+
+  const ReleaseRunDeepLink({
+    required this.runId,
+    required this.runName,
+    required this.status,
+    required this.checked,
+    required this.released,
+    required this.held,
+    required this.sourceHealth,
+    required this.finishedAt,
+    required this.tracks,
+  });
+}
+
+const _releaseRunMaxEncodedLength = 48000;
+const _releaseRunMaxTracks = 50;
+
+String? _boundedString(Object? value, int maxLength) {
+  if (value is! String) return null;
+  final trimmed = value.trim();
+  if (trimmed.isEmpty || trimmed.length > maxLength) return null;
+  return trimmed;
+}
+
+String? _optionalBoundedString(Object? value, int maxLength) {
+  if (value == null || value == '') return '';
+  return _boundedString(value, maxLength);
+}
+
+int? _boundedCount(Object? value) {
+  if (value is! int || value < 0 || value > 1000000) return null;
+  return value;
+}
+
+String? _optionalHttpsUrl(Object? value) {
+  final candidate = _optionalBoundedString(value, 2000);
+  if (candidate == null || candidate.isEmpty) return candidate;
+  final uri = Uri.tryParse(candidate);
+  if (uri == null ||
+      uri.scheme != 'https' ||
+      uri.host.isEmpty ||
+      uri.userInfo.isNotEmpty) {
+    return null;
+  }
+  return uri.toString();
+}
+
+ReleaseRunTrack? _parseReleaseRunTrack(Object? value) {
+  if (value is! Map<String, dynamic>) return null;
+  final id = _boundedString(value['id'], 160);
+  final artist = _boundedString(value['artist'], 200);
+  final title = _boundedString(value['title'], 240);
+  final version = _optionalBoundedString(value['version'], 160);
+  final label = _optionalBoundedString(value['label'], 200);
+  final releaseDate = _boundedString(value['releaseDate'], 40);
+  final artworkUrl = _optionalHttpsUrl(value['artworkUrl']);
+  final source = _boundedString(value['source'], 100);
+  final sourceUrl = _optionalHttpsUrl(value['sourceUrl']);
+  final detailsUrl = _optionalHttpsUrl(value['detailsUrl']);
+  if (id == null ||
+      artist == null ||
+      title == null ||
+      version == null ||
+      label == null ||
+      releaseDate == null ||
+      artworkUrl == null ||
+      source == null ||
+      sourceUrl == null ||
+      detailsUrl == null) {
+    return null;
+  }
+  return ReleaseRunTrack(
+    id: id,
+    artist: artist,
+    title: title,
+    version: version.isEmpty ? null : version,
+    label: label.isEmpty ? null : label,
+    releaseDate: releaseDate,
+    artworkUrl: artworkUrl.isEmpty ? null : artworkUrl,
+    source: source,
+    sourceUrl: sourceUrl.isEmpty ? null : sourceUrl,
+    detailsUrl: detailsUrl.isEmpty ? null : detailsUrl,
+  );
+}
+
+/// Parse a strict, versioned `buzz://release-run?data=<base64url-json>` link.
+///
+/// The payload is bounded before decoding, accepts only HTTPS media/actions,
+/// and requires the released count to equal the embedded track list exactly.
+ReleaseRunDeepLink? parseReleaseRunDeepLink(Uri uri) {
+  if (uri.scheme != 'buzz' || uri.host != 'release-run') return null;
+  if ((uri.path.isNotEmpty && uri.path != '/') ||
+      uri.hasFragment ||
+      uri.userInfo.isNotEmpty ||
+      uri.hasPort) {
+    return null;
+  }
+  if (uri.queryParametersAll.keys.any((key) => key != 'data') ||
+      uri.queryParametersAll['data']?.length != 1) {
+    return null;
+  }
+  final data = uri.queryParameters['data'];
+  if (data == null ||
+      data.isEmpty ||
+      data.length > _releaseRunMaxEncodedLength ||
+      !RegExp(r'^[A-Za-z0-9_-]+$').hasMatch(data)) {
+    return null;
+  }
+
+  Object? decoded;
+  try {
+    decoded = jsonDecode(
+      utf8.decode(base64Url.decode(base64Url.normalize(data))),
+    );
+  } on FormatException {
+    return null;
+  }
+  if (decoded is! Map<String, dynamic> || decoded['version'] != 1) return null;
+
+  final runId = _boundedString(decoded['runId'], 120);
+  final runName = _boundedString(decoded['runName'], 200);
+  final status = _boundedString(decoded['status'], 80);
+  final checked = _boundedCount(decoded['checked']);
+  final released = _boundedCount(decoded['released']);
+  final held = _boundedCount(decoded['held']);
+  final sourceHealth = _boundedString(decoded['sourceHealth'], 500);
+  final finishedAtText = _boundedString(decoded['finishedAt'], 80);
+  final finishedAt = finishedAtText == null
+      ? null
+      : DateTime.tryParse(finishedAtText);
+  final rawTracks = decoded['tracks'];
+  if (runId == null ||
+      !RegExp(r'^[A-Za-z0-9._:-]{1,120}$').hasMatch(runId) ||
+      runName == null ||
+      status == null ||
+      checked == null ||
+      released == null ||
+      held == null ||
+      sourceHealth == null ||
+      finishedAt == null ||
+      rawTracks is! List<dynamic> ||
+      rawTracks.length > _releaseRunMaxTracks) {
+    return null;
+  }
+  final tracks = rawTracks.map(_parseReleaseRunTrack).toList();
+  if (tracks.any((track) => track == null) || released != tracks.length) {
+    return null;
+  }
+
+  return ReleaseRunDeepLink(
+    runId: runId,
+    runName: runName,
+    status: status,
+    checked: checked,
+    released: released,
+    held: held,
+    sourceHealth: sourceHealth,
+    finishedAt: finishedAt,
+    tracks: tracks.cast<ReleaseRunTrack>(),
+  );
 }
 
 /// Build a canonical `buzz://message` link for a channel message.
@@ -287,7 +489,8 @@ InviteDeepLink? parseInviteDeepLink(Uri uri) {
 BuzzDeepLink? parseBuzzDeepLink(Uri uri) =>
     parseInviteDeepLink(uri) ??
     parseChannelDeepLink(uri) ??
-    parseMessageDeepLink(uri);
+    parseMessageDeepLink(uri) ??
+    parseReleaseRunDeepLink(uri);
 
 /// A validated Buzz repository, pull request, or issue permalink.
 class EntityDeepLink extends BuzzDeepLink {

--- a/mobile/lib/shared/widgets/release_run_sheet.dart
+++ b/mobile/lib/shared/widgets/release_run_sheet.dart
@@ -1,0 +1,456 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../deeplink/deep_link.dart';
+import '../theme/theme.dart';
+import 'modal_presentation.dart';
+
+enum _ReleaseRunState { loading, empty, failed, ready }
+
+_ReleaseRunState _releaseRunState(ReleaseRunDeepLink run) {
+  final status = run.status.toLowerCase();
+  if (RegExp(r'running|pending|queued|started').hasMatch(status)) {
+    return _ReleaseRunState.loading;
+  }
+  if (RegExp(r'failed|error|critical').hasMatch(status) && run.tracks.isEmpty) {
+    return _ReleaseRunState.failed;
+  }
+  return run.tracks.isEmpty ? _ReleaseRunState.empty : _ReleaseRunState.ready;
+}
+
+Future<void> showReleaseRunSheet(BuildContext context, ReleaseRunDeepLink run) {
+  return showBuzzModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    useRootNavigator: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: Colors.black.withValues(alpha: 0.28),
+    showCloseButton: false,
+    builder: (_) => _ReleaseRunSheet(run: run),
+  );
+}
+
+class _ReleaseRunSheet extends StatelessWidget {
+  const _ReleaseRunSheet({required this.run});
+
+  final ReleaseRunDeepLink run;
+
+  @override
+  Widget build(BuildContext context) {
+    final highContrast = MediaQuery.highContrastOf(context);
+    final surfaceColor = context.colors.surface.withValues(
+      alpha: highContrast ? 1 : 0.86,
+    );
+    final content = DecoratedBox(
+      decoration: BoxDecoration(
+        color: surfaceColor,
+        border: Border.all(
+          color: context.colors.outlineVariant.withValues(alpha: 0.72),
+        ),
+        borderRadius: const BorderRadius.vertical(
+          top: Radius.circular(Radii.dialog),
+        ),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x4D000000),
+            blurRadius: 54,
+            spreadRadius: -24,
+            offset: Offset(0, -10),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        top: false,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.sizeOf(context).height * 0.82,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _ReleaseRunHeader(run: run),
+              Flexible(child: _ReleaseRunBody(run: run)),
+              _ReleaseRunFooter(sourceHealth: run.sourceHealth),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    return ClipRRect(
+      borderRadius: const BorderRadius.vertical(
+        top: Radius.circular(Radii.dialog),
+      ),
+      child: highContrast
+          ? content
+          : BackdropFilter(
+              filter: ImageFilter.blur(sigmaX: 24, sigmaY: 24),
+              child: content,
+            ),
+    );
+  }
+}
+
+class _ReleaseRunHeader extends StatelessWidget {
+  const _ReleaseRunHeader({required this.run});
+
+  final ReleaseRunDeepLink run;
+
+  @override
+  Widget build(BuildContext context) {
+    final releaseLabel = run.released == 0
+        ? 'Release run'
+        : 'Released · ${run.released} ${run.released == 1 ? 'track' : 'tracks'}';
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(
+            color: context.colors.outlineVariant.withValues(alpha: 0.58),
+          ),
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          Grid.xs,
+          Grid.twelve,
+          Grid.xxs,
+          Grid.twelve,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                color: const Color(0xFFE24A59),
+                borderRadius: BorderRadius.circular(Radii.md),
+                boxShadow: const [
+                  BoxShadow(
+                    color: Color(0x4DE24A59),
+                    blurRadius: 18,
+                    spreadRadius: -9,
+                    offset: Offset(0, 8),
+                  ),
+                ],
+              ),
+              child: const Icon(
+                LucideIcons.disc3,
+                color: Colors.white,
+                size: 17,
+              ),
+            ),
+            const SizedBox(width: Grid.twelve),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    releaseLabel,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: context.textTheme.titleMedium?.copyWith(
+                      color: context.colors.onSurface,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: Grid.xxs),
+                  Row(
+                    children: [
+                      Icon(
+                        LucideIcons.clock3,
+                        size: 12,
+                        color: context.colors.onSurfaceVariant,
+                      ),
+                      const SizedBox(width: Grid.xxs),
+                      Expanded(
+                        child: Text(
+                          '${DateFormat('MMM d · h:mm a').format(run.finishedAt.toLocal())} · ${run.runName}',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: context.textTheme.labelSmall?.copyWith(
+                            color: context.colors.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            IconButton(
+              tooltip: 'Close release preview',
+              onPressed: () => Navigator.of(context).pop(),
+              icon: const Icon(LucideIcons.x, size: 18),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ReleaseRunBody extends StatelessWidget {
+  const _ReleaseRunBody({required this.run});
+
+  final ReleaseRunDeepLink run;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = _releaseRunState(run);
+    if (state == _ReleaseRunState.ready) {
+      return ListView.separated(
+        shrinkWrap: true,
+        padding: EdgeInsets.zero,
+        itemCount: run.tracks.length,
+        separatorBuilder: (_, _) => Divider(
+          height: 1,
+          color: context.colors.outlineVariant.withValues(alpha: 0.52),
+        ),
+        itemBuilder: (_, index) => _ReleaseTrackRow(track: run.tracks[index]),
+      );
+    }
+
+    final presentation = switch (state) {
+      _ReleaseRunState.loading => (
+        icon: LucideIcons.refreshCw,
+        title: 'Release check in progress',
+        description:
+            'This preview will be populated by the completed run report.',
+      ),
+      _ReleaseRunState.failed => (
+        icon: LucideIcons.circleAlert,
+        title: 'Run needs attention',
+        description: run.sourceHealth,
+      ),
+      _ => (
+        icon: LucideIcons.disc3,
+        title: 'No tracks released',
+        description:
+            '${run.checked} checks completed; ${run.held} stayed held.',
+      ),
+    };
+    return SizedBox(
+      height: 184,
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: Grid.sm),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: context.colors.onSurface.withValues(alpha: 0.055),
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  presentation.icon,
+                  size: 17,
+                  color: context.colors.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: Grid.sm),
+              Text(
+                presentation.title,
+                style: context.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: Grid.xxs),
+              Text(
+                presentation.description,
+                textAlign: TextAlign.center,
+                style: context.textTheme.bodySmall?.copyWith(
+                  color: context.colors.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ReleaseTrackRow extends StatelessWidget {
+  const _ReleaseTrackRow({required this.track});
+
+  final ReleaseRunTrack track;
+
+  @override
+  Widget build(BuildContext context) {
+    final destination = track.detailsUrl ?? track.sourceUrl;
+    return Semantics(
+      button: destination != null,
+      label: 'Open ${track.artist} — ${track.title} in Trakd',
+      child: InkWell(
+        onTap: destination == null
+            ? null
+            : () async {
+                Navigator.of(context).pop();
+                await launchUrl(
+                  Uri.parse(destination),
+                  mode: LaunchMode.externalApplication,
+                );
+              },
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: Grid.xs,
+            vertical: Grid.twelve,
+          ),
+          child: Row(
+            children: [
+              _ReleaseArtwork(track: track),
+              const SizedBox(width: Grid.twelve),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      track.artist,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: context.textTheme.labelMedium?.copyWith(
+                        color: context.colors.onSurfaceVariant,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: Grid.xxs),
+                    Text.rich(
+                      TextSpan(
+                        text: track.title,
+                        children: [
+                          if (track.version != null)
+                            TextSpan(
+                              text: ' · ${track.version}',
+                              style: TextStyle(
+                                color: context.colors.onSurfaceVariant,
+                                fontWeight: FontWeight.w400,
+                              ),
+                            ),
+                        ],
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: context.textTheme.bodyMedium?.copyWith(
+                        color: context.colors.onSurface,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: Grid.xxs),
+                    Text(
+                      [
+                        track.label,
+                        track.releaseDate,
+                        track.source,
+                      ].whereType<String>().join(' · '),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: context.textTheme.labelSmall?.copyWith(
+                        color: context.colors.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: Grid.xxs),
+              Icon(
+                destination == null
+                    ? LucideIcons.check
+                    : LucideIcons.arrowUpRight,
+                size: 17,
+                color: destination == null
+                    ? Colors.green
+                    : context.colors.onSurfaceVariant,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ReleaseArtwork extends StatelessWidget {
+  const _ReleaseArtwork({required this.track});
+
+  final ReleaseRunTrack track;
+
+  @override
+  Widget build(BuildContext context) {
+    final fallback = DecoratedBox(
+      decoration: BoxDecoration(
+        color: context.colors.onSurface.withValues(alpha: 0.055),
+        borderRadius: BorderRadius.circular(Radii.md),
+      ),
+      child: Center(
+        child: Icon(
+          track.artworkUrl == null ? LucideIcons.music2 : LucideIcons.imageOff,
+          size: 17,
+          color: context.colors.onSurfaceVariant,
+        ),
+      ),
+    );
+    return SizedBox.square(
+      dimension: 52,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(Radii.md),
+        child: track.artworkUrl == null
+            ? fallback
+            : Image.network(
+                track.artworkUrl!,
+                fit: BoxFit.cover,
+                errorBuilder: (_, _, _) => fallback,
+              ),
+      ),
+    );
+  }
+}
+
+class _ReleaseRunFooter extends StatelessWidget {
+  const _ReleaseRunFooter({required this.sourceHealth});
+
+  final String sourceHealth;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: context.colors.onSurface.withValues(alpha: 0.025),
+        border: Border(
+          top: BorderSide(
+            color: context.colors.outlineVariant.withValues(alpha: 0.58),
+          ),
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: Grid.xs,
+          vertical: Grid.twelve,
+        ),
+        child: Row(
+          children: [
+            const Icon(LucideIcons.shieldCheck, size: 15, color: Colors.green),
+            const SizedBox(width: Grid.xxs),
+            Expanded(
+              child: Text(
+                sourceHealth,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: context.textTheme.labelSmall?.copyWith(
+                  color: context.colors.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/test/shared/deeplink/deep_link_test.dart
+++ b/mobile/test/shared/deeplink/deep_link_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:buzz/shared/deeplink/deep_link.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -5,6 +7,7 @@ void main() {
   _inviteTests();
   _channelTests();
   _buildMessageLinkTests();
+  _releaseRunTests();
 
   group('parseMessageDeepLink', () {
     const channel = '580ca78b-9dae-46f3-8854-bd671853ba32';
@@ -47,6 +50,88 @@ void main() {
       ]) {
         expect(parseMessageDeepLink(Uri.parse(url)), isNull, reason: url);
       }
+    });
+  });
+}
+
+void _releaseRunTests() {
+  String link(Map<String, Object?> payload) {
+    final data = base64Url
+        .encode(utf8.encode(jsonEncode(payload)))
+        .replaceAll('=', '');
+    return 'buzz://release-run?data=$data';
+  }
+
+  final payload = <String, Object?>{
+    'version': 1,
+    'runId': 'deezer-2026-08-22T06:00:33.651Z',
+    'runName': 'Deezer release re-identification',
+    'status': 'completed',
+    'checked': 40,
+    'released': 1,
+    'held': 39,
+    'sourceHealth': 'Deezer healthy',
+    'finishedAt': '2026-08-22T06:00:33.651Z',
+    'tracks': [
+      {
+        'id': 'track-1',
+        'artist': 'D Stone',
+        'title': 'Total Unison',
+        'version': 'Original Mix',
+        'label': 'Heist Recordings',
+        'releaseDate': '2026-08-22',
+        'artworkUrl': 'https://cdn.example.com/total-unison.jpg',
+        'source': 'Deezer',
+        'detailsUrl': 'https://team.trakthat.app/releases?track=track-1',
+      },
+    ],
+  };
+
+  group('parseReleaseRunDeepLink', () {
+    test('parses an exact embedded release result', () {
+      final parsed = parseReleaseRunDeepLink(Uri.parse(link(payload)));
+      expect(parsed, isNotNull);
+      expect(parsed!.runId, 'deezer-2026-08-22T06:00:33.651Z');
+      expect(parsed.released, 1);
+      expect(parsed.tracks.single.artist, 'D Stone');
+      expect(parsed.tracks.single.version, 'Original Mix');
+      expect(
+        parseBuzzDeepLink(Uri.parse(link(payload))),
+        isA<ReleaseRunDeepLink>(),
+      );
+    });
+
+    test('rejects count mismatch, HTTP media, and ambiguous query params', () {
+      expect(
+        parseReleaseRunDeepLink(Uri.parse(link({...payload, 'released': 2}))),
+        isNull,
+      );
+      final tracks = List<Map<String, Object?>>.from(
+        payload['tracks']! as List,
+      );
+      expect(
+        parseReleaseRunDeepLink(
+          Uri.parse(
+            link({
+              ...payload,
+              'tracks': [
+                {
+                  ...tracks.single,
+                  'artworkUrl': 'http://cdn.example.com/x.jpg',
+                },
+              ],
+            }),
+          ),
+        ),
+        isNull,
+      );
+      final valid = link(payload);
+      final data = Uri.parse(valid).queryParameters['data'];
+      expect(parseReleaseRunDeepLink(Uri.parse('$valid&data=$data')), isNull);
+      expect(
+        parseReleaseRunDeepLink(Uri.parse('$valid&open=external')),
+        isNull,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- recognize a bounded, versioned `buzz://release-run` link carrying the exact signed run result
- open a liquid-glass, artwork-led release popover beside the report on desktop and a bottom sheet on narrow/mobile layouts
- show artist, title, version, label, release date, verification source, and safe track actions
- include loading, empty, and failed states plus strict HTTPS and payload-size validation
- add the equivalent native Flutter sheet and parser

### Related issue
N/A — no matching open release-run preview PR found.

### Testing
- repository `just ci` phases completed green; the initial aggregate run exhausted local disk during native test compilation, then the native desktop suite was rerun successfully after clearing generated build artifacts
- desktop unit tests: 4,994 passed
- mobile Flutter tests: 1,467 passed
- native desktop/Tauri tests: 2,514 library tests passed, 17 environment-dependent tests ignored; auxiliary suites passed
- production desktop and web builds passed; Flutter analysis passed
- targeted Playwright release-preview coverage: 2 passed (anchored desktop popover and narrow bottom sheet)