### PR TITLE
fix(buzz-acp): raise MODELS_TIMEOUT to 60s so slow-start agents don't fail `models`/probe subcommands

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -60,7 +60,7 @@ fn is_subcommand(name: &str) -> bool {
 }
 
 /// Timeout for lightweight helper subcommands (spawn + initialize + model/method probes).
-const MODELS_TIMEOUT: Duration = Duration::from_secs(10);
+const MODELS_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Timeout for `buzz-acp authenticate`. Browser-based vendor auth can require
 /// human interaction, so it must not share the short probe timeout.


### PR DESCRIPTION
# UPSTREAM-PR-DESC — buzz-acp models 超时修复 PR 草稿

- 草稿时间: 2026-08-23 · itops · huanxi-buzz v1 收尾 D2
- 目标仓库: `github.com/block/buzz`（main 分支，草稿基线 = commit `f995325`，2026-08-22 HEAD）
- 配套 diff: 同目录 `UPSTREAM-PR-DRAFT.patch`（干净可提交形态；本地 fork 版含标注注释，在 `/home/mk/buzz-huanxi/build/models-timeout.patch`）
- ⚠️ 状态: **草稿，未提交**。实际 push 到 GitHub 前需 main 最终确认（外部发布动作）。

---

## PR Title（建议）

```
fix(buzz-acp): raise MODELS_TIMEOUT to 60s so slow-start agents don't fail `models`/probe subcommands
```

## PR 描述（建议正文）

### Problem

`buzz-acp` lightweight helper subcommands (`models`, `methods`, and the initialize probe path) are
guarded by a hardcoded `MODELS_TIMEOUT = 10s` (`crates/buzz-acp/src/lib.rs`, `const MODELS_TIMEOUT`).
Any ACP agent whose process spawn + `initialize` handshake takes longer than 10s **cold** fails these
subcommands with `error: agent timed out (10s)`, even though the agent is fully functional.

Reproducible case: `openclaw acp` (Node.js-based ACP server, v2026.7.1) takes ~11.4s from spawn to
first `initialize` response on a cold start. Result:

```
$ BUZZ_ACP_AGENT_COMMAND=openclaw BUZZ_ACP_AGENT_ARGS=acp,--session,<id> buzz-acp models
error: agent timed out (10s)
```

Meanwhile the runtime agent-pool path already uses a 60s timeout for the exact same
`client.initialize()` call, so the runtime bridge works fine while the helper subcommands fail —
inconsistent behavior for the same operation.

### Proposed fix (minimal)

Raise the helper-subcommand timeout constant from 10s to **60s**, matching the runtime agent-pool
initialize timeout. Single-constant change, no behavior change for fast agents beyond a later
timeout error.

Alternative (happy to switch if preferred): make it configurable, e.g.
`BUZZ_ACP_MODELS_TIMEOUT` env var with a 60s default — useful for agents with even slower cold
starts (JVM, heavy Python envs). We kept the minimal diff here since 60s already matches the
runtime path constant.

### Evidence

- Cold-start timing: initialize first response at 11.44s, `session/new` at 12.19s (measured against
  openclaw-acp v2026.7.1-2, stdio probe).
- Official binary: `models` → `error: agent timed out (10s)` (reproduced twice).
- Patched binary (only this constant changed): `models` → exit 0, agent identity reported correctly;
  runtime agent-pool behavior unchanged.

### Testing

- [x] `buzz-acp models` against openclaw ACP agent: timeout → PASS after patch
- [x] `buzz-acp models --json`: structured agent name/version output correct
- [x] 25s full bridge run: `agent_pool_ready agents=1` (runtime path unaffected)
- [ ] cargo test suite on CI (upstream)

---

## 提交前 checklist（itops 执行，待 main 确认后进行）
1. fork block/buzz 到可发布账号（不使用个人机器凭据之外的新凭据；gh auth 现有身份）
2. 基于最新 upstream main 重做分支（草稿基线 f995325 可能已漂移；单 hunk 补丁上下文足够小，重放低风险）
3. `git diff` 重新生成（UPSTREAM-PR-DRAFT.patch 的 index hash 是草稿基线的，正式提交前需重算）
4. PR 正文 = 上面建议内容（去掉内部路径/内部项目名，替换为通用表述）
5. push + 开 PR，回填 PR URL 到 CLOSEOUT 文档

## 内部注意
- 提交内容**不得包含**任何密钥/私钥/内部域名/内部路径（本文件与 patch 已审查：无）
- patch 仅含 1 行常量变更 + doc comment 上下文，无敏感信息