### PR TITLE
feat(projects): make the home channel the project surface

### DIFF
--- a/desktop/src/app/routes/projects.$projectId.tsx
+++ b/desktop/src/app/routes/projects.$projectId.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { createFileRoute, useLocation } from "@tanstack/react-router";
 
+import { parseProjectDetailSearch } from "@/features/projects/lib/projectDetailSearch";
 import { usePreviewFeatureWarning } from "@/shared/features";
-import { isEntityLinkTab } from "@/shared/lib/entityLink";
 import { ViewLoadingFallback } from "@/shared/ui/ViewLoadingFallback";
 
 const ProjectDetailScreen = React.lazy(async () => {
@@ -12,18 +12,7 @@ const ProjectDetailScreen = React.lazy(async () => {
 
 export const Route = createFileRoute("/projects/$projectId")({
   component: ProjectDetailRouteComponent,
-  validateSearch: (search: Record<string, unknown>) => ({
-    commitHash:
-      typeof search.commitHash === "string" ? search.commitHash : undefined,
-    pullRequestId:
-      typeof search.pullRequestId === "string"
-        ? search.pullRequestId
-        : undefined,
-    issueId: typeof search.issueId === "string" ? search.issueId : undefined,
-    repositoryId:
-      typeof search.repositoryId === "string" ? search.repositoryId : undefined,
-    tab: isEntityLinkTab(search.tab) ? search.tab : undefined,
-  }),
+  validateSearch: parseProjectDetailSearch,
 });
 
 function ProjectDetailRouteComponent() {

--- a/desktop/src/features/channels/ui/ChannelPane.helpers.test.mjs
+++ b/desktop/src/features/channels/ui/ChannelPane.helpers.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getChannelIntroKind } from "./ChannelPane.helpers.ts";
+import {
+  getChannelIntroKind,
+  shouldUseFocusIdleDrawer,
+} from "./ChannelPane.helpers.ts";
 
 function channel(overrides = {}) {
   return {
@@ -11,6 +14,32 @@ function channel(overrides = {}) {
     ...overrides,
   };
 }
+
+test("focus idle drawers yield to every higher-priority auxiliary surface", () => {
+  const idleDrawer = {
+    channelManagementOpen: false,
+    hasAgentSession: false,
+    hasIdleAuxiliaryPanel: true,
+    hasIdlePanelCloseHandler: true,
+    hasProfilePanel: false,
+    hasThreadSurface: false,
+    useSplitAuxiliaryPane: true,
+  };
+
+  assert.equal(shouldUseFocusIdleDrawer(idleDrawer), true);
+  for (const surface of [
+    "channelManagementOpen",
+    "hasAgentSession",
+    "hasProfilePanel",
+    "hasThreadSurface",
+  ]) {
+    assert.equal(
+      shouldUseFocusIdleDrawer({ ...idleDrawer, [surface]: true }),
+      false,
+      `idle drawer must yield when ${surface} is open`,
+    );
+  }
+});
 
 test("getChannelIntroKind names project homes ahead of regular streams", () => {
   assert.equal(getChannelIntroKind(channel(), true), "project channel");

--- a/desktop/src/features/channels/ui/ChannelPane.helpers.ts
+++ b/desktop/src/features/channels/ui/ChannelPane.helpers.ts
@@ -3,6 +3,34 @@ import type { TimelineMessage } from "@/features/messages/types";
 import type { Channel } from "@/shared/api/types";
 import { KIND_SYSTEM_MESSAGE } from "@/shared/constants/kinds";
 
+export function shouldUseFocusIdleDrawer({
+  channelManagementOpen,
+  hasAgentSession,
+  hasIdleAuxiliaryPanel,
+  hasIdlePanelCloseHandler,
+  hasProfilePanel,
+  hasThreadSurface,
+  useSplitAuxiliaryPane,
+}: {
+  channelManagementOpen: boolean;
+  hasAgentSession: boolean;
+  hasIdleAuxiliaryPanel: boolean;
+  hasIdlePanelCloseHandler: boolean;
+  hasProfilePanel: boolean;
+  hasThreadSurface: boolean;
+  useSplitAuxiliaryPane: boolean;
+}): boolean {
+  return (
+    useSplitAuxiliaryPane &&
+    !channelManagementOpen &&
+    !hasAgentSession &&
+    !hasProfilePanel &&
+    !hasThreadSurface &&
+    hasIdleAuxiliaryPanel &&
+    hasIdlePanelCloseHandler
+  );
+}
+
 export function getChannelIntroKind(
   channel: Channel,
   projectHome = false,

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -45,7 +45,10 @@ import {
   WelcomeComposerGuidanceLayer,
 } from "@/features/channels/ui/WelcomeComposerBanner";
 import { useWelcomeComposerBanner } from "@/features/channels/ui/useWelcomeComposerBanner";
-import { mentionsKnownAgent } from "@/features/channels/ui/ChannelPane.helpers";
+import {
+  mentionsKnownAgent,
+  shouldUseFocusIdleDrawer,
+} from "@/features/channels/ui/ChannelPane.helpers";
 import { HuddleStartingView, HuddleTranscriptIntro } from "@/features/huddle";
 import { ChannelGlyph } from "@/features/channels/ui/ChannelGlyph";
 import { useChannelIntro } from "@/features/channels/ui/useChannelIntro";
@@ -464,10 +467,25 @@ export const ChannelPane = React.memo(function ChannelPane({
     threadViewMode === "focus" &&
     useSplitAuxiliaryPane &&
     (Boolean(threadHeadMessage) || shouldShowThreadSkeleton);
-  const useFocusIdleDrawer =
-    useSplitAuxiliaryPane &&
-    Boolean(idleAuxiliaryPanel) &&
-    Boolean(onCloseIdleAuxiliaryPanel);
+  const selectedAgent = React.useMemo(
+    () =>
+      agentSessionSelection.resolveSelectedAgentSession({
+        agentSessionAgents,
+        openAgentSessionPubkey,
+        profilePanelPubkey,
+        profiles,
+      }),
+    [agentSessionAgents, openAgentSessionPubkey, profilePanelPubkey, profiles],
+  );
+  const useFocusIdleDrawer = shouldUseFocusIdleDrawer({
+    channelManagementOpen,
+    hasAgentSession: Boolean(activeChannel && selectedAgent),
+    hasIdleAuxiliaryPanel: Boolean(idleAuxiliaryPanel),
+    hasIdlePanelCloseHandler: Boolean(onCloseIdleAuxiliaryPanel),
+    hasProfilePanel: Boolean(profilePanelPubkey),
+    hasThreadSurface: Boolean(threadHeadMessage) || shouldShowThreadSkeleton,
+    useSplitAuxiliaryPane,
+  });
   const { channelIsCovered, markExitComplete } = useFocusDrawerPresence(
     useFocusThreadDrawer || useFocusIdleDrawer,
     useFocusThreadDrawer
@@ -481,16 +499,6 @@ export const ChannelPane = React.memo(function ChannelPane({
       onExternalTargetResolved: onThreadScrollTargetResolved,
       onModeChange: markExitComplete,
     });
-  const selectedAgent = React.useMemo(
-    () =>
-      agentSessionSelection.resolveSelectedAgentSession({
-        agentSessionAgents,
-        openAgentSessionPubkey,
-        profilePanelPubkey,
-        profiles,
-      }),
-    [agentSessionAgents, openAgentSessionPubkey, profilePanelPubkey, profiles],
-  );
   const hasSplitAuxiliaryPane =
     useSplitAuxiliaryPane &&
     (channelManagementOpen ||

--- a/desktop/src/features/channels/ui/useChannelIntro.tsx
+++ b/desktop/src/features/channels/ui/useChannelIntro.tsx
@@ -9,6 +9,8 @@ import {
   isWelcomeChannel,
   isWelcomeExperienceChannel,
 } from "@/features/onboarding/welcome";
+import { useIsProjectHomeChannel } from "@/features/projects/lib/projectHomeChannel";
+import { ProjectChannelIcon } from "@/features/projects/ui/ProjectChannelIcon";
 import type { Channel } from "@/shared/api/types";
 import { HashSearch } from "@/shared/ui/icons";
 
@@ -43,6 +45,8 @@ export function useChannelIntro({
   onOpenMembers?: () => void;
   onWelcomeAddAgent?: () => void;
 }) {
+  const projectHome = useIsProjectHomeChannel(activeChannel?.id);
+
   return React.useMemo(() => {
     if (!activeChannel || activeChannel.channelType === "dm") {
       return null;
@@ -81,7 +85,7 @@ export function useChannelIntro({
         actions,
         channelKindLabel: isWelcomeChannel(activeChannel)
           ? "private welcome channel"
-          : getChannelIntroKind(activeChannel),
+          : getChannelIntroKind(activeChannel, projectHome),
         channelName: activeChannel.name,
         description: isWelcomeChannel(activeChannel)
           ? null
@@ -124,9 +128,12 @@ export function useChannelIntro({
 
     return {
       actions,
-      channelKindLabel: getChannelIntroKind(activeChannel),
+      channelKindLabel: getChannelIntroKind(activeChannel, projectHome),
       channelName: activeChannel.name,
       description: getChannelIntroDescription(activeChannel),
+      icon: projectHome ? (
+        <ProjectChannelIcon className="h-7 w-7" />
+      ) : undefined,
     };
   }, [
     activeChannel,
@@ -136,5 +143,6 @@ export function useChannelIntro({
     onCreateChannel,
     onOpenMembers,
     onWelcomeAddAgent,
+    projectHome,
   ]);
 }

--- a/desktop/src/features/projects/lib/projectAgentConversation.test.mjs
+++ b/desktop/src/features/projects/lib/projectAgentConversation.test.mjs
@@ -148,6 +148,53 @@ test("pointers to unknown channels or agents are not restorable", () => {
   );
 });
 
+test("a stored project-channel pointer restores when it matches the home channel", () => {
+  const home = {
+    id: "project-channel-1",
+    channelType: "stream",
+    isMember: true,
+    memberPubkeys: [SELF_PUBKEY, AGENT_PUBKEY],
+    participantPubkeys: [],
+  };
+  const restored = restoreProjectsAgentConversation({
+    stored: {
+      agentPubkey: AGENT_PUBKEY,
+      channelId: home.id,
+      opener: OPENER,
+    },
+    channels: [home],
+    candidates: [AGENT],
+    currentPubkey: SELF_PUBKEY,
+    homeChannelId: home.id,
+  });
+  assert.equal(restored?.channel, home);
+  assert.equal(restored?.agent, AGENT);
+});
+
+test("a stored project-channel pointer does not restore a different home", () => {
+  const home = {
+    id: "project-channel-1",
+    channelType: "stream",
+    isMember: true,
+    memberPubkeys: [SELF_PUBKEY],
+    participantPubkeys: [],
+  };
+  assert.equal(
+    restoreProjectsAgentConversation({
+      stored: {
+        agentPubkey: AGENT_PUBKEY,
+        channelId: home.id,
+        opener: OPENER,
+      },
+      channels: [home],
+      candidates: [AGENT],
+      currentPubkey: SELF_PUBKEY,
+      homeChannelId: "other-project-channel",
+    }),
+    null,
+  );
+});
+
 test("a pointer naming a non-DM or foreign-participant channel is not restorable", () => {
   const stored = {
     agentPubkey: AGENT_PUBKEY,
@@ -530,6 +577,29 @@ test("the captured scope rides every relay side effect of a first send", async (
   // The opener is a thread root: no parent reference.
   assert.equal(backend.state.sends[0].request.parentEventId, undefined);
   assert.equal(result.channel.id, "dm-on-wss://tenant-a.example");
+});
+
+test("a home channel first send does not open a DM", async () => {
+  const backend = makeScopedBackend("wss://tenant-a.example");
+  const home = { id: "project-channel-1" };
+  const result = await submitProjectAgentMessage({
+    agent: { pubkey: AGENT_PUBKEY, isManaged: false, isActive: true },
+    conversation: null,
+    content: "build this project",
+    mentionPubkeys: [AGENT_PUBKEY],
+    relayScope: "wss://tenant-a.example",
+    signerScope: SELF_PUBKEY,
+    homeChannel: home,
+    startAgent: backend.startAgent,
+    openDm: () => {
+      throw new Error("project home chat must use the project channel");
+    },
+    send: backend.send,
+  });
+
+  assert.deepEqual(backend.state.dmOpens, []);
+  assert.equal(result.channel.id, home.id);
+  assert.equal(backend.state.sends[0].request.channelId, home.id);
 });
 
 test("follow-ups reply to the opener so same-second id ordering cannot hide them", async () => {

--- a/desktop/src/features/projects/lib/projectAgentConversation.ts
+++ b/desktop/src/features/projects/lib/projectAgentConversation.ts
@@ -54,11 +54,14 @@ export function restoreProjectsAgentConversation<
   channels,
   candidates,
   currentPubkey,
+  homeChannelId,
 }: {
   stored: StoredProjectsAgentConversation | null;
   channels: readonly Channel[];
   candidates: readonly Agent[];
   currentPubkey: string | null;
+  /** When set, a stored pointer to this project channel (not a DM) can restore. */
+  homeChannelId?: string | null;
 }): {
   channel: Channel;
   agent: Agent;
@@ -74,9 +77,16 @@ export function restoreProjectsAgentConversation<
   const agent = candidates.find(
     (candidate) => candidate.pubkey === agentPubkey,
   );
-  if (!channel || !agent || channel.channelType !== "dm") return null;
-  const participants = channel.participantPubkeys.map(normalizePubkey);
+  if (!channel || !agent) return null;
   const self = normalizePubkey(currentPubkey);
+  if (homeChannelId && channel.id === homeChannelId) {
+    // Project-home chat lives on the project channel. Membership is the
+    // restore proof — the channel is not a 1:1 DM.
+    if (!channel.isMember) return null;
+    return { agent, channel, opener: stored.opener };
+  }
+  if (channel.channelType !== "dm") return null;
+  const participants = channel.participantPubkeys.map(normalizePubkey);
   const hasAgent = participants.includes(agentPubkey);
   // The contract is participants === {agent, self}: requiring the current
   // user's own membership matters as much as rejecting strangers — a stored
@@ -159,6 +169,7 @@ export async function submitProjectAgentMessage<Ch extends { id: string }>({
   mediaTags,
   relayScope,
   signerScope,
+  homeChannel,
   startAgent,
   openDm,
   send,
@@ -174,6 +185,8 @@ export async function submitProjectAgentMessage<Ch extends { id: string }>({
   /** Signing identity (owner pubkey, hex) captured together with
    * `relayScope`; null when unknown. */
   signerScope: string | null;
+  /** When set, the first message lands here instead of opening a 1:1 DM. */
+  homeChannel?: Ch | null;
   startAgent: (input: {
     pubkey: string;
     expectedRelayUrl?: string;
@@ -205,6 +218,7 @@ export async function submitProjectAgentMessage<Ch extends { id: string }>({
   }
   const channel =
     conversation?.channel ??
+    homeChannel ??
     (await openDm({
       pubkeys: [agent.pubkey],
       expectedRelayUrl,

--- a/desktop/src/features/projects/lib/projectCollection.test.mjs
+++ b/desktop/src/features/projects/lib/projectCollection.test.mjs
@@ -75,9 +75,9 @@ function standaloneRepo(overrides = {}) {
   };
 }
 
-test("absorbStandaloneProjectRepositories folds a home-channel repo into the project", () => {
+test("absorbStandaloneProjectRepositories folds an authorized home-channel repo into the project", () => {
   const project = explicitProject();
-  const repoCard = standaloneRepo();
+  const repoCard = standaloneRepo({ repository: { maintainers: [OWNER] } });
   const folded = absorbStandaloneProjectRepositories([project, repoCard]);
 
   assert.equal(folded.length, 1);
@@ -85,6 +85,16 @@ test("absorbStandaloneProjectRepositories folds a home-channel repo into the pro
   assert.equal(folded[0].repositories.length, 1);
   assert.equal(folded[0].repositories[0].repoAddress, repoCard.projectAddress);
   assert.equal(folded[0].repositoryAddresses[0], repoCard.projectAddress);
+});
+
+test("absorbStandaloneProjectRepositories rejects a hostile home-channel claim", () => {
+  const project = explicitProject();
+  const repoCard = standaloneRepo();
+  const folded = absorbStandaloneProjectRepositories([project, repoCard]);
+
+  assert.equal(folded.length, 2);
+  assert.deepEqual(folded[0].repositories, []);
+  assert.equal(folded[1].projectAddress, repoCard.projectAddress);
 });
 
 test("absorbStandaloneProjectRepositories folds the owner's same-slug repo", () => {
@@ -115,14 +125,25 @@ test("absorbStandaloneProjectRepositories keeps an unrelated standalone repo", (
   );
 });
 
-test("homeRepositoriesToBind lists absorbed channel repos missing from the signed project", () => {
+test("homeRepositoriesToBind lists authorized absorbed channel repos missing from the signed project", () => {
+  const repo = standaloneRepo({ repository: { maintainers: [OWNER] } });
   const project = explicitProject({
-    repositories: [standaloneRepo().repositories[0]],
-    repositoryAddresses: [standaloneRepo().projectAddress],
+    repositories: [repo.repositories[0]],
+    repositoryAddresses: [repo.projectAddress],
   });
   const pending = homeRepositoriesToBind(project, []);
   assert.equal(pending.length, 1);
-  assert.equal(pending[0].repoAddress, standaloneRepo().projectAddress);
+  assert.equal(pending[0].repoAddress, repo.projectAddress);
+});
+
+test("homeRepositoriesToBind rejects a hostile absorbed channel repo", () => {
+  const repo = standaloneRepo();
+  const project = explicitProject({
+    repositories: [repo.repositories[0]],
+    repositoryAddresses: [repo.projectAddress],
+  });
+
+  assert.deepEqual(homeRepositoriesToBind(project, []), []);
 });
 
 test("homeRepositoriesToBind ignores repos already on the signed project", () => {

--- a/desktop/src/features/projects/lib/projectCollection.ts
+++ b/desktop/src/features/projects/lib/projectCollection.ts
@@ -19,13 +19,28 @@ function withAbsorbedRepository(
   };
 }
 
+function repositoryAuthorizesProjectOwner(
+  project: Project,
+  repository: Repository,
+): boolean {
+  const projectOwner = project.owner.toLowerCase();
+  if (repository.owner.toLowerCase() === projectOwner) return true;
+  return Boolean(
+    repository.maintainers?.some(
+      (maintainer) => maintainer.toLowerCase() === projectOwner,
+    ),
+  );
+}
+
 function hostForStandaloneRepository(
   explicitProjects: Project[],
   repository: Repository,
 ): Project | undefined {
   const channelHost = repository.channelId
     ? explicitProjects.find(
-        (project) => project.projectChannelId === repository.channelId,
+        (project) =>
+          project.projectChannelId === repository.channelId &&
+          repositoryAuthorizesProjectOwner(project, repository),
       )
     : undefined;
   if (channelHost) return channelHost;
@@ -41,8 +56,10 @@ function repositoryBelongsOnProjectHome(
 ): boolean {
   return Boolean(
     (repository.channelId &&
-      repository.channelId === project.projectChannelId) ||
-      (repository.owner === project.owner && repository.dtag === project.dtag),
+      repository.channelId === project.projectChannelId &&
+      repositoryAuthorizesProjectOwner(project, repository)) ||
+      (repository.owner.toLowerCase() === project.owner.toLowerCase() &&
+        repository.dtag === project.dtag),
   );
 }
 

--- a/desktop/src/features/projects/lib/projectDetailSearch.test.mjs
+++ b/desktop/src/features/projects/lib/projectDetailSearch.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseProjectDetailSearch,
+  wantsProjectRepositorySurface,
+} from "./projectDetailSearch.ts";
+
+test("parseProjectDetailSearch keeps forge params and channel panel params", () => {
+  const search = parseProjectDetailSearch({
+    repositoryId: "30617:owner:buzz",
+    tab: "files",
+    thread: "abc123",
+    agentSession: "def456",
+    channelManagement: "1",
+    extra: "dropped",
+  });
+
+  assert.equal(search.repositoryId, "30617:owner:buzz");
+  assert.equal(search.tab, "files");
+  assert.equal(search.thread, "abc123");
+  assert.equal(search.agentSession, "def456");
+  assert.equal(search.channelManagement, "1");
+  assert.equal("extra" in search, false);
+});
+
+test("parseProjectDetailSearch drops empty channel panel params", () => {
+  const search = parseProjectDetailSearch({
+    thread: "",
+    messageId: "",
+    tab: "not-a-tab",
+  });
+
+  assert.equal(search.thread, undefined);
+  assert.equal(search.messageId, undefined);
+  assert.equal(search.tab, undefined);
+});
+
+test("wantsProjectRepositorySurface is false for channel-first project home", () => {
+  assert.equal(
+    wantsProjectRepositorySurface({
+      projectId: "30621:owner:platform",
+    }),
+    false,
+  );
+});
+
+test("wantsProjectRepositorySurface is true for repo, tab, or work-item params", () => {
+  assert.equal(
+    wantsProjectRepositorySurface({
+      projectId: "30621:owner:platform",
+      repositoryId: "30617:owner:buzz",
+    }),
+    true,
+  );
+  assert.equal(
+    wantsProjectRepositorySurface({
+      projectId: "30621:owner:platform",
+      tab: "files",
+    }),
+    true,
+  );
+});
+
+test("wantsProjectRepositorySurface is true for a legacy kind:30617 project id", () => {
+  assert.equal(
+    wantsProjectRepositorySurface({
+      projectId: "30617:owner:buzz",
+    }),
+    true,
+  );
+});

--- a/desktop/src/features/projects/lib/projectDetailSearch.ts
+++ b/desktop/src/features/projects/lib/projectDetailSearch.ts
@@ -1,0 +1,65 @@
+import {
+  parseProfilePanelTab,
+  parseProfilePanelView,
+} from "@/features/profile/ui/UserProfilePanelUtils";
+import { KIND_REPO_ANNOUNCEMENT } from "@/shared/constants/kinds";
+import { isEntityLinkTab } from "@/shared/lib/entityLink";
+
+function optionalSearchString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Project detail URLs carry forge params (repository, tab, issue) and, on
+ * channel-first home, the same auxiliary-panel params a stream channel uses
+ * (thread, agent session, profile). Both must survive `validateSearch` or
+ * ChannelScreen cannot keep threads and agent activity on this route.
+ */
+export function parseProjectDetailSearch(search: Record<string, unknown>) {
+  return {
+    commitHash: optionalSearchString(search.commitHash),
+    pullRequestId: optionalSearchString(search.pullRequestId),
+    issueId: optionalSearchString(search.issueId),
+    repositoryId: optionalSearchString(search.repositoryId),
+    tab: isEntityLinkTab(search.tab) ? search.tab : undefined,
+    agentSession: nonEmptyString(search.agentSession),
+    agentSessionChannel: nonEmptyString(search.agentSessionChannel),
+    autoSend: nonEmptyString(search.autoSend),
+    channelManagement: nonEmptyString(search.channelManagement),
+    messageId: nonEmptyString(search.messageId),
+    profile: nonEmptyString(search.profile),
+    profileTab: parseProfilePanelTab(search.profileTab) ?? undefined,
+    profileView: parseProfilePanelView(search.profileView) ?? undefined,
+    thread: nonEmptyString(search.thread),
+    threadRootId: nonEmptyString(search.threadRootId),
+  };
+}
+
+/**
+ * Channel-first project home is the default. A repository forge surface is
+ * requested by an explicit repo/work-item search param, or by a legacy
+ * kind:30617 project id (the project *is* that repository).
+ */
+export function wantsProjectRepositorySurface(input: {
+  commitHash?: string;
+  issueId?: string;
+  projectId: string;
+  pullRequestId?: string;
+  repositoryId?: string;
+  tab?: string;
+}): boolean {
+  if (
+    input.repositoryId ||
+    input.tab ||
+    input.issueId ||
+    input.pullRequestId ||
+    input.commitHash
+  ) {
+    return true;
+  }
+  return input.projectId.startsWith(`${KIND_REPO_ANNOUNCEMENT}:`);
+}

--- a/desktop/src/features/projects/lib/projectHomeChannel.test.mjs
+++ b/desktop/src/features/projects/lib/projectHomeChannel.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { isProjectHomeChannel } from "./projectHomeChannel.ts";
+import {
+  hasAuthoritativeHomeBinding,
+  isProjectHomeChannel,
+} from "./projectHomeChannel.ts";
 
 const OWNER = "a".repeat(64);
 const MAINTAINER = "b".repeat(64);
@@ -39,6 +42,13 @@ test("isProjectHomeChannel accepts a repository that authorizes the project owne
       }),
     ]),
     true,
+  );
+});
+
+test("hasAuthoritativeHomeBinding rejects a bare project route assertion", () => {
+  assert.equal(
+    hasAuthoritativeHomeBinding(project({ repositories: [] })),
+    false,
   );
 });
 

--- a/desktop/src/features/projects/lib/projectHomeChannel.ts
+++ b/desktop/src/features/projects/lib/projectHomeChannel.ts
@@ -10,7 +10,9 @@ export type ProjectHomeCandidate = {
   }>;
 };
 
-function hasAuthoritativeHomeBinding(project: ProjectHomeCandidate): boolean {
+export function hasAuthoritativeHomeBinding(
+  project: ProjectHomeCandidate,
+): boolean {
   const channelId = project.projectChannelId;
   if (!channelId) return false;
 

--- a/desktop/src/features/projects/lib/projectHomeSummary.test.mjs
+++ b/desktop/src/features/projects/lib/projectHomeSummary.test.mjs
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { presentContextCount } from "./projectHomeSummary.ts";
+
+test("presentContextCount hides empty values", () => {
+  assert.equal(presentContextCount(undefined), undefined);
+  assert.equal(presentContextCount(0), undefined);
+  assert.equal(presentContextCount(3), 3);
+});

--- a/desktop/src/features/projects/lib/projectHomeSummary.ts
+++ b/desktop/src/features/projects/lib/projectHomeSummary.ts
@@ -1,0 +1,6 @@
+/** Right-edge context counts omit empty values, matching the Projects overview. */
+export function presentContextCount(
+  value: number | undefined,
+): number | undefined {
+  return value != null && value > 0 ? value : undefined;
+}

--- a/desktop/src/features/projects/lib/projectHomeWorkspaceSheet.test.mjs
+++ b/desktop/src/features/projects/lib/projectHomeWorkspaceSheet.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isProjectHomeWorkspaceSheetTab,
+  projectHomeWorkspaceSheetTitle,
+} from "./projectHomeWorkspaceSheet.ts";
+
+test("isProjectHomeWorkspaceSheetTab accepts overview workspace rows", () => {
+  assert.equal(isProjectHomeWorkspaceSheetTab("issues"), true);
+  assert.equal(isProjectHomeWorkspaceSheetTab("files"), true);
+  assert.equal(isProjectHomeWorkspaceSheetTab("channels"), false);
+  assert.equal(isProjectHomeWorkspaceSheetTab(undefined), false);
+});
+
+test("projectHomeWorkspaceSheetTitle matches overview row labels", () => {
+  assert.equal(projectHomeWorkspaceSheetTitle("issues"), "Tasks");
+  assert.equal(projectHomeWorkspaceSheetTitle("prs"), "Reviews");
+  assert.equal(projectHomeWorkspaceSheetTitle("commits"), "Commits");
+  assert.equal(projectHomeWorkspaceSheetTitle("files"), "Files");
+  assert.equal(projectHomeWorkspaceSheetTitle("contributors"), "People");
+});

--- a/desktop/src/features/projects/lib/projectHomeWorkspaceSheet.ts
+++ b/desktop/src/features/projects/lib/projectHomeWorkspaceSheet.ts
@@ -1,0 +1,33 @@
+export const PROJECT_HOME_WORKSPACE_SHEET_TABS = [
+  "issues",
+  "prs",
+  "commits",
+  "files",
+  "contributors",
+] as const;
+
+export type ProjectHomeWorkspaceSheetTab =
+  (typeof PROJECT_HOME_WORKSPACE_SHEET_TABS)[number];
+
+export function isProjectHomeWorkspaceSheetTab(
+  value: string | undefined,
+): value is ProjectHomeWorkspaceSheetTab {
+  return (
+    value != null &&
+    (PROJECT_HOME_WORKSPACE_SHEET_TABS as readonly string[]).includes(value)
+  );
+}
+
+const WORKSPACE_SHEET_TITLES: Record<ProjectHomeWorkspaceSheetTab, string> = {
+  commits: "Commits",
+  contributors: "People",
+  files: "Files",
+  issues: "Tasks",
+  prs: "Reviews",
+};
+
+export function projectHomeWorkspaceSheetTitle(
+  tab: ProjectHomeWorkspaceSheetTab,
+): string {
+  return WORKSPACE_SHEET_TITLES[tab];
+}

--- a/desktop/src/features/projects/lib/projectRelatedChannels.test.mjs
+++ b/desktop/src/features/projects/lib/projectRelatedChannels.test.mjs
@@ -3,6 +3,8 @@ import { test } from "node:test";
 
 import {
   collectProjectRelatedChannelRows,
+  listProjectBoundChannels,
+  listProjectChildChannels,
   projectRelatedChannelRowKey,
   uniqueProjectRelatedChannelCount,
 } from "./projectRelatedChannels.ts";
@@ -181,5 +183,137 @@ test("row keys distinguish project-level bindings from repository bindings", () 
       repositoryName: "buzz",
     }),
     `${CHANNEL_A}:project-buzz:repo-buzz`,
+  );
+});
+
+test("listProjectBoundChannels puts the home channel first", () => {
+  assert.deepEqual(
+    listProjectBoundChannels(
+      makeProject({
+        projectChannelId: CHANNEL_B,
+        repositories: [
+          makeRepository({ channelId: CHANNEL_A }),
+          makeRepository({
+            id: "repo-relay",
+            name: "relay-tools",
+            channelId: CHANNEL_A,
+          }),
+        ],
+      }),
+    ),
+    [
+      {
+        channelId: CHANNEL_B,
+        repositoryId: null,
+        role: "home",
+      },
+      {
+        channelId: CHANNEL_A,
+        repositoryId: "repo-buzz",
+        role: "related",
+      },
+    ],
+  );
+});
+
+test("listProjectBoundChannels omits a repository channel that is the home channel", () => {
+  assert.deepEqual(
+    listProjectBoundChannels(
+      makeProject({
+        projectChannelId: CHANNEL_A,
+        repositories: [makeRepository({ channelId: CHANNEL_A })],
+      }),
+    ),
+    [
+      {
+        channelId: CHANNEL_A,
+        repositoryId: null,
+        role: "home",
+      },
+    ],
+  );
+});
+
+test("listProjectBoundChannels is empty when nothing is bound", () => {
+  assert.deepEqual(listProjectBoundChannels(makeProject()), []);
+});
+
+test("listProjectBoundChannels includes extra related channels after home", () => {
+  const related = "33333333-3333-4333-8333-333333333333";
+  assert.deepEqual(
+    listProjectBoundChannels(
+      makeProject({
+        projectChannelId: CHANNEL_B,
+        relatedChannelIds: [related],
+        repositories: [makeRepository({ channelId: CHANNEL_A })],
+      }),
+    ),
+    [
+      {
+        channelId: CHANNEL_B,
+        repositoryId: null,
+        role: "home",
+      },
+      {
+        channelId: related,
+        repositoryId: null,
+        role: "related",
+      },
+      {
+        channelId: CHANNEL_A,
+        repositoryId: "repo-buzz",
+        role: "related",
+      },
+    ],
+  );
+});
+
+test("listProjectChildChannels omits the home channel", () => {
+  const related = "33333333-3333-4333-8333-333333333333";
+  assert.deepEqual(
+    listProjectChildChannels(
+      makeProject({
+        projectChannelId: CHANNEL_B,
+        relatedChannelIds: [related],
+        repositories: [makeRepository({ channelId: CHANNEL_A })],
+      }),
+    ),
+    [
+      {
+        channelId: related,
+        repositoryId: null,
+        role: "related",
+      },
+      {
+        channelId: CHANNEL_A,
+        repositoryId: "repo-buzz",
+        role: "related",
+      },
+    ],
+  );
+});
+
+test("collectProjectRelatedChannelRows includes extra related channels", () => {
+  const related = "33333333-3333-4333-8333-333333333333";
+  const rows = collectProjectRelatedChannelRows([
+    makeProject({
+      projectChannelId: CHANNEL_B,
+      relatedChannelIds: [related, CHANNEL_A],
+      repositories: [makeRepository()],
+    }),
+  ]);
+  assert.equal(
+    rows.some((row) => row.channelId === related && row.repositoryId == null),
+    true,
+  );
+  assert.equal(
+    uniqueProjectRelatedChannelCount([
+      makeProject({
+        projectChannelId: CHANNEL_B,
+        relatedChannelIds: [related],
+        repositories: [makeRepository()],
+      }),
+    ]),
+    3,
   );
 });

--- a/desktop/src/features/projects/lib/projectRelatedChannels.ts
+++ b/desktop/src/features/projects/lib/projectRelatedChannels.ts
@@ -4,6 +4,7 @@ export type ProjectRelatedChannelSource = {
   id: string;
   name: string;
   projectChannelId: string | null;
+  relatedChannelIds?: readonly string[];
   repositories: Array<{
     id: string;
     name: string;
@@ -57,6 +58,19 @@ export function collectProjectRelatedChannelRows(
         repositoryId: null,
         repositoryName: null,
       });
+      repositoryChannelIds.add(projectChannelId);
+    }
+    for (const relatedChannelId of project.relatedChannelIds ?? []) {
+      const channelId = trimmedChannelId(relatedChannelId);
+      if (!channelId || repositoryChannelIds.has(channelId)) continue;
+      repositoryChannelIds.add(channelId);
+      rows.push({
+        channelId,
+        projectId: project.id,
+        projectName: project.name,
+        repositoryId: null,
+        repositoryName: null,
+      });
     }
   }
   return rows;
@@ -72,4 +86,69 @@ export function uniqueProjectRelatedChannelCount(
 
 export function projectRelatedChannelRowKey(row: ProjectRelatedChannelRow) {
   return `${row.channelId}:${row.projectId}:${row.repositoryId ?? "project"}`;
+}
+
+export type ProjectBoundChannel = {
+  channelId: string;
+  repositoryId: string | null;
+  role: "home" | "related";
+};
+
+/**
+ * Unique channels bound to one project: the home stream first, then each
+ * repository channel that is not already the home channel.
+ */
+export function listProjectBoundChannels(
+  project: Pick<
+    ProjectRelatedChannelSource,
+    "projectChannelId" | "relatedChannelIds" | "repositories"
+  >,
+): ProjectBoundChannel[] {
+  const channels: ProjectBoundChannel[] = [];
+  const seen = new Set<string>();
+  const homeChannelId = trimmedChannelId(project.projectChannelId);
+  if (homeChannelId) {
+    channels.push({
+      channelId: homeChannelId,
+      repositoryId: null,
+      role: "home",
+    });
+    seen.add(homeChannelId);
+  }
+  for (const relatedChannelId of project.relatedChannelIds ?? []) {
+    const channelId = trimmedChannelId(relatedChannelId);
+    if (!channelId || seen.has(channelId)) continue;
+    channels.push({
+      channelId,
+      repositoryId: null,
+      role: "related",
+    });
+    seen.add(channelId);
+  }
+  for (const repository of project.repositories) {
+    const channelId = trimmedChannelId(repository.channelId);
+    if (!channelId || seen.has(channelId)) continue;
+    channels.push({
+      channelId,
+      repositoryId: repository.id,
+      role: "related",
+    });
+    seen.add(channelId);
+  }
+  return channels;
+}
+
+/**
+ * Nested sidebar rows under a project: bound streams except the home
+ * channel, which is the project row itself.
+ */
+export function listProjectChildChannels(
+  project: Pick<
+    ProjectRelatedChannelSource,
+    "projectChannelId" | "relatedChannelIds" | "repositories"
+  >,
+): ProjectBoundChannel[] {
+  return listProjectBoundChannels(project).filter(
+    (channel) => channel.role !== "home",
+  );
 }

--- a/desktop/src/features/projects/ui/ProjectAgentChatPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectAgentChatPanel.tsx
@@ -24,6 +24,7 @@ import {
 import { MessageComposer } from "@/features/messages/ui/MessageComposer";
 import { useProfileQuery, useUsersBatchQuery } from "@/features/profile/hooks";
 import { useIdentityQuery } from "@/shared/api/hooks";
+import { addChannelMembers } from "@/shared/api/tauri";
 import { sendChannelMessage } from "@/shared/api/tauriMessages";
 import type { Channel } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
@@ -45,25 +46,29 @@ type ProjectAgentConversation = {
 };
 
 export function ProjectAgentChatPanel({
-  canResetWidth,
+  canResetWidth = false,
   constrainToAvailableSpace = true,
   context,
   detached = false,
+  homeChannel = null,
+  layout = "pane",
   onClose,
   onResetWidth,
   onResizeStart,
   sharedHeaderBackdrop,
-  widthPx,
+  widthPx = 0,
 }: {
-  canResetWidth: boolean;
+  canResetWidth?: boolean;
   constrainToAvailableSpace?: boolean;
   context: ProjectDetailAgentContext;
   detached?: boolean;
+  homeChannel?: Channel | null;
+  layout?: "pane" | "canvas";
   onClose?: () => void;
-  onResetWidth: () => void;
-  onResizeStart: (event: React.PointerEvent<HTMLButtonElement>) => void;
+  onResetWidth?: () => void;
+  onResizeStart?: (event: React.PointerEvent<HTMLButtonElement>) => void;
   sharedHeaderBackdrop?: boolean;
-  widthPx: number;
+  widthPx?: number;
 }) {
   const { activeCommunity } = useCommunities();
   const identityQuery = useIdentityQuery();
@@ -119,11 +124,13 @@ export function ProjectAgentChatPanel({
         candidates,
         channels: channelsQuery.data ?? [],
         currentPubkey: identityQuery.data?.pubkey ?? null,
+        homeChannelId: homeChannel?.id ?? null,
         stored: storedConversation,
       }),
     [
       candidates,
       channelsQuery.data,
+      homeChannel?.id,
       identityQuery.data?.pubkey,
       storedConversation,
     ],
@@ -148,10 +155,24 @@ export function ProjectAgentChatPanel({
         // `submitProjectAgentMessage` binds every relay side effect to the
         // scope captured here (fail closed), and threads follow-ups onto the
         // opener so a same-second follow-up cannot be hidden by id ordering.
+        if (homeChannel) {
+          const alreadyMember = homeChannel.memberPubkeys.some(
+            (pubkey) =>
+              normalizePubkey(pubkey) === normalizePubkey(selectedAgent.pubkey),
+          );
+          if (!alreadyMember) {
+            await addChannelMembers({
+              channelId: homeChannel.id,
+              pubkeys: [selectedAgent.pubkey],
+              role: "bot",
+            });
+          }
+        }
         const { channel, sent } = await submitProjectAgentMessage({
           agent: selectedAgent,
           conversation,
           content: `${trimmed}${contextPayload}`,
+          homeChannel,
           mentionPubkeys: [
             ...new Set([...mentionPubkeys, selectedAgent.pubkey]),
           ],
@@ -209,6 +230,7 @@ export function ProjectAgentChatPanel({
     [
       contextPayload,
       conversation,
+      homeChannel,
       identityQuery.data?.pubkey,
       isSending,
       openDmMutation,
@@ -225,98 +247,122 @@ export function ProjectAgentChatPanel({
     setConversation(null);
   }, [storageScope]);
 
-  return (
-    <RightAuxiliaryPane
-      canResetWidth={canResetWidth}
-      constrainToAvailableSpace={constrainToAvailableSpace}
-      detached={detached}
-      onResetWidth={onResetWidth}
-      onResizeStart={onResizeStart}
-      testId="project-agent-chat-panel"
-      widthPx={widthPx}
+  const conversationBody = (
+    <div
+      className={cn(
+        "relative flex min-h-0 min-w-0 flex-1 flex-col",
+        (detached || layout === "canvas") && "bg-background",
+      )}
     >
-      <div
-        className={cn(
-          "relative flex min-h-0 min-w-0 flex-1 flex-col",
-          detached && "bg-background",
-        )}
-      >
+      {layout === "pane" ? (
         <ProjectAgentContextStrip
           context={context}
           onClose={onClose}
           sharedBackdrop={sharedHeaderBackdrop}
         />
-        <div className="flex min-h-0 flex-1 flex-col">
-          <div
-            className="flex min-h-0 flex-1 flex-col overflow-x-hidden overflow-y-auto pb-4 pt-[4.25rem]"
-            data-testid="project-agent-conversation-scroll"
-          >
-            {conversation ? (
-              <ConversationThread
-                agent={conversation.agent}
-                agentAvatarUrl={selectedAgentAvatarUrl}
-                channel={conversation.channel}
-                currentPubkey={identityQuery.data?.pubkey ?? null}
-                selfAvatarUrl={profileQuery.data?.avatarUrl ?? null}
-                opener={conversation.opener}
-              />
-            ) : (
-              <div className="flex min-h-40 flex-1 flex-col items-center justify-center gap-2 text-center">
-                <p className="text-sm font-medium text-foreground">
-                  Ask about this page
-                </p>
-                <p className="max-w-56 text-xs text-muted-foreground">
-                  Start a conversation with the project agent.
-                </p>
-              </div>
-            )}
-          </div>
-          {context.selection?.length ? (
-            <ProjectAgentSelectionComposerBanner items={context.selection} />
-          ) : null}
-          <MessageComposer
-            channelId={conversation?.channel.id ?? null}
-            channelName={selectedAgent?.name ?? "project agent"}
-            channelType="dm"
-            containerClassName="px-3 pb-3"
-            disabled={!selectedAgent || isSending}
-            draftKey={`project-agent:${storageScope ?? "unscoped"}`}
-            isSending={isSending}
-            layoutMode="standalone"
-            onSend={handleSubmit}
-            placeholder={
-              selectedAgent
-                ? `Message ${selectedAgent.name}`
-                : "No agents available"
-            }
-            profiles={candidateProfilesQuery.data?.profiles}
-            showBackgroundUploadProgress={false}
-            showTopBorder={false}
-            toolbarExtraActions={
-              <>
-                <AgentContextPayloadPreview
-                  iconOnly
-                  payload={contextPayload}
-                  triggerLabel="Preview message context"
-                />
-                {conversation ? (
-                  <Button
-                    aria-label="Clear project agent chat"
-                    className="h-7 w-7"
-                    onClick={handleClear}
-                    size="icon"
-                    title="Clear conversation"
-                    type="button"
-                    variant="ghost"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
-                ) : null}
-              </>
-            }
-          />
+      ) : null}
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div
+          className={cn(
+            "flex min-h-0 flex-1 flex-col overflow-x-hidden overflow-y-auto pb-4",
+            layout === "pane" ? "pt-[4.25rem]" : "pt-6",
+          )}
+          data-testid="project-agent-conversation-scroll"
+        >
+          {conversation ? (
+            <ConversationThread
+              agent={conversation.agent}
+              agentAvatarUrl={selectedAgentAvatarUrl}
+              channel={conversation.channel}
+              currentPubkey={identityQuery.data?.pubkey ?? null}
+              selfAvatarUrl={profileQuery.data?.avatarUrl ?? null}
+              opener={conversation.opener}
+            />
+          ) : (
+            <div className="flex min-h-40 flex-1 flex-col items-center justify-center gap-2 text-center">
+              <p className="text-sm font-medium text-foreground">
+                {homeChannel
+                  ? "Explain what this project should be"
+                  : "Ask about this page"}
+              </p>
+              <p className="max-w-72 text-xs text-muted-foreground">
+                {homeChannel
+                  ? "The project agent will build it out from this channel."
+                  : "Start a conversation with the project agent."}
+              </p>
+            </div>
+          )}
         </div>
+        {context.selection?.length ? (
+          <ProjectAgentSelectionComposerBanner items={context.selection} />
+        ) : null}
+        <MessageComposer
+          channelId={conversation?.channel.id ?? homeChannel?.id ?? null}
+          channelName={selectedAgent?.name ?? "project agent"}
+          channelType={homeChannel?.channelType ?? "dm"}
+          containerClassName="px-3 pb-3"
+          disabled={!selectedAgent || isSending}
+          draftKey={`project-agent:${storageScope ?? "unscoped"}`}
+          isSending={isSending}
+          layoutMode="standalone"
+          onSend={handleSubmit}
+          placeholder={
+            selectedAgent
+              ? `Message ${selectedAgent.name}`
+              : "No agents available"
+          }
+          profiles={candidateProfilesQuery.data?.profiles}
+          showBackgroundUploadProgress={false}
+          showTopBorder={false}
+          toolbarExtraActions={
+            <>
+              <AgentContextPayloadPreview
+                iconOnly
+                payload={contextPayload}
+                triggerLabel="Preview message context"
+              />
+              {conversation ? (
+                <Button
+                  aria-label="Clear project agent chat"
+                  className="h-7 w-7"
+                  onClick={handleClear}
+                  size="icon"
+                  title="Clear conversation"
+                  type="button"
+                  variant="ghost"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              ) : null}
+            </>
+          }
+        />
       </div>
+    </div>
+  );
+
+  if (layout === "canvas") {
+    return (
+      <div
+        className="flex min-h-0 min-w-0 flex-1 flex-col"
+        data-testid="project-agent-chat-panel"
+      >
+        {conversationBody}
+      </div>
+    );
+  }
+
+  return (
+    <RightAuxiliaryPane
+      canResetWidth={canResetWidth}
+      constrainToAvailableSpace={constrainToAvailableSpace}
+      detached={detached}
+      onResetWidth={onResetWidth ?? (() => {})}
+      onResizeStart={onResizeStart ?? (() => {})}
+      testId="project-agent-chat-panel"
+      widthPx={widthPx}
+    >
+      {conversationBody}
     </RightAuxiliaryPane>
   );
 }

--- a/desktop/src/features/projects/ui/ProjectChannelHome.tsx
+++ b/desktop/src/features/projects/ui/ProjectChannelHome.tsx
@@ -1,0 +1,336 @@
+import { useSearch } from "@tanstack/react-router";
+import { Info } from "lucide-react";
+import * as React from "react";
+
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { useChannelsQuery } from "@/features/channels/hooks";
+import { ChannelScreenLoadingFallback } from "@/features/channels/ui/ChannelScreenLoadingFallback";
+import { useProfileQuery } from "@/features/profile/hooks";
+import type { Project } from "@/features/projects/hooks";
+import {
+  isProjectHomeWorkspaceSheetTab,
+  projectHomeWorkspaceSheetTitle,
+  type ProjectHomeWorkspaceSheetTab,
+} from "@/features/projects/lib/projectHomeWorkspaceSheet";
+import { useHealProjectHomeRepositories } from "@/features/projects/useHealProjectHomeRepositories";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import type { RelayEvent } from "@/shared/api/types";
+import type { EntityLinkTab } from "@/shared/lib/entityLink";
+import { useThreadPanelWidth } from "@/shared/hooks/useThreadPanelWidth";
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { DrawerPanelIcon } from "@/shared/ui/DrawerPanelIcon";
+import { useOptionalSidebar } from "@/shared/ui/sidebar";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+import { ViewLoadingFallback } from "@/shared/ui/ViewLoadingFallback";
+import { ProjectContextRail } from "./ProjectContextRail";
+import { ProjectDetailChrome } from "./ProjectDetailChrome";
+import { ProjectHomeColumn } from "./ProjectHomeColumn";
+import { ProjectHomeContextPanel } from "./ProjectHomeContextPanel";
+import { ProjectHomeWorkspaceSheet } from "./ProjectHomeWorkspaceSheet";
+import { ProjectRepositoryManagement } from "./ProjectRepositoryManagement";
+
+const EMPTY_TARGET_MESSAGE_EVENTS: RelayEvent[] = [];
+const PROJECT_HOME_SUMMARY_WIDTH_KEY =
+  "buzz.desktop.project-home-summary-width";
+
+const ChannelScreenView = React.lazy(async () => {
+  const module = await import("@/features/channels/ui/ChannelScreen");
+  return { default: module.ChannelScreen };
+});
+
+function ignoreForumPost() {}
+function ignoreForumPostSelect() {}
+
+function ProjectHomeHeaderToggle({
+  children,
+  label,
+  onClick,
+  open,
+  testId,
+}: {
+  children: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  open: boolean;
+  testId: string;
+}) {
+  return (
+    <Tooltip disableHoverableContent>
+      <TooltipTrigger asChild>
+        <Button
+          aria-label={open ? `Hide ${label}` : `Show ${label}`}
+          aria-pressed={open}
+          className="h-7 w-7 text-sidebar-foreground hover:bg-sidebar-accent"
+          data-testid={testId}
+          onClick={onClick}
+          size="icon"
+          title={label}
+          type="button"
+          variant="ghost"
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function ProjectChannelHome({
+  project,
+  projects,
+}: {
+  project: Project;
+  projects: Project[];
+}) {
+  const { goChannel, goProject, goProjects } = useAppNavigation();
+  const sidebar = useOptionalSidebar();
+  const identityQuery = useIdentityQuery();
+  const profileQuery = useProfileQuery();
+  const channelsQuery = useChannelsQuery();
+  const search = useSearch({ strict: false }) as {
+    autoSend?: string;
+    messageId?: string;
+  };
+  const [summaryOpen, setSummaryOpen] = React.useState(true);
+  const [addRepositoryOpen, setAddRepositoryOpen] = React.useState(false);
+  const [workspaceSheetTab, setWorkspaceSheetTab] =
+    React.useState<ProjectHomeWorkspaceSheetTab | null>(null);
+  const [workspaceRepositoryId, setWorkspaceRepositoryId] = React.useState<
+    string | null
+  >(null);
+  const summaryWidth = useThreadPanelWidth(undefined, {
+    sessionKey: PROJECT_HOME_SUMMARY_WIDTH_KEY,
+  });
+  const homeChannel =
+    channelsQuery.data?.find(
+      (channel) => channel.id === project.projectChannelId,
+    ) ?? null;
+  const waitingForChannel = channelsQuery.isPending && !homeChannel;
+  const workspaceRepository =
+    project.repositories.find(
+      (repository) => repository.id === workspaceRepositoryId,
+    ) ??
+    project.repositories[0] ??
+    null;
+  const workspaceSheetOpen =
+    workspaceSheetTab != null && workspaceRepository != null;
+  const summaryVisible = summaryOpen && !workspaceSheetOpen;
+
+  const openWorkspaceSheet = React.useCallback(
+    (tab: ProjectHomeWorkspaceSheetTab, repositoryId?: string) => {
+      if (repositoryId) {
+        setWorkspaceRepositoryId(repositoryId);
+      }
+      setWorkspaceSheetTab((current) => (current === tab ? null : tab));
+    },
+    [],
+  );
+  const closeWorkspaceSheet = React.useCallback(() => {
+    setWorkspaceSheetTab(null);
+  }, []);
+  const handleOpenWorkspace = React.useCallback(
+    (repositoryId: string, tab?: EntityLinkTab) => {
+      if (!isProjectHomeWorkspaceSheetTab(tab)) {
+        void goProject(project.id, { repositoryId, tab });
+        return;
+      }
+      openWorkspaceSheet(tab, repositoryId);
+    },
+    [goProject, openWorkspaceSheet, project.id],
+  );
+  const handleOpenRepository = React.useCallback(
+    (repositoryId: string) => {
+      void goProject(project.id, { repositoryId });
+    },
+    [goProject, project.id],
+  );
+  const handleRepositoryChange = React.useCallback(() => {
+    void goProject(project.id);
+  }, [goProject, project.id]);
+  const handleAddFiles = React.useCallback(() => {
+    setAddRepositoryOpen(true);
+  }, []);
+  const handleFilesAdded = React.useCallback((repositoryId: string) => {
+    setWorkspaceRepositoryId(repositoryId);
+    setWorkspaceSheetTab("files");
+  }, []);
+  const handleToggleFilesSheet = React.useCallback(() => {
+    if (!workspaceRepository) {
+      handleAddFiles();
+      return;
+    }
+    openWorkspaceSheet("files", workspaceRepository.id);
+  }, [handleAddFiles, openWorkspaceSheet, workspaceRepository]);
+  useHealProjectHomeRepositories(project, identityQuery.data?.pubkey);
+  const handleOpenCommit = React.useCallback(
+    (commitHash: string) => {
+      if (!workspaceRepository) return;
+      void goProject(project.id, {
+        commitHash,
+        repositoryId: workspaceRepository.id,
+        tab: "commits",
+      });
+    },
+    [goProject, project.id, workspaceRepository],
+  );
+  const workspaceSheet =
+    workspaceSheetOpen && workspaceSheetTab && workspaceRepository ? (
+      <ProjectHomeWorkspaceSheet
+        key={`${workspaceSheetTab}:${workspaceRepository.id}`}
+        identityPubkey={identityQuery.data?.pubkey}
+        onOpenCommit={handleOpenCommit}
+        onRepositoryAdded={handleFilesAdded}
+        onSelectRepository={setWorkspaceRepositoryId}
+        project={project}
+        projects={projects}
+        repository={workspaceRepository}
+        tab={workspaceSheetTab}
+      />
+    ) : null;
+
+  return (
+    <div
+      className={cn(
+        "relative flex min-h-0 min-w-0 flex-1 overflow-hidden",
+        summaryVisible && "bg-sidebar pb-2 pr-2 pt-px",
+        summaryVisible && sidebar?.open === false && "pl-2",
+      )}
+      data-project-context-detached={summaryVisible ? "true" : undefined}
+      data-project-detail-screen
+      data-testid="project-channel-home"
+    >
+      <div
+        className={cn(
+          "relative flex min-h-0 min-w-60 flex-1 flex-col overflow-hidden",
+          summaryVisible ? "ml-px rounded-2xl bg-background" : "bg-muted/20",
+        )}
+      >
+        <ProjectDetailChrome
+          actions={
+            <>
+              <ProjectHomeHeaderToggle
+                label="Overview"
+                onClick={() => {
+                  if (workspaceSheetOpen) {
+                    closeWorkspaceSheet();
+                    return;
+                  }
+                  setSummaryOpen((open) => !open);
+                }}
+                open={summaryVisible}
+                testId="project-home-drawer-toggle"
+              >
+                <Info
+                  className={cn(
+                    "h-4 w-4 transition-opacity duration-200 ease-linear",
+                    summaryVisible ? "opacity-100" : "opacity-60",
+                  )}
+                />
+              </ProjectHomeHeaderToggle>
+              <ProjectHomeHeaderToggle
+                label="Files"
+                onClick={handleToggleFilesSheet}
+                open={workspaceSheetTab === "files"}
+                testId="project-home-codebase-toggle"
+              >
+                <DrawerPanelIcon
+                  className="-scale-x-100"
+                  side={workspaceSheetTab === "files" ? "left" : "right"}
+                />
+              </ProjectHomeHeaderToggle>
+            </>
+          }
+          activeTabCrumb={null}
+          activeWorkItemCrumb={null}
+          onGoProjectHome={() => undefined}
+          onGoProjects={() => {
+            void goProjects();
+          }}
+          project={project}
+        />
+        {waitingForChannel ? (
+          <ViewLoadingFallback kind="channel" />
+        ) : homeChannel ? (
+          <React.Suspense
+            fallback={
+              <ChannelScreenLoadingFallback isHuddleTranscript={false} />
+            }
+          >
+            <ChannelScreenView
+              activeChannel={homeChannel}
+              autoSendDraftKey={search.autoSend ?? null}
+              currentIdentity={identityQuery.data}
+              currentProfile={profileQuery.data}
+              idleAuxiliaryPanel={workspaceSheet}
+              idleAuxiliaryTitle={
+                workspaceSheetTab
+                  ? projectHomeWorkspaceSheetTitle(workspaceSheetTab)
+                  : ""
+              }
+              onAddFiles={handleAddFiles}
+              onCloseIdleAuxiliaryPanel={closeWorkspaceSheet}
+              onCloseForumPost={ignoreForumPost}
+              onSelectForumPost={ignoreForumPostSelect}
+              selectedForumPostId={null}
+              targetForumReplyId={null}
+              targetMessageEvents={EMPTY_TARGET_MESSAGE_EVENTS}
+              targetMessageId={search.messageId ?? null}
+            />
+          </React.Suspense>
+        ) : (
+          <div className="flex min-h-0 flex-1 items-center justify-center px-6 py-8">
+            <p className="text-sm text-muted-foreground">
+              This project's channel could not be found.
+            </p>
+          </div>
+        )}
+      </div>
+      <ProjectRepositoryManagement
+        createOpen={addRepositoryOpen}
+        hideTriggers
+        identityPubkey={identityQuery.data?.pubkey}
+        onChange={handleFilesAdded}
+        onCreateOpenChange={setAddRepositoryOpen}
+        project={project}
+        projects={projects}
+      />
+      <ProjectContextRail
+        open={summaryVisible}
+        panelWidthPx={summaryWidth.widthPx}
+        resizing={summaryWidth.isResizing}
+        testId="project-home-summary-rail"
+      >
+        {summaryVisible ? (
+          <ProjectHomeColumn
+            bodyClassName="overflow-y-auto overflow-x-hidden overscroll-contain"
+            canResetWidth={summaryWidth.canReset}
+            onClose={() => setSummaryOpen(false)}
+            onResetWidth={summaryWidth.onResetWidth}
+            onResizeStart={summaryWidth.onResizeStart}
+            testId="project-home-summary-column"
+            title="Overview"
+            widthPx={summaryWidth.widthPx}
+          >
+            <ProjectHomeContextPanel
+              activeWorkspaceTab={workspaceSheetTab}
+              channel={homeChannel}
+              channels={channelsQuery.data ?? []}
+              identityPubkey={identityQuery.data?.pubkey}
+              onAddRepository={handleAddFiles}
+              onOpenChannel={(channelId) => {
+                void goChannel(channelId);
+              }}
+              onOpenRepository={handleOpenRepository}
+              onOpenWorkspace={handleOpenWorkspace}
+              onRepositoryChange={handleRepositoryChange}
+              project={project}
+              projects={projects}
+            />
+          </ProjectHomeColumn>
+        ) : null}
+      </ProjectContextRail>
+    </div>
+  );
+}

--- a/desktop/src/features/projects/ui/ProjectChannelManagement.tsx
+++ b/desktop/src/features/projects/ui/ProjectChannelManagement.tsx
@@ -1,0 +1,78 @@
+import { Plus } from "lucide-react";
+import * as React from "react";
+import { toast } from "sonner";
+
+import { useIsManagedAgent } from "@/features/agent-memory/hooks";
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { ownsAuthorAgent } from "@/features/profile/lib/identity";
+import type { Project } from "@/features/projects/hooks";
+import { useAddProjectChannelMutation } from "@/features/projects/useAddProjectChannel";
+import { CreateChannelDialog } from "@/features/sidebar/ui/CreateChannelDialog";
+import { Button } from "@/shared/ui/button";
+
+export function ProjectChannelManagement({
+  identityPubkey,
+  project,
+}: {
+  identityPubkey?: string;
+  project: Project;
+}) {
+  const { goChannel } = useAppNavigation();
+  const [createOpen, setCreateOpen] = React.useState(false);
+  const createMutation = useAddProjectChannelMutation();
+  const ownerProfileQuery = useUsersBatchQuery([project.owner], {
+    enabled: Boolean(identityPubkey),
+  });
+  const projectOwnerProfile =
+    ownerProfileQuery.data?.profiles[project.owner.toLowerCase()];
+  const projectOwnerIsManaged = useIsManagedAgent(project.owner) === true;
+  const viewerIsProjectOwner =
+    identityPubkey?.toLowerCase() === project.owner.toLowerCase();
+  const viewerOwnsProjectAgent = ownsAuthorAgent(
+    projectOwnerProfile,
+    identityPubkey,
+  );
+  const canEdit =
+    !project.legacy &&
+    (viewerIsProjectOwner || projectOwnerIsManaged || viewerOwnsProjectAgent);
+  const ownerControlAgentPubkey =
+    viewerOwnsProjectAgent && !projectOwnerIsManaged && !viewerIsProjectOwner
+      ? project.owner
+      : undefined;
+
+  if (!canEdit) return null;
+
+  return (
+    <>
+      <CreateChannelDialog
+        channelKind={createOpen ? "stream" : null}
+        description="Add another stream to this project. A template can keep the same canvas and agents."
+        isCreating={createMutation.isPending}
+        onCreate={async (input) => {
+          const result = await createMutation.mutateAsync({
+            ...input,
+            ownerControlAgentPubkey,
+            project,
+          });
+          toast.success(`Channel "#${result.channel.name}" created.`);
+          await goChannel(result.channel.id);
+        }}
+        onOpenChange={setCreateOpen}
+        testId="create-project-channel-dialog"
+        title="Create a project channel"
+      />
+      <Button
+        aria-label="Add channel"
+        className="h-6 w-6 shrink-0 rounded-md text-muted-foreground hover:bg-muted/70 hover:text-foreground"
+        data-testid="add-project-channel"
+        onClick={() => setCreateOpen(true)}
+        size="icon"
+        type="button"
+        variant="ghost"
+      >
+        <Plus className="h-4 w-4" />
+      </Button>
+    </>
+  );
+}

--- a/desktop/src/features/projects/ui/ProjectDetailChrome.tsx
+++ b/desktop/src/features/projects/ui/ProjectDetailChrome.tsx
@@ -26,8 +26,63 @@ export function ProjectDetailChrome({
   onGoProjectHome: () => void;
   onGoProjects: () => void;
   project: Project;
-  repository: Repository;
+  repository?: Repository | null;
 }) {
+  const repositoryCrumb = repository ? (
+    activeWorkItemCrumb ? (
+      <>
+        <button
+          className="min-w-0 truncate rounded-md px-0.5 py-1 font-medium transition-colors hover:text-sidebar-accent-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+          data-testid="project-breadcrumb-repository"
+          onClick={onGoProjectHome}
+          type="button"
+        >
+          {repository.name}
+        </button>
+        <ChevronRight className="h-3 w-3 shrink-0 opacity-60" />
+        <button
+          className="shrink-0 rounded-md px-0.5 py-1 font-medium transition-colors hover:text-sidebar-accent-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+          onClick={activeWorkItemCrumb.clear}
+          type="button"
+        >
+          {activeWorkItemCrumb.category}
+        </button>
+        <ChevronRight className="h-3 w-3 shrink-0 opacity-60" />
+        <span
+          aria-current="page"
+          className="min-w-0 truncate px-0.5 font-medium opacity-60"
+        >
+          {activeWorkItemCrumb.title}
+        </span>
+      </>
+    ) : activeTabCrumb ? (
+      <>
+        <button
+          className="min-w-0 truncate rounded-md px-0.5 py-1 font-medium transition-colors hover:text-sidebar-accent-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+          data-testid="project-breadcrumb-repository"
+          onClick={onGoProjectHome}
+          type="button"
+        >
+          {repository.name}
+        </button>
+        <ChevronRight className="h-3 w-3 shrink-0 opacity-60" />
+        <span
+          aria-current="page"
+          className="min-w-0 truncate px-0.5 font-medium opacity-60"
+        >
+          {activeTabCrumb}
+        </span>
+      </>
+    ) : (
+      <span
+        aria-current="page"
+        className="min-w-0 truncate px-0.5 font-medium opacity-60"
+        data-testid="project-breadcrumb-repository"
+      >
+        {repository.name}
+      </span>
+    )
+  ) : null;
   return (
     <AppTopChromePortal>
       <div
@@ -51,66 +106,26 @@ export function ProjectDetailChrome({
             Projects
           </button>
           <ChevronRight className="h-3 w-3 shrink-0 opacity-60" />
-          <button
-            className="min-w-0 truncate rounded-md px-0.5 py-1 font-medium transition-colors hover:text-sidebar-accent-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-            data-testid="project-breadcrumb-project"
-            onClick={onGoProjectHome}
-            type="button"
-          >
-            {project.name}
-          </button>
-          <ChevronRight className="h-3 w-3 shrink-0 opacity-60" />
-          {activeWorkItemCrumb ? (
+          {repositoryCrumb ? (
             <>
               <button
                 className="min-w-0 truncate rounded-md px-0.5 py-1 font-medium transition-colors hover:text-sidebar-accent-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-                data-testid="project-breadcrumb-repository"
+                data-testid="project-breadcrumb-project"
                 onClick={onGoProjectHome}
                 type="button"
               >
-                {repository.name}
+                {project.name}
               </button>
               <ChevronRight className="h-3 w-3 shrink-0 opacity-60" />
-              <button
-                className="shrink-0 rounded-md px-0.5 py-1 font-medium transition-colors hover:text-sidebar-accent-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-                onClick={activeWorkItemCrumb.clear}
-                type="button"
-              >
-                {activeWorkItemCrumb.category}
-              </button>
-              <ChevronRight className="h-3 w-3 shrink-0 opacity-60" />
-              <span
-                aria-current="page"
-                className="min-w-0 truncate px-0.5 font-medium opacity-60"
-              >
-                {activeWorkItemCrumb.title}
-              </span>
-            </>
-          ) : activeTabCrumb ? (
-            <>
-              <button
-                className="min-w-0 truncate rounded-md px-0.5 py-1 font-medium transition-colors hover:text-sidebar-accent-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-                data-testid="project-breadcrumb-repository"
-                onClick={onGoProjectHome}
-                type="button"
-              >
-                {repository.name}
-              </button>
-              <ChevronRight className="h-3 w-3 shrink-0 opacity-60" />
-              <span
-                aria-current="page"
-                className="min-w-0 truncate px-0.5 font-medium opacity-60"
-              >
-                {activeTabCrumb}
-              </span>
+              {repositoryCrumb}
             </>
           ) : (
             <span
               aria-current="page"
               className="min-w-0 truncate px-0.5 font-medium opacity-60"
-              data-testid="project-breadcrumb-repository"
+              data-testid="project-breadcrumb-project"
             >
-              {repository.name}
+              {project.name}
             </span>
           )}
         </nav>

--- a/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
+++ b/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
@@ -45,6 +45,8 @@ import {
   projectRepoUnavailableReason,
   refineRepoUnavailableReason,
 } from "@/features/projects/lib/projectRepoAvailability";
+import { wantsProjectRepositorySurface } from "@/features/projects/lib/projectDetailSearch";
+import { hasAuthoritativeHomeBinding } from "@/features/projects/lib/projectHomeChannel";
 import { selectProjectRepository } from "@/features/projects/projectModels";
 import { ProjectSelectionProvider } from "@/features/projects/lib/useProjectSelection";
 import { useMemberChannelIds } from "@/features/projects/useRepositoryAccess";
@@ -61,6 +63,7 @@ import { ProjectDetailChrome } from "./ProjectDetailChrome";
 import { ProjectConversationPanelController } from "./ProjectConversationPanelContext";
 import { ProjectDetailRightPanel } from "./ProjectDetailRightPanel";
 import { ProjectDetailUnavailableState } from "./ProjectDetailUnavailableState";
+import { ProjectChannelHome } from "./ProjectChannelHome";
 import { ProjectRightPanelControls } from "./ProjectRightPanelControls";
 import { buildProjectDetailCrumbs } from "./useProjectDetailCrumbs";
 import { useProjectDetailPeople } from "./useProjectDetailPeople";
@@ -282,15 +285,17 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
   const handleBranchChange = React.useCallback(
     (branch: string | null) => {
       selectBranch(branch);
+      if (!branch) return;
+      const localBranches = repoSyncStatusQuery.data?.localBranches;
       if (
-        branch &&
         repoSource === "local" &&
-        branch !== repoSyncStatusQuery.data?.localBranch
+        localBranches &&
+        !localBranches.includes(branch)
       ) {
         setRepoSource("remote");
       }
     },
-    [repoSource, repoSyncStatusQuery.data?.localBranch, selectBranch],
+    [repoSource, repoSyncStatusQuery.data?.localBranches, selectBranch],
   );
   const handleTagChange = React.useCallback(
     (tag: string) => {
@@ -673,6 +678,24 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
       />
     );
   }
+  const showChannelHome =
+    hasAuthoritativeHomeBinding(project) &&
+    !wantsProjectRepositorySurface({
+      commitHash,
+      issueId,
+      projectId,
+      pullRequestId,
+      repositoryId,
+      tab,
+    });
+  if (showChannelHome) {
+    return (
+      <ProjectChannelHome
+        project={project}
+        projects={projectsQuery.data ?? [project]}
+      />
+    );
+  }
   if (!repository) {
     return (
       <ProjectDetailUnavailableState
@@ -720,6 +743,13 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
       setSelectedPullRequestId,
       setTabsResetKey,
     });
+  const goChannelHome = () => {
+    if (project.projectChannelId) {
+      void goProject(project.id);
+      return;
+    }
+    handleGoToProjectHome();
+  };
   const agentPageContext = buildProjectDetailAgentContext({
     activeTab,
     branch: activeBranch,
@@ -834,7 +864,7 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
                 actions={repositoryPanelAction}
                 activeTabCrumb={activeTabCrumb}
                 activeWorkItemCrumb={activeWorkItemCrumb}
-                onGoProjectHome={handleGoToProjectHome}
+                onGoProjectHome={goChannelHome}
                 onGoProjects={() => {
                   void goProjects();
                 }}
@@ -900,6 +930,7 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
                       handleSelectedPullRequestIdChange
                     }
                     onSelectedTabChange={setActiveTab}
+                    onBack={goChannelHome}
                     profiles={profiles}
                     project={repository}
                     projectId={project.id}

--- a/desktop/src/features/projects/ui/ProjectHomeCodebasePanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectHomeCodebasePanel.tsx
@@ -1,0 +1,126 @@
+import { ChevronDown, FolderGit2 } from "lucide-react";
+
+import {
+  useProjectRepoSnapshotQuery,
+  useRepoStateQuery,
+  type Project,
+  type Repository,
+} from "@/features/projects/hooks";
+import { resolveProjectDefaultBranch } from "@/features/projects/lib/projectBranches";
+import { Button } from "@/shared/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
+import { ProjectRepositoryManagement } from "./ProjectRepositoryManagement";
+import { RepositoryFilesPanel } from "./ProjectRepositoryPanel";
+import { useRepositoryFileContentSource } from "./useRepositoryFileContentSource";
+
+export function ProjectHomeCodebasePanel({
+  identityPubkey,
+  onOpenCommit,
+  onRepositoryAdded,
+  onSelectRepository,
+  project,
+  projects,
+  repository,
+}: {
+  identityPubkey?: string;
+  onOpenCommit?: (commitHash: string) => void;
+  onRepositoryAdded: (repositoryId: string) => void;
+  onSelectRepository: (repositoryId: string) => void;
+  project: Project;
+  projects: Project[];
+  repository: Repository | null;
+}) {
+  const repoStateQuery = useRepoStateQuery(repository);
+  const defaultBranch = repository
+    ? resolveProjectDefaultBranch(repository.defaultBranch, repoStateQuery.data)
+    : null;
+  const snapshotQuery = useProjectRepoSnapshotQuery(
+    repository,
+    defaultBranch,
+    null,
+    null,
+    Boolean(repository),
+  );
+  const fileContentSource = useRepositoryFileContentSource({
+    activeBranch: defaultBranch,
+    activeTag: null,
+    pullRequest: null,
+    repository,
+    selectedTag: null,
+    source: "remote",
+  });
+  const snapshot = snapshotQuery.data ?? null;
+  const files = snapshot?.files ?? [];
+
+  if (!repository) {
+    return (
+      <div
+        className="space-y-3 px-4 pb-6 pt-1"
+        data-testid="project-home-codebase-empty"
+      >
+        <p className="text-sm text-muted-foreground">
+          Attach a repository to browse the file tree beside this channel.
+        </p>
+        <ProjectRepositoryManagement
+          identityPubkey={identityPubkey}
+          onChange={onRepositoryAdded}
+          project={project}
+          projects={projects}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex min-h-0 flex-1 flex-col overflow-hidden"
+      data-testid="project-home-codebase-panel"
+    >
+      {project.repositories.length > 1 ? (
+        <div className="shrink-0 px-4 pb-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                className="h-7 max-w-full justify-start gap-2 px-2 text-sm font-normal"
+                data-testid="project-home-codebase-repo-trigger"
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                <FolderGit2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 truncate">{repository.name}</span>
+                <ChevronDown className="ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              {project.repositories.map((candidate) => (
+                <DropdownMenuItem
+                  key={candidate.id}
+                  onSelect={() => onSelectRepository(candidate.id)}
+                >
+                  {candidate.name}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      ) : null}
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4">
+        <RepositoryFilesPanel
+          error={snapshotQuery.error}
+          fallbackAuthorPubkey={repository.owner}
+          fileContentSource={fileContentSource}
+          files={files}
+          isLoading={snapshotQuery.isPending}
+          onOpenCommit={onOpenCommit}
+          snapshot={snapshot}
+        />
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/projects/ui/ProjectHomeColumn.tsx
+++ b/desktop/src/features/projects/ui/ProjectHomeColumn.tsx
@@ -1,0 +1,67 @@
+import type * as React from "react";
+
+import { RightAuxiliaryPane } from "@/features/channels/ui/RightAuxiliaryPane";
+import {
+  AuxiliaryPanel,
+  AuxiliaryPanelBody,
+  AuxiliaryPanelHeader,
+  AuxiliaryPanelHeaderGroup,
+  AuxiliaryPanelHeaderTitleBlock,
+} from "@/shared/layout/AuxiliaryPanel";
+import { cn } from "@/shared/lib/cn";
+
+export function ProjectHomeColumn({
+  bodyClassName,
+  canResetWidth,
+  children,
+  onClose,
+  onResetWidth,
+  onResizeStart,
+  testId,
+  title,
+  widthPx,
+}: {
+  bodyClassName?: string;
+  canResetWidth: boolean;
+  children: React.ReactNode;
+  onClose: () => void;
+  onResetWidth: () => void;
+  onResizeStart: (event: React.PointerEvent<HTMLButtonElement>) => void;
+  testId: string;
+  title: string;
+  widthPx: number;
+}) {
+  return (
+    <RightAuxiliaryPane
+      canResetWidth={canResetWidth}
+      constrainToAvailableSpace={false}
+      detached
+      onResetWidth={onResetWidth}
+      onResizeStart={onResizeStart}
+      testId={testId}
+      widthPx={widthPx}
+    >
+      <div className="relative z-30 flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-2xl bg-background">
+        <AuxiliaryPanel
+          layout="split"
+          onClose={onClose}
+          transparentChrome
+          widthPx={widthPx}
+          header={
+            <AuxiliaryPanelHeader transparent>
+              <AuxiliaryPanelHeaderGroup>
+                <AuxiliaryPanelHeaderTitleBlock title={title} />
+              </AuxiliaryPanelHeaderGroup>
+            </AuxiliaryPanelHeader>
+          }
+        >
+          <AuxiliaryPanelBody
+            className={cn("min-h-0 flex-1 overflow-hidden", bodyClassName)}
+          >
+            {children}
+          </AuxiliaryPanelBody>
+        </AuxiliaryPanel>
+      </div>
+    </RightAuxiliaryPane>
+  );
+}

--- a/desktop/src/features/projects/ui/ProjectHomeContextPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectHomeContextPanel.tsx
@@ -1,0 +1,373 @@
+import {
+  CircleDot,
+  FileCode2,
+  FolderGit2,
+  GitCommitHorizontal,
+  GitPullRequest,
+  Hash,
+  Users,
+} from "lucide-react";
+import type * as React from "react";
+
+import { presentContextCount } from "@/features/projects/lib/projectHomeSummary";
+import type { ProjectHomeWorkspaceSheetTab } from "@/features/projects/lib/projectHomeWorkspaceSheet";
+import { resolveProjectDefaultBranch } from "@/features/projects/lib/projectBranches";
+import { listProjectBoundChannels } from "@/features/projects/lib/projectRelatedChannels";
+import {
+  useProjectActivitySummariesQuery,
+  useProjectRepoSnapshotQuery,
+  useRepoStateQuery,
+  type Project,
+} from "@/features/projects/hooks";
+import { ProjectChannelIcon } from "@/features/projects/ui/ProjectChannelIcon";
+import type { Channel } from "@/shared/api/types";
+import { cn } from "@/shared/lib/cn";
+import type { EntityLinkTab } from "@/shared/lib/entityLink";
+import { Button } from "@/shared/ui/button";
+import { ProjectChannelManagement } from "./ProjectChannelManagement";
+import { ProjectRepositoryManagement } from "./ProjectRepositoryManagement";
+import { PROJECT_CONTEXT_ACTION_BUTTON_CLASS } from "./projectContextActionStyles";
+
+function ContextSection({
+  children,
+  headerAction,
+  testId,
+  title,
+}: {
+  children: React.ReactNode;
+  headerAction?: React.ReactNode;
+  testId?: string;
+  title?: string;
+}) {
+  return (
+    <section className="space-y-0.5" data-testid={testId}>
+      {title || headerAction ? (
+        <div className="flex h-7 min-w-0 items-center justify-between gap-2">
+          {title ? (
+            <h3 className="min-w-0 truncate text-sm font-normal text-muted-foreground/70">
+              {title}
+            </h3>
+          ) : (
+            <span />
+          )}
+          {headerAction}
+        </div>
+      ) : null}
+      {children}
+    </section>
+  );
+}
+
+function ContextRowContent({
+  children,
+  count,
+  icon,
+}: {
+  children: React.ReactNode;
+  count?: number;
+  icon: React.ReactNode;
+}) {
+  return (
+    <>
+      <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground">
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-left">{children}</span>
+      <span className="w-8 shrink-0 text-right tabular-nums text-muted-foreground">
+        {count ?? ""}
+      </span>
+    </>
+  );
+}
+
+function ContextNavButton({
+  children,
+  count,
+  disabled,
+  icon,
+  onClick,
+  pressed,
+  testId,
+  title,
+}: {
+  children: React.ReactNode;
+  count?: number;
+  disabled?: boolean;
+  icon: React.ReactNode;
+  onClick?: () => void;
+  pressed?: boolean;
+  testId?: string;
+  title?: string;
+}) {
+  return (
+    <Button
+      aria-pressed={pressed}
+      className={cn(
+        PROJECT_CONTEXT_ACTION_BUTTON_CLASS,
+        pressed && "bg-muted/70",
+      )}
+      data-testid={testId}
+      disabled={disabled}
+      onClick={onClick}
+      size="sm"
+      title={title}
+      type="button"
+      variant="ghost"
+    >
+      <ContextRowContent count={count} icon={icon}>
+        {children}
+      </ContextRowContent>
+    </Button>
+  );
+}
+
+function ChannelContextRow({
+  channel,
+  onClick,
+  projectHome,
+  testId,
+}: {
+  channel: Channel;
+  onClick?: () => void;
+  projectHome?: boolean;
+  testId: string;
+}) {
+  const count = presentContextCount(channel.memberCount);
+  const Icon = projectHome ? ProjectChannelIcon : Hash;
+  if (onClick) {
+    return (
+      <ContextNavButton
+        count={count}
+        icon={<Icon />}
+        onClick={onClick}
+        testId={testId}
+      >
+        {channel.name}
+      </ContextNavButton>
+    );
+  }
+  return (
+    <div
+      className={`${PROJECT_CONTEXT_ACTION_BUTTON_CLASS} pointer-events-none flex items-center`}
+      data-testid={testId}
+    >
+      <ContextRowContent count={count} icon={<Icon />}>
+        {channel.name}
+      </ContextRowContent>
+    </div>
+  );
+}
+
+export function ProjectHomeContextPanel({
+  activeWorkspaceTab,
+  channel,
+  channels = [],
+  identityPubkey,
+  onAddRepository,
+  onOpenChannel,
+  onOpenRepository,
+  onOpenWorkspace,
+  onRepositoryChange,
+  project,
+  projects,
+}: {
+  activeWorkspaceTab?: ProjectHomeWorkspaceSheetTab | null;
+  channel: Channel | null;
+  channels?: Channel[];
+  identityPubkey?: string;
+  onAddRepository?: () => void;
+  onOpenChannel?: (channelId: string) => void;
+  onOpenRepository: (repositoryId: string) => void;
+  onOpenWorkspace: (repositoryId: string, tab?: EntityLinkTab) => void;
+  onRepositoryChange: (repositoryId: string) => void;
+  project: Project;
+  projects: Project[];
+}) {
+  const firstRepository = project.repositories[0] ?? null;
+  const addRepositoryTitle = firstRepository
+    ? undefined
+    : "Add a repository to this project";
+  const openWorkspace = (tab: EntityLinkTab) => {
+    if (firstRepository) {
+      onOpenWorkspace(firstRepository.id, tab);
+      return;
+    }
+    onAddRepository?.();
+  };
+  const peopleCount = new Set([
+    project.owner,
+    ...project.repositories.flatMap((repository) => repository.contributors),
+  ]).size;
+  const activityQuery = useProjectActivitySummariesQuery([project]);
+  const activity = activityQuery.data?.[project.id];
+  const repoStateQuery = useRepoStateQuery(firstRepository);
+  const defaultBranch = firstRepository
+    ? resolveProjectDefaultBranch(
+        firstRepository.defaultBranch,
+        repoStateQuery.data,
+      )
+    : null;
+  const snapshotQuery = useProjectRepoSnapshotQuery(
+    firstRepository,
+    defaultBranch,
+    null,
+    null,
+    Boolean(firstRepository),
+  );
+  const channelsById = new Map(
+    channels.map((candidate) => [candidate.id, candidate]),
+  );
+  const boundChannels = listProjectBoundChannels(project).flatMap((binding) => {
+    const boundChannel = channelsById.get(binding.channelId);
+    if (!boundChannel) return [];
+    return [{ ...binding, channel: boundChannel }];
+  });
+  const listedChannels =
+    boundChannels.length > 0
+      ? boundChannels
+      : channel
+        ? [
+            {
+              channel,
+              channelId: channel.id,
+              repositoryId: null,
+              role: "home" as const,
+            },
+          ]
+        : [];
+
+  return (
+    <div
+      className="space-y-4 px-4 pb-8 pt-1"
+      data-testid="project-home-context-panel"
+    >
+      <ContextSection testId="project-home-context-workspace">
+        <ContextNavButton
+          count={presentContextCount(activity?.issueCount)}
+          disabled={!firstRepository && !onAddRepository}
+          icon={<CircleDot />}
+          onClick={() => openWorkspace("issues")}
+          pressed={activeWorkspaceTab === "issues"}
+          testId="project-home-context-tasks"
+          title={addRepositoryTitle}
+        >
+          Tasks
+        </ContextNavButton>
+        <ContextNavButton
+          count={presentContextCount(activity?.prCount)}
+          disabled={!firstRepository && !onAddRepository}
+          icon={<GitPullRequest />}
+          onClick={() => openWorkspace("prs")}
+          pressed={activeWorkspaceTab === "prs"}
+          testId="project-home-context-reviews"
+          title={addRepositoryTitle}
+        >
+          Reviews
+        </ContextNavButton>
+        <ContextNavButton
+          count={presentContextCount(activity?.commitCount)}
+          disabled={!firstRepository && !onAddRepository}
+          icon={<GitCommitHorizontal />}
+          onClick={() => openWorkspace("commits")}
+          pressed={activeWorkspaceTab === "commits"}
+          testId="project-home-context-commits"
+          title={addRepositoryTitle}
+        >
+          Commits
+        </ContextNavButton>
+        <ContextNavButton
+          count={presentContextCount(snapshotQuery.data?.files.length)}
+          disabled={!firstRepository && !onAddRepository}
+          icon={<FileCode2 />}
+          onClick={() => openWorkspace("files")}
+          pressed={activeWorkspaceTab === "files"}
+          testId="project-home-context-files"
+          title={addRepositoryTitle}
+        >
+          Files
+        </ContextNavButton>
+        <ContextNavButton
+          count={presentContextCount(peopleCount)}
+          disabled={!firstRepository}
+          icon={<Users />}
+          onClick={() =>
+            firstRepository &&
+            onOpenWorkspace(firstRepository.id, "contributors")
+          }
+          pressed={activeWorkspaceTab === "contributors"}
+          testId="project-home-context-people"
+          title={addRepositoryTitle}
+        >
+          People
+        </ContextNavButton>
+      </ContextSection>
+      <ContextSection
+        headerAction={
+          <ProjectChannelManagement
+            identityPubkey={identityPubkey}
+            project={project}
+          />
+        }
+        testId="project-home-context-channel"
+        title="Channels"
+      >
+        {listedChannels.length > 0 ? (
+          listedChannels.map((binding) => {
+            const isHome = binding.role === "home";
+            return (
+              <ChannelContextRow
+                channel={binding.channel}
+                key={`${binding.role}:${binding.channel.id}`}
+                onClick={
+                  isHome || !onOpenChannel
+                    ? undefined
+                    : () => onOpenChannel(binding.channel.id)
+                }
+                projectHome={isHome}
+                testId={
+                  isHome
+                    ? "project-home-context-home-channel"
+                    : `project-home-context-channel-${binding.channel.name}`
+                }
+              />
+            );
+          })
+        ) : (
+          <p
+            className={`${PROJECT_CONTEXT_ACTION_BUTTON_CLASS} pointer-events-none flex items-center`}
+          >
+            <ContextRowContent icon={<Hash />}>Unavailable</ContextRowContent>
+          </p>
+        )}
+      </ContextSection>
+      <ContextSection
+        headerAction={
+          <ProjectRepositoryManagement
+            compact
+            identityPubkey={identityPubkey}
+            onChange={onRepositoryChange}
+            project={project}
+            projects={projects}
+          />
+        }
+        testId="project-home-context-codebase"
+        title="Codebase"
+      >
+        {project.repositories.length > 0 ? (
+          project.repositories.map((repository) => (
+            <ContextNavButton
+              icon={<FolderGit2 />}
+              key={repository.id}
+              onClick={() => onOpenRepository(repository.id)}
+              testId={`project-home-context-repo-${repository.dtag}`}
+            >
+              {repository.name}
+            </ContextNavButton>
+          ))
+        ) : (
+          <p className="text-sm text-muted-foreground">None yet</p>
+        )}
+      </ContextSection>
+    </div>
+  );
+}

--- a/desktop/src/features/projects/ui/ProjectHomeWorkspaceSheet.tsx
+++ b/desktop/src/features/projects/ui/ProjectHomeWorkspaceSheet.tsx
@@ -1,0 +1,150 @@
+import * as React from "react";
+
+import {
+  useProjectIssuesQuery,
+  useProjectPullRequestsQuery,
+  useProjectRepoSnapshotQuery,
+  useRepoStateQuery,
+  type Project,
+} from "@/features/projects/hooks";
+import { gitContributorPubkeysFromCommits } from "@/features/projects/lib/projectContributorMatching";
+import { resolveProjectDefaultBranch } from "@/features/projects/lib/projectBranches";
+import type { ProjectHomeWorkspaceSheetTab } from "@/features/projects/lib/projectHomeWorkspaceSheet";
+import { ActivityPanel, ContributorsPanel } from "./ProjectDetailFeedPanels";
+import { ProjectHomeCodebasePanel } from "./ProjectHomeCodebasePanel";
+import { ProjectIssuesPanel } from "./ProjectIssuesPanel";
+import { PullRequestsPanel } from "./ProjectPullRequestsPanel";
+import { useProjectDetailPeople } from "./useProjectDetailPeople";
+
+export function ProjectHomeWorkspaceSheet({
+  identityPubkey,
+  onOpenCommit,
+  onRepositoryAdded,
+  onSelectRepository,
+  project,
+  projects,
+  repository,
+  tab,
+}: {
+  identityPubkey?: string;
+  onOpenCommit: (commitHash: string) => void;
+  onRepositoryAdded: (repositoryId: string) => void;
+  onSelectRepository: (repositoryId: string) => void;
+  project: Project;
+  projects: Project[];
+  repository: Project["repositories"][number];
+  tab: ProjectHomeWorkspaceSheetTab;
+}) {
+  const [selectedIssueId, setSelectedIssueId] = React.useState<string | null>(
+    null,
+  );
+  const [selectedPullRequestId, setSelectedPullRequestId] = React.useState<
+    string | null
+  >(null);
+
+  const issuesQuery = useProjectIssuesQuery(repository);
+  const pullRequestsQuery = useProjectPullRequestsQuery(repository);
+  const issues = issuesQuery.data ?? [];
+  const pullRequests = pullRequestsQuery.data ?? [];
+  const people = useProjectDetailPeople({
+    issues,
+    pullRequests,
+    repository,
+  });
+  const repoStateQuery = useRepoStateQuery(repository);
+  const defaultBranch = resolveProjectDefaultBranch(
+    repository.defaultBranch,
+    repoStateQuery.data,
+  );
+  const snapshotQuery = useProjectRepoSnapshotQuery(
+    repository,
+    defaultBranch,
+    null,
+    null,
+    true,
+  );
+  const snapshot = snapshotQuery.data ?? null;
+  const contributorPubkeysByGitIdentity = React.useMemo(
+    () =>
+      gitContributorPubkeysFromCommits(snapshot?.commits ?? [], pullRequests),
+    [pullRequests, snapshot?.commits],
+  );
+  const selectedPullRequest =
+    pullRequests.find(
+      (pullRequest) => pullRequest.id === selectedPullRequestId,
+    ) ?? null;
+
+  let body: React.ReactNode;
+  switch (tab) {
+    case "issues":
+      body = (
+        <ProjectIssuesPanel
+          onSelectedIssueIdChange={setSelectedIssueId}
+          profiles={people.profiles}
+          project={repository}
+          selectedIssueId={selectedIssueId}
+        />
+      );
+      break;
+    case "prs":
+      body = (
+        <PullRequestsPanel
+          error={pullRequestsQuery.error}
+          isLoading={pullRequestsQuery.isLoading}
+          onSelectedPullRequestIdChange={setSelectedPullRequestId}
+          profiles={people.profiles}
+          project={repository}
+          pullRequests={pullRequests}
+          selectedPullRequest={selectedPullRequest}
+        />
+      );
+      break;
+    case "commits":
+      body = (
+        <ActivityPanel
+          branch={defaultBranch ?? undefined}
+          error={snapshotQuery.error}
+          isLoading={snapshotQuery.isPending}
+          onSelectCommit={(commit) => onOpenCommit(commit.hash)}
+          profiles={people.profiles}
+          project={repository}
+          projectId={project.id}
+          pullRequests={pullRequests}
+          repoContributors={snapshot?.contributors ?? []}
+          snapshot={snapshot}
+          viewerGitIdentity={people.viewerGitIdentity}
+        />
+      );
+      break;
+    case "files":
+      body = (
+        <ProjectHomeCodebasePanel
+          identityPubkey={identityPubkey}
+          onOpenCommit={onOpenCommit}
+          onRepositoryAdded={onRepositoryAdded}
+          onSelectRepository={onSelectRepository}
+          project={project}
+          projects={projects}
+          repository={repository}
+        />
+      );
+      break;
+    case "contributors":
+      body = (
+        <ContributorsPanel
+          activityCounts={people.contributorActivityCounts}
+          contributorPubkeys={people.contributorPubkeys}
+          contributorPubkeysByGitIdentity={contributorPubkeysByGitIdentity}
+          profiles={people.profiles}
+          repoContributors={snapshot?.contributors ?? []}
+        />
+      );
+      break;
+  }
+
+  return (
+    <div data-tab={tab} data-testid="project-home-workspace-sheet">
+      {body}
+    </div>
+  );
+}

--- a/desktop/src/features/projects/ui/ProjectRepositoryManagement.tsx
+++ b/desktop/src/features/projects/ui/ProjectRepositoryManagement.tsx
@@ -23,20 +23,29 @@ import { AttachProjectRepositoryDialog } from "./AttachProjectRepositoryDialog";
 
 export function ProjectRepositoryManagement({
   compact = false,
+  createOpen: createOpenProp,
+  hideTriggers = false,
   identityPubkey,
   onChange,
+  onCreateOpenChange,
   project,
   projects,
   repository,
 }: {
   compact?: boolean;
+  createOpen?: boolean;
+  hideTriggers?: boolean;
   identityPubkey?: string;
   onChange: (repositoryId: string) => void;
+  onCreateOpenChange?: (open: boolean) => void;
   project: Project;
   projects: Project[];
-  repository: Repository;
+  repository?: Repository | null;
 }) {
-  const [createOpen, setCreateOpen] = React.useState(false);
+  const [uncontrolledCreateOpen, setUncontrolledCreateOpen] =
+    React.useState(false);
+  const createOpen = createOpenProp ?? uncontrolledCreateOpen;
+  const setCreateOpen = onCreateOpenChange ?? setUncontrolledCreateOpen;
   const [attachOpen, setAttachOpen] = React.useState(false);
   const channelsQuery = useChannelsQuery();
   const createMutation = useAddProjectRepositoryMutation();
@@ -71,18 +80,19 @@ export function ProjectRepositoryManagement({
     [channelsQuery.data],
   );
   const inheritedChannelId = [
-    repository.channelId,
+    repository?.channelId,
     project.projectChannelId,
     project.repositories.find(
-      (candidate) => candidate.id !== repository.id && candidate.channelId,
+      (candidate) => candidate.id !== repository?.id && candidate.channelId,
     )?.channelId,
   ].find(
     (candidate) =>
       candidate && accessChannels.some((channel) => channel.id === candidate),
   );
   const canManageAccess =
+    Boolean(repository) &&
     accessChannels.length > 0 &&
-    identityPubkey?.toLowerCase() === repository.owner.toLowerCase();
+    identityPubkey?.toLowerCase() === repository?.owner.toLowerCase();
   const attachCandidates = React.useMemo(() => {
     const currentAddresses = new Set(project.repositoryAddresses);
     const candidates = new Map<string, Repository>();
@@ -132,7 +142,7 @@ export function ProjectRepositoryManagement({
         project={project}
         repositories={attachCandidates}
       />
-      {canEdit ? (
+      {canEdit && !hideTriggers ? (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -199,7 +209,8 @@ export function ProjectRepositoryManagement({
                 className="justify-between gap-4"
                 key={channel.id}
                 onSelect={() => {
-                  if (channel.id === repository.channelId) return;
+                  if (channel.id === repository?.channelId) return;
+                  if (!repository) return;
                   void repairMutation
                     .mutateAsync({
                       channelId: channel.id,
@@ -220,7 +231,7 @@ export function ProjectRepositoryManagement({
                 }}
               >
                 <span className="min-w-0 truncate">#{channel.name}</span>
-                {channel.id === repository.channelId ? (
+                {channel.id === repository?.channelId ? (
                   <Check className="h-4 w-4 shrink-0" />
                 ) : null}
               </DropdownMenuItem>

--- a/desktop/src/features/projects/ui/ProjectWorkspaceTabList.tsx
+++ b/desktop/src/features/projects/ui/ProjectWorkspaceTabList.tsx
@@ -1,4 +1,4 @@
-import { Glasses } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 
 import { cn } from "@/shared/lib/cn";
 import { TabsList, TabsTrigger } from "@/shared/ui/tabs";
@@ -7,49 +7,59 @@ export const PROJECT_TAB_TRIGGER_CLASS =
   "h-7 shrink-0 rounded-full bg-muted/30 px-3 text-xs font-medium leading-5 tracking-tight text-muted-foreground shadow-none transition-colors hover:bg-muted/55 hover:text-foreground data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none";
 
 export const PROJECT_TAB_SELECTED_CLASS = "bg-muted text-foreground";
-const PROJECT_OVERVIEW_TAB_CLASS =
-  "h-7 w-7 shrink-0 rounded-full bg-muted/30 p-1.5 text-muted-foreground shadow-none transition-colors hover:bg-muted/55 hover:text-foreground data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none";
+const PROJECT_TAB_ICON_BUTTON_CLASS =
+  "h-7 w-7 shrink-0 rounded-full bg-muted/30 p-1.5 text-muted-foreground shadow-none transition-colors hover:bg-muted/55 hover:text-foreground";
 
 function ProjectTabLabel({ children }: { children: string }) {
   return <span>{children}</span>;
 }
 
-export function ProjectTabsList({ prsActive }: { prsActive?: boolean }) {
+export function ProjectTabsList({
+  onBack,
+  prsActive,
+}: {
+  onBack: () => void;
+  prsActive?: boolean;
+}) {
   return (
-    <TabsList className="h-full min-w-0 max-w-full flex-none justify-start gap-1.5 overflow-x-auto bg-transparent p-0 scrollbar-none">
-      <TabsTrigger
-        aria-label="Overview"
-        className={PROJECT_OVERVIEW_TAB_CLASS}
-        title="README"
-        value="overview"
+    <div className="flex h-full min-w-0 max-w-full flex-none items-center gap-1.5 overflow-x-auto scrollbar-none">
+      <button
+        aria-label="Back"
+        className={PROJECT_TAB_ICON_BUTTON_CLASS}
+        data-testid="project-workspace-back"
+        onClick={onBack}
+        title="Back"
+        type="button"
       >
-        <Glasses className="h-full w-full" strokeWidth={2} />
-      </TabsTrigger>
-      <TabsTrigger className={PROJECT_TAB_TRIGGER_CLASS} value="files">
-        <ProjectTabLabel>Files</ProjectTabLabel>
-      </TabsTrigger>
-      <TabsTrigger className={PROJECT_TAB_TRIGGER_CLASS} value="activity">
-        <ProjectTabLabel>Commits</ProjectTabLabel>
-      </TabsTrigger>
-      <TabsTrigger className={PROJECT_TAB_TRIGGER_CLASS} value="issues">
-        <ProjectTabLabel>Tasks</ProjectTabLabel>
-      </TabsTrigger>
-      <TabsTrigger
-        aria-current={prsActive ? "page" : undefined}
-        className={cn(
-          PROJECT_TAB_TRIGGER_CLASS,
-          prsActive && PROJECT_TAB_SELECTED_CLASS,
-        )}
-        value="prs"
-      >
-        <ProjectTabLabel>Review</ProjectTabLabel>
-      </TabsTrigger>
-      <TabsTrigger className={PROJECT_TAB_TRIGGER_CLASS} value="channels">
-        <ProjectTabLabel>Channels</ProjectTabLabel>
-      </TabsTrigger>
-      <TabsTrigger className={PROJECT_TAB_TRIGGER_CLASS} value="contributors">
-        <ProjectTabLabel>Contributors</ProjectTabLabel>
-      </TabsTrigger>
-    </TabsList>
+        <ArrowLeft className="h-full w-full" strokeWidth={2} />
+      </button>
+      <TabsList className="h-full min-w-0 max-w-full flex-none justify-start gap-1.5 overflow-x-auto bg-transparent p-0 scrollbar-none">
+        <TabsTrigger className={PROJECT_TAB_TRIGGER_CLASS} value="files">
+          <ProjectTabLabel>Files</ProjectTabLabel>
+        </TabsTrigger>
+        <TabsTrigger className={PROJECT_TAB_TRIGGER_CLASS} value="activity">
+          <ProjectTabLabel>Commits</ProjectTabLabel>
+        </TabsTrigger>
+        <TabsTrigger className={PROJECT_TAB_TRIGGER_CLASS} value="issues">
+          <ProjectTabLabel>Tasks</ProjectTabLabel>
+        </TabsTrigger>
+        <TabsTrigger
+          aria-current={prsActive ? "page" : undefined}
+          className={cn(
+            PROJECT_TAB_TRIGGER_CLASS,
+            prsActive && PROJECT_TAB_SELECTED_CLASS,
+          )}
+          value="prs"
+        >
+          <ProjectTabLabel>Review</ProjectTabLabel>
+        </TabsTrigger>
+        <TabsTrigger className={PROJECT_TAB_TRIGGER_CLASS} value="channels">
+          <ProjectTabLabel>Channels</ProjectTabLabel>
+        </TabsTrigger>
+        <TabsTrigger className={PROJECT_TAB_TRIGGER_CLASS} value="contributors">
+          <ProjectTabLabel>Contributors</ProjectTabLabel>
+        </TabsTrigger>
+      </TabsList>
+    </div>
   );
 }

--- a/desktop/src/features/projects/ui/ProjectWorkspaceTabs.tsx
+++ b/desktop/src/features/projects/ui/ProjectWorkspaceTabs.tsx
@@ -119,6 +119,7 @@ export function WorkspaceTabs({
   onSelectedIssueIdChange,
   onSelectedPullRequestIdChange,
   onSelectedTabChange,
+  onBack,
   onOpenMergeRecoveryTerminal,
   snapshot,
   snapshotError,
@@ -170,6 +171,7 @@ export function WorkspaceTabs({
   onSelectedPullRequestIdChange: (id: string | null) => void;
   /** Reports the active tab so the screen breadcrumb can mirror it. */
   onSelectedTabChange?: (tab: string) => void;
+  onBack: () => void;
   onOpenMergeRecoveryTerminal?: OpenMergeRecoveryTerminal;
   snapshot: ProjectRepoSnapshot | null | undefined;
   snapshotError: unknown;
@@ -412,7 +414,7 @@ export function WorkspaceTabs({
           }`}
           data-testid="project-workspace-tab-menu"
         >
-          <ProjectTabsList prsActive={isPullRequestSelected} />
+          <ProjectTabsList onBack={onBack} prsActive={isPullRequestSelected} />
           <div className="ml-auto flex shrink-0 items-center gap-1">
             {updatePullRequestAction ? (
               <Button

--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -767,6 +767,7 @@ export function ProjectsView() {
               }
               handleRepositoryScopeChange("all");
               handleFilterChange("projects");
+              await goProject(result.project.id);
             }}
             onOpenChange={setCreateProjectOpen}
             open={createProjectOpen}

--- a/desktop/src/features/projects/useAddProjectChannel.test.mjs
+++ b/desktop/src/features/projects/useAddProjectChannel.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { addProjectChannel } from "./useAddProjectChannel.ts";
+
+const OWNER = "a".repeat(64);
+const CREATED_CHANNEL = "22222222-2222-4222-8222-222222222222";
+
+function makeProject(overrides = {}) {
+  return {
+    id: `30621:${OWNER}:platform`,
+    dtag: "platform",
+    name: "Platform",
+    description: "",
+    owner: OWNER,
+    createdAt: 100,
+    projectChannelId: "11111111-1111-4111-8111-111111111111",
+    relatedChannelIds: [],
+    status: "active",
+    projectAddress: `30621:${OWNER}:platform`,
+    primaryRepositoryAddress: null,
+    repositoryAddresses: [],
+    repositories: [],
+    legacy: false,
+    ...overrides,
+  };
+}
+
+function makeLiveHead(createdAt, overrides = {}) {
+  return {
+    id: "f".repeat(64),
+    kind: 30621,
+    pubkey: OWNER,
+    created_at: createdAt,
+    content: "",
+    tags: [["d", "platform"]],
+    sig: "0".repeat(128),
+    ...overrides,
+  };
+}
+
+function input() {
+  return {
+    name: "Engineering",
+    project: makeProject(),
+    visibility: "private",
+  };
+}
+
+function dependencies(fetchEvents) {
+  let createCalls = 0;
+  return {
+    deps: {
+      applyAgents: async () => {},
+      applyCanvas: async () => {},
+      createChannel: async () => {
+        createCalls += 1;
+        throw new Error(
+          "createChannel must not run before live-head preflight",
+        );
+      },
+      fetchEvents,
+    },
+    createCalls: () => createCalls,
+  };
+}
+
+test("addProjectChannel does not create a channel when the live project head is stale", async () => {
+  const harness = dependencies(async () => [makeLiveHead(101)]);
+
+  await assert.rejects(
+    addProjectChannel(input(), harness.deps),
+    /updated by another session/,
+  );
+  assert.equal(harness.createCalls(), 0);
+});
+
+test("addProjectChannel does not create a channel when the live project head is missing", async () => {
+  const harness = dependencies(async () => []);
+
+  await assert.rejects(
+    addProjectChannel(input(), harness.deps),
+    /Could not find this project on the relay/,
+  );
+  assert.equal(harness.createCalls(), 0);
+});
+
+test("addProjectChannel removes its channel and does not publish when the project changes during creation", async () => {
+  const originalHead = makeLiveHead(100);
+  const concurrentHead = makeLiveHead(101, {
+    id: "e".repeat(64),
+    tags: [
+      ["d", "platform"],
+      ["buzz-related-channel", "33333333-3333-4333-8333-333333333333"],
+    ],
+  });
+  const fetchResults = [[originalHead], [concurrentHead]];
+  const deleted = [];
+  let publishCalls = 0;
+
+  await assert.rejects(
+    addProjectChannel(input(), {
+      applyAgents: async () => {},
+      applyCanvas: async () => {},
+      createChannel: async () => ({ id: CREATED_CHANNEL }),
+      deleteChannel: async (channelId) => deleted.push(channelId),
+      fetchEvents: async () => fetchResults.shift() ?? [],
+      publishOwnerAnnouncement: async () => {
+        publishCalls += 1;
+        throw new Error("must not publish a stale project replacement");
+      },
+    }),
+    /updated by another session while the channel was being created/,
+  );
+
+  assert.deepEqual(deleted, [CREATED_CHANNEL]);
+  assert.equal(publishCalls, 0);
+});
+
+test("addProjectChannel removes its channel when project publication fails", async () => {
+  const liveHead = makeLiveHead(100);
+  const deleted = [];
+  let fetchCalls = 0;
+
+  await assert.rejects(
+    addProjectChannel(input(), {
+      applyAgents: async () => {},
+      applyCanvas: async () => {},
+      createChannel: async () => ({ id: CREATED_CHANNEL }),
+      deleteChannel: async (channelId) => deleted.push(channelId),
+      fetchEvents: async () => {
+        fetchCalls += 1;
+        return [liveHead];
+      },
+      publishOwnerAnnouncement: async () => {
+        throw new Error("publication failed");
+      },
+    }),
+    /publication failed/,
+  );
+
+  assert.equal(fetchCalls, 2);
+  assert.deepEqual(deleted, [CREATED_CHANNEL]);
+});

--- a/desktop/src/features/projects/useAddProjectChannel.ts
+++ b/desktop/src/features/projects/useAddProjectChannel.ts
@@ -1,0 +1,201 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  channelsQueryKey,
+  upsertCachedChannel,
+  useCreateChannelMutation,
+} from "@/features/channels/hooks";
+import { useApplyTemplate } from "@/features/channel-templates/useApplyTemplate";
+import { type Project, projectsQueryKey } from "@/features/projects/hooks";
+import { isUnsupportedProjectKindError } from "@/features/projects/projectCreation";
+import { buildProjectRelatedChannelPatchTemplate } from "@/features/projects/projectChannelCreation";
+import { addRelatedChannelToProject } from "@/features/projects/projectModels";
+import { publishOwnedAgentProjectAnnouncements } from "@/features/projects/projectOwnerControl";
+import { publishProjectOwnerAnnouncement } from "@/shared/api/projectGit";
+import { relayClient } from "@/shared/api/relayClient";
+import { deleteChannel as deleteChannelApi } from "@/shared/api/tauriChannels";
+import type { Channel, ChannelVisibility } from "@/shared/api/types";
+import { KIND_PROJECT_ANNOUNCEMENT } from "@/shared/constants/kinds";
+
+export type AddProjectChannelInput = {
+  description?: string;
+  name: string;
+  ownerControlAgentPubkey?: string;
+  project: Project;
+  templateId?: string;
+  ttlSeconds?: number;
+  visibility: ChannelVisibility;
+};
+
+export async function addProjectChannel(
+  input: AddProjectChannelInput,
+  deps: {
+    applyAgents: (
+      templateId: string | undefined,
+      channelId: string,
+    ) => void | Promise<void>;
+    applyCanvas: (
+      templateId: string | undefined,
+      channelId: string,
+      channelName: string,
+    ) => Promise<void>;
+    createChannel: ReturnType<typeof useCreateChannelMutation>["mutateAsync"];
+    deleteChannel?: typeof deleteChannelApi;
+    fetchEvents?: typeof relayClient.fetchEvents;
+    publishOwnedAgentAnnouncements?: typeof publishOwnedAgentProjectAnnouncements;
+    publishOwnerAnnouncement?: typeof publishProjectOwnerAnnouncement;
+  },
+): Promise<{ channel: Channel; project: Project }> {
+  const {
+    applyAgents,
+    applyCanvas,
+    createChannel,
+    deleteChannel = deleteChannelApi,
+    fetchEvents = relayClient.fetchEvents.bind(relayClient),
+    publishOwnedAgentAnnouncements = publishOwnedAgentProjectAnnouncements,
+    publishOwnerAnnouncement = publishProjectOwnerAnnouncement,
+  } = deps;
+  const targetOwner = input.project.owner.toLowerCase();
+
+  const fetchLiveHead = async () =>
+    (
+      await fetchEvents({
+        authors: [targetOwner],
+        kinds: [KIND_PROJECT_ANNOUNCEMENT],
+        "#d": [input.project.dtag],
+        limit: 1,
+      })
+    )[0];
+  const liveHead = await fetchLiveHead();
+  if (!liveHead) {
+    throw new Error(
+      "Could not find this project on the relay. Refresh and try again.",
+    );
+  }
+  if (liveHead.created_at > input.project.createdAt) {
+    throw new Error(
+      "This project was updated by another session while you were working. Refresh and try again.",
+    );
+  }
+
+  const channel = await createChannel({
+    channelType: "stream",
+    description: input.description,
+    name: input.name,
+    ttlSeconds: input.ttlSeconds,
+    visibility: input.visibility,
+  });
+
+  const removeCreatedChannelAndThrow = async (error: Error): Promise<never> => {
+    try {
+      await deleteChannel(channel.id);
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        "Buzz could not verify the project after creating the channel, and could not remove the unlinked channel. Delete it manually, then refresh and try again.",
+      );
+    }
+    throw error;
+  };
+
+  const confirmedLiveHead = await fetchLiveHead().catch((error: unknown) =>
+    removeCreatedChannelAndThrow(
+      error instanceof Error
+        ? error
+        : new Error("Could not verify the project after creating the channel."),
+    ),
+  );
+  if (!confirmedLiveHead || confirmedLiveHead.id !== liveHead.id) {
+    await removeCreatedChannelAndThrow(
+      new Error(
+        "This project was updated by another session while the channel was being created. Refresh and try again.",
+      ),
+    );
+  }
+
+  const templates = buildProjectRelatedChannelPatchTemplate({
+    channelId: channel.id,
+    liveHead: confirmedLiveHead,
+    ownerPubkey: targetOwner,
+  });
+  let projectCreatedAt = confirmedLiveHead.created_at;
+  if (!templates.alreadyBound) {
+    const createdAt = Math.max(
+      Math.floor(Date.now() / 1_000),
+      confirmedLiveHead.created_at + 1,
+    );
+    try {
+      if (input.ownerControlAgentPubkey) {
+        const events = await publishOwnedAgentAnnouncements(
+          input.ownerControlAgentPubkey,
+          [{ ...templates.project, createdAt }],
+        );
+        projectCreatedAt =
+          events.find((event) => event.kind === KIND_PROJECT_ANNOUNCEMENT)
+            ?.created_at ?? createdAt;
+      } else {
+        const publication = await publishOwnerAnnouncement({
+          ...templates.project,
+          createdAt,
+          targetOwner,
+        });
+        if (publication.publicationError) {
+          throw new Error(publication.publicationError);
+        }
+        projectCreatedAt = publication.event.created_at;
+      }
+    } catch (error) {
+      await removeCreatedChannelAndThrow(
+        isUnsupportedProjectKindError(error)
+          ? new Error(
+              "This relay does not support projects yet, so the channel could not be linked.",
+            )
+          : error instanceof Error
+            ? error
+            : new Error("Could not link the channel to this project."),
+      );
+    }
+  }
+
+  await applyCanvas(input.templateId, channel.id, input.name);
+  void applyAgents(input.templateId, channel.id);
+
+  return {
+    channel,
+    project: addRelatedChannelToProject(
+      input.project,
+      channel.id,
+      projectCreatedAt,
+    ),
+  };
+}
+
+export function useAddProjectChannelMutation() {
+  const queryClient = useQueryClient();
+  const createChannelMutation = useCreateChannelMutation();
+  const { applyAgents, applyCanvas } = useApplyTemplate();
+
+  return useMutation({
+    mutationFn: (input: AddProjectChannelInput) =>
+      addProjectChannel(input, {
+        applyAgents,
+        applyCanvas,
+        createChannel: createChannelMutation.mutateAsync,
+      }),
+    onSuccess: ({ channel, project }) => {
+      queryClient.setQueryData<Project[]>(projectsQueryKey, (current = []) =>
+        current.map((candidate) =>
+          candidate.id === project.id ? project : candidate,
+        ),
+      );
+      queryClient.setQueryData<Channel[]>(channelsQueryKey, (current) =>
+        upsertCachedChannel(current, channel),
+      );
+      void queryClient.invalidateQueries({ queryKey: projectsQueryKey });
+      void queryClient.invalidateQueries({
+        queryKey: channelsQueryKey,
+        refetchType: "none",
+      });
+    },
+  });
+}

--- a/desktop/src/features/projects/useHealProjectHomeRepositories.ts
+++ b/desktop/src/features/projects/useHealProjectHomeRepositories.ts
@@ -1,0 +1,62 @@
+import * as React from "react";
+
+import { homeRepositoriesToBind } from "@/features/projects/lib/projectCollection";
+import type { Project } from "@/features/projects/projectModels";
+import { useAttachProjectRepositoryMutation } from "@/features/projects/useAttachProjectRepository";
+import { relayClient } from "@/shared/api/relayClient";
+import { KIND_PROJECT_ANNOUNCEMENT } from "@/shared/constants/kinds";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+/**
+ * When the signed-in user owns this project, bind absorbed home-channel
+ * repositories onto the `kind:30621` so Overview, other clients, and NIP-MP
+ * agree. Agents can announce a repo with `--channel` but cannot edit the
+ * owner's project event.
+ */
+export function useHealProjectHomeRepositories(
+  project: Project,
+  identityPubkey?: string,
+) {
+  const attachMutation = useAttachProjectRepositoryMutation();
+  const attemptedRef = React.useRef(new Set<string>());
+  const mutateAsync = attachMutation.mutateAsync;
+
+  React.useEffect(() => {
+    if (!identityPubkey) return;
+    if (normalizePubkey(identityPubkey) !== normalizePubkey(project.owner)) {
+      return;
+    }
+    if (project.repositories.length === 0) return;
+
+    let cancelled = false;
+    void (async () => {
+      const liveHeads = await relayClient.fetchEvents({
+        authors: [project.owner],
+        kinds: [KIND_PROJECT_ANNOUNCEMENT],
+        limit: 1,
+        "#d": [project.dtag],
+      });
+      if (cancelled) return;
+      const liveHead = liveHeads[0];
+      if (!liveHead) return;
+      const signedAddresses = liveHead.tags
+        .filter((tag) => tag[0] === "a" && tag[1])
+        .map((tag) => tag[1] as string);
+      const pending = homeRepositoriesToBind(project, signedAddresses);
+      for (const repository of pending) {
+        const key = `${project.projectAddress}:${repository.repoAddress}`;
+        if (attemptedRef.current.has(key)) continue;
+        attemptedRef.current.add(key);
+        try {
+          await mutateAsync({ project, repository });
+        } catch {
+          // Already bound, raced, or not owner-writable this session.
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [identityPubkey, mutateAsync, project]);
+}

--- a/desktop/src/features/sidebar/ui/CreateChannelDialog.tsx
+++ b/desktop/src/features/sidebar/ui/CreateChannelDialog.tsx
@@ -17,6 +17,7 @@ type ChannelKind = "stream" | "forum";
 type CreateChannelDialogProps = {
   /** Which kind of channel to create, or null when closed. */
   channelKind: ChannelKind | null;
+  description?: string;
   isCreating: boolean;
   onOpenChange: (open: boolean) => void;
   onCreate: (input: {
@@ -26,13 +27,18 @@ type CreateChannelDialogProps = {
     ttlSeconds?: number;
     templateId?: string;
   }) => Promise<void>;
+  testId?: string;
+  title?: string;
 };
 
 export function CreateChannelDialog({
   channelKind,
+  description,
   isCreating,
   onOpenChange,
   onCreate,
+  testId = "create-channel-dialog",
+  title,
 }: CreateChannelDialogProps) {
   const open = channelKind !== null;
 
@@ -57,14 +63,15 @@ export function CreateChannelDialog({
       <ChooserDialogContent
         className="max-w-lg"
         contentClassName="pt-3"
-        data-testid="create-channel-dialog"
+        data-testid={testId}
         footerClassName="border-t-0 pt-0"
         headerClassName="pb-2"
-        title={`Create a new ${kindLabel}`}
+        title={title ?? `Create a new ${kindLabel}`}
         description={
-          channelKind === "forum"
+          description ??
+          (channelKind === "forum"
             ? "Forums organize threaded discussions around a topic."
-            : "Channels are real-time streams for team conversation."
+            : "Channels are real-time streams for team conversation.")
         }
         footer={<CreateChannelFormFooter form={form} />}
       >

--- a/desktop/src/features/sidebar/ui/SidebarProjectsSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarProjectsSection.tsx
@@ -2,13 +2,14 @@ import { useLocation } from "@tanstack/react-router";
 import {
   ArrowUpDown,
   ChevronDown,
+  ChevronRight,
   EllipsisVertical,
   Folder,
-  FolderGit2,
-  FolderOpen,
   Folders,
+  Hash,
   Link2,
   ListMinus,
+  Lock,
   Plus,
   Trash2,
 } from "lucide-react";
@@ -16,11 +17,13 @@ import * as React from "react";
 import { toast } from "sonner";
 
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { useChannelsQuery } from "@/features/channels/hooks";
 import {
   type Project,
   useDeleteProjectMutation,
   useProjectsQuery,
 } from "@/features/projects/hooks";
+import { listProjectChildChannels } from "@/features/projects/lib/projectRelatedChannels";
 import { isProjectOwnedByCurrentUser } from "@/features/projects/lib/projectsViewHelpers";
 import { projectShareLink } from "@/features/projects/lib/projectShareLinks";
 import {
@@ -28,9 +31,9 @@ import {
   removeProjectFromSidebar,
 } from "@/features/projects/lib/projectSidebarMembership";
 import { useProjectSidebarMembership } from "@/features/projects/lib/useProjectSidebarMembership";
-import { selectProjectRepository } from "@/features/projects/projectModels";
 import { projectMatchesRouteId } from "@/features/projects/projectRoutes";
 import { ProjectBrowserDialog } from "@/features/projects/ui/ProjectBrowserDialog";
+import { ProjectChannelIcon } from "@/features/projects/ui/ProjectChannelIcon";
 import { useCreateProjectMutation } from "@/features/projects/useCreateProject";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import { FeatureGate } from "@/shared/features";
@@ -91,6 +94,7 @@ import {
   readSidebarProjectExpansion,
   readSidebarProjectsFilter,
   readSidebarProjectsSort,
+  selectedChannelRouteId,
   selectedProjectRouteId,
   type SidebarProjectExpansionState,
   type SidebarProjectsFilter,
@@ -122,17 +126,13 @@ export function SidebarProjectsSection() {
 
 function SidebarProjectsSectionContent() {
   const projectsQuery = useProjectsQuery();
+  const channelsQuery = useChannelsQuery();
   const identityQuery = useIdentityQuery();
   const currentPubkey = identityQuery.data?.pubkey;
-  const { goProject, goProjects } = useAppNavigation();
+  const { goChannel, goProject, goProjects } = useAppNavigation();
   const pathname = useLocation({ select: (location) => location.pathname });
-  const routeRepositoryId = useLocation({
-    select: (location) => {
-      const value = (location.search as Record<string, unknown>).repositoryId;
-      return typeof value === "string" ? value : undefined;
-    },
-  });
   const routeProjectId = selectedProjectRouteId(pathname);
+  const routeChannelId = selectedChannelRouteId(pathname);
   const relayOrigin = getCachedRelayOrigin();
   const [collapsed, setCollapsed] = React.useState(false);
   const [actionsOpen, setActionsOpen] = React.useState(false);
@@ -181,24 +181,13 @@ function SidebarProjectsSectionContent() {
       }),
     [addedProjectAddressSet, currentPubkey, filter, projectsQuery.data, sort],
   );
-  React.useEffect(() => {
-    if (!routeProjectId) return;
-    const selectedProject = projects.find((project) =>
-      projectMatchesRouteId(project, routeProjectId),
-    );
-    if (
-      !selectedProject ||
-      projectExpansion[selectedProject.projectAddress] !== undefined
-    ) {
-      return;
-    }
-    setProjectExpansion((current) => {
-      const next = { ...current, [selectedProject.projectAddress]: true };
-      writeSidebarProjectExpansion(next, relayOrigin, currentPubkey);
-      return next;
-    });
-  }, [currentPubkey, projectExpansion, projects, relayOrigin, routeProjectId]);
-
+  const channelsById = React.useMemo(
+    () =>
+      new Map(
+        (channelsQuery.data ?? []).map((channel) => [channel.id, channel]),
+      ),
+    [channelsQuery.data],
+  );
   const handleFilterChange = (next: SidebarProjectsFilter) => {
     setFilter(next);
     writeSidebarProjectsFilter(next, relayOrigin, currentPubkey);
@@ -309,11 +298,15 @@ function SidebarProjectsSectionContent() {
                 const isActive =
                   routeProjectId != null &&
                   projectMatchesRouteId(project, routeProjectId);
-                const selectedRepository = isActive
-                  ? selectProjectRepository(project, routeRepositoryId)
-                  : null;
+                const childChannels = listProjectChildChannels(project).flatMap(
+                  (binding) => {
+                    const channel = channelsById.get(binding.channelId);
+                    return channel ? [{ binding, channel }] : [];
+                  },
+                );
                 const isExpanded =
-                  projectExpansion[project.projectAddress] ?? isActive;
+                  childChannels.length > 0 &&
+                  (projectExpansion[project.projectAddress] ?? false);
 
                 return (
                   <React.Fragment key={project.id}>
@@ -322,38 +315,46 @@ function SidebarProjectsSectionContent() {
                         project,
                         currentPubkey,
                       )}
+                      childCount={childChannels.length}
                       deleteDisabled={deleteProjectMutation.isPending}
                       isActive={isActive}
                       isExpanded={isExpanded}
                       onDelete={() => setProjectToDelete(project)}
-                      onOpen={() => setProjectExpanded(project, !isExpanded)}
+                      onOpen={() => {
+                        void goProject(project.id);
+                      }}
                       onRemove={() => handleRemove(project)}
+                      onToggleExpanded={() =>
+                        setProjectExpanded(project, !isExpanded)
+                      }
                       project={project}
                     />
                     {isExpanded
-                      ? project.repositories.map((repository) => (
-                          <SidebarMenuItem key={repository.id}>
-                            <SidebarMenuButton
-                              className="h-7 pl-7 text-sidebar-foreground/70 data-[active=true]:!bg-transparent data-[active=true]:font-semibold data-[active=true]:text-sidebar-foreground data-[active=true]:shadow-none data-[active=true]:hover:!bg-transparent data-[active=true]:hover:text-sidebar-foreground data-[active=true]:active:!bg-transparent"
-                              data-testid={`sidebar-project-repository-${repository.dtag}`}
-                              isActive={
-                                repository.id === selectedRepository?.id
-                              }
-                              onClick={() =>
-                                goProject(project.id, {
-                                  repositoryId: repository.id,
-                                })
-                              }
-                              tooltip={repository.name}
-                              type="button"
+                      ? childChannels.map(({ binding, channel }) => {
+                          const ChannelIcon =
+                            channel.visibility === "private" ? Lock : Hash;
+                          return (
+                            <SidebarMenuItem
+                              key={`${project.id}:${binding.role}:${channel.id}`}
                             >
-                              <FolderGit2 className="h-3.5 w-3.5" />
-                              <SidebarMenuLabel>
-                                {repository.name}
-                              </SidebarMenuLabel>
-                            </SidebarMenuButton>
-                          </SidebarMenuItem>
-                        ))
+                              <SidebarMenuButton
+                                className="h-7 pl-7 text-sidebar-foreground/70 data-[active=true]:!bg-transparent data-[active=true]:font-semibold data-[active=true]:text-sidebar-foreground data-[active=true]:shadow-none data-[active=true]:hover:!bg-transparent data-[active=true]:hover:text-sidebar-foreground data-[active=true]:active:!bg-transparent"
+                                data-testid={`sidebar-project-channel-${project.dtag}-${channel.name}`}
+                                isActive={channel.id === routeChannelId}
+                                onClick={() => {
+                                  void goChannel(channel.id);
+                                }}
+                                tooltip={`#${channel.name}`}
+                                type="button"
+                              >
+                                <ChannelIcon className="h-3.5 w-3.5" />
+                                <SidebarMenuLabel>
+                                  {`#${channel.name}`}
+                                </SidebarMenuLabel>
+                              </SidebarMenuButton>
+                            </SidebarMenuItem>
+                          );
+                        })
                       : null}
                   </React.Fragment>
                 );
@@ -560,45 +561,74 @@ function SidebarProjectsHeaderActions({
 
 function SidebarProjectRow({
   canDelete,
+  childCount,
   deleteDisabled,
   isActive,
   isExpanded,
   onDelete,
   onOpen,
   onRemove,
+  onToggleExpanded,
   project,
 }: {
   canDelete: boolean;
+  childCount: number;
   deleteDisabled: boolean;
   isActive: boolean;
   isExpanded: boolean;
   onDelete: () => void;
   onOpen: () => void;
   onRemove: () => void;
+  onToggleExpanded: () => void;
   project: Project;
 }) {
   const shareLink = projectShareLink(project);
-  const ProjectIcon = isExpanded ? FolderOpen : Folders;
+  const hasChildren = childCount > 0;
 
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <SidebarMenuItem>
           <SidebarMenuButton
-            aria-expanded={isExpanded}
-            className="data-[active=true]:!bg-transparent data-[active=true]:font-normal data-[active=true]:text-sidebar-foreground data-[active=true]:shadow-none data-[active=true]:hover:!bg-transparent data-[active=true]:hover:text-sidebar-foreground data-[active=true]:active:!bg-transparent"
+            className={cn(
+              "data-[active=true]:!bg-transparent data-[active=true]:font-normal data-[active=true]:text-sidebar-foreground data-[active=true]:shadow-none data-[active=true]:hover:!bg-transparent data-[active=true]:hover:text-sidebar-foreground data-[active=true]:active:!bg-transparent",
+              hasChildren && "pr-8",
+            )}
             data-testid={`sidebar-project-${project.dtag}`}
             isActive={isActive}
             onClick={onOpen}
             tooltip={project.name}
             type="button"
           >
-            <ProjectIcon className={cn("h-4 w-4", !isActive && "opacity-80")} />
+            <ProjectChannelIcon className={cn(!isActive && "opacity-80")} />
             <SidebarMenuLabel className={cn(!isActive && "opacity-80")}>
               {project.name}
             </SidebarMenuLabel>
           </SidebarMenuButton>
-          {canDelete ? (
+          {hasChildren ? (
+            <SidebarMenuAction
+              aria-expanded={isExpanded}
+              aria-label={
+                isExpanded
+                  ? `Hide channels in ${project.name}`
+                  : `Show channels in ${project.name}`
+              }
+              data-testid={`sidebar-project-expand-${project.dtag}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onToggleExpanded();
+              }}
+              type="button"
+            >
+              <ChevronRight
+                className={cn(
+                  "transition-transform duration-150",
+                  isExpanded && "rotate-90",
+                )}
+              />
+            </SidebarMenuAction>
+          ) : null}
+          {canDelete && !hasChildren ? (
             <SidebarMenuAction
               aria-label={`Delete ${project.name}`}
               data-testid={`sidebar-project-delete-${project.dtag}`}

--- a/desktop/src/features/sidebar/ui/listSidebarProjects.ts
+++ b/desktop/src/features/sidebar/ui/listSidebarProjects.ts
@@ -79,6 +79,17 @@ export function selectedProjectRouteId(pathname: string): string | undefined {
   }
 }
 
+export function selectedChannelRouteId(pathname: string): string | undefined {
+  if (!pathname.startsWith("/channels/")) return undefined;
+  const raw = pathname.slice("/channels/".length).split("/")[0];
+  if (!raw) return undefined;
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
 export function readSidebarProjectsFilter(
   relayOrigin: string | null,
   currentPubkey?: string,

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1515,6 +1515,7 @@ const OWNED_RELAY_AGENT_PUBKEY =
   "a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff00";
 const MOCK_IDENTITY_PUBKEY = DEFAULT_MOCK_IDENTITY.pubkey;
 const STARTER_GENERAL_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const STARTER_PROJECT_HOME_CHANNEL_ID = "cf63feec-21bb-5bf0-a2f8-0e4c3de8ec73";
 const STARTER_WELCOME_CHANNEL_ID = "5f0b1b3c-2a37-5366-9b8c-31a4b21d8e77";
 const STARTER_GENERAL_CHANNEL_NAME = "general";
 const STARTER_WELCOME_CHANNEL_NAME = "welcome-everyone";
@@ -2671,6 +2672,28 @@ const mockChannels: MockChannel[] = [
       createMockMember(BOB_PUBKEY, "member", 960),
       createMockMember(PROFILE_ONLY_AGENT_PUBKEY, "member", 840),
     ],
+  }),
+  createMockChannel({
+    id: STARTER_PROJECT_HOME_CHANNEL_ID,
+    name: "buzz",
+    channel_type: "stream",
+    visibility: "open",
+    description: "Project home for the Buzz community platform.",
+    topic: null,
+    purpose: null,
+    last_message_at: null,
+    archived_at: null,
+    created_by: MOCK_IDENTITY_PUBKEY,
+    topic_set_by: null,
+    topic_set_at: null,
+    purpose_set_by: null,
+    purpose_set_at: null,
+    topic_required: false,
+    max_members: null,
+    nip29_group_id: null,
+    created_minutes_ago: 1440,
+    updated_minutes_ago: 1440,
+    members: [createMockMember(MOCK_IDENTITY_PUBKEY, "owner", 1440)],
   }),
   createMockChannel({
     id: STARTER_WELCOME_CHANNEL_ID,
@@ -5874,7 +5897,7 @@ function buildMockProjectEvents(): RelayEvent[] {
           [
             "buzz-channel",
             getConfig()?.mock?.projectAccessChannelId ??
-              "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50",
+              STARTER_PROJECT_HOME_CHANNEL_ID,
           ],
           ["clone", seed.cloneUrl],
           ...(seed.webUrl ? [["web", seed.webUrl]] : []),
@@ -5964,6 +5987,12 @@ function buildMockProjectEvents(): RelayEvent[] {
         ["description", "The complete Buzz community platform."],
         ["a", `${KIND_REPO_ANNOUNCEMENT}:${projectOwner}:buzz`],
         ["a", `${KIND_REPO_ANNOUNCEMENT}:${ALICE_PUBKEY}:relay-tools`],
+        [
+          "buzz-channel",
+          getConfig()?.mock?.projectAccessChannelId ??
+            STARTER_PROJECT_HOME_CHANNEL_ID,
+        ],
+        ["buzz-related-channel", "9dae0116-799b-5071-a0a8-fdd30a91a35d"],
       ],
       projectOwner,
       now,

--- a/desktop/tests/e2e/channel-browser.spec.ts
+++ b/desktop/tests/e2e/channel-browser.spec.ts
@@ -80,6 +80,7 @@ test("channel browser sorts alphabetically or by member count", async ({
   await expect(rows).toHaveText([
     /#agents/,
     /#all-replies/,
+    /#buzz/,
     /#deep-history/,
     /#design/,
     /#engineering/,
@@ -103,6 +104,7 @@ test("channel browser sorts alphabetically or by member count", async ({
     /#design/,
     /#sales/,
     /#secret-projects/,
+    /#buzz/,
     /#welcome-everyone/,
   ]);
   await expect(page.getByTestId("channel-browser-sort")).toHaveAttribute(
@@ -128,6 +130,7 @@ test("channel browser sorts by recent activity", async ({ page }) => {
     /#sales/,
     /#engineering/,
     /#design/,
+    /#buzz/,
     /#random/,
     /#secret-projects/,
     /#welcome-everyone/,

--- a/desktop/tests/e2e/entity-link-recipient-cards.spec.ts
+++ b/desktop/tests/e2e/entity-link-recipient-cards.spec.ts
@@ -579,10 +579,7 @@ test("reopening the same entity link reapplies its workspace state", async ({
     name: "Project breadcrumb",
   });
   await breadcrumb.getByRole("button").nth(1).click();
-  await expect(page.getByRole("tab", { name: "Overview" })).toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
+  await expect(page.getByTestId("project-channel-home")).toBeVisible();
 
   await emitEntityLink(repoLink);
   await expect(pullRequestsTab).toHaveAttribute("aria-selected", "true");

--- a/desktop/tests/e2e/project-commit-detail.spec.ts
+++ b/desktop/tests/e2e/project-commit-detail.spec.ts
@@ -31,6 +31,19 @@ async function addProjectToSidebar(
   await expect(page.getByTestId(`sidebar-project-${dtag}`)).toBeVisible();
 }
 
+async function openProjectRepository(
+  page: import("@playwright/test").Page,
+  repositoryId: string,
+) {
+  await expect(page).toHaveURL(/\/projects\//);
+  const target = await page.evaluate((id) => {
+    const url = new URL(window.location.href);
+    url.searchParams.set("repositoryId", id);
+    return `${url.pathname}${url.search}`;
+  }, repositoryId);
+  await page.goto(target, { waitUntil: "domcontentloaded" });
+}
+
 async function waitForMockLiveSubscription(
   page: import("@playwright/test").Page,
   channelName: string,
@@ -247,9 +260,7 @@ test("top-level project lists show metadata and overflow actions", async ({
   ).toBe(true);
 });
 
-test("creating a project publishes its initial repository grouping", async ({
-  page,
-}) => {
+test("creating a project opens its channel conversation", async ({ page }) => {
   await enableProjectsFeature(page);
   await installMockBridge(page);
   await page.goto("/", { waitUntil: "domcontentloaded" });
@@ -260,16 +271,111 @@ test("creating a project publishes its initial repository grouping", async ({
   await page
     .getByTestId("create-project-description")
     .fill("A grouped project created through the desktop app.");
+  await expect(page.getByTestId("create-project-listing")).toHaveText("Listed");
+  await expect(page.getByTestId("create-project-agent")).toHaveText("None");
   await page.getByTestId("create-project-submit").click();
 
   await expect(page.getByTestId("create-project-dialog")).toBeHidden();
+  await expect(page.getByTestId("project-channel-home")).toBeVisible();
+  await expect(page.getByTestId("project-breadcrumb-project")).toHaveText(
+    "multi-repo-demo",
+  );
+  await expect(page.getByTestId("chat-title")).toHaveText("multi-repo-demo");
+  await expect(page.getByTestId("project-agent-chat-panel")).toHaveCount(0);
+  await expect(page.getByTestId("message-channel-intro")).toBeVisible();
+  await expect(page.getByTestId("message-channel-intro")).toContainText(
+    "project channel",
+  );
   await expect(
     page
-      .locator(
-        '[data-testid="project-card-multi-repo-demo"], [data-testid="project-row-multi-repo-demo"]',
-      )
-      .first(),
+      .getByTestId("message-channel-intro-icon")
+      .getByTestId("project-channel-icon"),
   ).toBeVisible();
+  await expect(
+    page.getByTestId("chat-header").getByTestId("project-channel-icon"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("channel-intro-action-add-files"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("channel-intro-action-add-files-title"),
+  ).toHaveText("Add files");
+  await page.getByTestId("channel-intro-action-add-files").click();
+  await expect(page.getByTestId("add-project-repository-dialog")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("add-project-repository-dialog")).toBeHidden();
+  await expect(page.getByTestId("project-home-summary-column")).toBeVisible();
+  await expect(page.getByTestId("project-home-context-panel")).toBeVisible();
+  await expect(page.getByTestId("project-home-context-about")).toHaveCount(0);
+  await expect(
+    page.getByTestId("project-home-context-home-channel"),
+  ).toContainText("multi-repo-demo");
+  await expect(
+    page
+      .getByTestId("project-home-context-home-channel")
+      .getByTestId("project-channel-icon"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("project-home-context-home-channel"),
+  ).not.toContainText("#multi-repo-demo");
+  await expect(
+    page.getByTestId("project-home-context-channel"),
+  ).not.toContainText("people in this channel");
+  await expect(page.getByTestId("add-project-channel")).toBeVisible();
+  await page.getByTestId("add-project-channel").click();
+  await expect(page.getByTestId("create-project-channel-dialog")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("create-project-channel-dialog")).toBeHidden();
+  await expect(
+    page.getByTestId("sidebar-project-multi-repo-demo"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("sidebar-project-home-channel-multi-repo-demo"),
+  ).toHaveCount(0);
+  await expect(
+    page.getByTestId("sidebar-project-expand-multi-repo-demo"),
+  ).toHaveCount(0);
+  await expect(page.getByTestId("project-home-context-codebase")).toContainText(
+    "multi-repo-demo",
+  );
+  await expect(
+    page.getByTestId("project-home-context-workspace"),
+  ).toBeVisible();
+  await expect(
+    page
+      .getByTestId("project-home-context-workspace")
+      .getByRole("heading", { name: "Workspace" }),
+  ).toHaveCount(0);
+  await expect(page.getByTestId("project-home-context-tasks")).toBeEnabled();
+  await expect(page.getByTestId("project-home-context-people")).toContainText(
+    "1",
+  );
+  await expect(page.getByTestId("project-home-drawer-toggle")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await page.getByTestId("channel-management-trigger").click();
+  await expect(page.getByTestId("channel-management-type")).toContainText(
+    "Project",
+  );
+  await page
+    .getByTestId("channel-management-sheet")
+    .getByTestId("auxiliary-panel-close")
+    .click();
+  await expect(page.getByTestId("channel-management-sheet")).toHaveCount(0);
+  await page.getByTestId("project-home-codebase-toggle").click();
+  await expect(page.getByTestId("project-home-workspace-sheet")).toBeVisible();
+  await expect(
+    page.getByTestId("project-home-workspace-sheet"),
+  ).toHaveAttribute("data-tab", "files");
+  await expect(page.getByTestId("focus-thread-drawer")).toBeVisible();
+  await expect(page.getByTestId("project-home-summary-column")).toHaveCount(0);
+  await page
+    .getByTestId("focus-thread-drawer")
+    .getByTestId("auxiliary-panel-close")
+    .click();
+  await expect(page.getByTestId("project-home-workspace-sheet")).toHaveCount(0);
+  await expect(page.getByTestId("project-home-summary-column")).toBeVisible();
 
   const createdEvents = await page.evaluate(
     () =>
@@ -279,16 +385,20 @@ test("creating a project publishes its initial repository grouping", async ({
         ),
       ) ?? [],
   );
-  expect(createdEvents.map((event) => event.kind).sort()).toEqual([
-    30617, 30621,
-  ]);
+  expect(createdEvents.map((event) => event.kind)).toEqual([30621, 30617]);
   const projectEvent = createdEvents.find((event) => event.kind === 30621);
-  expect(projectEvent?.tags).toContainEqual([
-    "a",
-    `30617:${"deadbeef".repeat(8)}:multi-repo-demo`,
-  ]);
   expect(projectEvent?.content).toBe("");
+  expect(projectEvent?.tags.some((tag) => tag[0] === "a")).toBe(true);
+  expect(
+    projectEvent?.tags.find((tag) => tag[0] === "buzz-channel")?.[1],
+  ).toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+  );
 
+  await page
+    .getByTestId("project-detail-chrome")
+    .getByRole("button", { name: "Projects" })
+    .click();
   await page.getByTestId("projects-create-menu").hover();
   await page.getByRole("menuitem", { name: "Project" }).click();
   await page.getByTestId("create-project-name").fill("multi-repo-demo");
@@ -364,13 +474,10 @@ test("project creation can retry after its repository publication fails", async 
 
   await page.getByTestId("create-project-submit").click();
   await expect(page.getByTestId("create-project-dialog")).toBeHidden();
-  await expect(
-    page
-      .locator(
-        '[data-testid="project-card-retry-project"], [data-testid="project-row-retry-project"]',
-      )
-      .first(),
-  ).toBeVisible();
+  await expect(page.getByTestId("project-channel-home")).toBeVisible();
+  await expect(page.getByTestId("project-breadcrumb-project")).toHaveText(
+    "retry-project",
+  );
 });
 
 test("project creation is idempotent after a lost publish acknowledgement", async ({
@@ -395,13 +502,10 @@ test("project creation is idempotent after a lost publish acknowledgement", asyn
 
   await page.getByTestId("create-project-submit").click();
   await expect(page.getByTestId("create-project-dialog")).toBeHidden();
-  await expect(
-    page
-      .locator(
-        '[data-testid="project-card-lost-ack-project"], [data-testid="project-row-lost-ack-project"]',
-      )
-      .first(),
-  ).toBeVisible();
+  await expect(page.getByTestId("project-channel-home")).toBeVisible();
+  await expect(page.getByTestId("project-breadcrumb-project")).toHaveText(
+    "lost-ack-project",
+  );
   await expect
     .poll(() =>
       page.evaluate(
@@ -416,7 +520,7 @@ test("project creation is idempotent after a lost publish acknowledgement", asyn
     .toBe(2);
 });
 
-test("multi-repository projects switch the active repository", async ({
+test("project sidebar rows open the home channel and nest extra channels", async ({
   page,
 }) => {
   await enableProjectsFeature(page);
@@ -424,31 +528,37 @@ test("multi-repository projects switch the active repository", async ({
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await addProjectToSidebar(page, "buzz");
 
-  const primaryRepository = page.getByTestId("sidebar-project-repository-buzz");
-  const relayToolsRepository = page.getByTestId(
-    "sidebar-project-repository-relay-tools",
-  );
   const projectRow = page.getByTestId("sidebar-project-buzz");
-  await expect(projectRow).toHaveAttribute("aria-expanded", "true");
-  await expect(primaryRepository).toHaveAttribute("data-active", "true");
-  await expect(relayToolsRepository).toBeVisible();
+  const expand = page.getByTestId("sidebar-project-expand-buzz");
+  const nestedChannel = page.getByTestId("sidebar-project-channel-buzz-random");
+  await expect(page).toHaveURL(/\/projects\//);
+  await expect(page.getByTestId("project-channel-home")).toBeVisible();
+  await expect(projectRow).toHaveAttribute("data-active", "true");
+  await expect(expand).toHaveAttribute("aria-expanded", "false");
+  await expect(nestedChannel).toBeHidden();
+  await expect(page.getByTestId("sidebar-project-repository-buzz")).toHaveCount(
+    0,
+  );
+  await expect(
+    page.getByTestId("sidebar-project-home-channel-buzz"),
+  ).toHaveCount(0);
 
-  await projectRow.click();
-  await expect(projectRow).toHaveAttribute("aria-expanded", "false");
-  await expect(relayToolsRepository).toBeHidden();
+  await expand.click();
+  await expect(expand).toHaveAttribute("aria-expanded", "true");
+  await expect(nestedChannel).toBeVisible();
+  await expect(page).toHaveURL(/\/projects\//);
 
   await page.reload({ waitUntil: "domcontentloaded" });
   await addProjectToSidebar(page, "buzz");
-  await expect(projectRow).toHaveAttribute("aria-expanded", "false");
-  await expect(relayToolsRepository).toBeHidden();
+  await expect(expand).toHaveAttribute("aria-expanded", "true");
+  await expect(nestedChannel).toBeVisible();
 
-  await projectRow.click();
-  await expect(projectRow).toHaveAttribute("aria-expanded", "true");
-  await expect(relayToolsRepository).toBeVisible();
+  await nestedChannel.click();
+  await expect(page).toHaveURL(/\/channels\//);
+  await expect(page.getByTestId("chat-title")).toHaveText("random");
+  await expect(nestedChannel).toHaveAttribute("data-active", "true");
+  await expect(projectRow).toHaveAttribute("data-active", "false");
 
-  await page.getByTestId("channel-general").click();
-  await expect(projectRow).toHaveAttribute("aria-expanded", "true");
-  await expect(relayToolsRepository).toBeVisible();
   const sidebarScrollContent = page.getByTestId("sidebar-scroll-content");
   const channelSidebarMetrics = await sidebarScrollContent.evaluate(
     (element) => {
@@ -460,15 +570,14 @@ test("multi-repository projects switch the active repository", async ({
       };
     },
   );
-  await projectRow.click();
-  await expect(page).not.toHaveURL(/\/projects\//);
-  await expect(projectRow).toHaveAttribute("aria-expanded", "false");
-  await expect(relayToolsRepository).toBeHidden();
+  await expand.click();
+  await expect(expand).toHaveAttribute("aria-expanded", "false");
+  await expect(nestedChannel).toBeHidden();
+  await expect(page).toHaveURL(/\/channels\//);
 
-  await projectRow.click();
-  await expect(page).not.toHaveURL(/\/projects\//);
-  await expect(projectRow).toHaveAttribute("aria-expanded", "true");
-  await expect(relayToolsRepository).toBeVisible();
+  await expand.click();
+  await expect(expand).toHaveAttribute("aria-expanded", "true");
+  await expect(nestedChannel).toBeVisible();
   const projectSidebarMetrics = await sidebarScrollContent.evaluate(
     (element) => {
       const bounds = element.getBoundingClientRect();
@@ -482,35 +591,23 @@ test("multi-repository projects switch the active repository", async ({
   expect(projectSidebarMetrics).toEqual(channelSidebarMetrics);
 
   await projectRow.click();
-  await expect(projectRow).toHaveAttribute("aria-expanded", "false");
-  await page.getByTestId("channel-general").click();
-  const sidebarScroller = page.locator('[data-sidebar="content"]');
-  const anchoredScrollTop = await sidebarScroller.evaluate((element) => {
-    element.scrollTop = Math.min(
-      20,
-      Math.max(0, element.scrollHeight - element.clientHeight),
-    );
-    return element.scrollTop;
-  });
-  await projectRow.click();
-  await expect(page).not.toHaveURL(/\/projects\//);
-  await expect(projectRow).toHaveAttribute("aria-expanded", "true");
-  await expect
-    .poll(() =>
-      sidebarScroller.evaluate((element) => Math.round(element.scrollTop)),
-    )
-    .toBe(Math.round(anchoredScrollTop));
+  await expect(page).toHaveURL(/\/projects\//);
+  await expect(projectRow).toHaveAttribute("data-active", "true");
   await waitForAnimations(page);
   await page.screenshot({
     path: `${SHOTS}/04-multi-repository-picker.png`,
   });
 
-  await relayToolsRepository.click();
-  await expect(relayToolsRepository).toHaveAttribute("data-active", "true");
+  await openProjectRepository(
+    page,
+    `${TEST_IDENTITIES.alice.pubkey}:relay-tools`,
+  );
   await expect(page).toHaveURL(
     new RegExp(`repositoryId=${TEST_IDENTITIES.alice.pubkey}%3Arelay-tools`),
   );
 
+  await page.getByTestId("sidebar-project-buzz").click();
+  await expect(page.getByTestId("project-home-context-panel")).toBeVisible();
   await page.getByTestId("add-project-repository").click();
   await expect(page.getByTestId("attach-project-repository")).toBeVisible();
   await page.getByTestId("create-project-repository").click();
@@ -518,8 +615,11 @@ test("multi-repository projects switch the active repository", async ({
   await page.getByTestId("add-project-repository-submit").click();
   await expect(page.getByTestId("add-project-repository-dialog")).toBeHidden();
   await expect(
-    page.getByTestId("sidebar-project-repository-mobile-app"),
+    page.getByTestId("project-home-context-repo-mobile-app"),
   ).toBeVisible();
+  await expect(
+    page.getByTestId("sidebar-project-repository-mobile-app"),
+  ).toHaveCount(0);
   const addedEvents = await page.evaluate(
     () =>
       window.__BUZZ_E2E_ACCEPTED_PROJECT_EVENTS__?.filter(
@@ -536,7 +636,7 @@ test("multi-repository projects switch the active repository", async ({
   expect(addedEvents.map((event) => event.kind)).toEqual([30621, 30617]);
   expect(
     addedEvents.find((event) => event.kind === 30617)?.tags,
-  ).toContainEqual(["buzz-channel", "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50"]);
+  ).toContainEqual(["buzz-channel", "cf63feec-21bb-5bf0-a2f8-0e4c3de8ec73"]);
 
   await page.getByTestId("add-project-repository").click();
   await page.getByTestId("attach-project-repository").click();
@@ -548,7 +648,7 @@ test("multi-repository projects switch the active repository", async ({
     page.getByTestId("attach-project-repository-dialog"),
   ).toBeHidden();
   await expect(
-    page.getByTestId("sidebar-project-repository-design-system"),
+    page.getByTestId("project-home-context-repo-design-system"),
   ).toBeVisible();
   await expect
     .poll(() =>
@@ -581,6 +681,7 @@ test("latest files commit opens its detail without a divider", async ({
     .first();
   await expect(projectEntry).toBeVisible({ timeout: 10_000 });
   await projectEntry.click();
+  await page.getByTestId("project-home-context-repo-buzz").click();
   await page.getByRole("tab", { name: "Files" }).click();
 
   const latestCommit = page.getByTestId("project-repository-latest-commit");
@@ -632,6 +733,29 @@ test("commit detail opens from the commits feed with a diff", async ({
     .first();
   await expect(projectEntry).toBeVisible({ timeout: 10_000 });
   await projectEntry.click();
+  await page.getByTestId("project-home-context-tasks").click();
+  await expect(page.getByTestId("project-home-workspace-sheet")).toBeVisible();
+  await expect(
+    page.getByTestId("project-home-workspace-sheet"),
+  ).toHaveAttribute("data-tab", "issues");
+  await expect(page.getByTestId("focus-thread-drawer")).toBeVisible();
+  await expect(page.getByTestId("project-channel-home")).toBeVisible();
+  await expect(page.getByTestId("project-home-summary-column")).toHaveCount(0);
+  await expect(page.getByTestId("project-workspace-back")).toHaveCount(0);
+  await page
+    .getByTestId("focus-thread-drawer")
+    .getByTestId("auxiliary-panel-close")
+    .click();
+  await expect(page.getByTestId("project-home-workspace-sheet")).toHaveCount(0);
+  await expect(page.getByTestId("project-home-summary-column")).toBeVisible();
+  await page.getByTestId("project-home-context-repo-buzz").click();
+  await expect(page.getByTestId("app-sidebar")).toBeVisible();
+  await expect(page.getByTestId("project-workspace-back")).toBeVisible();
+  await page.getByTestId("project-workspace-back").click();
+  await expect(page.getByTestId("project-channel-home")).toBeVisible();
+  await expect(page.getByTestId("app-sidebar")).toBeVisible();
+  await page.getByTestId("project-home-context-repo-buzz").click();
+  await expect(page.getByTestId("project-workspace-back")).toBeVisible();
 
   await page.getByRole("tab", { name: "Commits" }).click();
   const commitRows = page.getByTestId("project-activity-feed-item");
@@ -728,7 +852,7 @@ test("commit detail opens from the commits feed with a diff", async ({
     page.getByRole("navigation", { name: "Project breadcrumb" }),
   ).toContainText("Commits");
 
-  // The project-name segment goes to the project home (Overview tab).
+  // The repository segment returns to the project channel home.
   await commitRows
     .first()
     .getByRole("button", { name: /Add Trello board workflow details/ })
@@ -738,10 +862,8 @@ test("commit detail opens from the commits feed with a diff", async ({
     .getByRole("navigation", { name: "Project breadcrumb" })
     .getByTestId("project-breadcrumb-repository")
     .click();
-  await expect(page.getByRole("tab", { name: "Overview" })).toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
+  await expect(page.getByTestId("project-channel-home")).toBeVisible();
+  await expect(page.getByTestId("app-sidebar")).toBeVisible();
 
   // The Projects root segment leaves the project entirely.
   await page
@@ -793,6 +915,7 @@ test("project discussion row opens its channel thread in context", async ({
     )
     .first()
     .click();
+  await page.getByTestId("project-home-context-repo-buzz").click();
   await page.getByRole("tab", { name: "Commits" }).click();
   const commitRow = page.getByTestId("project-activity-feed-item").first();
   await commitRow
@@ -834,6 +957,7 @@ test("pull request and issue feeds use compact work item rows", async ({
   await projectEntry.click();
 
   // Reviews use the compact single-line work-item row.
+  await page.getByTestId("project-home-context-repo-buzz").click();
   await page.getByRole("tab", { name: "Review" }).click();
   const prRows = page.getByTestId("project-pull-request-row");
   await expect(prRows.first()).toBeVisible({ timeout: 10_000 });
@@ -996,10 +1120,13 @@ test("adding a repository treats a lost 30617 acknowledgement as success", async
 
   // The dialog should close — the operation recovered from the lost ACK.
   await expect(page.getByTestId("add-project-repository-dialog")).toBeHidden();
-  // The sidebar must reflect the newly added repository.
+  // The overview must reflect the newly added repository.
+  await expect(
+    page.getByTestId("project-home-context-repo-lost-ack-repo"),
+  ).toBeVisible();
   await expect(
     page.getByTestId("sidebar-project-repository-lost-ack-repo"),
-  ).toBeVisible();
+  ).toHaveCount(0);
 
   // Both events must have been accepted: the 30621 (project update) and the
   // 30617 (repository — accepted by relay even though ACK was lost).

--- a/desktop/tests/e2e/project-issue-comments.spec.ts
+++ b/desktop/tests/e2e/project-issue-comments.spec.ts
@@ -21,6 +21,7 @@ async function openBuzzProject(page: import("@playwright/test").Page) {
     .first();
   await expect(projectEntry).toBeVisible({ timeout: 10_000 });
   await projectEntry.click();
+  await page.getByTestId("project-home-context-repo-buzz").click();
 }
 
 test("issue detail can open agent chat or seed a channel question", async ({
@@ -114,11 +115,11 @@ test("issue discussion ignores an author-claimed origin channel", async ({
     "project-context-related-channel",
   );
   await expect(relatedChannel).toHaveCount(1);
-  await expect(relatedChannel).toContainText("#general");
+  await expect(relatedChannel).toContainText("#buzz");
   await expect(channelChoices).not.toContainText("#random");
   await relatedChannel.click();
 
-  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await expect(page.getByTestId("chat-title")).toHaveText("buzz");
   const issueDraftChip = page
     .getByTestId("message-input")
     .locator('[data-composer-buzz-link=""]', {

--- a/desktop/tests/e2e/project-pr-review.spec.ts
+++ b/desktop/tests/e2e/project-pr-review.spec.ts
@@ -61,6 +61,7 @@ async function openBuzzProject(page: import("@playwright/test").Page) {
     .first();
   await expect(projectEntry).toBeVisible({ timeout: 10_000 });
   await projectEntry.click();
+  await page.getByTestId("project-home-context-repo-buzz").click();
 }
 
 async function addProjectToSidebar(
@@ -72,6 +73,21 @@ async function addProjectToSidebar(
   const browser = page.getByTestId("project-browser-dialog");
   await browser.getByRole("searchbox", { name: "Search projects" }).fill(dtag);
   await browser.getByTestId(`project-browser-result-${dtag}`).click();
+  await expect(browser).toBeHidden();
+  await expect(page.getByTestId(`sidebar-project-${dtag}`)).toBeVisible();
+}
+
+async function openProjectRepository(
+  page: import("@playwright/test").Page,
+  repositoryId: string,
+) {
+  await expect(page).toHaveURL(/\/projects\//);
+  const target = await page.evaluate((id) => {
+    const url = new URL(window.location.href);
+    url.searchParams.set("repositoryId", id);
+    return `${url.pathname}${url.search}`;
+  }, repositoryId);
+  await page.goto(target, { waitUntil: "domcontentloaded" });
 }
 
 function pullRequestRowByAuthor(
@@ -1150,19 +1166,14 @@ test("sidebar distinguishes the Projects overview from an open project", async (
   await projectsOverview.click();
   await expect(projectsOverview).toHaveAttribute("data-active", "true");
   await expect(sidebarProject).toHaveAttribute("data-active", "false");
-  await expect(sidebarProject.locator("svg").first()).toHaveCSS(
-    "opacity",
-    "0.8",
-  );
   await expect(sidebarProject.locator('[data-sidebar="menu-label"]')).toHaveCSS(
     "opacity",
     "0.8",
   );
 
   await sidebarProject.click();
-  await expect(projectsOverview).toHaveAttribute("data-active", "true");
-  await expect(sidebarProject).toHaveAttribute("data-active", "false");
-  await expect(sidebarProject).toHaveAttribute("aria-expanded", "false");
+  await expect(projectsOverview).toHaveAttribute("data-active", "false");
+  await expect(sidebarProject).toHaveAttribute("data-active", "true");
 });
 
 test("collapsed sidebar leaves a balanced Projects surface gutter", async ({
@@ -1518,6 +1529,7 @@ test("channels tab opens the latest matching conversation without leaving the pr
     .first();
   await expect(projectEntry).toBeVisible({ timeout: 10_000 });
   await projectEntry.click();
+  await page.getByTestId("project-home-context-repo-buzz").click();
   await page.getByRole("tab", { name: "Channels", exact: true }).click();
   const channelRow = page.getByTestId("project-channel-row").first();
   await expect(channelRow).toBeVisible({ timeout: 10_000 });
@@ -1834,7 +1846,7 @@ test("project overview presents collapsible context beside grouped activity", as
   );
   const channelRows = page.getByTestId("project-channel-row");
   expect(await channelRows.count()).toBeGreaterThan(0);
-  await expect(channelRows.first()).toContainText("#general");
+  await expect(channelRows.first()).toContainText("#buzz");
   const channelsList = page.getByTestId("projects-channels-list");
   await expect(channelsList).toContainText("buzz");
   await expect(channelsList).toContainText("relay-tools");
@@ -2222,7 +2234,7 @@ test("repository changes discard captured selection context before agent sends",
   await installMockBridge(page);
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await addProjectToSidebar(page, "buzz");
-  await page.getByTestId("sidebar-project-repository-buzz").click();
+  await page.getByTestId("project-home-context-repo-buzz").click();
   await page.getByRole("tab", { name: "Tasks", exact: true }).click();
 
   const selectedRow = page.getByTestId("project-issue-row").first();
@@ -2241,8 +2253,10 @@ test("repository changes discard captured selection context before agent sends",
     agentPanel.getByText(selectedTitle, { exact: true }),
   ).toBeVisible();
 
-  await page.getByTestId("sidebar-project-repository-relay-tools").click();
+  await page.getByTestId("project-workspace-back").click();
+  await page.getByTestId("project-home-context-repo-relay-tools").click();
   await expect(page).toHaveURL(/repositoryId=.*relay-tools/);
+  await page.getByTestId("project-right-panel-chat-tab").click();
   await expect(agentPanel).toBeVisible();
   await expect(
     agentPanel.getByTestId("projects-agent-selection-toggle"),
@@ -2251,7 +2265,7 @@ test("repository changes discard captured selection context before agent sends",
   const prompt = "Explain the current repository.";
   const composer = agentPanel.getByTestId("message-composer");
   await composer.locator('[contenteditable="true"]').fill(prompt);
-  await composer.getByRole("button", { name: "Send message" }).click();
+  await composer.locator('[contenteditable="true"]').press("Enter");
   await expect
     .poll(() =>
       page.evaluate((prefix) => {
@@ -2478,6 +2492,7 @@ test("selecting repository workspace rows switches the context pod to the cluste
     )
     .first()
     .click();
+  await page.getByTestId("project-home-context-repo-buzz").click();
 
   await page.getByRole("tab", { name: "Commits" }).click();
   const commitRows = page.getByTestId("project-activity-feed-item");
@@ -2810,14 +2825,7 @@ test("project detail content areas do not paint background fills", async ({
     }
   };
 
-  for (const tab of [
-    "Overview",
-    "Files",
-    "Commits",
-    "Tasks",
-    "Review",
-    "Contributors",
-  ]) {
+  for (const tab of ["Files", "Commits", "Tasks", "Review", "Contributors"]) {
     await page.getByRole("tab", { name: tab, exact: true }).click();
     await expectVisiblePanelsToBeTransparent();
   }
@@ -3070,7 +3078,9 @@ test("external repositories stay on local source after a branch round trip", asy
   await installMockBridge(page);
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await addProjectToSidebar(page, "buzz");
-  await page.getByTestId("sidebar-project-repository-relay-tools").click();
+  await page.getByTestId("project-home-context-repo-relay-tools").click();
+  await page.getByRole("button", { name: "github.com" }).click();
+  await page.getByRole("menuitemradio", { name: /^Local/ }).click();
 
   await expect(
     page.getByRole("heading", { name: "Local branch README" }),
@@ -3164,7 +3174,9 @@ test("repository files beyond the eager preview limit load on demand", async ({
   await installMockBridge(page);
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await addProjectToSidebar(page, "buzz");
-  await page.getByTestId("sidebar-project-repository-relay-tools").click();
+  await page.getByTestId("project-home-context-repo-relay-tools").click();
+  await page.getByRole("button", { name: "github.com" }).click();
+  await page.getByRole("menuitemradio", { name: /^Local/ }).click();
 
   await expect(
     page.getByRole("heading", { name: "Deferred README" }),

--- a/desktop/tests/e2e/projects-v3-screenshots.spec.ts
+++ b/desktop/tests/e2e/projects-v3-screenshots.spec.ts
@@ -61,6 +61,7 @@ async function openBuzzProject(page: import("@playwright/test").Page) {
     .first();
   await expect(projectEntry).toBeVisible({ timeout: 10_000 });
   await projectEntry.click();
+  await page.getByTestId("project-home-context-repo-buzz").click();
 }
 
 test("projects activity overview screenshot", async ({ page }) => {
@@ -152,6 +153,11 @@ test("sidebar project add flow browses before creating", async ({ page }) => {
   await expect(page.getByTestId("create-project-name")).toHaveValue(
     "new workspace",
   );
+  await expect(
+    page.getByTestId("create-project-channel-permissions"),
+  ).toBeVisible();
+  await expect(page.getByTestId("create-project-listing")).toHaveText("Listed");
+  await expect(page.getByTestId("create-project-agent")).toHaveText("None");
   await page.getByRole("button", { name: "Back to projects" }).click();
   await expect(browser).toBeVisible();
 
@@ -272,7 +278,7 @@ test("projects v3 workspace screenshot states", async ({ page }) => {
 
   // Borderless workspace: repository controls live in the persistent,
   // resizable auxiliary panel instead of a header row.
-  const overviewTab = page.getByRole("tab", { name: "Overview" });
+  const backButton = page.getByTestId("project-workspace-back");
   const filesTab = page.getByRole("tab", { name: "Files" });
   const channelsTab = page.getByRole("tab", { name: "Channels" });
   const contributorsTab = page.getByRole("tab", { name: "Contributors" });
@@ -306,8 +312,11 @@ test("projects v3 workspace screenshot states", async ({ page }) => {
     );
   };
   await expect(filesTab).toBeVisible();
+  await expect(backButton).toBeVisible();
+  await expect(page.getByTestId("app-sidebar")).toBeVisible();
   await expect(projectDetailScroll).toHaveCSS("overscroll-behavior-y", "none");
-  await expect(overviewTab).toHaveAttribute("data-state", "active");
+  await filesTab.click();
+  await expect(filesTab).toHaveAttribute("data-state", "active");
   const [projectDetailScrollBounds, initialTabMenuBounds] = await Promise.all([
     projectDetailScroll.boundingBox(),
     tabMenu.boundingBox(),
@@ -640,7 +649,7 @@ test("projects v3 workspace screenshot states", async ({ page }) => {
   await expect(agentChatPanel.getByTestId("message-composer")).toBeVisible();
   const agentContext = agentChatPanel.getByTestId("project-agent-context");
   await expect(agentContext).toBeVisible();
-  await expect(agentContext).toContainText("Overview");
+  await expect(agentContext).toContainText("Files");
   await expect(agentContext).not.toContainText("Buzz /");
   // The context rail reveals the chat panel with a width transition; measure
   // only after it settles or the panel's unclipped box overhangs the rail.
@@ -785,20 +794,20 @@ test("projects v3 workspace screenshot states", async ({ page }) => {
   await expect(
     workspacePanel.getByTestId("project-workspace-tab-menu"),
   ).toHaveCount(0);
-  const overviewBounds = await overviewTab.boundingBox();
+  const backBounds = await backButton.boundingBox();
   const channelsBounds = await channelsTab.boundingBox();
   const contributorsBounds = await contributorsTab.boundingBox();
   const tabMenuBounds = await tabMenu.boundingBox();
   const workspaceBounds = await workspacePanel.boundingBox();
   const repositoryActionsBounds = await repositoryActionsPanel.boundingBox();
-  expect(overviewBounds).not.toBeNull();
+  expect(backBounds).not.toBeNull();
   expect(channelsBounds).not.toBeNull();
   expect(contributorsBounds).not.toBeNull();
   expect(tabMenuBounds).not.toBeNull();
   expect(workspaceBounds).not.toBeNull();
   expect(repositoryActionsBounds).not.toBeNull();
   expect(channelsBounds?.x).toBeLessThan(contributorsBounds?.x ?? 0);
-  expect(overviewBounds?.x).toBeGreaterThan(workspaceBounds?.x ?? 0);
+  expect(backBounds?.x).toBeGreaterThan(workspaceBounds?.x ?? 0);
   expect(tabMenuBounds?.y).toBeLessThan(workspaceBounds?.y ?? 0);
   expect(repositoryActionsBounds?.x).toBeGreaterThan(workspaceBounds?.x ?? 0);
   await expect(
@@ -806,7 +815,7 @@ test("projects v3 workspace screenshot states", async ({ page }) => {
   ).toHaveCount(0);
   await expect(
     workspacePanel.getByTestId("project-section-header-icon"),
-  ).toHaveCount(0);
+  ).toHaveCount(1);
   await waitForAnimations(page);
   await page.screenshot({ path: `${SHOTS}/01-workspace-overview.png` });
 
@@ -1237,7 +1246,7 @@ test("projects v3 work-item list metadata", async ({ page }) => {
   const channelRow = page.getByTestId("project-channel-row").first();
   await expect(channelRow).toBeVisible();
   await expectSinglePrimaryTextColumn(channelRow);
-  await expect(channelRow).toContainText("#general");
+  await expect(channelRow).toContainText("#buzz");
   await expect(
     page.getByTestId("project-channel-project").first(),
   ).toBeVisible();

--- a/desktop/tests/e2e/terminal-wheel.spec.ts
+++ b/desktop/tests/e2e/terminal-wheel.spec.ts
@@ -185,6 +185,7 @@ test("project terminal button opens Buzz Term for the repository", async ({
     .first();
   await expect(projectEntry).toBeVisible({ timeout: 10_000 });
   await projectEntry.click();
+  await page.getByTestId("project-home-context-repo-buzz").click();
 
   const terminalButton = page.getByTestId("project-terminal-toggle");
   await expect(terminalButton).toBeEnabled();


### PR DESCRIPTION
## Summary
- render an explicit project's home channel through the normal channel timeline and composer
- add a resizable project context rail with codebase, channel, people, and workspace navigation
- keep project agent conversations bounded to the project home and preserve repository/detail routes

This is Part 4 of the channel-first Projects stack, based on #6594. The final part contains overview and workspace completion polish.

## Testing
- focused project conversation, route, summary, workspace-sheet, and related-channel tests: 39/39 passed
- Desktop unit suite: 5,439/5,439 passed
- E2E-mode Desktop build passed
- TypeScript, Biome, and differential file-size checks passed
- full pre-push gate passed

## Post-Deploy Monitoring & Validation
- open project homes from project and channel entry points in the first staging Desktop session
- healthy signals: one channel timeline/composer, stable repository context, bounded project agent history, and reversible workspace sheets
- failure signals: duplicate channel surfaces, stale repository selection, unrelated DM history, or sheets replacing the channel route; mitigate by reverting this PR