### PR TITLE
Answer a rate-limited EVENT with OK false and retry it once the gate clears

### DIFF
--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -1234,6 +1234,19 @@ impl BgState {
         while let Some(event) = self.observer_in_flight.pop_back() {
             self.gated_observer_pending.push_front(event);
         }
+        self.trim_gated_observer_pending();
+    }
+
+    /// Restore one observer write the relay refused with `OK false
+    /// rate-limited:` — correlated by id, so only that frame is retried.
+    fn requeue_observer_frame(&mut self, event_id: &str) {
+        if let Some(event) = self.take_observer_in_flight(event_id) {
+            self.gated_observer_pending.push_front(event);
+            self.trim_gated_observer_pending();
+        }
+    }
+
+    fn trim_gated_observer_pending(&mut self) {
         while self.gated_observer_pending.len() > GATED_OBSERVER_QUEUE_CAP {
             self.gated_observer_pending.pop_front();
             self.gated_observer_dropped += 1;
@@ -1253,13 +1266,15 @@ impl BgState {
     }
 
     fn acknowledge_observer_frame(&mut self, event_id: &str) {
-        if let Some(index) = self
+        self.take_observer_in_flight(event_id);
+    }
+
+    fn take_observer_in_flight(&mut self, event_id: &str) -> Option<Box<Event>> {
+        let index = self
             .observer_in_flight
             .iter()
-            .position(|event| event.id.to_hex() == event_id)
-        {
-            self.observer_in_flight.remove(index);
-        }
+            .position(|event| event.id.to_hex() == event_id)?;
+        self.observer_in_flight.remove(index)
     }
 }
 
@@ -2391,6 +2406,22 @@ async fn handle_ws_message(
                         // AUTH OK with accepted=false means auth was rejected.
                         warn!("mid-session AUTH rejected (event {event_id}): {message} — triggering reconnect");
                         return false;
+                    }
+                    if !accepted && message.starts_with("rate-limited:") {
+                        // The relay refused this EVENT for back-pressure. Arm the
+                        // gate and put the frame (if it was a durable observer
+                        // write) back at the head of the paced drain.
+                        let secs = parse_rate_limit_retry_secs(&message).unwrap_or(0);
+                        let deadline = state.set_rate_limit_gate(secs);
+                        state.requeue_observer_frame(&event_id);
+                        warn!(
+                            "event {event_id} rate-limited — gate armed until ~{:.1}s from now",
+                            deadline
+                                .checked_duration_since(tokio::time::Instant::now())
+                                .unwrap_or_default()
+                                .as_secs_f64()
+                        );
+                        return true;
                     }
                     state.acknowledge_observer_frame(&event_id);
                     debug!("OK for event {event_id}: accepted={accepted} message={message}");
@@ -6025,6 +6056,37 @@ mod tests {
             .collect();
         assert_eq!(ids, [rejected.id, later.id]);
         assert!(state.observer_in_flight.is_empty());
+    }
+
+    #[test]
+    fn rate_limited_ok_requeues_only_the_refused_frame() {
+        let mut state = BgState::new();
+        let keys = Keys::generate();
+        let still_in_flight = make_observer_frame(&keys);
+        let refused = make_observer_frame(&keys);
+        let later = make_observer_frame(&keys);
+
+        state.track_observer_in_flight(Box::new(still_in_flight.clone()));
+        state.track_observer_in_flight(Box::new(refused.clone()));
+        state.park_gated_observer_frame(Box::new(later.clone()));
+        state.requeue_observer_frame(&refused.id.to_hex());
+
+        let pending: Vec<_> = state
+            .gated_observer_pending
+            .iter()
+            .map(|event| event.id)
+            .collect();
+        assert_eq!(
+            pending,
+            [refused.id, later.id],
+            "refused frame drains first"
+        );
+        let in_flight: Vec<_> = state.observer_in_flight.iter().map(|e| e.id).collect();
+        assert_eq!(
+            in_flight,
+            [still_in_flight.id],
+            "unrefused frame keeps waiting for OK"
+        );
     }
 
     /// The parked-frame queue is bounded: overflow evicts the oldest frame and

--- a/crates/buzz-relay/src/connection.rs
+++ b/crates/buzz-relay/src/connection.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 use buzz_auth::{generate_challenge, AuthContext, LimitType};
 use buzz_core::tenant::TenantContext;
-use nostr::Filter;
+use nostr::{Event, Filter};
 
 use crate::handlers;
 use crate::protocol::{ClientMessage, RelayMessage};
@@ -571,7 +571,8 @@ async fn handle_text_message(text: String, conn: Arc<ConnectionState>, state: Ar
             let permit = match state.handler_semaphore.clone().try_acquire_owned() {
                 Ok(p) => p,
                 Err(_) => {
-                    conn.send(RelayMessage::notice(
+                    conn.send(request_rejection_message(
+                        RejectionTarget::Event(&event),
                         "rate-limited: too many concurrent requests",
                     ));
                     return;
@@ -600,7 +601,7 @@ async fn handle_text_message(text: String, conn: Arc<ConnectionState>, state: Ar
                 Ok(p) => p,
                 Err(_) => {
                     conn.send(request_rejection_message(
-                        Some(&sub_id),
+                        RejectionTarget::Subscription(&sub_id),
                         "rate-limited: too many concurrent requests",
                     ));
                     return;
@@ -642,10 +643,24 @@ async fn handle_text_message(text: String, conn: Arc<ConnectionState>, state: Ar
     }
 }
 
-fn request_rejection_message(sub_id: Option<&str>, reason: &str) -> String {
-    match sub_id {
-        Some(sub_id) => RelayMessage::closed(sub_id, reason),
-        None => RelayMessage::notice(reason),
+/// Which client-side frame a rejection is correlated with.
+///
+/// A publisher waits on `OK <event_id>` and a subscriber waits on
+/// `CLOSED <sub_id>`; an uncorrelated `NOTICE` leaves the client hanging
+/// until its own timeout fires.
+#[derive(Debug, Clone, Copy)]
+enum RejectionTarget<'a> {
+    Event(&'a Event),
+    Subscription(&'a str),
+    /// COUNT has no correlated rejection frame; fall back to NOTICE.
+    Uncorrelated,
+}
+
+fn request_rejection_message(target: RejectionTarget<'_>, reason: &str) -> String {
+    match target {
+        RejectionTarget::Event(event) => RelayMessage::ok(&event.id.to_hex(), false, reason),
+        RejectionTarget::Subscription(sub_id) => RelayMessage::closed(sub_id, reason),
+        RejectionTarget::Uncorrelated => RelayMessage::notice(reason),
     }
 }
 
@@ -679,11 +694,12 @@ async fn enforce_ws_admission(
         ws_limit,
     )
     .await;
-    let sub_id = match msg {
-        ClientMessage::Req { sub_id, .. } => Some(sub_id.as_str()),
-        _ => None,
+    let target = match msg {
+        ClientMessage::Event(event) => RejectionTarget::Event(event),
+        ClientMessage::Req { sub_id, .. } => RejectionTarget::Subscription(sub_id),
+        _ => RejectionTarget::Uncorrelated,
     };
-    if !send_admission_result(conn, ws_result, sub_id) {
+    if !send_admission_result(conn, ws_result, target) {
         return false;
     }
 
@@ -702,7 +718,7 @@ async fn enforce_ws_admission(
             message_limit,
         )
         .await;
-        if !send_admission_result(conn, message_result, None) {
+        if !send_admission_result(conn, message_result, target) {
             return false;
         }
     }
@@ -713,14 +729,14 @@ async fn enforce_ws_admission(
 fn send_admission_result(
     conn: &ConnectionState,
     result: Result<(), crate::admission::AdmissionError>,
-    sub_id: Option<&str>,
+    target: RejectionTarget<'_>,
 ) -> bool {
     match result {
         Ok(()) => true,
         Err(crate::admission::AdmissionError::Exceeded { reset_in_secs }) => {
             metrics::counter!("buzz_admission_rejections_total", "transport" => "websocket", "reason" => "quota").increment(1);
             conn.send(request_rejection_message(
-                sub_id,
+                target,
                 &format!("rate-limited: quota exceeded; retry in {reset_in_secs}s"),
             ));
             false
@@ -728,7 +744,7 @@ fn send_admission_result(
         Err(crate::admission::AdmissionError::Unavailable) => {
             metrics::counter!("buzz_admission_rejections_total", "transport" => "websocket", "reason" => "unavailable").increment(1);
             conn.send(request_rejection_message(
-                sub_id,
+                target,
                 "rate-limited: shared admission unavailable",
             ));
             false
@@ -835,16 +851,29 @@ mod tests {
     }
 
     #[test]
-    fn req_rejections_are_subscription_scoped() {
+    fn rejections_are_correlated_with_the_rejected_frame() {
         let reason = "rate-limited: too many concurrent requests";
-        let closed: serde_json::Value =
-            serde_json::from_str(&request_rejection_message(Some("history-123"), reason))
-                .expect("parse CLOSED");
-        assert_eq!(closed, serde_json::json!(["CLOSED", "history-123", reason]));
+        let parse = |target| -> serde_json::Value {
+            serde_json::from_str(&request_rejection_message(target, reason)).expect("parse frame")
+        };
 
-        let notice: serde_json::Value =
-            serde_json::from_str(&request_rejection_message(None, reason)).expect("parse NOTICE");
-        assert_eq!(notice, serde_json::json!(["NOTICE", reason]));
+        // A rejected EVENT must settle the publisher's pending OK, not leave
+        // it waiting on the publish timeout.
+        let event = nostr::EventBuilder::text_note("hi")
+            .sign_with_keys(&nostr::Keys::generate())
+            .expect("sign event");
+        assert_eq!(
+            parse(RejectionTarget::Event(&event)),
+            serde_json::json!(["OK", event.id.to_hex(), false, reason])
+        );
+        assert_eq!(
+            parse(RejectionTarget::Subscription("history-123")),
+            serde_json::json!(["CLOSED", "history-123", reason])
+        );
+        assert_eq!(
+            parse(RejectionTarget::Uncorrelated),
+            serde_json::json!(["NOTICE", reason])
+        );
     }
 
     #[tokio::test]

--- a/desktop/src/shared/api/relayClientSession.publishRateLimit.test.mjs
+++ b/desktop/src/shared/api/relayClientSession.publishRateLimit.test.mjs
@@ -34,6 +34,14 @@ Date.now = () => fakeNow;
 globalThis.window = {
   setTimeout: fakeSetTimeout,
   clearTimeout: fakeClearTimeout,
+  // resetConnection() closes the socket through the Tauri bridge; answer it
+  // so the test stays quiet and a real warning cannot hide in the noise.
+  __TAURI_INTERNALS__: {
+    invoke: async (command) => {
+      if (command === "plugin:websocket|disconnect") return;
+      throw new Error(`Unexpected Tauri command: ${command}`);
+    },
+  },
 };
 
 // Import after the window shim is installed.
@@ -130,22 +138,20 @@ test("a non-rate-limit OK=false still rejects immediately", async () => {
   assert.equal(publish.error?.message, "restricted: not a channel member");
 });
 
-test("legacy NOTICE rate-limited gives pending publishes the same single retry", async () => {
+test("an uncorrelated NOTICE rate-limited arms the gate but never re-sends", async () => {
   const { client, sent } = makeClient();
   const publish = watch(client.publishEvent(event, "timeout", "send failed"));
   await tickTo(0);
 
+  // The NOTICE may have been triggered by a REQ or COUNT, and an ephemeral
+  // event the relay already fanned out would be delivered twice on resend.
   await deliver(client, ["NOTICE", RATE_LIMITED]);
   await tickTo(0);
-  assert.equal(publish.settled, false);
-  assert.equal(sent.length, 1);
+  assert.equal(isRateLimited(), true, "gate armed from the NOTICE");
+  assert.equal(publish.settled, false, "NOTICE cannot be attributed; no fail");
 
-  // A second uncorrelated NOTICE cannot be attributed to this publish; it must
-  // neither fail it nor grant a second retry.
-  await deliver(client, ["NOTICE", RATE_LIMITED]);
   await tickTo(3_000);
-  assert.equal(publish.settled, false);
-  assert.equal(sent.length, 2, "exactly one resend");
+  assert.equal(sent.length, 1, "no resend from an uncorrelated NOTICE");
 
   await deliver(client, ["OK", "e1", true, ""]);
   await tickTo(3_000);

--- a/desktop/src/shared/api/relayClientSession.publishRateLimit.test.mjs
+++ b/desktop/src/shared/api/relayClientSession.publishRateLimit.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// ── Fake-timer setup ──────────────────────────────────────────────────────────
+// The rate-limit gate and publish timeout both use window.setTimeout.
+
+let fakeNow = 0;
+const pendingTimers = new Map();
+let nextTimerId = 1;
+
+function fakeSetTimeout(fn, ms) {
+  const id = nextTimerId++;
+  pendingTimers.set(id, { fn, fireAt: fakeNow + ms });
+  return id;
+}
+
+function fakeClearTimeout(id) {
+  pendingTimers.delete(id);
+}
+
+async function tickTo(ms) {
+  fakeNow = ms;
+  for (const [id, { fn, fireAt }] of Array.from(pendingTimers.entries())) {
+    if (fireAt <= fakeNow) {
+      pendingTimers.delete(id);
+      fn();
+    }
+  }
+  // Let promise chains hanging off fired timers (the gate) run.
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+Date.now = () => fakeNow;
+globalThis.window = {
+  setTimeout: fakeSetTimeout,
+  clearTimeout: fakeClearTimeout,
+};
+
+// Import after the window shim is installed.
+const { resetRateLimitGate, isRateLimited } = await import(
+  "./relayRateLimitGate.ts"
+);
+const { RelayClient } = await import("./relayClientSession.ts");
+
+const RATE_LIMITED = "rate-limited: quota exceeded; retry in 3s";
+
+function makeClient() {
+  pendingTimers.clear();
+  nextTimerId = 1;
+  fakeNow = 0;
+  resetRateLimitGate();
+
+  const client = new RelayClient();
+  const sent = [];
+  // Pretend the socket is open; capture frames instead of invoking Tauri.
+  client.wsId = 1;
+  client.sendRaw = async (payload) => {
+    sent.push(payload);
+  };
+  return { client, sent };
+}
+
+function deliver(client, frame) {
+  return client.handleWsMessage(JSON.stringify(frame), 0);
+}
+
+function watch(promise) {
+  const state = { settled: false, value: undefined, error: undefined };
+  promise.then(
+    (value) => Object.assign(state, { settled: true, value }),
+    (error) => Object.assign(state, { settled: true, error }),
+  );
+  return state;
+}
+
+const event = { id: "e1", kind: 9, content: "hi" };
+
+test("OK=false rate-limited arms the gate and re-sends the EVENT once it clears", async () => {
+  const { client, sent } = makeClient();
+  const publish = watch(client.publishEvent(event, "timeout", "send failed"));
+  await tickTo(0);
+  assert.equal(sent.length, 1);
+
+  await deliver(client, ["OK", "e1", false, RATE_LIMITED]);
+  await tickTo(0);
+  assert.equal(publish.settled, false, "first refusal must not fail the send");
+  assert.equal(isRateLimited(), true, "gate armed from the OK reason");
+  assert.equal(sent.length, 1, "no resend while the gate is closed");
+
+  await tickTo(3_000);
+  assert.equal(sent.length, 2, "EVENT re-sent when the gate cleared");
+  assert.deepEqual(sent[1], ["EVENT", event]);
+
+  await deliver(client, ["OK", "e1", true, ""]);
+  await tickTo(3_000);
+  assert.equal(
+    publish.value,
+    event,
+    "retry's OK resolves the original publish",
+  );
+});
+
+test("a second rate-limited refusal fails fast with the relay's reason", async () => {
+  const { client, sent } = makeClient();
+  const publish = watch(client.publishEvent(event, "timeout", "send failed"));
+  await tickTo(0);
+
+  await deliver(client, ["OK", "e1", false, RATE_LIMITED]);
+  await tickTo(3_000);
+  assert.equal(sent.length, 2);
+
+  await deliver(client, ["OK", "e1", false, RATE_LIMITED]);
+  await tickTo(3_000);
+  assert.equal(publish.error?.message, RATE_LIMITED);
+  assert.equal(sent.length, 2, "retry is bounded to one");
+});
+
+test("a non-rate-limit OK=false still rejects immediately", async () => {
+  const { client } = makeClient();
+  const publish = watch(client.publishEvent(event, "timeout", "send failed"));
+  await tickTo(0);
+
+  await deliver(client, [
+    "OK",
+    "e1",
+    false,
+    "restricted: not a channel member",
+  ]);
+  await tickTo(0);
+  assert.equal(publish.error?.message, "restricted: not a channel member");
+});
+
+test("legacy NOTICE rate-limited gives pending publishes the same single retry", async () => {
+  const { client, sent } = makeClient();
+  const publish = watch(client.publishEvent(event, "timeout", "send failed"));
+  await tickTo(0);
+
+  await deliver(client, ["NOTICE", RATE_LIMITED]);
+  await tickTo(0);
+  assert.equal(publish.settled, false);
+  assert.equal(sent.length, 1);
+
+  // A second uncorrelated NOTICE cannot be attributed to this publish; it must
+  // neither fail it nor grant a second retry.
+  await deliver(client, ["NOTICE", RATE_LIMITED]);
+  await tickTo(3_000);
+  assert.equal(publish.settled, false);
+  assert.equal(sent.length, 2, "exactly one resend");
+
+  await deliver(client, ["OK", "e1", true, ""]);
+  await tickTo(3_000);
+  assert.equal(publish.value, event);
+});
+
+test("a retry scheduled before a connection reset does not fire on the dead socket", async () => {
+  const { client, sent } = makeClient();
+  const publish = watch(client.publishEvent(event, "timeout", "send failed"));
+  await tickTo(0);
+
+  await deliver(client, ["OK", "e1", false, RATE_LIMITED]);
+  await tickTo(0);
+  client.resetConnection(new Error("Relay connection closed."), {
+    reconnect: false,
+  });
+  await tickTo(0);
+  assert.equal(publish.error?.message, "Relay connection closed.");
+
+  await tickTo(3_000);
+  assert.equal(sent.length, 1, "no resend after the publish was settled");
+});

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -38,10 +38,10 @@ import {
 } from "@/shared/api/relayClosedRecovery";
 import { getChannelReconnectRepairEvents } from "@/shared/api/channelReconnectRepair";
 import { replayLiveSubscriptions } from "@/shared/api/relayReconnectReplay";
+import { handlePublishOk } from "@/shared/api/relayPublishRecovery";
 import {
   activateRateLimit,
   parseRateLimitHint,
-  rateLimitRemainingMs,
   waitForRateLimit,
 } from "@/shared/api/relayRateLimitGate";
 import {
@@ -834,47 +834,8 @@ export class RelayClient {
       // Relay back-pressure — arm the gate until the window expires.
       if (notice.startsWith("rate-limited:")) {
         activateRateLimit(parseRateLimitHint(notice));
-        // Older relays answer an over-quota EVENT with this uncorrelated
-        // NOTICE instead of `OK false`; the publish would otherwise sit until
-        // PUBLISH_TIMEOUT_MS. Give every in-flight publish its one retry.
-        for (const pendingEvent of this.pendingEvents.values()) {
-          this.retryPublishAfterRateLimit(pendingEvent);
-        }
       }
     }
-  }
-
-  /**
-   * The relay refused an EVENT for back-pressure. Re-send it once the gate
-   * clears instead of failing the user's send — the burst that tripped the
-   * limit is typically our own post-(re)connect REQ fan-out, and the relay
-   * dedups by id so a resend can never double-post. One retry only; a second
-   * refusal is reported. Returns `false` when no retry is available.
-   */
-  private retryPublishAfterRateLimit(pendingEvent: PendingEvent): boolean {
-    if (
-      pendingEvent.retriedAfterRateLimit ||
-      rateLimitRemainingMs() >= PUBLISH_TIMEOUT_MS
-    ) {
-      return false;
-    }
-    pendingEvent.retriedAfterRateLimit = true;
-    const { event } = pendingEvent;
-    void waitForRateLimit().then(async () => {
-      // Settled meanwhile (timeout, reset, community switch) — nothing to do.
-      if (this.pendingEvents.get(event.id) !== pendingEvent) return;
-      try {
-        await this.sendRaw(["EVENT", event]);
-      } catch (error) {
-        if (this.pendingEvents.get(event.id) !== pendingEvent) return;
-        window.clearTimeout(pendingEvent.timeout);
-        this.pendingEvents.delete(event.id);
-        pendingEvent.reject(
-          this.normalizeRelayError(error, "Failed to re-send event to relay."),
-        );
-      }
-    });
-    return true;
   }
 
   private async handleAuthChallenge(challenge: string, generation: number) {
@@ -951,24 +912,13 @@ export class RelayClient {
       return;
     }
 
-    const pendingEvent = this.pendingEvents.get(eventId);
-    if (!pendingEvent) {
-      return;
-    }
-
-    if (!success && message.startsWith("rate-limited:")) {
-      activateRateLimit(parseRateLimitHint(message));
-      if (this.retryPublishAfterRateLimit(pendingEvent)) return;
-    }
-
-    window.clearTimeout(pendingEvent.timeout);
-    this.pendingEvents.delete(eventId);
-
-    if (success) {
-      pendingEvent.resolve(pendingEvent.event);
-    } else {
-      pendingEvent.reject(new Error(message || "Relay rejected the event."));
-    }
+    handlePublishOk({
+      pendingEvents: this.pendingEvents,
+      eventId,
+      success,
+      message,
+      sendEvent: (event) => this.sendRaw(["EVENT", event]),
+    });
   }
 
   private hasLiveSubscriptions() {

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -41,6 +41,7 @@ import { replayLiveSubscriptions } from "@/shared/api/relayReconnectReplay";
 import {
   activateRateLimit,
   parseRateLimitHint,
+  rateLimitRemainingMs,
   waitForRateLimit,
 } from "@/shared/api/relayRateLimitGate";
 import {
@@ -833,8 +834,47 @@ export class RelayClient {
       // Relay back-pressure — arm the gate until the window expires.
       if (notice.startsWith("rate-limited:")) {
         activateRateLimit(parseRateLimitHint(notice));
+        // Older relays answer an over-quota EVENT with this uncorrelated
+        // NOTICE instead of `OK false`; the publish would otherwise sit until
+        // PUBLISH_TIMEOUT_MS. Give every in-flight publish its one retry.
+        for (const pendingEvent of this.pendingEvents.values()) {
+          this.retryPublishAfterRateLimit(pendingEvent);
+        }
       }
     }
+  }
+
+  /**
+   * The relay refused an EVENT for back-pressure. Re-send it once the gate
+   * clears instead of failing the user's send — the burst that tripped the
+   * limit is typically our own post-(re)connect REQ fan-out, and the relay
+   * dedups by id so a resend can never double-post. One retry only; a second
+   * refusal is reported. Returns `false` when no retry is available.
+   */
+  private retryPublishAfterRateLimit(pendingEvent: PendingEvent): boolean {
+    if (
+      pendingEvent.retriedAfterRateLimit ||
+      rateLimitRemainingMs() >= PUBLISH_TIMEOUT_MS
+    ) {
+      return false;
+    }
+    pendingEvent.retriedAfterRateLimit = true;
+    const { event } = pendingEvent;
+    void waitForRateLimit().then(async () => {
+      // Settled meanwhile (timeout, reset, community switch) — nothing to do.
+      if (this.pendingEvents.get(event.id) !== pendingEvent) return;
+      try {
+        await this.sendRaw(["EVENT", event]);
+      } catch (error) {
+        if (this.pendingEvents.get(event.id) !== pendingEvent) return;
+        window.clearTimeout(pendingEvent.timeout);
+        this.pendingEvents.delete(event.id);
+        pendingEvent.reject(
+          this.normalizeRelayError(error, "Failed to re-send event to relay."),
+        );
+      }
+    });
+    return true;
   }
 
   private async handleAuthChallenge(challenge: string, generation: number) {
@@ -914,6 +954,11 @@ export class RelayClient {
     const pendingEvent = this.pendingEvents.get(eventId);
     if (!pendingEvent) {
       return;
+    }
+
+    if (!success && message.startsWith("rate-limited:")) {
+      activateRateLimit(parseRateLimitHint(message));
+      if (this.retryPublishAfterRateLimit(pendingEvent)) return;
     }
 
     window.clearTimeout(pendingEvent.timeout);

--- a/desktop/src/shared/api/relayClientShared.ts
+++ b/desktop/src/shared/api/relayClientShared.ts
@@ -89,6 +89,8 @@ export type PendingEvent = {
   resolve: (event: RelayEvent) => void;
   reject: (error: Error) => void;
   timeout: number;
+  /** Set once the EVENT has been re-sent after a `rate-limited:` refusal. */
+  retriedAfterRateLimit?: boolean;
 };
 
 export type RelaySubscription =

--- a/desktop/src/shared/api/relayPublishRecovery.ts
+++ b/desktop/src/shared/api/relayPublishRecovery.ts
@@ -1,0 +1,81 @@
+import type { PendingEvent } from "@/shared/api/relayClientShared";
+import { PUBLISH_TIMEOUT_MS } from "@/shared/api/relayClientTimings";
+import {
+  activateRateLimit,
+  parseRateLimitHint,
+  rateLimitRemainingMs,
+  waitForRateLimit,
+} from "@/shared/api/relayRateLimitGate";
+
+/**
+ * Settle a pending publish from the relay's `OK` frame.
+ *
+ * An `OK false "rate-limited: …"` is not a verdict on the event, only on
+ * timing: the burst that tripped the limit is typically our own
+ * post-(re)connect REQ fan-out. Arm the gate and re-send the EVENT once it
+ * clears instead of failing the user's send. Because the refusal is
+ * correlated, the relay has not applied the event, so the resend cannot
+ * double-deliver — unlike an uncorrelated `NOTICE`, which is never retried.
+ * One retry per publish; a second refusal, or a gate longer than the publish
+ * timeout, rejects with the relay's reason.
+ */
+export function handlePublishOk({
+  pendingEvents,
+  eventId,
+  success,
+  message,
+  sendEvent,
+}: {
+  pendingEvents: Map<string, PendingEvent>;
+  eventId: string;
+  success: boolean;
+  message: string;
+  sendEvent: (event: PendingEvent["event"]) => Promise<void>;
+}) {
+  const pendingEvent = pendingEvents.get(eventId);
+  if (!pendingEvent) return;
+
+  if (!success && message.startsWith("rate-limited:")) {
+    activateRateLimit(parseRateLimitHint(message));
+    if (
+      !pendingEvent.retriedAfterRateLimit &&
+      rateLimitRemainingMs() < PUBLISH_TIMEOUT_MS
+    ) {
+      pendingEvent.retriedAfterRateLimit = true;
+      void waitForRateLimit().then(async () => {
+        // Settled meanwhile (timeout, reset, community switch) — nothing to do.
+        if (pendingEvents.get(eventId) !== pendingEvent) return;
+        try {
+          await sendEvent(pendingEvent.event);
+        } catch (error) {
+          if (pendingEvents.get(eventId) !== pendingEvent) return;
+          settle(pendingEvents, eventId, pendingEvent, () =>
+            pendingEvent.reject(
+              error instanceof Error
+                ? error
+                : new Error("Failed to re-send event to relay."),
+            ),
+          );
+        }
+      });
+      return;
+    }
+  }
+
+  settle(pendingEvents, eventId, pendingEvent, () =>
+    success
+      ? pendingEvent.resolve(pendingEvent.event)
+      : pendingEvent.reject(new Error(message || "Relay rejected the event.")),
+  );
+}
+
+function settle(
+  pendingEvents: Map<string, PendingEvent>,
+  eventId: string,
+  pendingEvent: PendingEvent,
+  finish: () => void,
+) {
+  window.clearTimeout(pendingEvent.timeout);
+  pendingEvents.delete(eventId);
+  finish();
+}

--- a/mobile/lib/shared/relay/relay_rate_limit_gate.dart
+++ b/mobile/lib/shared/relay/relay_rate_limit_gate.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'relay_closed_policy.dart';
+
 /// Creates a timer used by [RelayRateLimitGate].
 typedef RelayTimerFactory =
     Timer Function(Duration duration, void Function() callback);
@@ -45,6 +47,13 @@ class RelayRateLimitGate {
     _timer?.cancel();
     _completer ??= Completer<void>();
     _timer = _timerFactory(duration, _expire);
+  }
+
+  /// Arms the gate from any relay refusal (`CLOSED`, `OK false`, HTTP error)
+  /// whose message classifies as back-pressure; a no-op otherwise.
+  void activateIfRateLimited(String message) {
+    if (classifyRelayClosed(message) != RelayClosedClass.rateLimited) return;
+    activate(parseRateLimitRetrySeconds(message));
   }
 
   /// Resolves when the active rate-limit window expires.

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -815,6 +815,11 @@ class RelaySessionNotifier extends Notifier<SessionState> {
         );
       }
     } else {
+      // The relay refused the EVENT for back-pressure: arm the gate so
+      // concurrent subscribes/publishes back off instead of piling on.
+      if (classifyRelayClosed(message) == RelayClosedClass.rateLimited) {
+        _rateLimitGate.activate(parseRateLimitRetrySeconds(message));
+      }
       if (!pending.completer.isCompleted) {
         pending.completer.completeError(
           Exception(message.isNotEmpty ? message : 'Event rejected'),

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -220,11 +220,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     }
     if (decoded is! Map<String, dynamic>) return;
     final message = decoded['error'];
-    if (message is! String ||
-        classifyRelayClosed(message) != RelayClosedClass.rateLimited) {
-      return;
-    }
-    _rateLimitGate.activate(parseRateLimitRetrySeconds(message));
+    if (message is String) _rateLimitGate.activateIfRateLimited(message);
   }
 
   /// Fetch historical events matching [filter]. Sends REQ, collects events
@@ -692,9 +688,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
 
     final historySub = _historySubscriptions.remove(subId);
     if (historySub != null) {
-      if (closedClass == RelayClosedClass.rateLimited) {
-        _rateLimitGate.activate(parseRateLimitRetrySeconds(message));
-      }
+      _rateLimitGate.activateIfRateLimited(message);
       historySub.timeout.cancel();
       if (!historySub.completer.isCompleted) {
         historySub.completer.completeError(Exception(message));
@@ -815,11 +809,8 @@ class RelaySessionNotifier extends Notifier<SessionState> {
         );
       }
     } else {
-      // The relay refused the EVENT for back-pressure: arm the gate so
-      // concurrent subscribes/publishes back off instead of piling on.
-      if (classifyRelayClosed(message) == RelayClosedClass.rateLimited) {
-        _rateLimitGate.activate(parseRateLimitRetrySeconds(message));
-      }
+      // Back-pressure refusal: arm the gate so concurrent requests back off.
+      _rateLimitGate.activateIfRateLimited(message);
       if (!pending.completer.isCompleted) {
         pending.completer.completeError(
           Exception(message.isNotEmpty ? message : 'Event rejected'),

--- a/mobile/test/shared/relay/relay_rate_limit_gate_test.dart
+++ b/mobile/test/shared/relay/relay_rate_limit_gate_test.dart
@@ -92,6 +92,19 @@ void main() {
     expect(timers.single.isActive, isFalse);
     expect(gate.isActive, isFalse);
   });
+
+  test('activateIfRateLimited arms only on a back-pressure message', () {
+    final gate = RelayRateLimitGate(
+      now: () => DateTime.utc(2026),
+      timerFactory: (duration, callback) => _ManualTimer(duration, callback),
+    );
+
+    gate.activateIfRateLimited('restricted: not a channel member');
+    expect(gate.isActive, isFalse);
+
+    gate.activateIfRateLimited('rate-limited: quota exceeded; retry in 3s');
+    expect(gate.remainingMs(), 3000);
+  });
 }
 
 class _ManualTimer implements Timer {

--- a/mobile/test/shared/relay/relay_session_test.dart
+++ b/mobile/test/shared/relay/relay_session_test.dart
@@ -943,6 +943,49 @@ void main() {
     expect(disposeTimer.isActive, isFalse);
   });
 
+  test('rate-limited OK=false fails the publish and arms the gate', () async {
+    final gateTimers = <_ManualTimer>[];
+    final gate = RelayRateLimitGate(
+      timerFactory: (duration, callback) {
+        final timer = _ManualTimer(duration, callback);
+        gateTimers.add(timer);
+        return timer;
+      },
+    );
+    final session = RelaySessionNotifier(rateLimitGate: gate);
+    session.debugAttachSocketForTest(_RecordingRelaySocket());
+    final event = NostrEvent(
+      id: 'e1',
+      pubkey: '',
+      createdAt: 0,
+      kind: 9,
+      tags: const [],
+      content: 'hi',
+      sig: '',
+    );
+
+    final publish = session.publish(event);
+    session.debugHandleMessage([
+      'OK',
+      'e1',
+      false,
+      'rate-limited: quota exceeded; retry in 4s',
+    ]);
+
+    await expectLater(
+      publish,
+      throwsA(
+        isA<Exception>().having(
+          (error) => error.toString(),
+          'message',
+          contains('rate-limited: quota exceeded'),
+        ),
+      ),
+    );
+    expect(gate.isActive, isTrue);
+    expect(gateTimers.single.duration, const Duration(seconds: 4));
+  });
+
   test('rate-limited live CLOSED honours the gate floor', () async {
     final retryTimers = <_ManualTimer>[];
     final gateTimers = <_ManualTimer>[];


### PR DESCRIPTION
## Problem

The first message after switching communities in the desktop app (and for some users, the first message after a `just production` cold launch) spins, fails with **"Timed out while sending the message."** after 25s, then works on the second try.

Reported by Tyler in #buzz-bugs; root cause and live reproduction in `RESEARCH/FIRST_SEND_AFTER_COMMUNITY_SWITCH.md` (Meli's workspace).

## Root cause

1. A community switch remounts `<AppReady key={communityKey}>`, so every relay hook re-subscribes on the fresh socket. `useLiveChannelUpdates` alone sends 2 REQs per sidebar channel (`useLiveChannelUpdates.ts:393,497`) plus ~10 singleton REQs. The initial `subscribe()` path is unpaced.
2. Relay WS admission bills **REQ and EVENT frames against the same per-pubkey window**: `human_ws_events_per_sec` (10) × `WS_BURST_WINDOW_SECS` (5) = 50 frames / 5s (`crates/buzz-relay/src/admission.rs`). ≳20 channels blows the budget on every switch.
3. The rejection was asymmetric (`connection.rs` `send_admission_result`): an over-quota **REQ** got `CLOSED <subId> rate-limited:…` (correlated → client retries it). An over-quota **EVENT** got a bare `NOTICE rate-limited:…` — uncorrelated. The desktop client armed its gate but `pendingEvents[id]` never received an `OK`, so it sat until `PUBLISH_TIMEOUT_MS` = 25s.
4. The retry lands after the window rolls → success.

**Live proof** against the prod relay with my agent key (`.scratch/firstsend-probe.mjs`, node + nostr-tools):

```
10 REQ + 1 EVENT → OK false "restricted: not a channel member"     ← admission passed
60 REQ + 1 EVENT → NOTICE "rate-limited: quota exceeded; retry in 3s"; no OK for the EVENT, ever
```

## Fix (both halves, one PR — per Tyler)

### Relay — `crates/buzz-relay/src/connection.rs`
`request_rejection_message(Option<&str>, …)` → `request_rejection_message(RejectionTarget, …)`. An EVENT refused by admission (both `Exceeded` and `Unavailable`) or by the handler semaphore is now answered with `["OK", <event_id>, false, "rate-limited: …"]`. REQ keeps `CLOSED`; COUNT keeps `NOTICE`. The `rate-limited:` prefix and `retry in Ns` hint are unchanged, so every client's existing parser still applies. With only this half, the desktop fails in ~RTT with a real reason instead of spinning 25s.

### Desktop — `desktop/src/shared/api/relayPublishRecovery.ts` (`handlePublishOk`, called from `relayClientSession.ts` `handleOk`)
On `OK false rate-limited:` arm the gate and **re-send the EVENT once the gate clears** instead of rejecting the publish — the relay dedups by id (`insert_event` is `ON CONFLICT DO NOTHING`, duplicate → `OK true "duplicate:"`), so a resend can never double-post. Exactly one retry per publish (`PendingEvent.retriedAfterRateLimit`); a second refusal, or a gate ≥ `PUBLISH_TIMEOUT_MS`, fails fast with the relay's reason. The retry is guarded by identity on the `pendingEvents` entry, so a timeout/reset/community switch during the wait cancels it. The uncorrelated `NOTICE rate-limited:` still arms the gate but **never retries**: a NOTICE may have been caused by a REQ/COUNT, and an ephemeral event (e.g. presence kind 20001, which goes through `publishEvent`) that the relay already fanned out has no id dedup, so a blanket resend could double-deliver (Max's review finding). With this half the first send **succeeds** (≈ gate duration later) rather than failing.

### buzz-acp — `crates/buzz-acp/src/relay.rs`
Previously an `OK false rate-limited:` fell through to `acknowledge_observer_frame`, silently dropping the refused observer frame from the in-flight window (no requeue, no gate). Now: arm the gate and put *that one* frame back at the head of the paced drain (`requeue_observer_frame`, correlated by id — narrower than the NOTICE path's requeue-everything).

### Mobile — `mobile/lib/shared/relay/relay_session.dart`
`_handleOk` arms the gate on `OK false rate-limited:` before failing the publish, so concurrent work backs off. (Mobile's 8s publish timeout and simpler send path didn't exhibit the 25s spin; this is consistency.)

### Unchanged
CLI publishes via REST (429 path) — not affected.

## Tests

| Where | What | Fail-first? |
|---|---|---|
| `connection.rs` `rejections_are_correlated_with_the_rejected_frame` | EVENT→OK false / REQ→CLOSED / COUNT→NOTICE shapes | replaces `req_rejections_are_subscription_scoped` |
| `relayClientSession.publishRateLimit.test.mjs` (5 tests, fake timers, driven through `handleWsMessage`) | retry once gate clears; second refusal fails fast + bounded; non-rate-limit OK=false rejects immediately; uncorrelated NOTICE arms the gate but never resends; reset during the wait cancels the retry | ✅ 3/5 failed before the change (non-rate-limit and NOTICE paths are unchanged behavior) |
| `relay_rate_limit_gate_test.dart` `activateIfRateLimited arms only on a back-pressure message` | the shared classify→arm helper that replaced three copies in `relay_session.dart` | new |
| `relay.rs` `rate_limited_ok_requeues_only_the_refused_frame` | only the refused observer frame moves to the drain head; unrefused stays in flight | new |
| `relay_session_test.dart` `rate-limited OK=false fails the publish and arms the gate` | gate armed with the 4s hint | ✅ verified failing with lib change stashed |

**Suites at `43c5dc8d2` (review follow-up — desktop retry extracted to `relayPublishRecovery.ts`, NOTICE retry dropped, mobile classify→arm deduped; both oversized session files now net-shrink under the file-size ratchet: `relayClientSession.ts` 1084→1078, `relay_session.dart` 1000→995):** desktop `pnpm test` 5402/5402, `tsc --noEmit` clean, biome clean; `just file-size-check` green (desktop/web/mobile); mobile `flutter test` 1663/1663, `flutter analyze` clean, `dart format` clean. Rust crates untouched since `e3a3247b1`.

**Suites at `e3a3247b1`:** `cargo test -p buzz-acp` 802/802; `cargo test -p buzz-relay` 905 pass + 2 fail — both fail identically on clean `origin/main e23632941` (`api::mesh_demo::tests::demo_join_forwarded_arm_round_trips_echo` known flaky; `telemetry::tests::trace_context_lookup_does_not_enable_callsites` order-dependent, passes in isolation). `cargo clippy -p buzz-relay -p buzz-acp --all-targets -D warnings` clean; `cargo fmt --check` clean. Desktop `pnpm test` 5402/5402, `tsc --noEmit` clean, biome clean. Mobile `flutter test test/shared/relay/` 44/44, `dart analyze` clean.

## Notes for reviewers

- Overlaps open **#4912** (Eva/Sami, `eva/rate-limit-fixes`), which also edits `send_admission_result` (adds a `limit_type` arg). Whichever lands second has a small textual conflict in that function; the `RejectionTarget` parameter composes with their change.
- Behavior I'm not fixing here (follow-up): the REQ fan-out itself. Coalescing per-channel live+mention REQs into multi-filter frames would keep startup under 50 frames and make the rate limiter a non-event. Separate PR.
- Not in the PR: the desktop e2e `relay-reconnect*.spec.ts` harness has no rate-limit fixture; the unit tests above drive the real `handleWsMessage` → `handleOk` → gate → `sendRaw` path with fake timers instead.

