### PR TITLE
fix(mobile): hide deleted thread tombstones

### DIFF
--- a/mobile/lib/features/channels/thread_detail_page/message_list.dart
+++ b/mobile/lib/features/channels/thread_detail_page/message_list.dart
@@ -96,13 +96,7 @@ class _ThreadMessageList extends StatelessWidget {
                 }
                 if (index == headIndex) {
                   if (headIsDeleted) {
-                    return trackActiveScrollPosition(
-                      const Padding(
-                        key: ValueKey('thread-message-deleted'),
-                        padding: EdgeInsets.only(bottom: Grid.xs),
-                        child: Text('This message was deleted'),
-                      ),
-                    );
+                    return trackActiveScrollPosition(const SizedBox.shrink());
                   }
                   return trackActiveScrollPosition(
                     Padding(

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -11990,70 +11990,72 @@ void main() {
       expect(find.byKey(const ValueKey('reaction-pill-👍')), findsOneWidget);
     });
 
-    testWidgets('a live deletion does not restore the routed thread head', (
-      tester,
-    ) async {
-      final rootEvent = _textMsg(
-        id: 'thread-root',
-        pubkey: 'alice',
-        content: 'Thread root',
-        createdAt: 1000,
-      );
-      final reply = _textMsg(
-        id: 'reply-1',
-        pubkey: 'bob',
-        content: 'A reply',
-        createdAt: 1100,
-        extraTags: const [
-          ['e', 'thread-root', '', 'reply'],
-        ],
-      );
-      final messagesNotifier = _FakeMessagesNotifier([rootEvent]);
+    testWidgets(
+      'a live deletion hides the routed thread head without a tombstone',
+      (tester) async {
+        final rootEvent = _textMsg(
+          id: 'thread-root',
+          pubkey: 'alice',
+          content: 'Thread root',
+          createdAt: 1000,
+        );
+        final reply = _textMsg(
+          id: 'reply-1',
+          pubkey: 'bob',
+          content: 'A reply',
+          createdAt: 1100,
+          extraTags: const [
+            ['e', 'thread-root', '', 'reply'],
+          ],
+        );
+        final messagesNotifier = _FakeMessagesNotifier([rootEvent]);
 
-      await tester.pumpWidget(
-        _buildTestable(
-          messages: [rootEvent],
-          messagesNotifier: messagesNotifier,
-          threadReplies: {
-            'thread-root': [reply],
-          },
-          users: const {
-            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
-            'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
-          },
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      final threadHead = formatTimeline([rootEvent]).single;
-      Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
-        MaterialPageRoute<void>(
-          builder: (_) => ThreadDetailPage(
-            threadHead: threadHead,
-            allMessages: [threadHead],
-            channelId: _channelId,
-            currentPubkey: 'self',
-            isMember: true,
-            isArchived: false,
+        await tester.pumpWidget(
+          _buildTestable(
+            messages: [rootEvent],
+            messagesNotifier: messagesNotifier,
+            threadReplies: {
+              'thread-root': [reply],
+            },
+            users: const {
+              'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+              'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+            },
           ),
-        ),
-      );
-      await tester.pumpAndSettle();
-      expect(find.text('Thread root'), findsOneWidget);
+        );
+        await tester.pumpAndSettle();
 
-      messagesNotifier.setMessages([
-        rootEvent,
-        _deletion(id: 'delete-root', targetIds: ['thread-root']),
-      ]);
-      await tester.pumpAndSettle();
+        final threadHead = formatTimeline([rootEvent]).single;
+        Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
+          MaterialPageRoute<void>(
+            builder: (_) => ThreadDetailPage(
+              threadHead: threadHead,
+              allMessages: [threadHead],
+              channelId: _channelId,
+              currentPubkey: 'self',
+              isMember: true,
+              isArchived: false,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.text('Thread root'), findsOneWidget);
 
-      expect(find.text('Thread root'), findsNothing);
-      expect(
-        find.byKey(const ValueKey('thread-message-deleted')),
-        findsOneWidget,
-      );
-      expect(find.text('This message was deleted'), findsOneWidget);
-    });
+        messagesNotifier.setMessages([
+          rootEvent,
+          _deletion(id: 'delete-root', targetIds: ['thread-root']),
+        ]);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Thread root'), findsNothing);
+        expect(
+          find.byKey(const ValueKey('thread-message-deleted')),
+          findsNothing,
+        );
+        expect(find.text('This message was deleted'), findsNothing);
+        expect(find.text('A reply'), findsOneWidget);
+      },
+    );
 
     testWidgets('thread replies earn the + only once they carry a reaction', (
       tester,


### PR DESCRIPTION
## Summary
- hide the deleted-message tombstone and its padding when a routed mobile thread head is removed
- keep surviving thread replies visible
- update the live-deletion regression test to cover both behaviors

## Test plan
- `just ci`
- focused mobile regression test for deleted routed thread heads
- full `channel_detail_page_test.dart` widget suite (189 tests)
- scoped `flutter analyze`

## Duplicate search
- No matching open pull request found.
