### PR TITLE
feat(native-jobs): admit relay lifecycle and enable ACP workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,6 +846,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.29.0",
@@ -1250,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "buzz-relay"
-version = "0.2.1"
+version = "0.2.2-rc.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -79,3 +79,4 @@ nix = { version = "0.31", default-features = false, features = ["signal"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 httparse = "1"
+tempfile = "3"

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -119,6 +119,38 @@ All configuration is via environment variables (or CLI flags — every env var h
 
 **Legacy env vars:** `BUZZ_ACP_PRIVATE_KEY`, `BUZZ_ACP_API_TOKEN`, and `BUZZ_ACP_TURN_TIMEOUT` (replaced by `BUZZ_ACP_IDLE_TIMEOUT`) are still accepted as fallbacks.
 
+### Native agent jobs (opt-in)
+
+Native jobs use durable kinds `43001`–`43006` to suspend a delegating turn and
+wake it only when a typed terminal result arrives. They are off by default, so
+existing agents retain the message-based behavior.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `BUZZ_ACP_NATIVE_JOBS` | no | `false` | Exact `true` enables native jobs for this harness. |
+| `BUZZ_ACP_NATIVE_JOB_ROLE` | when enabled | — | `manager`, `research`, `builder`, `qa`, `screenshots`, `memory`, `git`, or `translation`. Specialist roles use worker behavior. |
+| `BUZZ_ACP_DELEGATION_TARGETS` | manager | — | JSON object mapping configured specialist roles (for ATLAS: `research`, `builder`, `qa`, `screenshots`, `memory`, `git`, and `translation`) to exact public keys. |
+| `BUZZ_ACP_NATIVE_JOB_DELEGATOR` | worker | — | Exact manager public key this worker accepts. |
+| `BUZZ_ACP_NATIVE_JOB_DEADLINE_SECS` | no | `900` | Deadline attached to newly delegated jobs (30–86400 seconds). |
+| `BUZZ_ACP_NATIVE_JOB_HYBRID` | no | `false` | Exact `true` enables the opt-in deterministic Helpdesk article path. Routine Memory, structural QA, and Git jobs complete as host workers without ACP/model turns; predictable stage transitions are host-routed. |
+| `BUZZ_ACP_HYBRID_MEMORY_INDEX` | hybrid Memory | — | Absolute path to the compact authoritative Memory JSON index. |
+| `BUZZ_ACP_HYBRID_ALLOWED_ROOTS` | hybrid Manager/QA/Git | — | Platform path-list of exact roots deterministic checks may inspect. Requests outside these roots fail closed. |
+
+The terminal assistant message must be either ordinary owner-facing prose
+(manager only) or exactly `BUZZ_ACTION_V1` followed by one typed JSON action.
+Translation workers are the narrow exception: they return only
+`PASS`, `REVIEW_NEEDED`, or `FAIL` plus at most one bounded finding, and the
+host constructs their terminal protocol envelope.
+The host publishes delegation, accepted, result, cancellation, and error
+events; agents do not poll, send completion messages, or confirm publication.
+Status events are displayed to clients but never invoke a model. Keep evidence
+bodies in durable artifacts and send only compact references in job payloads.
+Hybrid execution uses the same typed job events and is also off by default. It
+recognizes only a bounded `helpdesk_article_v1` state marker in the task
+constraints; other native jobs and every non-native agent keep their existing
+behavior. Deterministic Git operations set `GIT_OPTIONAL_LOCKS=0`, never fetch,
+and never mutate the repository.
+
 ### Parallel Agents & Heartbeat
 
 | Flag | Env Var | Default | Description |

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -210,6 +210,10 @@ pub struct AcpClient {
     steer_rx: Option<tokio::sync::mpsc::Receiver<crate::pool::SteerRequest>>,
     /// Usage tracker for goose/buzz-agent's cumulative notification format.
     goose_usage: UsageTracker,
+    /// Bounded assistant messages captured during the current turn. Native
+    /// jobs consume only the final message after ACP returns, so no MCP tool
+    /// result or confirmation prompt is required.
+    assistant_messages: Vec<(Option<String>, String)>,
     /// Per-turn prompt-response usage and Claude's optional cumulative cost.
     standard_usage: StandardUsageTracker,
     /// Known adapter identity for prompt-response usage mapping.
@@ -561,6 +565,7 @@ impl AcpClient {
             steering_supported: false,
             steer_rx: None,
             goose_usage: UsageTracker::default(),
+            assistant_messages: Vec::new(),
             standard_usage: StandardUsageTracker::default(),
             standard_adapter,
         })
@@ -781,6 +786,7 @@ impl AcpClient {
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
+        self.assistant_messages.clear();
         let params = build_prompt_params(session_id, prompt_blocks);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
@@ -1756,6 +1762,46 @@ impl AcpClient {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
                     tracing::info!(target: "acp::stream", "{text}");
+                    let message_id = update
+                        .get("messageId")
+                        .and_then(|value| value.as_str())
+                        .map(str::to_string);
+                    const MAX_CAPTURE_BYTES: usize = 64 * 1024;
+                    if let Some((_, accumulated)) = self
+                        .assistant_messages
+                        .iter_mut()
+                        .rev()
+                        .find(|(existing, _)| existing == &message_id)
+                    {
+                        // ACP adapters may emit either deltas or a newer full
+                        // snapshot for the same message id. Re-appending a
+                        // snapshot duplicates terminal JSON.
+                        if text.starts_with(accumulated.as_str()) {
+                            accumulated.clear();
+                            for ch in text.chars() {
+                                if accumulated.len() + ch.len_utf8() > MAX_CAPTURE_BYTES {
+                                    break;
+                                }
+                                accumulated.push(ch);
+                            }
+                        } else if !accumulated.starts_with(text) {
+                            for ch in text.chars() {
+                                if accumulated.len() + ch.len_utf8() > MAX_CAPTURE_BYTES {
+                                    break;
+                                }
+                                accumulated.push(ch);
+                            }
+                        }
+                    } else if self.assistant_messages.len() < 16 {
+                        let mut captured = String::new();
+                        for ch in text.chars() {
+                            if captured.len() + ch.len_utf8() > MAX_CAPTURE_BYTES {
+                                break;
+                            }
+                            captured.push(ch);
+                        }
+                        self.assistant_messages.push((message_id, captured));
+                    }
                 }
                 false
             }
@@ -1875,6 +1921,19 @@ impl AcpClient {
             None => return,
         };
         self.standard_usage.record_cost(session_id, cost);
+    }
+
+    /// Take the final bounded assistant message captured during the last turn.
+    pub(crate) fn take_final_assistant_message(&mut self) -> Option<String> {
+        let final_message = self
+            .assistant_messages
+            .iter()
+            .rev()
+            .map(|(_, text)| text.trim())
+            .find(|text| !text.is_empty())
+            .map(str::to_string);
+        self.assistant_messages.clear();
+        final_message
     }
 
     /// Parse a `_goose/unstable/session/update` notification and record the
@@ -3720,6 +3779,59 @@ mod tests {
         AcpClient::spawn("cat", &[], &[], false)
             .await
             .expect("spawn cat as inert client")
+    }
+
+    #[tokio::test]
+    async fn captures_only_the_final_assistant_message_for_native_terminal_output() {
+        let mut client = spawn_inert_client().await;
+        for (message_id, text) in [
+            ("thinking", "intermediate prose"),
+            ("terminal", "BUZZ_ACTION_V1\n"),
+            ("terminal", "{\"op\":\"complete_task\"}"),
+        ] {
+            let update = serde_json::json!({
+                "params": {
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "messageId": message_id,
+                        "content": {"text": text}
+                    }
+                }
+            });
+            assert!(!client.handle_session_update(&update));
+        }
+
+        assert_eq!(
+            client.take_final_assistant_message().as_deref(),
+            Some("BUZZ_ACTION_V1\n{\"op\":\"complete_task\"}")
+        );
+        assert!(client.take_final_assistant_message().is_none());
+    }
+
+    #[tokio::test]
+    async fn replaces_replayed_full_message_snapshot_instead_of_duplicating_it() {
+        let mut client = spawn_inert_client().await;
+        for text in [
+            "BUZZ_ACTION_V1 ",
+            "BUZZ_ACTION_V1 {\"op\":\"complete_task\"}",
+            "BUZZ_ACTION_V1 {\"op\":\"complete_task\"}",
+        ] {
+            let update = serde_json::json!({
+                "params": {
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "messageId": "terminal",
+                        "content": {"text": text}
+                    }
+                }
+            });
+            assert!(!client.handle_session_update(&update));
+        }
+
+        assert_eq!(
+            client.take_final_assistant_message().as_deref(),
+            Some("BUZZ_ACTION_V1 {\"op\":\"complete_task\"}")
+        );
     }
 
     /// Build a `session/update` JSON-RPC notification carrying a

--- a/crates/buzz-acp/src/hybrid.rs
+++ b/crates/buzz-acp/src/hybrid.rs
@@ -1,0 +1,1039 @@
+//! Opt-in deterministic execution for a single sequential Helpdesk workflow.
+//!
+//! This module deliberately does not introduce a second job protocol. Workflow
+//! state is a private artifact carried by the existing kinds 43001-43006, and
+//! every host worker emits the same typed `JobResult` as a model worker.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::process::Stdio;
+
+use buzz_core::agent_job::{
+    EvidenceRef, JobBudget, JobRequest, JobResult, JobStatus, JobTerminalStatus, ResultContract,
+    AGENT_JOB_VERSION,
+};
+use buzz_core::kind::{KIND_JOB_ACCEPTED, KIND_JOB_ERROR, KIND_JOB_REQUEST, KIND_JOB_RESULT};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+use uuid::Uuid;
+
+use crate::jobs::{event_tag, submit_builder, NativeJobRole, NativeJobsConfig};
+use crate::relay::{BuzzEvent, RestClient};
+
+const WORKFLOW_PREFIX: &str = "HYBRID_WORKFLOW_V1:";
+const MAX_OUTPUT_BYTES: usize = 8192;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Stage {
+    Memory,
+    Research,
+    Builder,
+    StructuralQa,
+    ReasoningQa,
+    Git,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HelpdeskWorkflow {
+    kind: String,
+    stage: Stage,
+    evidence_id: String,
+    #[serde(alias = "absolute_worktree")]
+    worktree: PathBuf,
+    #[serde(alias = "repository-relative target_file")]
+    target_file: PathBuf,
+    expected_branch: String,
+    expected_head: String,
+    research_command: String,
+    #[serde(default)]
+    research_requirements: Vec<String>,
+    #[serde(default = "default_true")]
+    preserve_screenshot_placeholders: bool,
+    #[serde(default)]
+    allow_human_reviewed: bool,
+    #[serde(default = "default_true")]
+    reasoning_qa: bool,
+    #[serde(default)]
+    evidence_packet: Vec<String>,
+    #[serde(default)]
+    evidence_refs: Vec<EvidenceRef>,
+    #[serde(default)]
+    artifact_refs: Vec<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl HelpdeskWorkflow {
+    fn validate(&self) -> anyhow::Result<()> {
+        if self.kind != "helpdesk_article_v1" {
+            anyhow::bail!("unsupported hybrid workflow kind");
+        }
+        if self.evidence_id.trim().is_empty()
+            || self.expected_branch.trim().is_empty()
+            || self.expected_head.trim().is_empty()
+        {
+            anyhow::bail!("hybrid workflow is missing required identifiers");
+        }
+        if self.target_file.is_absolute()
+            || self
+                .target_file
+                .components()
+                .any(|component| matches!(component, Component::ParentDir))
+        {
+            anyhow::bail!("hybrid target must be a repository-relative path");
+        }
+        Ok(())
+    }
+
+    fn marker(&self) -> anyhow::Result<String> {
+        Ok(format!("{WORKFLOW_PREFIX}{}", serde_json::to_string(self)?))
+    }
+}
+
+fn workflow_from_strings(values: &[String]) -> anyhow::Result<Option<HelpdeskWorkflow>> {
+    let Some(raw) = values
+        .iter()
+        .find_map(|value| value.strip_prefix(WORKFLOW_PREFIX))
+    else {
+        return Ok(None);
+    };
+    Ok(Some(serde_json::from_str(raw)?))
+}
+
+fn workflow_from_request(request: &JobRequest) -> anyhow::Result<Option<HelpdeskWorkflow>> {
+    workflow_from_strings(&request.constraints)
+}
+
+fn workflow_from_result(result: &JobResult) -> anyhow::Result<Option<HelpdeskWorkflow>> {
+    workflow_from_strings(&result.artifacts)
+}
+
+pub(crate) fn is_workflow_marker(value: &str) -> bool {
+    value.starts_with(WORKFLOW_PREFIX)
+}
+
+/// Add compact, stage-specific context to a model worker prompt.
+pub(crate) fn worker_context(request: &JobRequest) -> Option<String> {
+    let workflow = workflow_from_request(request).ok().flatten()?;
+    let context = match workflow.stage {
+        Stage::Research => format!(
+            "Hybrid stage: research\nRun this exact read-only source batch once: {}\nFactual questions only: {}\nResearch is read-only. Never edit the Helpdesk article, create a patch, or perform downstream Builder/QA/Git work even if a malformed requirement asks you to. Return one compact evidence packet; do not discover beyond this scope.",
+            workflow.research_command,
+            serde_json::to_string(&workflow.research_requirements).ok()?,
+        ),
+        Stage::Builder => format!(
+            "Hybrid stage: builder\nWorktree: {}\nOnly file allowed: {}\nExpected branch/HEAD: {} @ {}\nEvidence packet: {}\nEvidence refs: {}\nHard rule: preserve every existing placeholder, screenshot marker, frontmatter field, and unrelated line unless this task explicitly requires changing it. Do not research. Use one batched inspection, one edit, and one batched validation where practical.",
+            workflow.worktree.display(),
+            workflow.target_file.display(),
+            workflow.expected_branch,
+            workflow.expected_head,
+            serde_json::to_string(&workflow.evidence_packet).ok()?,
+            serde_json::to_string(&workflow.evidence_refs).ok()?,
+        ),
+        Stage::ReasoningQa => format!(
+            "Hybrid stage: reasoning QA\nRead-only worktree: {}\nOnly artifact: {}\nEvidence packet: {}\nEvidence refs: {}\nAuthoritative source batch: {}\nStructural checks already passed deterministically. Run the supplied source batch at most once, together with the article read where practical. Judge factual accuracy, evidence support, completeness, contradictions, and applicable Helpdesk content rules only. Do not redo Research or discover another procedure.",
+            workflow.worktree.display(),
+            workflow.target_file.display(),
+            serde_json::to_string(&workflow.evidence_packet).ok()?,
+            serde_json::to_string(&workflow.evidence_refs).ok()?,
+            workflow.research_command,
+        ),
+        _ => return None,
+    };
+    Some(context)
+}
+
+/// Preserve private routing state when a model worker emits its typed result.
+pub(crate) fn carry_workflow_marker(request: &JobRequest, artifacts: &mut Vec<String>) {
+    if let Some(marker) = request
+        .constraints
+        .iter()
+        .find(|value| is_workflow_marker(value))
+    {
+        artifacts.retain(|value| !is_workflow_marker(value));
+        artifacts.push(marker.clone());
+    }
+}
+
+/// Consume a routine native request without starting an ACP/model turn.
+pub(crate) async fn try_handle_deterministic_request(
+    config: &NativeJobsConfig,
+    rest: &RestClient,
+    inbound: &BuzzEvent,
+) -> anyhow::Result<bool> {
+    if !config.hybrid_enabled
+        || config.role != Some(NativeJobRole::Worker)
+        || inbound.event.kind.as_u16() as u32 != KIND_JOB_REQUEST
+    {
+        return Ok(false);
+    }
+    let request = buzz_core::agent_job::parse_job_request(&inbound.event.content)?;
+    let workflow = match workflow_from_request(&request) {
+        Ok(Some(workflow)) => workflow,
+        Ok(None) => return Ok(false),
+        Err(error) => {
+            publish_deterministic_contract_failure(rest, inbound, &request, &error.to_string())
+                .await?;
+            return Ok(true);
+        }
+    };
+    if let Err(error) = workflow.validate() {
+        publish_deterministic_contract_failure(rest, inbound, &request, &error.to_string()).await?;
+        return Ok(true);
+    }
+    let deterministic = matches!(
+        (request.assigned_role.as_str(), workflow.stage),
+        ("memory", Stage::Memory) | ("qa", Stage::StructuralQa) | ("git", Stage::Git)
+    );
+    if !deterministic {
+        return Ok(false);
+    }
+
+    publish_status(config, rest, inbound, &request).await?;
+    let result = match workflow.stage {
+        Stage::Memory => memory_lookup(config, &request, workflow).await,
+        Stage::StructuralQa => structural_qa(config, &request, workflow).await,
+        Stage::Git => git_readiness(config, &request, workflow).await,
+        _ => unreachable!("deterministic stages checked above"),
+    };
+    let result = result.unwrap_or_else(|error| JobResult {
+        v: AGENT_JOB_VERSION,
+        task_id: request.task_id,
+        status: JobTerminalStatus::Failed,
+        summary: vec![format!(
+            "Deterministic {} failed safely",
+            request.assigned_role
+        )],
+        artifacts: request
+            .constraints
+            .iter()
+            .filter(|value| is_workflow_marker(value))
+            .cloned()
+            .collect(),
+        evidence_refs: vec![],
+        checks: vec![error.to_string()],
+        gaps: vec![],
+    });
+    publish_result(rest, inbound, &request, &result).await?;
+    tracing::info!(
+        task_id = %request.task_id,
+        role = %request.assigned_role,
+        status = ?result.status,
+        "hybrid deterministic job completed without a model turn"
+    );
+    Ok(true)
+}
+
+async fn publish_deterministic_contract_failure(
+    rest: &RestClient,
+    inbound: &BuzzEvent,
+    request: &JobRequest,
+    error: &str,
+) -> anyhow::Result<()> {
+    let result = JobResult {
+        v: AGENT_JOB_VERSION,
+        task_id: request.task_id,
+        status: JobTerminalStatus::Failed,
+        summary: vec![format!(
+            "Deterministic {} contract failed safely",
+            request.assigned_role
+        )],
+        artifacts: vec![],
+        evidence_refs: vec![],
+        checks: vec![error.to_string()],
+        gaps: vec![],
+    };
+    publish_result(rest, inbound, request, &result).await
+}
+
+/// Route an obvious successful stage directly to the next native worker.
+/// Returns true when the Manager must stay suspended.
+pub(crate) async fn try_route_manager_result(
+    config: &NativeJobsConfig,
+    rest: &RestClient,
+    inbound: &BuzzEvent,
+) -> anyhow::Result<bool> {
+    if !config.hybrid_enabled
+        || config.role != Some(NativeJobRole::Manager)
+        || !matches!(
+            inbound.event.kind.as_u16() as u32,
+            KIND_JOB_RESULT | KIND_JOB_ERROR
+        )
+    {
+        return Ok(false);
+    }
+    let result = buzz_core::agent_job::parse_job_result(&inbound.event.content)?;
+    let Some(mut workflow) = workflow_from_result(&result)? else {
+        return Ok(false);
+    };
+    workflow.validate()?;
+    allowed_worktree(config, &workflow.worktree)?;
+    if result.status != JobTerminalStatus::Completed {
+        return Ok(false);
+    }
+
+    let next = match workflow.stage {
+        Stage::Memory => {
+            if result.evidence_refs.is_empty() {
+                workflow.stage = Stage::Research;
+                (
+                    "research",
+                    "Collect the exact missing source evidence for the assigned Helpdesk article",
+                )
+            } else {
+                workflow.evidence_refs = result.evidence_refs.clone();
+                workflow.evidence_packet = result.summary.clone();
+                workflow.stage = Stage::Builder;
+                (
+                    "builder",
+                    "Update only the assigned Helpdesk article from current approved evidence",
+                )
+            }
+        }
+        Stage::Research => {
+            workflow.evidence_packet = result
+                .summary
+                .iter()
+                .chain(result.checks.iter())
+                .chain(result.gaps.iter())
+                .take(16)
+                .cloned()
+                .collect();
+            workflow.evidence_refs = result.evidence_refs.clone();
+            workflow.stage = Stage::Builder;
+            (
+                "builder",
+                "Update only the assigned Helpdesk article from the supplied evidence packet",
+            )
+        }
+        Stage::Builder => {
+            workflow.artifact_refs = result
+                .artifacts
+                .iter()
+                .filter(|value| !is_workflow_marker(value))
+                .cloned()
+                .collect();
+            if workflow.artifact_refs.is_empty() {
+                workflow
+                    .artifact_refs
+                    .push(workflow.target_file.display().to_string());
+            }
+            workflow.stage = Stage::StructuralQa;
+            (
+                "qa",
+                "Run deterministic structural Helpdesk validation on the assigned article",
+            )
+        }
+        Stage::StructuralQa => {
+            if workflow.reasoning_qa {
+                workflow.stage = Stage::ReasoningQa;
+                (
+                    "qa",
+                    "Independently judge the assigned article against its approved evidence",
+                )
+            } else {
+                workflow.stage = Stage::Git;
+                (
+                    "git",
+                    "Inspect the assigned worktree for read-only Git readiness",
+                )
+            }
+        }
+        Stage::ReasoningQa => {
+            workflow.stage = Stage::Git;
+            (
+                "git",
+                "Inspect the QA-passed worktree for read-only Git readiness",
+            )
+        }
+        Stage::Git => return Ok(false),
+    };
+    publish_next_request(config, rest, inbound, &result, workflow, next.0, next.1).await?;
+    Ok(true)
+}
+
+async fn publish_status(
+    _config: &NativeJobsConfig,
+    rest: &RestClient,
+    inbound: &BuzzEvent,
+    request: &JobRequest,
+) -> anyhow::Result<()> {
+    let status = JobStatus {
+        v: AGENT_JOB_VERSION,
+        task_id: request.task_id,
+        status: "running".into(),
+        detail: Some(format!(
+            "{} running (deterministic host worker)",
+            request.assigned_role
+        )),
+    };
+    let builder = buzz_sdk::build_agent_job_status(
+        KIND_JOB_ACCEPTED,
+        inbound.channel_id,
+        &inbound.event.pubkey.to_hex(),
+        &request.root_task_id,
+        &inbound.event.id.to_hex(),
+        &status,
+    )?;
+    submit_builder(rest, builder, "hybrid-accepted").await
+}
+
+async fn publish_result(
+    rest: &RestClient,
+    inbound: &BuzzEvent,
+    request: &JobRequest,
+    result: &JobResult,
+) -> anyhow::Result<()> {
+    let kind = if result.status == JobTerminalStatus::Completed {
+        KIND_JOB_RESULT
+    } else {
+        KIND_JOB_ERROR
+    };
+    let builder = buzz_sdk::build_agent_job_result(
+        kind,
+        inbound.channel_id,
+        &inbound.event.pubkey.to_hex(),
+        &request.root_task_id,
+        &inbound.event.id.to_hex(),
+        result,
+    )?;
+    submit_builder(rest, builder, "hybrid-terminal").await
+}
+
+async fn publish_next_request(
+    config: &NativeJobsConfig,
+    rest: &RestClient,
+    inbound: &BuzzEvent,
+    previous: &JobResult,
+    workflow: HelpdeskWorkflow,
+    role: &str,
+    objective: &str,
+) -> anyhow::Result<()> {
+    let assignee = config
+        .delegation_targets
+        .get(role)
+        .ok_or_else(|| anyhow::anyhow!("hybrid manager has no {role} target"))?;
+    let root = event_tag(&inbound.event, "root")
+        .ok_or_else(|| anyhow::anyhow!("hybrid result has no root tag"))?;
+    let marker = workflow.marker()?;
+    let request = JobRequest {
+        v: AGENT_JOB_VERSION,
+        task_id: Uuid::new_v4(),
+        root_task_id: root.to_string(),
+        parent_task_id: Some(previous.task_id),
+        assigned_role: role.to_string(),
+        objective: objective.to_string(),
+        evidence_refs: workflow.evidence_refs.clone(),
+        result_contract: ResultContract {
+            kind: match role {
+                "research" => "evidence_packet",
+                "builder" => "build_result",
+                "qa" => "qa_result",
+                "git" => "git_readiness",
+                _ => "job_result",
+            }
+            .into(),
+            required: vec!["summary".into(), "checks".into()],
+        },
+        constraints: vec![marker],
+        budget: JobBudget {
+            deadline_at: (Utc::now()
+                + chrono::Duration::from_std(config.deadline)
+                    .unwrap_or_else(|_| chrono::Duration::minutes(15)))
+            .to_rfc3339(),
+            max_model_calls: match role {
+                "research" => Some(3),
+                "builder" => Some(4),
+                "qa" => Some(3),
+                _ => Some(0),
+            },
+            max_output_bytes: MAX_OUTPUT_BYTES,
+        },
+        attempt: 1,
+    };
+    let builder = buzz_sdk::build_agent_job_request(
+        inbound.channel_id,
+        assignee,
+        &rest.keys.public_key().to_hex(),
+        &request,
+    )?;
+    submit_builder(rest, builder, "hybrid-route").await
+}
+
+#[derive(Deserialize)]
+struct MemoryIndex {
+    records: Vec<MemoryRecord>,
+}
+
+#[derive(Deserialize)]
+struct MemoryRecord {
+    evidence_id: String,
+    evidence_ref: String,
+    summary: String,
+    status: String,
+    freshness: String,
+    #[serde(default)]
+    superseded_by: Option<String>,
+    source: MemorySource,
+}
+
+#[derive(Deserialize)]
+struct MemorySource {
+    revision: String,
+}
+
+async fn memory_lookup(
+    config: &NativeJobsConfig,
+    request: &JobRequest,
+    workflow: HelpdeskWorkflow,
+) -> anyhow::Result<JobResult> {
+    let path = config
+        .hybrid_memory_index
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("hybrid Memory index is not configured"))?;
+    let bytes = fs::read(path)?;
+    let index: MemoryIndex = serde_json::from_slice(&bytes)?;
+    let matches: Vec<_> = index
+        .records
+        .iter()
+        .filter(|record| {
+            record.evidence_id == workflow.evidence_id
+                && record.status == "authoritative"
+                && record.freshness == "current"
+                && record.superseded_by.is_none()
+        })
+        .collect();
+    if matches.len() > 1 {
+        anyhow::bail!("Memory index has duplicate authoritative current records");
+    }
+    let marker = workflow.marker()?;
+    let Some(record) = matches.first() else {
+        return Ok(JobResult {
+            v: AGENT_JOB_VERSION,
+            task_id: request.task_id,
+            status: JobTerminalStatus::Completed,
+            summary: vec![format!("MISS: {}", workflow.evidence_id)],
+            artifacts: vec![marker],
+            evidence_refs: vec![],
+            checks: vec!["Authoritative Memory index checked once".into()],
+            gaps: vec![],
+        });
+    };
+    Ok(JobResult {
+        v: AGENT_JOB_VERSION,
+        task_id: request.task_id,
+        status: JobTerminalStatus::Completed,
+        summary: vec![format!(
+            "HIT: {} — {}",
+            workflow.evidence_id, record.summary
+        )],
+        artifacts: vec![marker],
+        evidence_refs: vec![EvidenceRef {
+            uri: record.evidence_ref.clone(),
+            revision: Some(record.source.revision.clone()),
+            section: None,
+        }],
+        checks: vec!["Record is authoritative, current, unique, and not superseded".into()],
+        gaps: vec![],
+    })
+}
+
+async fn structural_qa(
+    config: &NativeJobsConfig,
+    request: &JobRequest,
+    workflow: HelpdeskWorkflow,
+) -> anyhow::Result<JobResult> {
+    let worktree = allowed_worktree(config, &workflow.worktree)?;
+    let target = worktree.join(&workflow.target_file);
+    let current = fs::read_to_string(&target)?;
+    let baseline = git_output(
+        &worktree,
+        &["show", &format!("HEAD:{}", workflow.target_file.display())],
+    )
+    .await?;
+    let status = git_output(
+        &worktree,
+        &["status", "--porcelain=v1", "--untracked-files=all"],
+    )
+    .await?;
+    let diff_check = git_command(&worktree, &["diff", "--check"]).await?;
+    let mut failures = Vec::new();
+
+    let changed = parse_status_paths(&status);
+    if changed != BTreeSet::from([workflow.target_file.display().to_string()]) {
+        failures.push(format!("unexpected changed-file scope: {changed:?}"));
+    }
+    if !diff_check.status.success() {
+        failures.push(format!(
+            "git diff --check failed: {}",
+            stderr_text(&diff_check)
+        ));
+    }
+    if frontmatter(&baseline) != frontmatter(&current) {
+        failures.push("frontmatter changed unexpectedly".into());
+    }
+    for heading in [
+        "## Answer",
+        "## Key facts",
+        "## Steps",
+        "## Questions people ask",
+        "## Next",
+    ] {
+        if !current.contains(heading) {
+            failures.push(format!("required heading missing: {heading}"));
+        }
+    }
+    if workflow.preserve_screenshot_placeholders {
+        let before = screenshot_placeholders(&baseline);
+        let after = screenshot_placeholders(&current);
+        if before != after {
+            failures.push(format!(
+                "screenshot placeholders changed (expected {}, found {})",
+                before.len(),
+                after.len()
+            ));
+        }
+    }
+    if !workflow.allow_human_reviewed && current.contains("HUMAN REVIEWED") {
+        failures.push("HUMAN REVIEWED marker is not allowed".into());
+    }
+    if let Some(pattern) = privacy_pattern(&current) {
+        failures.push(format!("possible private/customer data pattern: {pattern}"));
+    }
+    if let Some(link) = malformed_root_link(&current) {
+        failures.push(format!("malformed root-relative Markdown link: {link}"));
+    }
+
+    let marker = workflow.marker()?;
+    let passed = failures.is_empty();
+    Ok(JobResult {
+        v: AGENT_JOB_VERSION,
+        task_id: request.task_id,
+        status: if passed {
+            JobTerminalStatus::Completed
+        } else {
+            JobTerminalStatus::Failed
+        },
+        summary: vec![if passed {
+            "STRUCTURAL QA PASS".into()
+        } else {
+            "STRUCTURAL QA FAIL".into()
+        }],
+        artifacts: workflow
+            .artifact_refs
+            .iter()
+            .cloned()
+            .chain(std::iter::once(marker))
+            .collect(),
+        evidence_refs: workflow.evidence_refs,
+        checks: if passed {
+            vec![
+                "frontmatter and required structure preserved".into(),
+                "screenshot placeholders preserved".into(),
+                "changed-file scope and git diff --check passed".into(),
+                "HUMAN REVIEWED/privacy/link static guards passed".into(),
+            ]
+        } else {
+            failures
+        },
+        gaps: vec![],
+    })
+}
+
+async fn git_readiness(
+    config: &NativeJobsConfig,
+    request: &JobRequest,
+    workflow: HelpdeskWorkflow,
+) -> anyhow::Result<JobResult> {
+    let worktree = allowed_worktree(config, &workflow.worktree)?;
+    let branch = git_output(&worktree, &["branch", "--show-current"]).await?;
+    let head = git_output(&worktree, &["rev-parse", "HEAD"]).await?;
+    let status = git_output(
+        &worktree,
+        &["status", "--porcelain=v1", "--untracked-files=all"],
+    )
+    .await?;
+    let diff_check = git_command(&worktree, &["diff", "--check"]).await?;
+    let changed = parse_status_paths(&status);
+    let expected = BTreeSet::from([workflow.target_file.display().to_string()]);
+    let mut blockers = Vec::new();
+    if branch.trim() != workflow.expected_branch {
+        blockers.push(format!("branch mismatch: {}", branch.trim()));
+    }
+    if head.trim() != workflow.expected_head {
+        blockers.push(format!("HEAD mismatch: {}", head.trim()));
+    }
+    if changed != expected {
+        blockers.push(format!("changed-file scope mismatch: {changed:?}"));
+    }
+    if !diff_check.status.success() {
+        blockers.push(format!(
+            "git diff --check failed: {}",
+            stderr_text(&diff_check)
+        ));
+    }
+    let ahead_behind = match git_command(
+        &worktree,
+        &["rev-list", "--left-right", "--count", "@{upstream}...HEAD"],
+    )
+    .await
+    {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        }
+        _ => "unavailable (no fetch performed)".into(),
+    };
+    let marker = workflow.marker()?;
+    let ready = blockers.is_empty();
+    Ok(JobResult {
+        v: AGENT_JOB_VERSION,
+        task_id: request.task_id,
+        status: JobTerminalStatus::Completed,
+        summary: vec![if ready {
+            "GIT READY".into()
+        } else {
+            "GIT BLOCKED".into()
+        }],
+        artifacts: workflow
+            .artifact_refs
+            .iter()
+            .cloned()
+            .chain(std::iter::once(marker))
+            .collect(),
+        evidence_refs: workflow.evidence_refs,
+        checks: vec![
+            format!("branch: {}", branch.trim()),
+            format!("HEAD: {}", head.trim()),
+            format!("changed files: {changed:?}"),
+            format!(
+                "diff check: {}",
+                if diff_check.status.success() {
+                    "PASS"
+                } else {
+                    "FAIL"
+                }
+            ),
+            format!("upstream behind/ahead: {ahead_behind}"),
+            format!("scope verdict: {}", if ready { "READY" } else { "BLOCKED" }),
+        ]
+        .into_iter()
+        .chain(blockers)
+        .collect(),
+        gaps: vec![],
+    })
+}
+
+fn allowed_worktree(config: &NativeJobsConfig, requested: &Path) -> anyhow::Result<PathBuf> {
+    let requested = requested.canonicalize()?;
+    let allowed = config
+        .hybrid_allowed_roots
+        .iter()
+        .filter_map(|root| root.canonicalize().ok())
+        .any(|root| requested == root || requested.starts_with(&root));
+    if !allowed {
+        anyhow::bail!("hybrid worktree is outside configured read-only/write scope");
+    }
+    Ok(requested)
+}
+
+async fn git_output(worktree: &Path, args: &[&str]) -> anyhow::Result<String> {
+    let output = git_command(worktree, args).await?;
+    if !output.status.success() {
+        anyhow::bail!("git {} failed: {}", args.join(" "), stderr_text(&output));
+    }
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+async fn git_command(worktree: &Path, args: &[&str]) -> anyhow::Result<std::process::Output> {
+    Ok(Command::new("git")
+        .arg("--no-optional-locks")
+        .args(args)
+        .current_dir(worktree)
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .env("GIT_CONFIG_COUNT", "2")
+        .env("GIT_CONFIG_KEY_0", "maintenance.auto")
+        .env("GIT_CONFIG_VALUE_0", "false")
+        .env("GIT_CONFIG_KEY_1", "gc.auto")
+        .env("GIT_CONFIG_VALUE_1", "0")
+        .stdin(Stdio::null())
+        .output()
+        .await?)
+}
+
+fn parse_status_paths(status: &str) -> BTreeSet<String> {
+    status
+        .lines()
+        .filter_map(|line| line.get(3..))
+        .map(|path| path.rsplit(" -> ").next().unwrap_or(path).to_string())
+        .collect()
+}
+
+fn frontmatter(value: &str) -> Option<&str> {
+    value
+        .strip_prefix("---\n")
+        .and_then(|rest| rest.find("\n---\n").map(|end| &rest[..end]))
+}
+
+fn screenshot_placeholders(value: &str) -> Vec<&str> {
+    value
+        .lines()
+        .filter(|line| line.contains("[SCREENSHOT PLACEHOLDER:"))
+        .collect()
+}
+
+fn privacy_pattern(value: &str) -> Option<&'static str> {
+    let lower = value.to_ascii_lowercase();
+    for (needle, name) in [
+        ("-----begin private key-----", "private key"),
+        ("api_key=", "API key assignment"),
+        ("access_token=", "access token assignment"),
+        ("customer password", "customer password"),
+    ] {
+        if lower.contains(needle) {
+            return Some(name);
+        }
+    }
+    None
+}
+
+fn malformed_root_link(value: &str) -> Option<&str> {
+    value
+        .lines()
+        .find(|line| line.contains("](/ ") || line.contains("](// ") || line.contains("](/# "))
+}
+
+fn stderr_text(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn config(root: &Path, index: &Path) -> NativeJobsConfig {
+        let mut config = NativeJobsConfig::enabled_for_test();
+        config.role = Some(NativeJobRole::Worker);
+        config.hybrid_enabled = true;
+        config.hybrid_memory_index = Some(index.to_path_buf());
+        config.hybrid_allowed_roots = vec![root.to_path_buf()];
+        config
+    }
+
+    fn workflow(root: &Path, stage: Stage) -> HelpdeskWorkflow {
+        HelpdeskWorkflow {
+            kind: "helpdesk_article_v1".into(),
+            stage,
+            evidence_id: "asset-evidence".into(),
+            worktree: root.into(),
+            target_file: "content/data/find-assets.md".into(),
+            expected_branch: "trial".into(),
+            expected_head: String::new(),
+            research_command: "rg exact".into(),
+            research_requirements: vec!["fact".into()],
+            preserve_screenshot_placeholders: true,
+            allow_human_reviewed: false,
+            reasoning_qa: true,
+            evidence_packet: vec![],
+            evidence_refs: vec![],
+            artifact_refs: vec![],
+        }
+    }
+
+    async fn fixture() -> (TempDir, PathBuf, String) {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join("content/data")).unwrap();
+        fs::write(
+            root.join("content/data/find-assets.md"),
+            "---\ntitle: Find assets\ndraft: true\n---\n## Answer\nTODO\n## Key facts\nTODO\n## Steps\n1. TODO\n   [SCREENSHOT PLACEHOLDER: keep]\n## Questions people ask\nTODO\n## Next\nTODO\n",
+        )
+        .unwrap();
+        let index = root.join("memory.json");
+        fs::write(
+            &index,
+            r#"{"records":[{"evidence_id":"asset-evidence","evidence_ref":"atlas-memory://asset-evidence@r1","summary":"current","status":"authoritative","freshness":"current","superseded_by":null,"source":{"revision":"r1"}}]}"#,
+        )
+        .unwrap();
+        for args in [
+            vec!["init", "-b", "trial"],
+            vec!["config", "user.email", "atlas@example.test"],
+            vec!["config", "user.name", "ATLAS Test"],
+            vec!["add", "content/data/find-assets.md"],
+            vec!["add", "memory.json"],
+            vec!["commit", "-m", "baseline"],
+        ] {
+            let output = Command::new("git")
+                .args(["-c", "commit.gpgsign=false"])
+                .args(&args)
+                .current_dir(root)
+                .output()
+                .await
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        let head = git_output(root, &["rev-parse", "HEAD"])
+            .await
+            .unwrap()
+            .trim()
+            .to_string();
+        (temp, index, head)
+    }
+
+    #[tokio::test]
+    async fn memory_lookup_returns_current_hit_and_miss_without_mutation() {
+        let (temp, index, head) = fixture().await;
+        let mut hit = workflow(temp.path(), Stage::Memory);
+        hit.expected_head = head;
+        let request = test_request(&hit);
+        let result = memory_lookup(&config(temp.path(), &index), &request, hit)
+            .await
+            .unwrap();
+        assert_eq!(
+            result.status,
+            JobTerminalStatus::Completed,
+            "{:?}",
+            result.checks
+        );
+        assert_eq!(result.evidence_refs.len(), 1);
+
+        let mut miss = workflow(temp.path(), Stage::Memory);
+        miss.expected_head = request.root_task_id;
+        miss.evidence_id = "missing".into();
+        let request = test_request(&miss);
+        let result = memory_lookup(&config(temp.path(), &index), &request, miss)
+            .await
+            .unwrap();
+        assert!(result.evidence_refs.is_empty());
+        assert!(result.summary[0].starts_with("MISS:"));
+    }
+
+    #[test]
+    fn workflow_parser_accepts_explicit_path_aliases_without_relaxing_schema() {
+        let marker = concat!(
+            "HYBRID_WORKFLOW_V1:{\"kind\":\"helpdesk_article_v1\",\"stage\":\"memory\",",
+            "\"evidence_id\":\"e\",\"absolute_worktree\":\"/tmp/worktree\",",
+            "\"repository-relative target_file\":\"content/a.md\",\"expected_branch\":\"b\",",
+            "\"expected_head\":\"h\",\"research_command\":\"rg exact\"}"
+        );
+        let parsed = workflow_from_strings(&[marker.into()]).unwrap().unwrap();
+        assert_eq!(parsed.worktree, PathBuf::from("/tmp/worktree"));
+        assert_eq!(parsed.target_file, PathBuf::from("content/a.md"));
+    }
+
+    #[tokio::test]
+    async fn structural_qa_passes_and_rejects_placeholder_or_scope_changes() {
+        let (temp, index, head) = fixture().await;
+        let path = temp.path().join("content/data/find-assets.md");
+        let baseline = fs::read_to_string(&path).unwrap();
+        fs::write(&path, baseline.replacen("TODO", "Verified", 1)).unwrap();
+        let mut plan = workflow(temp.path(), Stage::StructuralQa);
+        plan.expected_head = head;
+        let request = test_request(&plan);
+        let result = structural_qa(&config(temp.path(), &index), &request, plan.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            result.status,
+            JobTerminalStatus::Completed,
+            "{:?}",
+            result.checks
+        );
+
+        fs::write(
+            &path,
+            baseline.replace("   [SCREENSHOT PLACEHOLDER: keep]\n", ""),
+        )
+        .unwrap();
+        let result = structural_qa(&config(temp.path(), &index), &request, plan.clone())
+            .await
+            .unwrap();
+        assert_eq!(result.status, JobTerminalStatus::Failed);
+        assert!(result
+            .checks
+            .iter()
+            .any(|check| check.contains("screenshot")));
+
+        fs::write(&path, &baseline).unwrap();
+        fs::write(temp.path().join("extra.txt"), "unexpected\n").unwrap();
+        let result = structural_qa(&config(temp.path(), &index), &request, plan)
+            .await
+            .unwrap();
+        assert_eq!(result.status, JobTerminalStatus::Failed);
+        assert!(result.checks.iter().any(|check| check.contains("scope")));
+    }
+
+    #[tokio::test]
+    async fn git_readiness_is_read_only_and_reports_ready_or_blocked() {
+        let (temp, index, head) = fixture().await;
+        let path = temp.path().join("content/data/find-assets.md");
+        let before_index = fs::read(temp.path().join(".git/index")).unwrap();
+        let baseline = fs::read_to_string(&path).unwrap();
+        fs::write(&path, baseline.replacen("TODO", "Verified", 1)).unwrap();
+        let mut plan = workflow(temp.path(), Stage::Git);
+        plan.expected_head = head.clone();
+        let request = test_request(&plan);
+        let result = git_readiness(&config(temp.path(), &index), &request, plan.clone())
+            .await
+            .unwrap();
+        assert_eq!(result.summary, vec!["GIT READY"], "{:?}", result.checks);
+        assert_eq!(
+            git_output(temp.path(), &["rev-parse", "HEAD"])
+                .await
+                .unwrap()
+                .trim(),
+            head
+        );
+        assert_eq!(
+            fs::read(temp.path().join(".git/index")).unwrap(),
+            before_index
+        );
+
+        plan.expected_head = "deadbeef".into();
+        let request = test_request(&plan);
+        let result = git_readiness(&config(temp.path(), &index), &request, plan)
+            .await
+            .unwrap();
+        assert_eq!(result.summary, vec!["GIT BLOCKED"]);
+    }
+
+    fn test_request(workflow: &HelpdeskWorkflow) -> JobRequest {
+        JobRequest {
+            v: AGENT_JOB_VERSION,
+            task_id: Uuid::new_v4(),
+            root_task_id: workflow.expected_head.clone(),
+            parent_task_id: None,
+            assigned_role: match workflow.stage {
+                Stage::Memory => "memory",
+                Stage::Research => "research",
+                Stage::Builder => "builder",
+                Stage::StructuralQa | Stage::ReasoningQa => "qa",
+                Stage::Git => "git",
+            }
+            .into(),
+            objective: "test".into(),
+            evidence_refs: vec![],
+            result_contract: ResultContract {
+                kind: "test".into(),
+                required: vec![],
+            },
+            constraints: vec![workflow.marker().unwrap()],
+            budget: JobBudget {
+                deadline_at: Utc::now().to_rfc3339(),
+                max_model_calls: Some(0),
+                max_output_bytes: MAX_OUTPUT_BYTES,
+            },
+            attempt: 1,
+        }
+    }
+}

--- a/crates/buzz-acp/src/jobs.rs
+++ b/crates/buzz-acp/src/jobs.rs
@@ -1,0 +1,1390 @@
+//! Opt-in, event-driven native agent-job delegation.
+//!
+//! The model never polls. A terminal assistant response is either a typed
+//! `BUZZ_ACTION_V1` control record or, for a manager, the final owner-facing
+//! response. Buzz publishes the corresponding durable event after the ACP turn
+//! has ended.
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use buzz_core::agent_job::{
+    EvidenceRef, JobBudget, JobRequest, JobResult, JobStatus, JobTerminalStatus, ResultContract,
+    AGENT_JOB_VERSION,
+};
+use buzz_core::kind::{
+    KIND_JOB_ACCEPTED, KIND_JOB_CANCEL, KIND_JOB_ERROR, KIND_JOB_REQUEST, KIND_JOB_RESULT,
+};
+use chrono::Utc;
+use nostr::{Event, EventId, PublicKey};
+use serde::{Deserialize, Deserializer};
+use uuid::Uuid;
+
+use crate::queue::{parse_thread_tags, FlushBatch, ThreadTags};
+use crate::relay::RestClient;
+
+const ACTION_PREFIX: &str = "BUZZ_ACTION_V1";
+const DEFAULT_DEADLINE_SECS: u64 = 900;
+const DEFAULT_MAX_OUTPUT_BYTES: usize = 8192;
+const MANAGER_CONTROL_PROMPT: &str = concat!(
+    "[NATIVE_JOB_CONTROL_V1]\n",
+    "To delegate, end this turn with exactly one record: BUZZ_ACTION_V1 followed by JSON ",
+    "{\"op\":\"delegate_task\",\"role\":\"research|builder|qa|screenshots|memory|git|translation\",",
+    "\"objective\":\"one bounded task\",\"evidence_refs\":[],\"result_contract\":",
+    "{\"kind\":\"evidence_packet|build_result|qa_result|screenshot_manifest|memory_result|git_readiness|translation_manifest\",",
+    "\"required\":[]},\"constraints\":[],\"max_model_calls\":3}. ",
+    "The host sends it, ends this turn, suspends you, and wakes you with only the compact ",
+    "specialist result as the next prompt. Never use Buzz tools to delegate, poll, wait, ",
+    "check presence, send progress, or deliver the final response. Do not inspect facts ",
+    "assigned to Research or reread artifacts yourself. Preserve a specialist's exact ",
+    "evidence refs unchanged in downstream tasks unless that specialist explicitly marks ",
+    "a ref invalid. Treat evidence references—especially atlas-memory:// URIs—as opaque ",
+    "machine strings: copy them byte-for-byte from the result, never retype, shorten repeated ",
+    "words, normalize, or reconstruct them. Copy every artifact reference byte-for-byte into ",
+    "downstream tasks and owner responses; never abbreviate, normalize, or retype an artifact ",
+    "basename. Screenshots receives only one exact product route, approved evidence refs, ",
+    "capture requirements, and an ATLAS-owned output directory. Memory receives only structured ",
+    "verified findings or exact evidence IDs; route a current Memory reference directly without ",
+    "asking Research to recheck it. Git receives one exact worktree path, expected branch/HEAD, ",
+    "requested file scope, and whether a read-only remote check is allowed; it only inspects and ",
+    "prepares commands for later human approval. After every READY Builder result, delegate one ",
+    "bounded QA check with the same evidence refs and artifact scope before presenting work as ",
+    "ready. On QA PASS, answer the owner. On QA FAIL, allow at most one bounded Builder correction ",
+    "and one QA recheck; if that recheck fails, escalate the exact failures to the owner. Never ",
+    "create an open-ended Builder/QA loop. The host publishes ordinary final assistant content ",
+    "to the owner. If no delegation is needed, answer the owner normally. For an opt-in hybrid ",
+    "Helpdesk article task, delegate Memory once with one HYBRID_WORKFLOW_V1:{json} constraint. ",
+    "Use these exact JSON keys: kind=helpdesk_article_v1, stage=memory, evidence_id, worktree ",
+    "(an absolute path), target_file (a repository-relative path), expected_branch, expected_head, one exact batched ",
+    "research_command, research_requirements, preserve_screenshot_placeholders=true, ",
+    "allow_human_reviewed=false, and reasoning_qa=true. The host performs the predictable ",
+    "transitions after Memory; do not delegate later hybrid stages yourself. Put only the ",
+    "specific product facts or questions Research must answer in research_requirements; never ",
+    "put Builder, QA, Git, preservation, publication, or workflow instructions there.",
+);
+
+/// Native-job runtime role for an opted-in harness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeJobRole {
+    /// Receives owner requests, delegates, then presents the final result.
+    Manager,
+    /// Receives one bounded job and returns one terminal result.
+    Worker,
+}
+
+/// Default-off native-job configuration resolved from the managed-agent env.
+#[derive(Debug, Clone)]
+pub struct NativeJobsConfig {
+    /// Whether the native job path is enabled.
+    pub enabled: bool,
+    /// Harness behavior when enabled.
+    pub role: Option<NativeJobRole>,
+    /// Logical role to exact worker pubkey, used only by a manager.
+    pub delegation_targets: HashMap<String, String>,
+    /// Logical worker role (`research`, `builder`, `qa`, `screenshots`,
+    /// `memory`, `git`, or `translation`) for worker harnesses.
+    pub worker_role: Option<String>,
+    /// Exact manager pubkey accepted by a worker harness.
+    pub delegator: Option<String>,
+    /// Opt-in deterministic execution and sequential Helpdesk routing.
+    pub hybrid_enabled: bool,
+    /// Authoritative ATLAS Memory index used by model-free lookup work.
+    pub hybrid_memory_index: Option<PathBuf>,
+    /// Filesystem roots deterministic workers may inspect.
+    pub hybrid_allowed_roots: Vec<PathBuf>,
+    /// Default wall-clock deadline assigned to new jobs.
+    pub deadline: Duration,
+    /// Process-local duplicate suppression for replayed task events.
+    seen_requests: Arc<Mutex<HashSet<Uuid>>>,
+    seen_terminals: Arc<Mutex<HashSet<Uuid>>>,
+    seen_cancels: Arc<Mutex<HashSet<Uuid>>>,
+}
+
+impl Default for NativeJobsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            role: None,
+            delegation_targets: HashMap::new(),
+            worker_role: None,
+            delegator: None,
+            hybrid_enabled: false,
+            hybrid_memory_index: None,
+            hybrid_allowed_roots: vec![],
+            deadline: Duration::from_secs(DEFAULT_DEADLINE_SECS),
+            seen_requests: Arc::new(Mutex::new(HashSet::new())),
+            seen_terminals: Arc::new(Mutex::new(HashSet::new())),
+            seen_cancels: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+}
+
+impl NativeJobsConfig {
+    #[cfg(test)]
+    pub(crate) fn enabled_for_test() -> Self {
+        Self {
+            enabled: true,
+            ..Self::default()
+        }
+    }
+
+    /// Resolve native-job settings from environment variables.
+    pub fn from_env() -> anyhow::Result<Self> {
+        if std::env::var("BUZZ_ACP_NATIVE_JOBS").as_deref() != Ok("true") {
+            return Ok(Self::default());
+        }
+        let role = std::env::var("BUZZ_ACP_NATIVE_JOB_ROLE")?;
+        let (role, worker_role) = match role.trim().to_ascii_lowercase().as_str() {
+            "manager" => (NativeJobRole::Manager, None),
+            "research" => (NativeJobRole::Worker, Some("research".to_string())),
+            "builder" => (NativeJobRole::Worker, Some("builder".to_string())),
+            "qa" => (NativeJobRole::Worker, Some("qa".to_string())),
+            "screenshots" => (NativeJobRole::Worker, Some("screenshots".to_string())),
+            "memory" => (NativeJobRole::Worker, Some("memory".to_string())),
+            "git" => (NativeJobRole::Worker, Some("git".to_string())),
+            "translation" => (NativeJobRole::Worker, Some("translation".to_string())),
+            _ => {
+                anyhow::bail!(
+                    "BUZZ_ACP_NATIVE_JOB_ROLE must be manager, research, builder, qa, screenshots, memory, git, or translation"
+                )
+            }
+        };
+        let raw_targets =
+            std::env::var("BUZZ_ACP_DELEGATION_TARGETS").unwrap_or_else(|_| "{}".to_string());
+        let raw_delegation_targets: HashMap<String, String> = serde_json::from_str(&raw_targets)
+            .map_err(|error| {
+                anyhow::anyhow!("BUZZ_ACP_DELEGATION_TARGETS must be a JSON object: {error}")
+            })?;
+        let mut delegation_targets = HashMap::new();
+        for (name, pubkey) in raw_delegation_targets {
+            let name = name.trim().to_ascii_lowercase();
+            let pubkey = pubkey.trim().to_ascii_lowercase();
+            PublicKey::from_hex(&pubkey).map_err(|_| {
+                anyhow::anyhow!("delegation target {name:?} is not a valid public key")
+            })?;
+            delegation_targets.insert(name, pubkey);
+        }
+        if role == NativeJobRole::Manager
+            && !(delegation_targets.contains_key("research")
+                && delegation_targets.contains_key("builder"))
+        {
+            anyhow::bail!("native manager requires research and builder delegation targets");
+        }
+        let delegator = if role == NativeJobRole::Worker {
+            let pubkey = std::env::var("BUZZ_ACP_NATIVE_JOB_DELEGATOR")?
+                .trim()
+                .to_ascii_lowercase();
+            PublicKey::from_hex(&pubkey).map_err(|_| {
+                anyhow::anyhow!("native worker delegator is not a valid public key")
+            })?;
+            Some(pubkey)
+        } else {
+            None
+        };
+        let deadline_secs = std::env::var("BUZZ_ACP_NATIVE_JOB_DEADLINE_SECS")
+            .ok()
+            .map(|value| value.parse::<u64>())
+            .transpose()?
+            .unwrap_or(DEFAULT_DEADLINE_SECS)
+            .clamp(30, 86_400);
+        let hybrid_enabled = std::env::var("BUZZ_ACP_NATIVE_JOB_HYBRID").as_deref() == Ok("true");
+        let hybrid_memory_index = std::env::var_os("BUZZ_ACP_HYBRID_MEMORY_INDEX")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from);
+        let hybrid_allowed_roots: Vec<PathBuf> = std::env::var_os("BUZZ_ACP_HYBRID_ALLOWED_ROOTS")
+            .map(|value| std::env::split_paths(&value).collect())
+            .unwrap_or_default();
+        if hybrid_enabled && role == NativeJobRole::Worker {
+            match worker_role.as_deref() {
+                Some("memory") if hybrid_memory_index.is_none() => {
+                    anyhow::bail!("hybrid memory worker requires BUZZ_ACP_HYBRID_MEMORY_INDEX")
+                }
+                Some("git" | "qa") if hybrid_allowed_roots.is_empty() => {
+                    anyhow::bail!("hybrid git/qa worker requires BUZZ_ACP_HYBRID_ALLOWED_ROOTS")
+                }
+                _ => {}
+            }
+        }
+        if hybrid_enabled
+            && role == NativeJobRole::Manager
+            && !["memory", "research", "builder", "qa", "git"]
+                .iter()
+                .all(|target| delegation_targets.contains_key(*target))
+        {
+            anyhow::bail!("hybrid manager requires memory, research, builder, qa, and git targets");
+        }
+        if hybrid_enabled && role == NativeJobRole::Manager && hybrid_allowed_roots.is_empty() {
+            anyhow::bail!("hybrid manager requires BUZZ_ACP_HYBRID_ALLOWED_ROOTS");
+        }
+        Ok(Self {
+            enabled: true,
+            role: Some(role),
+            delegation_targets,
+            worker_role,
+            delegator,
+            hybrid_enabled,
+            hybrid_memory_index,
+            hybrid_allowed_roots,
+            deadline: Duration::from_secs(deadline_secs),
+            seen_requests: Arc::new(Mutex::new(HashSet::new())),
+            seen_terminals: Arc::new(Mutex::new(HashSet::new())),
+            seen_cancels: Arc::new(Mutex::new(HashSet::new())),
+        })
+    }
+
+    /// Event kinds added to the ordinary mention subscription when enabled.
+    pub fn subscription_kinds(&self) -> &'static [u32] {
+        if self.enabled {
+            &[
+                buzz_core::kind::KIND_JOB_REQUEST,
+                buzz_core::kind::KIND_JOB_ACCEPTED,
+                buzz_core::kind::KIND_JOB_PROGRESS,
+                buzz_core::kind::KIND_JOB_RESULT,
+                buzz_core::kind::KIND_JOB_CANCEL,
+                buzz_core::kind::KIND_JOB_ERROR,
+            ]
+        } else {
+            &[]
+        }
+    }
+
+    /// Authorize and atomically claim one inbound native event.
+    ///
+    /// This role gate runs before queueing, so an unrelated same-owner agent
+    /// cannot spend an ATLAS model call. Replayed task IDs are also dropped.
+    pub fn claim_inbound_event(&self, event: &Event) -> bool {
+        if !self.enabled {
+            return true;
+        }
+        let kind = event.kind.as_u16() as u32;
+        let author = event.pubkey.to_hex();
+        match (self.role, kind) {
+            (Some(NativeJobRole::Worker), KIND_JOB_REQUEST) => {
+                if self.delegator.as_deref() != Some(author.as_str()) {
+                    return false;
+                }
+                let Ok(request) = buzz_core::agent_job::parse_job_request(&event.content) else {
+                    return false;
+                };
+                if self.worker_role.as_deref() != Some(request.assigned_role.as_str()) {
+                    return false;
+                }
+                claim_task(&self.seen_requests, request.task_id)
+            }
+            (Some(NativeJobRole::Worker), KIND_JOB_CANCEL) => {
+                if self.delegator.as_deref() != Some(author.as_str()) {
+                    return false;
+                }
+                buzz_core::agent_job::parse_job_cancel(&event.content)
+                    .is_ok_and(|cancel| claim_task(&self.seen_cancels, cancel.task_id))
+            }
+            (Some(NativeJobRole::Manager), KIND_JOB_RESULT | KIND_JOB_ERROR) => {
+                if !self
+                    .delegation_targets
+                    .values()
+                    .any(|pubkey| pubkey == &author)
+                {
+                    return false;
+                }
+                buzz_core::agent_job::parse_job_result(&event.content)
+                    .is_ok_and(|result| claim_task(&self.seen_terminals, result.task_id))
+            }
+            _ => false,
+        }
+    }
+
+    /// Compact host instruction appended to an opted-in manager's ordinary
+    /// owner prompt. Native callback prompts already carry their own contract.
+    pub fn manager_control_prompt(&self) -> Option<&'static str> {
+        (self.enabled && self.role == Some(NativeJobRole::Manager))
+            .then_some(MANAGER_CONTROL_PROMPT)
+    }
+}
+
+fn claim_task(tasks: &Mutex<HashSet<Uuid>>, task_id: Uuid) -> bool {
+    let Ok(mut tasks) = tasks.lock() else {
+        return false;
+    };
+    if tasks.len() >= 4096 {
+        tasks.clear();
+    }
+    tasks.insert(task_id)
+}
+
+/// Typed terminal output emitted by native-job agents.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case", deny_unknown_fields)]
+pub enum NativeAction {
+    /// Delegate exactly one sequential child task.
+    #[serde(rename = "delegate_task")]
+    Delegate {
+        /// Configured logical role.
+        role: String,
+        /// One bounded objective.
+        objective: String,
+        /// Durable evidence references to reuse.
+        #[serde(default, deserialize_with = "deserialize_evidence_refs")]
+        evidence_refs: Vec<EvidenceRef>,
+        /// Expected result type.
+        result_contract: ResultContract,
+        /// Task-specific restrictions.
+        #[serde(default)]
+        constraints: Vec<String>,
+        /// Advisory model-call ceiling.
+        #[serde(default)]
+        max_model_calls: Option<u32>,
+    },
+    /// Complete the assigned task.
+    #[serde(rename = "complete_task")]
+    Complete {
+        /// Assigned task identifier.
+        task_id: Uuid,
+        /// At most five concise result bullets.
+        #[serde(default, deserialize_with = "deserialize_compact_strings")]
+        summary: Vec<String>,
+        /// Durable artifact references.
+        #[serde(default, deserialize_with = "deserialize_compact_strings")]
+        artifacts: Vec<String>,
+        /// Evidence supporting the result.
+        #[serde(default, deserialize_with = "deserialize_evidence_refs")]
+        evidence_refs: Vec<EvidenceRef>,
+        /// Checks performed.
+        #[serde(default, deserialize_with = "deserialize_compact_strings")]
+        checks: Vec<String>,
+        /// Unresolved facts.
+        #[serde(default, deserialize_with = "deserialize_compact_strings")]
+        gaps: Vec<String>,
+    },
+    /// Report a real blocker without retry chatter.
+    #[serde(rename = "block_task")]
+    Block {
+        /// Assigned task identifier.
+        task_id: Uuid,
+        /// Concise blocker summary.
+        #[serde(deserialize_with = "deserialize_compact_strings")]
+        summary: Vec<String>,
+        /// Unresolved facts or decisions.
+        #[serde(default, deserialize_with = "deserialize_compact_strings")]
+        gaps: Vec<String>,
+    },
+    /// Report terminal failure.
+    #[serde(rename = "fail_task")]
+    Fail {
+        /// Assigned task identifier.
+        task_id: Uuid,
+        /// Concise failure summary.
+        #[serde(deserialize_with = "deserialize_compact_strings")]
+        summary: Vec<String>,
+        /// Checks attempted before failure.
+        #[serde(default, deserialize_with = "deserialize_compact_strings")]
+        checks: Vec<String>,
+    },
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum ActionEvidenceRef {
+    Structured(EvidenceRef),
+    Compact(String),
+}
+
+fn deserialize_evidence_refs<'de, D>(deserializer: D) -> Result<Vec<EvidenceRef>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Vec::<ActionEvidenceRef>::deserialize(deserializer).map(|references| {
+        references
+            .into_iter()
+            .map(|reference| match reference {
+                ActionEvidenceRef::Structured(reference) => reference,
+                ActionEvidenceRef::Compact(uri) => EvidenceRef {
+                    uri,
+                    revision: None,
+                    section: None,
+                },
+            })
+            .collect()
+    })
+}
+
+fn deserialize_compact_strings<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Vec::<serde_json::Value>::deserialize(deserializer).map(|values| {
+        values
+            .into_iter()
+            .map(|value| match value {
+                serde_json::Value::String(value) => value,
+                value => value.to_string(),
+            })
+            .collect()
+    })
+}
+
+/// Parse an exact terminal native action. Ordinary prose returns `Ok(None)`.
+pub fn parse_terminal_action(output: &str) -> anyhow::Result<Option<NativeAction>> {
+    let trimmed = output.trim();
+    let Some(remainder) = trimmed.strip_prefix(ACTION_PREFIX) else {
+        return Ok(None);
+    };
+    if !remainder
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_ascii_whitespace())
+    {
+        anyhow::bail!("BUZZ_ACTION_V1 must be followed by whitespace and one JSON record");
+    }
+    let json = remainder.trim_start_matches(|character: char| character.is_ascii_whitespace());
+    if json.contains(ACTION_PREFIX) {
+        anyhow::bail!("terminal output contains multiple native actions");
+    }
+    let action = serde_json::from_str(json)
+        .map_err(|error| anyhow::anyhow!("invalid BUZZ_ACTION_V1: {error}"))?;
+    Ok(Some(action))
+}
+
+fn translation_terminal_action(output: &str, request: &JobRequest) -> anyhow::Result<NativeAction> {
+    let mut lines = output.trim().lines();
+    let verdict = lines.next().unwrap_or_default().trim();
+    let finding = lines.collect::<Vec<_>>().join("\n").trim().to_string();
+    if finding.len() > 1024 {
+        anyhow::bail!("translation QA finding exceeds 1024 characters");
+    }
+    if finding.contains(ACTION_PREFIX) || output.contains('{') || output.contains('}') {
+        anyhow::bail!("translation QA must not construct a native-job envelope");
+    }
+
+    let manifest_refs: Vec<String> = request
+        .evidence_refs
+        .iter()
+        .filter(|reference| reference.section.as_deref() == Some("TranslationManifest"))
+        .map(|reference| reference.uri.clone())
+        .collect();
+    if manifest_refs.len() != 1 {
+        anyhow::bail!("translation QA requires exactly one TranslationManifest reference");
+    }
+
+    match verdict {
+        "PASS" if finding.is_empty() => Ok(NativeAction::Complete {
+            task_id: request.task_id,
+            summary: vec!["PASS".into()],
+            artifacts: manifest_refs,
+            evidence_refs: request.evidence_refs.clone(),
+            checks: vec!["Bounded linguistic QA passed".into()],
+            gaps: vec![],
+        }),
+        "REVIEW_NEEDED" if !finding.is_empty() => Ok(NativeAction::Complete {
+            task_id: request.task_id,
+            summary: vec!["REVIEW_NEEDED".into()],
+            artifacts: manifest_refs,
+            evidence_refs: request.evidence_refs.clone(),
+            checks: vec!["Deterministic validation passed before linguistic QA".into()],
+            gaps: vec![finding],
+        }),
+        "FAIL" if !finding.is_empty() => Ok(NativeAction::Fail {
+            task_id: request.task_id,
+            summary: vec!["FAIL".into()],
+            checks: vec![finding],
+        }),
+        "PASS" => anyhow::bail!("PASS must not include a finding"),
+        "REVIEW_NEEDED" | "FAIL" => {
+            anyhow::bail!("{verdict} requires one bounded finding")
+        }
+        _ => anyhow::bail!("translation QA verdict must be PASS, REVIEW_NEEDED, or FAIL"),
+    }
+}
+
+pub(crate) fn event_tag<'a>(event: &'a Event, name: &str) -> Option<&'a str> {
+    event.tags.iter().find_map(|tag| {
+        let parts = tag.as_slice();
+        (parts.first().map(String::as_str) == Some(name))
+            .then(|| parts.get(1).map(String::as_str))
+            .flatten()
+    })
+}
+
+fn native_event(batch: &FlushBatch) -> Option<&Event> {
+    batch
+        .events
+        .iter()
+        .rev()
+        .map(|event| &event.event)
+        .find(|event| {
+            matches!(
+                event.kind.as_u16() as u32,
+                KIND_JOB_REQUEST | KIND_JOB_RESULT | KIND_JOB_ERROR
+            )
+        })
+}
+
+/// Whether a batch is a request or terminal native-job turn.
+pub fn is_native_job_batch(batch: &FlushBatch) -> bool {
+    native_event(batch).is_some()
+}
+
+fn root_task_id(batch: &FlushBatch) -> anyhow::Result<String> {
+    if let Some(root) = native_event(batch).and_then(|event| event_tag(event, "root")) {
+        return Ok(root.to_string());
+    }
+    let last = &batch
+        .events
+        .last()
+        .ok_or_else(|| anyhow::anyhow!("native job batch is empty"))?
+        .event;
+    Ok(parse_thread_tags(last)
+        .root_event_id
+        .unwrap_or_else(|| last.id.to_hex()))
+}
+
+fn worker_request(batch: &FlushBatch) -> anyhow::Result<(&Event, JobRequest)> {
+    let event = native_event(batch)
+        .filter(|event| event.kind.as_u16() as u32 == KIND_JOB_REQUEST)
+        .ok_or_else(|| anyhow::anyhow!("worker terminal action has no job request"))?;
+    Ok((
+        event,
+        buzz_core::agent_job::parse_job_request(&event.content)?,
+    ))
+}
+
+/// Build a compact prompt for a native job event, bypassing conversation fetch.
+pub fn compact_prompt(batch: &FlushBatch) -> Option<String> {
+    let event = native_event(batch)?;
+    match event.kind.as_u16() as u32 {
+        KIND_JOB_REQUEST => {
+            let request = buzz_core::agent_job::parse_job_request(&event.content).ok()?;
+            let hybrid_context = crate::hybrid::worker_context(&request)
+                .map(|context| format!("\n{context}"))
+                .unwrap_or_default();
+            let efficiency = match request.assigned_role.as_str() {
+                "research" => "Efficiency: use the exact evidence refs/resolver first. One fresh authoritative result is sufficient. Do not broadly discover files or verify the same fact twice unless that result reports stale, conflict, or error.",
+                "builder" => "Efficiency: the envelope is complete. Do not load the full Helpdesk manual, unrelated skills/maps, or independently research supplied evidence. Use one scoped inspection, one edit, and one batched validation where practical. Never remove or rewrite existing placeholders, screenshot markers, frontmatter, metadata, or unrelated content unless explicitly required.",
+                "qa" => "Efficiency: independently validate only the assigned artifact against the supplied evidence refs and applicable rules. Do not redo Research or use Git history/file discovery to locate evidence. Run the literal authoritative resolver command supplied in evidence refs exactly once and batch it with artifact/status/diff checks in one tool operation. If that command is missing, report a precise evidence gap instead of discovering it. Report exact PASS or FAIL findings. Keep summary to one PASS/FAIL string (the native contract permits at most five); put details in checks. A second tool operation requires a precise conflict or evidence gap. Read-only except your own ATLAS runtime/output directory.",
+                "screenshots" => "Efficiency: treat Manager-supplied evidence refs as approved and resolved; never open their source files. Resolve the deferred guarded Playwright namespace with exactly one narrow tool-search call for browser_navigate and browser_take_screenshot (include browser_resize only when the requested dimensions differ from the attached 1280x720 viewport); never use shell/process discovery or a second tool search. Navigate once to the exact assigned Synup product route, then capture it. Do not browse for alternatives, use recovery/helper navigation, or change product data. Inspect the image returned by browser_take_screenshot directly; do not reread it with view_image or take a separate accessibility snapshot. If the named US demo fixture is absent, block immediately. Otherwise save only in the assigned ATLAS Screenshots output directory, run file type/dimensions/size/SHA-256 in one batched command, and return one compact screenshot_manifest terminal result. Emit no intermediate commentary: the terminal BUZZ_ACTION_V1 record must be your first and only assistant content. Never edit Helpdesk content.",
+                "memory" => "Efficiency: use only the structured findings or exact evidence IDs in the task. Promote only a reusable verified claim with a source revision/date; reject transient task status, narrative, or unsupported candidates. Run the supplied deterministic memory resolver/index command once, preferably as one batch. No broad repository scans, source rereads, transcript storage, or independent fact research. If an identical current finding exists, return its exact evidence reference without rewriting. Supersede only when the candidate explicitly names the current reference and carries a newer verified source date. Write only under atlas/evidence/memory/ and return one compact memory_result terminal record with exact references. Emit no acknowledgement or intermediate commentary.",
+                "git" => "Efficiency: inspect only the exact assigned worktree and scope. Run the supplied deterministic read-only Git inspector exactly once; use its existing tracking refs unless the task explicitly allows its read-only ls-remote check. Do not run repository-wide discovery or a second Git command. Never fetch, commit, stage, push, merge, rebase, reset, checkout, clean, delete, or edit. Return one compact git_readiness result. Summary must contain exactly one READY or BLOCKED string; put branch, HEAD, state, changed files, scope verdict, diff-check result, ahead/behind, blockers, and exact unexecuted future commit/push commands in checks. Emit no acknowledgement or intermediate commentary.",
+                "translation" => "Efficiency: perform only bounded linguistic judgment on the exact source and generated locale references in the packet. The deterministic host already owns eligibility, hashing, translation memory, provider calls, batching, retries, writes, Markdown safety, protected terms, links, routes, SEO/build validation, usage accounting, reporting, and tracker output. Do not run the pipeline, translate content, discover repositories, edit files, publish, or delegate. Use only the relevant glossary subset and policy supplied in this task.",
+                _ => "Efficiency: use only the task envelope and its exact references; avoid discovery and duplicate verification.",
+            };
+            let terminal_contract = if request.assigned_role == "translation" {
+                "The host owns the native-job terminal envelope. Return exactly PASS on one line, or REVIEW_NEEDED/FAIL on the first line followed by one bounded finding on the remaining line. Return no JSON, prose preface, Markdown, acknowledgement, progress, polling, or delegation."
+            } else {
+                "This native callback overrides the legacy ATLAS_RESULT_V1/message-return instruction. Your final assistant content must contain only BUZZ_ACTION_V1 followed by one JSON record—no prose or Markdown. Complete shape: {\"op\":\"complete_task\",\"task_id\":\"TASK_ID\",\"summary\":[],\"artifacts\":[],\"evidence_refs\":[],\"checks\":[],\"gaps\":[]}. Blocked shape: {\"op\":\"block_task\",\"task_id\":\"TASK_ID\",\"summary\":[],\"gaps\":[]}. Failed shape: {\"op\":\"fail_task\",\"task_id\":\"TASK_ID\",\"summary\":[],\"checks\":[]}. Do not add fields to these shapes. Do not send a Buzz message and do not poll."
+            }
+            .replace("TASK_ID", &request.task_id.to_string());
+            Some(format!(
+                "[NATIVE_JOB_V1]\nTask: {}\nRole: {}\nObjective: {}\nEvidence refs: {}\nConstraints: {}\nResult contract: {}\n{}{}\n\n{}",
+                request.task_id,
+                request.assigned_role,
+                request.objective,
+                serde_json::to_string(&request.evidence_refs).ok()?,
+                serde_json::to_string(&request.constraints).ok()?,
+                serde_json::to_string(&request.result_contract).ok()?,
+                efficiency,
+                hybrid_context,
+                terminal_contract,
+            ))
+        }
+        KIND_JOB_RESULT | KIND_JOB_ERROR => {
+            let result = buzz_core::agent_job::parse_job_result(&event.content).ok()?;
+            let public_artifacts: Vec<_> = result
+                .artifacts
+                .iter()
+                .filter(|value| !crate::hybrid::is_workflow_marker(value))
+                .collect();
+            Some(format!(
+                "[SPECIALIST_RESULT_V1]\nTask: {}\nStatus: {:?}\nSummary: {}\nArtifacts: {}\nEvidence refs: {}\nChecks: {}\nGaps: {}\n\nReturn the concise final owner response or follow this delegation contract for the next sequential specialist:\n{}",
+                result.task_id,
+                result.status,
+                serde_json::to_string(&result.summary).ok()?,
+                serde_json::to_string(&public_artifacts).ok()?,
+                serde_json::to_string(&result.evidence_refs).ok()?,
+                serde_json::to_string(&result.checks).ok()?,
+                serde_json::to_string(&result.gaps).ok()?,
+                MANAGER_CONTROL_PROMPT,
+            ))
+        }
+        _ => None,
+    }
+}
+
+/// Publish a host-generated accepted/running event before the worker prompt.
+pub async fn publish_accepted(config: &NativeJobsConfig, rest: &RestClient, batch: &FlushBatch) {
+    if !config.enabled || config.role != Some(NativeJobRole::Worker) {
+        return;
+    }
+    let Ok((request_event, request)) = worker_request(batch) else {
+        return;
+    };
+    if config.worker_role.as_deref() != Some(request.assigned_role.as_str()) {
+        return;
+    }
+    let status = JobStatus {
+        v: AGENT_JOB_VERSION,
+        task_id: request.task_id,
+        status: "running".into(),
+        detail: Some(format!("{} running", request.assigned_role)),
+    };
+    let builder = match buzz_sdk::build_agent_job_status(
+        KIND_JOB_ACCEPTED,
+        batch.channel_id,
+        &request_event.pubkey.to_hex(),
+        &request.root_task_id,
+        &request_event.id.to_hex(),
+        &status,
+    ) {
+        Ok(builder) => builder,
+        Err(error) => {
+            tracing::warn!("native job accepted build failed: {error}");
+            return;
+        }
+    };
+    if let Err(error) = submit_builder(rest, builder, "accepted").await {
+        tracing::warn!("native job accepted publish failed: {error}");
+    }
+}
+
+/// Effect of consuming a completed native-job ACP response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NativeTurnEffect {
+    /// Whether native mode consumed/published the assistant response.
+    pub handled: bool,
+    /// Whether the task-local worker session should be discarded.
+    pub invalidate_session: bool,
+}
+
+impl NativeTurnEffect {
+    fn ignored() -> Self {
+        Self {
+            handled: false,
+            invalidate_session: false,
+        }
+    }
+}
+
+/// Consume a successful turn's terminal output and publish its durable effect.
+pub async fn handle_terminal_output(
+    config: &NativeJobsConfig,
+    rest: &RestClient,
+    batch: &FlushBatch,
+    output: &str,
+) -> anyhow::Result<NativeTurnEffect> {
+    if !config.enabled {
+        return Ok(NativeTurnEffect::ignored());
+    }
+    let action = if config.role == Some(NativeJobRole::Worker)
+        && config.worker_role.as_deref() == Some("translation")
+    {
+        let (_, request) = worker_request(batch)?;
+        Some(translation_terminal_action(output, &request)?)
+    } else {
+        parse_terminal_action(output)?
+    };
+    match (config.role, action) {
+        (
+            Some(NativeJobRole::Manager),
+            Some(NativeAction::Delegate {
+                role,
+                objective,
+                evidence_refs,
+                result_contract,
+                constraints,
+                max_model_calls,
+            }),
+        ) => {
+            let role = role.trim().to_ascii_lowercase();
+            let assignee = config
+                .delegation_targets
+                .get(&role)
+                .ok_or_else(|| anyhow::anyhow!("no native delegation target for role {role:?}"))?;
+            let parent_task_id = native_event(batch)
+                .and_then(|event| buzz_core::agent_job::parse_job_result(&event.content).ok())
+                .map(|result| result.task_id);
+            let request = JobRequest {
+                v: AGENT_JOB_VERSION,
+                task_id: Uuid::new_v4(),
+                root_task_id: root_task_id(batch)?,
+                parent_task_id,
+                assigned_role: role,
+                objective,
+                evidence_refs,
+                result_contract,
+                constraints,
+                budget: JobBudget {
+                    deadline_at: (Utc::now()
+                        + chrono::Duration::from_std(config.deadline)
+                            .unwrap_or_else(|_| chrono::Duration::minutes(15)))
+                    .to_rfc3339(),
+                    max_model_calls,
+                    max_output_bytes: DEFAULT_MAX_OUTPUT_BYTES,
+                },
+                attempt: 1,
+            };
+            let builder = buzz_sdk::build_agent_job_request(
+                batch.channel_id,
+                assignee,
+                &rest.keys.public_key().to_hex(),
+                &request,
+            )?;
+            submit_builder(rest, builder, "request").await?;
+            Ok(NativeTurnEffect {
+                handled: true,
+                // Suspend the Manager session so it retains the owner's plan;
+                // the next turn adds only the compact specialist result.
+                invalidate_session: false,
+            })
+        }
+        (Some(NativeJobRole::Manager), None) => {
+            if output.trim().is_empty() {
+                anyhow::bail!("native manager returned empty final output");
+            }
+            let thread_tags = owner_thread_tags(batch);
+            crate::pool::post_failure_notice(rest, batch.channel_id, &thread_tags, output.trim())
+                .await;
+            Ok(NativeTurnEffect {
+                handled: true,
+                invalidate_session: true,
+            })
+        }
+        (Some(NativeJobRole::Worker), Some(action)) => {
+            let (request_event, request) = worker_request(batch)?;
+            if config.worker_role.as_deref() != Some(request.assigned_role.as_str()) {
+                anyhow::bail!("job assigned to a different worker role");
+            }
+            let (task_id, status, mut summary, mut artifacts, evidence_refs, mut checks, gaps) =
+                match action {
+                    NativeAction::Complete {
+                        task_id,
+                        summary,
+                        artifacts,
+                        evidence_refs,
+                        checks,
+                        gaps,
+                    } => (
+                        task_id,
+                        JobTerminalStatus::Completed,
+                        summary,
+                        artifacts,
+                        evidence_refs,
+                        checks,
+                        gaps,
+                    ),
+                    NativeAction::Block {
+                        task_id,
+                        summary,
+                        gaps,
+                    } => (
+                        task_id,
+                        JobTerminalStatus::Blocked,
+                        summary,
+                        vec![],
+                        vec![],
+                        vec![],
+                        gaps,
+                    ),
+                    NativeAction::Fail {
+                        task_id,
+                        summary,
+                        checks,
+                    } => (
+                        task_id,
+                        JobTerminalStatus::Failed,
+                        summary,
+                        vec![],
+                        vec![],
+                        checks,
+                        vec![],
+                    ),
+                    NativeAction::Delegate { .. } => {
+                        anyhow::bail!("native worker may not delegate")
+                    }
+                };
+            if task_id != request.task_id {
+                anyhow::bail!("worker result task_id does not match request");
+            }
+            if summary.len() > 5 {
+                checks.extend(
+                    summary
+                        .drain(5..)
+                        .map(|line| format!("Additional result detail: {line}")),
+                );
+            }
+            for line in &mut summary {
+                if line.len() > 1024 {
+                    *line = line.chars().take(1024).collect();
+                }
+            }
+            crate::hybrid::carry_workflow_marker(&request, &mut artifacts);
+            let result = JobResult {
+                v: AGENT_JOB_VERSION,
+                task_id,
+                status,
+                summary,
+                artifacts,
+                evidence_refs,
+                checks,
+                gaps,
+            };
+            let kind = if status == JobTerminalStatus::Completed {
+                KIND_JOB_RESULT
+            } else {
+                KIND_JOB_ERROR
+            };
+            let builder = buzz_sdk::build_agent_job_result(
+                kind,
+                batch.channel_id,
+                &request_event.pubkey.to_hex(),
+                &request.root_task_id,
+                &request_event.id.to_hex(),
+                &result,
+            )?;
+            submit_builder(rest, builder, "terminal").await?;
+            Ok(NativeTurnEffect {
+                handled: true,
+                invalidate_session: true,
+            })
+        }
+        (Some(NativeJobRole::Worker), None) => {
+            anyhow::bail!("native worker must return a terminal BUZZ_ACTION_V1 record")
+        }
+        _ => Ok(NativeTurnEffect::ignored()),
+    }
+}
+
+/// Publish a terminal contract error for a worker so its manager resumes once.
+pub async fn publish_contract_error(
+    config: &NativeJobsConfig,
+    rest: &RestClient,
+    batch: &FlushBatch,
+    error: &str,
+) {
+    if !config.enabled || config.role != Some(NativeJobRole::Worker) {
+        return;
+    }
+    let Ok((request_event, request)) = worker_request(batch) else {
+        return;
+    };
+    let result = JobResult {
+        v: AGENT_JOB_VERSION,
+        task_id: request.task_id,
+        status: JobTerminalStatus::Failed,
+        summary: vec![format!("Worker result contract failed: {error}")],
+        artifacts: vec![],
+        evidence_refs: vec![],
+        checks: vec![],
+        gaps: vec![],
+    };
+    let builder = match buzz_sdk::build_agent_job_result(
+        KIND_JOB_ERROR,
+        batch.channel_id,
+        &request_event.pubkey.to_hex(),
+        &request.root_task_id,
+        &request_event.id.to_hex(),
+        &result,
+    ) {
+        Ok(builder) => builder,
+        Err(build_error) => {
+            tracing::warn!("native job contract error build failed: {build_error}");
+            return;
+        }
+    };
+    if let Err(publish_error) = submit_builder(rest, builder, "contract-error").await {
+        tracing::warn!("native job contract error publish failed: {publish_error}");
+    }
+}
+
+/// Surface a terminal-processing failure without spending another model call.
+///
+/// Workers publish a typed job error so the delegating manager resumes. A
+/// manager failure is posted to the owner thread because there is no parent
+/// job event to wake.
+pub async fn publish_turn_error(
+    config: &NativeJobsConfig,
+    rest: &RestClient,
+    batch: &FlushBatch,
+    error: &str,
+) {
+    match config.role {
+        Some(NativeJobRole::Worker) => {
+            publish_contract_error(config, rest, batch, error).await;
+        }
+        Some(NativeJobRole::Manager) => {
+            let thread_tags = owner_thread_tags(batch);
+            let notice = format!("ATLAS delegation failed safely: {error}");
+            crate::pool::post_failure_notice(rest, batch.channel_id, &thread_tags, &notice).await;
+        }
+        None => {}
+    }
+}
+
+/// Convert a validated worker cancellation into a terminal event immediately.
+///
+/// The worker model is cancelled separately by the harness. Publishing here
+/// wakes the manager without waiting for another worker inference.
+pub async fn publish_cancelled(
+    config: &NativeJobsConfig,
+    rest: &RestClient,
+    channel_id: Uuid,
+    cancel_event: &Event,
+) -> anyhow::Result<()> {
+    if config.role != Some(NativeJobRole::Worker) {
+        anyhow::bail!("only a native worker may consume a job cancellation");
+    }
+    let cancel = buzz_core::agent_job::parse_job_cancel(&cancel_event.content)?;
+    let root = event_tag(cancel_event, "root")
+        .ok_or_else(|| anyhow::anyhow!("job cancellation has no root tag"))?;
+    let request = event_tag(cancel_event, "request")
+        .ok_or_else(|| anyhow::anyhow!("job cancellation has no request tag"))?;
+    let result = JobResult {
+        v: AGENT_JOB_VERSION,
+        task_id: cancel.task_id,
+        status: JobTerminalStatus::Cancelled,
+        summary: vec![format!("Job cancelled: {}", cancel.reason)],
+        artifacts: vec![],
+        evidence_refs: vec![],
+        checks: vec![],
+        gaps: vec![],
+    };
+    let builder = buzz_sdk::build_agent_job_result(
+        KIND_JOB_ERROR,
+        channel_id,
+        &cancel_event.pubkey.to_hex(),
+        root,
+        request,
+        &result,
+    )?;
+    submit_builder(rest, builder, "cancelled").await
+}
+
+fn owner_thread_tags(batch: &FlushBatch) -> ThreadTags {
+    if let Some(root) = native_event(batch).and_then(|event| event_tag(event, "root")) {
+        return ThreadTags {
+            root_event_id: EventId::from_hex(root).ok().map(|id| id.to_hex()),
+            parent_event_id: EventId::from_hex(root).ok().map(|id| id.to_hex()),
+            mentioned_pubkeys: vec![],
+        };
+    }
+    batch
+        .events
+        .last()
+        .map(|event| parse_thread_tags(&event.event))
+        .unwrap_or_default()
+}
+
+pub(crate) async fn submit_builder(
+    rest: &RestClient,
+    builder: nostr::EventBuilder,
+    label: &str,
+) -> anyhow::Result<()> {
+    let event = builder
+        .sign_with_keys(&rest.keys)
+        .map_err(|error| anyhow::anyhow!("native job {label} sign failed: {error}"))?;
+    match tokio::time::timeout(Duration::from_secs(5), rest.submit_event(&event)).await {
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(error)) => Err(anyhow::anyhow!(
+            "native job {label} publish failed: {error}"
+        )),
+        Err(_) => Err(anyhow::anyhow!("native job {label} publish timed out")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn worker_config(manager: &nostr::Keys) -> NativeJobsConfig {
+        NativeJobsConfig {
+            enabled: true,
+            role: Some(NativeJobRole::Worker),
+            worker_role: Some("research".into()),
+            delegator: Some(manager.public_key().to_hex()),
+            ..NativeJobsConfig::default()
+        }
+    }
+
+    fn request_event(manager: &nostr::Keys, role: &str, task_id: Uuid) -> Event {
+        let request = JobRequest {
+            v: AGENT_JOB_VERSION,
+            task_id,
+            root_task_id: "owner-event".into(),
+            parent_task_id: None,
+            assigned_role: role.into(),
+            objective: "Verify one fact".into(),
+            evidence_refs: vec![],
+            result_contract: ResultContract {
+                kind: "evidence_packet".into(),
+                required: vec!["summary".into()],
+            },
+            constraints: vec!["read-only".into()],
+            budget: JobBudget {
+                deadline_at: "2026-08-21T12:00:00Z".into(),
+                max_model_calls: Some(3),
+                max_output_bytes: 8192,
+            },
+            attempt: 1,
+        };
+        buzz_sdk::build_agent_job_request(
+            Uuid::new_v4(),
+            &nostr::Keys::generate().public_key().to_hex(),
+            &manager.public_key().to_hex(),
+            &request,
+        )
+        .unwrap()
+        .sign_with_keys(manager)
+        .unwrap()
+    }
+
+    fn translation_request(task_id: Uuid) -> JobRequest {
+        JobRequest {
+            v: AGENT_JOB_VERSION,
+            task_id,
+            root_task_id: "owner-event".into(),
+            parent_task_id: None,
+            assigned_role: "translation".into(),
+            objective: "Judge one bounded es/fr translation".into(),
+            evidence_refs: vec![EvidenceRef {
+                uri: "atlas-translation://acceptance/manifest.json".into(),
+                revision: Some("source-sha".into()),
+                section: Some("TranslationManifest".into()),
+            }],
+            result_contract: ResultContract {
+                kind: "translation_manifest".into(),
+                required: vec!["validation_result".into()],
+            },
+            constraints: vec!["No file or provider mutation".into()],
+            budget: JobBudget {
+                deadline_at: "2026-08-21T12:00:00Z".into(),
+                max_model_calls: Some(1),
+                max_output_bytes: 8192,
+            },
+            attempt: 1,
+        }
+    }
+
+    #[test]
+    fn native_jobs_default_off() {
+        let config = NativeJobsConfig::default();
+        assert!(!config.enabled);
+        assert!(config.subscription_kinds().is_empty());
+    }
+
+    #[test]
+    fn manager_contract_makes_host_responsible_for_delivery() {
+        assert!(MANAGER_CONTROL_PROMPT.contains("ends this turn"));
+        assert!(MANAGER_CONTROL_PROMPT
+            .contains("only the compact specialist result as the next prompt"));
+        assert!(MANAGER_CONTROL_PROMPT.contains("host publishes ordinary final assistant content"));
+        assert!(MANAGER_CONTROL_PROMPT.contains("Never use Buzz tools"));
+        assert!(MANAGER_CONTROL_PROMPT.contains("Do not inspect facts assigned to Research"));
+        assert!(MANAGER_CONTROL_PROMPT.contains("After every READY Builder result"));
+        assert!(MANAGER_CONTROL_PROMPT.contains("at most one bounded Builder correction"));
+        assert!(MANAGER_CONTROL_PROMPT.contains("Never create an open-ended Builder/QA loop"));
+        assert!(MANAGER_CONTROL_PROMPT.contains("Copy every artifact reference byte-for-byte"));
+        assert!(MANAGER_CONTROL_PROMPT.contains("atlas-memory:// URIs"));
+        assert!(MANAGER_CONTROL_PROMPT.contains("opaque machine strings"));
+        assert!(MANAGER_CONTROL_PROMPT.contains("research|builder|qa|screenshots|memory|git"));
+        assert!(MANAGER_CONTROL_PROMPT.contains("git|translation"));
+        assert!(MANAGER_CONTROL_PROMPT.contains("translation_manifest"));
+        assert!(MANAGER_CONTROL_PROMPT.contains("it only inspects and prepares commands"));
+    }
+
+    #[test]
+    fn worker_prompt_carries_role_specific_efficiency_contract() {
+        let manager = nostr::Keys::generate();
+        let request = request_event(&manager, "research", Uuid::new_v4());
+        let batch = FlushBatch {
+            channel_id: Uuid::new_v4(),
+            events: vec![crate::queue::BatchEvent {
+                event: request,
+                received_at: std::time::Instant::now(),
+                prompt_tag: "native-job".into(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let prompt = compact_prompt(&batch).unwrap();
+        assert!(prompt.contains("exact evidence refs/resolver first"));
+        assert!(prompt.contains("Do not broadly discover files"));
+
+        let qa_request = request_event(&manager, "qa", Uuid::new_v4());
+        let qa_batch = FlushBatch {
+            channel_id: Uuid::new_v4(),
+            events: vec![crate::queue::BatchEvent {
+                event: qa_request,
+                received_at: std::time::Instant::now(),
+                prompt_tag: "native-job".into(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let qa_prompt = compact_prompt(&qa_batch).unwrap();
+        assert!(qa_prompt.contains("Do not redo Research"));
+        assert!(qa_prompt.contains("literal authoritative resolver command"));
+        assert!(qa_prompt.contains("Read-only except your own ATLAS runtime/output directory"));
+
+        let screenshot_request = request_event(&manager, "screenshots", Uuid::new_v4());
+        let screenshot_batch = FlushBatch {
+            channel_id: Uuid::new_v4(),
+            events: vec![crate::queue::BatchEvent {
+                event: screenshot_request,
+                received_at: std::time::Instant::now(),
+                prompt_tag: "native-job".into(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let screenshot_prompt = compact_prompt(&screenshot_batch).unwrap();
+        assert!(screenshot_prompt.contains("exact assigned Synup product route"));
+        assert!(screenshot_prompt.contains("evidence refs as approved and resolved"));
+        assert!(screenshot_prompt.contains("exactly one narrow tool-search call"));
+        assert!(screenshot_prompt.contains("never use shell/process discovery"));
+        assert!(screenshot_prompt.contains("do not reread it with view_image"));
+        assert!(screenshot_prompt.contains("one batched command"));
+        assert!(screenshot_prompt.contains("Do not browse for alternatives"));
+        assert!(screenshot_prompt.contains("first and only assistant content"));
+        assert!(screenshot_prompt.contains("screenshot_manifest"));
+
+        let memory_request = request_event(&manager, "memory", Uuid::new_v4());
+        let memory_batch = FlushBatch {
+            channel_id: Uuid::new_v4(),
+            events: vec![crate::queue::BatchEvent {
+                event: memory_request,
+                received_at: std::time::Instant::now(),
+                prompt_tag: "native-job".into(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let memory_prompt = compact_prompt(&memory_batch).unwrap();
+        assert!(memory_prompt.contains("deterministic memory resolver"));
+        assert!(memory_prompt.contains("No broad repository scans"));
+        assert!(memory_prompt.contains("reject transient task status"));
+        assert!(memory_prompt.contains("memory_result"));
+
+        let git_request = request_event(&manager, "git", Uuid::new_v4());
+        let git_batch = FlushBatch {
+            channel_id: Uuid::new_v4(),
+            events: vec![crate::queue::BatchEvent {
+                event: git_request,
+                received_at: std::time::Instant::now(),
+                prompt_tag: "native-job".into(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let git_prompt = compact_prompt(&git_batch).unwrap();
+        assert!(git_prompt.contains("deterministic read-only Git inspector"));
+        assert!(git_prompt.contains("read-only ls-remote check"));
+        assert!(git_prompt.contains("Never fetch, commit, stage, push"));
+        assert!(git_prompt.contains("Summary must contain exactly one"));
+        assert!(git_prompt.contains("git_readiness"));
+
+        let translation_request = request_event(&manager, "translation", Uuid::new_v4());
+        let translation_batch = FlushBatch {
+            channel_id: Uuid::new_v4(),
+            events: vec![crate::queue::BatchEvent {
+                event: translation_request,
+                received_at: std::time::Instant::now(),
+                prompt_tag: "native-job".into(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let translation_prompt = compact_prompt(&translation_batch).unwrap();
+        assert!(translation_prompt.contains("bounded linguistic judgment"));
+        assert!(translation_prompt.contains("deterministic host already owns eligibility"));
+        assert!(translation_prompt.contains("host owns the native-job terminal envelope"));
+        assert!(!translation_prompt
+            .contains("Your final assistant content must contain only BUZZ_ACTION_V1"));
+    }
+
+    #[test]
+    fn translation_judgment_is_host_wrapped() {
+        let task_id = Uuid::new_v4();
+        let request = translation_request(task_id);
+
+        let pass = translation_terminal_action("PASS", &request).unwrap();
+        assert!(matches!(
+            pass,
+            NativeAction::Complete {
+                task_id: returned,
+                summary,
+                artifacts,
+                gaps,
+                ..
+            } if returned == task_id
+                && summary == ["PASS"]
+                && artifacts == ["atlas-translation://acceptance/manifest.json"]
+                && gaps.is_empty()
+        ));
+
+        let review = translation_terminal_action(
+            "REVIEW_NEEDED\nOwner must approve the localized product term.",
+            &request,
+        )
+        .unwrap();
+        assert!(matches!(
+            review,
+            NativeAction::Complete { summary, gaps, .. }
+                if summary == ["REVIEW_NEEDED"] && gaps.len() == 1
+        ));
+
+        let fail = translation_terminal_action(
+            "FAIL\nThe French sentence changes the approved product claim.",
+            &request,
+        )
+        .unwrap();
+        assert!(matches!(
+            fail,
+            NativeAction::Fail { summary, checks, .. }
+                if summary == ["FAIL"] && checks.len() == 1
+        ));
+    }
+
+    #[test]
+    fn translation_judgment_rejects_protocol_json_and_ambiguous_results() {
+        let request = translation_request(Uuid::new_v4());
+        assert!(translation_terminal_action("PASS\nunexpected finding", &request).is_err());
+        assert!(translation_terminal_action("REVIEW_NEEDED", &request).is_err());
+        assert!(translation_terminal_action("MAYBE", &request).is_err());
+        assert!(translation_terminal_action("PASS\nBUZZ_ACTION_V1 {}", &request).is_err());
+
+        let mut missing_manifest = request;
+        missing_manifest.evidence_refs.clear();
+        assert!(translation_terminal_action("PASS", &missing_manifest).is_err());
+    }
+
+    #[test]
+    fn terminal_delegate_is_strict_and_typed() {
+        let action = parse_terminal_action(
+            "BUZZ_ACTION_V1\n{\"op\":\"delegate_task\",\"role\":\"research\",\"objective\":\"Verify X\",\"evidence_refs\":[],\"result_contract\":{\"kind\":\"evidence_packet\",\"required\":[\"summary\"]},\"constraints\":[\"read-only\"],\"max_model_calls\":3}",
+        )
+        .unwrap();
+        assert!(matches!(
+            action,
+            Some(NativeAction::Delegate { role, .. }) if role == "research"
+        ));
+        assert_eq!(
+            parse_terminal_action("ordinary final response").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn terminal_action_accepts_acp_single_space_separator() {
+        let action = parse_terminal_action(
+            "BUZZ_ACTION_V1 {\"op\":\"delegate_task\",\"role\":\"research\",\"objective\":\"Verify X\",\"evidence_refs\":[],\"result_contract\":{\"kind\":\"evidence_packet\",\"required\":[\"summary\"]},\"constraints\":[],\"max_model_calls\":3}",
+        )
+        .unwrap();
+        assert!(matches!(
+            action,
+            Some(NativeAction::Delegate { role, .. }) if role == "research"
+        ));
+    }
+
+    #[test]
+    fn terminal_action_accepts_compact_evidence_reference() {
+        let action = parse_terminal_action(
+            "BUZZ_ACTION_V1 {\"op\":\"delegate_task\",\"role\":\"research\",\"objective\":\"Verify X\",\"evidence_refs\":[\"maps/STATUS.md § census\"],\"result_contract\":{\"kind\":\"evidence_packet\",\"required\":[\"summary\"]},\"constraints\":[],\"max_model_calls\":3}",
+        )
+        .unwrap();
+        assert!(matches!(
+            action,
+            Some(NativeAction::Delegate { evidence_refs, .. })
+                if evidence_refs == vec![EvidenceRef {
+                    uri: "maps/STATUS.md § census".into(),
+                    revision: None,
+                    section: None,
+                }]
+        ));
+    }
+
+    #[test]
+    fn terminal_action_compacts_structured_artifacts_and_checks() {
+        let task_id = Uuid::new_v4();
+        let output = format!(
+            "BUZZ_ACTION_V1 {{\"op\":\"complete_task\",\"task_id\":\"{task_id}\",\"summary\":[\"done\"],\"artifacts\":[{{\"kind\":\"evidence_packet\"}}],\"evidence_refs\":[],\"checks\":[{{\"name\":\"census\",\"result\":\"pass\"}}],\"gaps\":[]}}"
+        );
+        let action = parse_terminal_action(&output).unwrap();
+        assert!(matches!(
+            action,
+            Some(NativeAction::Complete { artifacts, checks, .. })
+                if artifacts == ["{\"kind\":\"evidence_packet\"}"]
+                    && checks == ["{\"name\":\"census\",\"result\":\"pass\"}"]
+        ));
+    }
+
+    #[test]
+    fn malformed_action_does_not_fall_back_to_chat() {
+        assert!(parse_terminal_action("BUZZ_ACTION_V1\n{bad-json}").is_err());
+    }
+
+    #[test]
+    fn worker_claims_only_its_manager_role_and_first_task_delivery() {
+        let manager = nostr::Keys::generate();
+        let impostor = nostr::Keys::generate();
+        let config = worker_config(&manager);
+        let task_id = Uuid::new_v4();
+        let request = request_event(&manager, "research", task_id);
+        assert!(config.claim_inbound_event(&request));
+        assert!(
+            !config.claim_inbound_event(&request),
+            "duplicate task is dropped"
+        );
+        assert!(!config.claim_inbound_event(&request_event(&manager, "builder", Uuid::new_v4())));
+        assert!(!config.claim_inbound_event(&request_event(&impostor, "research", Uuid::new_v4())));
+    }
+
+    #[test]
+    fn qa_worker_claims_only_qa_requests() {
+        let manager = nostr::Keys::generate();
+        let mut config = worker_config(&manager);
+        config.worker_role = Some("qa".into());
+        assert!(config.claim_inbound_event(&request_event(&manager, "qa", Uuid::new_v4())));
+        assert!(!config.claim_inbound_event(&request_event(&manager, "builder", Uuid::new_v4())));
+    }
+
+    #[test]
+    fn screenshots_worker_claims_only_screenshot_requests() {
+        let manager = nostr::Keys::generate();
+        let mut config = worker_config(&manager);
+        config.worker_role = Some("screenshots".into());
+        assert!(config.claim_inbound_event(&request_event(
+            &manager,
+            "screenshots",
+            Uuid::new_v4()
+        )));
+        assert!(!config.claim_inbound_event(&request_event(&manager, "builder", Uuid::new_v4())));
+    }
+
+    #[test]
+    fn memory_worker_claims_only_memory_requests() {
+        let manager = nostr::Keys::generate();
+        let mut config = worker_config(&manager);
+        config.worker_role = Some("memory".into());
+        assert!(config.claim_inbound_event(&request_event(&manager, "memory", Uuid::new_v4())));
+        assert!(!config.claim_inbound_event(&request_event(&manager, "research", Uuid::new_v4())));
+    }
+
+    #[test]
+    fn git_worker_claims_only_git_requests() {
+        let manager = nostr::Keys::generate();
+        let mut config = worker_config(&manager);
+        config.worker_role = Some("git".into());
+        assert!(config.claim_inbound_event(&request_event(&manager, "git", Uuid::new_v4())));
+        assert!(!config.claim_inbound_event(&request_event(&manager, "builder", Uuid::new_v4())));
+    }
+
+    #[test]
+    fn translation_worker_claims_only_translation_requests_once() {
+        let manager = nostr::Keys::generate();
+        let mut config = worker_config(&manager);
+        config.worker_role = Some("translation".into());
+        let request = request_event(&manager, "translation", Uuid::new_v4());
+        assert!(config.claim_inbound_event(&request));
+        assert!(!config.claim_inbound_event(&request));
+        assert!(!config.claim_inbound_event(&request_event(&manager, "qa", Uuid::new_v4())));
+    }
+}

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4,6 +4,8 @@ mod acp;
 mod config;
 mod engram_fetch;
 mod filter;
+mod hybrid;
+mod jobs;
 mod observer;
 mod pool;
 mod pool_lifecycle;
@@ -21,8 +23,9 @@ use std::time::Duration;
 use acp::{AcpClient, EnvVar, McpServer};
 use anyhow::{ensure, Context, Result};
 use buzz_core::kind::{
-    KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
-    KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
+    KIND_JOB_ACCEPTED, KIND_JOB_CANCEL, KIND_JOB_ERROR, KIND_JOB_PROGRESS, KIND_JOB_REQUEST,
+    KIND_JOB_RESULT, KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION,
+    KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use buzz_core::observer::{
     decrypt_observer_payload, encrypt_observer_payload, OBSERVER_FRAME_TELEMETRY,
@@ -57,6 +60,25 @@ use uuid::Uuid;
 /// name (e.g., `buzz-acp --verbose models`) are not supported.
 fn is_subcommand(name: &str) -> bool {
     std::env::args().nth(1).map(|a| a == name).unwrap_or(false)
+}
+
+fn extend_channel_filters_for_native_jobs(
+    filters: &mut HashMap<Uuid, config::ChannelFilter>,
+    native_jobs: &jobs::NativeJobsConfig,
+) {
+    if !native_jobs.enabled {
+        return;
+    }
+    for filter in filters.values_mut() {
+        let Some(kinds) = filter.kinds.as_mut() else {
+            continue;
+        };
+        for kind in native_jobs.subscription_kinds() {
+            if !kinds.contains(kind) {
+                kinds.push(*kind);
+            }
+        }
+    }
 }
 
 /// Timeout for lightweight helper subcommands (spawn + initialize + model/method probes).
@@ -1676,6 +1698,34 @@ fn idle_pool_sleep_due(
 }
 
 #[cfg(test)]
+mod native_job_subscription_tests {
+    use super::*;
+
+    #[test]
+    fn native_job_kinds_are_added_to_wire_subscription() {
+        let channel_id = Uuid::new_v4();
+        let mut filters = HashMap::from([(
+            channel_id,
+            config::ChannelFilter {
+                kinds: Some(vec![KIND_STREAM_MESSAGE]),
+                require_mention: true,
+            },
+        )]);
+        let native_jobs = jobs::NativeJobsConfig::enabled_for_test();
+
+        extend_channel_filters_for_native_jobs(&mut filters, &native_jobs);
+
+        let kinds = filters[&channel_id].kinds.as_ref().unwrap();
+        for kind in native_jobs.subscription_kinds() {
+            assert!(
+                kinds.contains(kind),
+                "wire subscription omitted kind {kind}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
 mod inactivity_tests {
     use super::*;
 
@@ -1943,6 +1993,8 @@ async fn tokio_main() -> Result<()> {
         .init();
 
     let mut config = Config::from_cli().map_err(|e| anyhow::anyhow!("configuration error: {e}"))?;
+    let native_jobs = jobs::NativeJobsConfig::from_env()
+        .map_err(|error| anyhow::anyhow!("native jobs configuration error: {error}"))?;
 
     // ── Setup-mode early branch ───────────────────────────────────────────────
     //
@@ -2098,7 +2150,7 @@ async fn tokio_main() -> Result<()> {
     tracing::info!("discovered {} channel(s)", channel_info_map.len());
     let channel_ids: Vec<Uuid> = channel_info_map.keys().copied().collect();
 
-    let rules: Vec<SubscriptionRule> = match config.subscribe_mode {
+    let mut rules: Vec<SubscriptionRule> = match config.subscribe_mode {
         SubscribeMode::Mentions => {
             vec![SubscriptionRule {
                 name: "mentions".into(),
@@ -2134,8 +2186,23 @@ async fn tokio_main() -> Result<()> {
             config::load_rules(&config.config_path)?
         }
     };
+    if native_jobs.enabled {
+        for rule in &mut rules {
+            for kind in native_jobs.subscription_kinds() {
+                if !rule.kinds.contains(kind) {
+                    rule.kinds.push(*kind);
+                }
+            }
+        }
+        tracing::info!(
+            role = ?native_jobs.role,
+            worker_role = ?native_jobs.worker_role,
+            "native agent jobs enabled"
+        );
+    }
 
-    let channel_filters = config::resolve_channel_filters(&config, &channel_ids, &rules);
+    let mut channel_filters = config::resolve_channel_filters(&config, &channel_ids, &rules);
+    extend_channel_filters_for_native_jobs(&mut channel_filters, &native_jobs);
     if channel_filters.is_empty() {
         tracing::warn!("no channel subscriptions resolved — agent will sit idle");
     }
@@ -2221,6 +2288,7 @@ async fn tokio_main() -> Result<()> {
         memory_enabled: config.memory_enabled,
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
         relay_url: config.relay_url.clone(),
+        native_jobs,
     });
 
     if !config.memory_enabled {
@@ -2630,6 +2698,81 @@ async fn tokio_main() -> Result<()> {
                         Some(buzz_event) => {
                             let kind_u32 = buzz_event.event.kind.as_u16() as u32;
 
+                            if ctx.native_jobs.enabled
+                                && matches!(kind_u32, KIND_JOB_ACCEPTED | KIND_JOB_PROGRESS)
+                            {
+                                // Host-generated lifecycle events are visible in
+                                // clients but never wake an agent/model.
+                                continue;
+                            }
+                            let native_job_authorized = ctx.native_jobs.enabled
+                                && matches!(
+                                    kind_u32,
+                                    KIND_JOB_REQUEST
+                                        | KIND_JOB_RESULT
+                                        | KIND_JOB_ERROR
+                                        | KIND_JOB_CANCEL
+                                );
+                            if native_job_authorized
+                                && !ctx.native_jobs.claim_inbound_event(&buzz_event.event)
+                            {
+                                tracing::debug!(
+                                    kind = kind_u32,
+                                    "dropping unauthorized or duplicate native job event"
+                                );
+                                continue;
+                            }
+                            if native_job_authorized {
+                                match hybrid::try_route_manager_result(
+                                    &ctx.native_jobs,
+                                    &ctx.rest_client,
+                                    &buzz_event,
+                                )
+                                .await
+                                {
+                                    Ok(true) => continue,
+                                    Ok(false) => {}
+                                    Err(error) => tracing::warn!(
+                                        "hybrid manager routing failed; waking Manager safely: {error}"
+                                    ),
+                                }
+                                match hybrid::try_handle_deterministic_request(
+                                    &ctx.native_jobs,
+                                    &ctx.rest_client,
+                                    &buzz_event,
+                                )
+                                .await
+                                {
+                                    Ok(true) => continue,
+                                    Ok(false) => {}
+                                    Err(error) => {
+                                        tracing::warn!(
+                                            "hybrid deterministic dispatch failed; refusing model fallback: {error}"
+                                        );
+                                        continue;
+                                    }
+                                }
+                            }
+                            if ctx.native_jobs.enabled && kind_u32 == KIND_JOB_CANCEL {
+                                if let Err(error) = jobs::publish_cancelled(
+                                    &ctx.native_jobs,
+                                    &ctx.rest_client,
+                                    buzz_event.channel_id,
+                                    &buzz_event.event,
+                                )
+                                .await
+                                {
+                                    tracing::warn!("native job cancellation publish failed: {error}");
+                                    continue;
+                                }
+                                let _ = signal_in_flight_task(
+                                    &mut pool,
+                                    buzz_event.channel_id,
+                                    ControlSignal::Cancel,
+                                );
+                                continue;
+                            }
+
                             if kind_u32 == KIND_MEMBER_ADDED_NOTIFICATION
                                 || kind_u32 == KIND_MEMBER_REMOVED_NOTIFICATION
                             {
@@ -2865,7 +3008,7 @@ async fn tokio_main() -> Result<()> {
                             // launched by the same human). Allowlist adds the
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
-                            {
+                            if !native_job_authorized {
                                 let author = buzz_event.event.pubkey.to_hex();
                                 // DM hardening: resolve channel type (fail-closed
                                 // to DM) so allowlist/anyone modes cannot be
@@ -3144,15 +3287,75 @@ async fn tokio_main() -> Result<()> {
 
         match pool_event {
             Some(PoolEvent::Result(result)) => {
+                let mut result = *result;
                 // Stop typing indicator for the completed channel.
                 if let PromptSource::Channel(ch) = &result.source {
                     typing_channels.remove(ch);
+                }
+                if ctx.native_jobs.enabled && !matches!(result.outcome, PromptOutcome::Ok(_)) {
+                    if let Some(batch) = result
+                        .batch
+                        .as_ref()
+                        .filter(|batch| jobs::is_native_job_batch(batch))
+                    {
+                        let error = format!(
+                            "native turn ended without a terminal result ({})",
+                            prompt_outcome_label(&result.outcome)
+                        );
+                        jobs::publish_turn_error(&ctx.native_jobs, &ctx.rest_client, batch, &error)
+                            .await;
+                        result.agent.state.invalidate(&result.source);
+                        // Native jobs fail terminally. Do not let the ordinary
+                        // chat retry queue replay the task and spend more model
+                        // calls after its manager has already been resumed.
+                        result.batch = None;
+                    }
+                }
+                if ctx.native_jobs.enabled && matches!(result.outcome, PromptOutcome::Ok(_)) {
+                    if let Some(batch) = result.batch.as_ref() {
+                        let terminal_result = match result.agent.acp.take_final_assistant_message()
+                        {
+                            Some(output) => {
+                                jobs::handle_terminal_output(
+                                    &ctx.native_jobs,
+                                    &ctx.rest_client,
+                                    batch,
+                                    &output,
+                                )
+                                .await
+                            }
+                            None if jobs::compact_prompt(batch).is_some() => Err(anyhow::anyhow!(
+                                "native turn produced no terminal assistant output"
+                            )),
+                            None => Ok(jobs::NativeTurnEffect {
+                                handled: false,
+                                invalidate_session: false,
+                            }),
+                        };
+                        match terminal_result {
+                            Ok(effect) if effect.invalidate_session => {
+                                result.agent.state.invalidate(&result.source);
+                            }
+                            Ok(_) => {}
+                            Err(error) => {
+                                tracing::warn!("native job terminal action failed: {error}");
+                                jobs::publish_turn_error(
+                                    &ctx.native_jobs,
+                                    &ctx.rest_client,
+                                    batch,
+                                    &error.to_string(),
+                                )
+                                .await;
+                                result.agent.state.invalidate(&result.source);
+                            }
+                        }
+                    }
                 }
                 if handle_prompt_result(
                     &mut pool,
                     &mut queue,
                     &config,
-                    *result,
+                    result,
                     &mut heartbeat_in_flight,
                     &removed_channels,
                     &mut crash_history,
@@ -3842,6 +4045,18 @@ fn is_auth_error(error: &acp::AcpError) -> bool {
     message.contains("Re-authenticate") || message.contains("API Error: 401")
 }
 
+fn prompt_outcome_label(outcome: &PromptOutcome) -> &'static str {
+    match outcome {
+        PromptOutcome::Ok(_) => "completed",
+        PromptOutcome::Error(_) => "error",
+        PromptOutcome::AgentExited => "agent_exited",
+        PromptOutcome::Timeout(TimeoutKind::Idle) => "idle_timeout",
+        PromptOutcome::Timeout(TimeoutKind::Hard { .. }) => "hard_timeout",
+        PromptOutcome::Cancelled => "cancelled",
+        PromptOutcome::CancelDrainTimeout(_) => "cancel_drain_timeout",
+    }
+}
+
 /// Spawn a task that posts a user-visible failure notice to the relay.
 ///
 /// Shared by the hard-cap immediate dead-letter path and the retries-exhausted
@@ -3920,106 +4135,111 @@ fn handle_prompt_result(
     // retry_counts. If mark_complete runs first, retry_counts is cleared and
     // every retry starts at attempt 1 — defeating exponential backoff and
     // dead-letter protection.
-    if let Some(batch) = result.batch.take() {
-        // Don't requeue batches for channels the agent was removed from —
-        // those events are stale and should be silently dropped.
-        if !removed_channels.contains(&batch.channel_id) {
-            if matches!(
-                result.outcome,
-                PromptOutcome::Cancelled | PromptOutcome::CancelDrainTimeout(_)
-            ) {
-                // Cancel re-prompt: store as cancelled events so flush_next()
-                // merges them into the next FlushBatch.cancelled_events,
-                // enabling the annotated merged-prompt format. The batch's
-                // cancel_reason (set by the pool task per the control signal)
-                // selects steer vs interrupt framing. It is always set on this
-                // path; if somehow unset, fall back to the gentler Steer framing
-                // — consistent with MergeFraming::for_reason(None) and the
-                // system default — rather than telling the agent to supersede.
-                //
-                // CancelDrainTimeout shares this path with Cancelled: a failed
-                // 5s drain after a control-signal cancel is a cleanup-deadline
-                // problem, not the deterministic hard-cap death below — the
-                // original batch must survive with no retry/dead-letter
-                // accounting, same as a clean cancel.
-                let reason = batch.cancel_reason.unwrap_or(CancelReason::Steer);
-                queue.requeue_as_cancelled(batch, reason);
-            } else if matches!(
-                result.outcome,
-                PromptOutcome::Timeout(TimeoutKind::Hard {
-                    recently_active: false
-                })
-            ) {
-                tracing::error!(
-                    channel_id = %batch.channel_id,
-                    events = batch.events.len(),
-                    "dead-lettering batch after hard-cap timeout (no recent activity) — discarding {} events",
-                    batch.events.len(),
-                );
-                let content = format!(
+    if !matches!(result.outcome, PromptOutcome::Ok(_)) {
+        if let Some(batch) = result.batch.take() {
+            // Don't requeue batches for channels the agent was removed from —
+            // those events are stale and should be silently dropped.
+            if !removed_channels.contains(&batch.channel_id) {
+                if matches!(
+                    result.outcome,
+                    PromptOutcome::Cancelled | PromptOutcome::CancelDrainTimeout(_)
+                ) {
+                    // Cancel re-prompt: store as cancelled events so flush_next()
+                    // merges them into the next FlushBatch.cancelled_events,
+                    // enabling the annotated merged-prompt format. The batch's
+                    // cancel_reason (set by the pool task per the control signal)
+                    // selects steer vs interrupt framing. It is always set on this
+                    // path; if somehow unset, fall back to the gentler Steer framing
+                    // — consistent with MergeFraming::for_reason(None) and the
+                    // system default — rather than telling the agent to supersede.
+                    //
+                    // CancelDrainTimeout shares this path with Cancelled: a failed
+                    // 5s drain after a control-signal cancel is a cleanup-deadline
+                    // problem, not the deterministic hard-cap death below — the
+                    // original batch must survive with no retry/dead-letter
+                    // accounting, same as a clean cancel.
+                    let reason = batch.cancel_reason.unwrap_or(CancelReason::Steer);
+                    queue.requeue_as_cancelled(batch, reason);
+                } else if matches!(
+                    result.outcome,
+                    PromptOutcome::Timeout(TimeoutKind::Hard {
+                        recently_active: false
+                    })
+                ) {
+                    tracing::error!(
+                        channel_id = %batch.channel_id,
+                        events = batch.events.len(),
+                        "dead-lettering batch after hard-cap timeout (no recent activity) — discarding {} events",
+                        batch.events.len(),
+                    );
+                    let content = format!(
                     "⚠️ I couldn't process the last request (the turn exceeded the maximum duration ({}s)). Please re-send if it's still needed.",
                     config.max_turn_duration_secs
                 );
-                spawn_failure_notice(rest_client, &batch, content);
-                hard_timeout_fate_suffix = Some(" — dead-lettered (no recent activity)");
-            } else if matches!(
-                result.outcome,
-                PromptOutcome::Timeout(TimeoutKind::Hard {
-                    recently_active: true
-                })
-            ) {
-                tracing::warn!(
-                    channel_id = %batch.channel_id,
-                    events = batch.events.len(),
-                    "hard-cap timeout with recent activity — requeueing for retry"
-                );
-                if let Some(dead) = queue.requeue(batch) {
-                    let content = format!(
+                    spawn_failure_notice(rest_client, &batch, content);
+                    hard_timeout_fate_suffix = Some(" — dead-lettered (no recent activity)");
+                } else if matches!(
+                    result.outcome,
+                    PromptOutcome::Timeout(TimeoutKind::Hard {
+                        recently_active: true
+                    })
+                ) {
+                    tracing::warn!(
+                        channel_id = %batch.channel_id,
+                        events = batch.events.len(),
+                        "hard-cap timeout with recent activity — requeueing for retry"
+                    );
+                    if let Some(dead) = queue.requeue(batch) {
+                        let content = format!(
                         "⚠️ I couldn't process the last request after multiple retries (the turn exceeded the maximum duration ({}s)). Please re-send if it's still needed.",
                         config.max_turn_duration_secs
                     );
-                    spawn_failure_notice(rest_client, &dead, content);
-                    hard_timeout_fate_suffix = Some(" — dead-lettered (retry budget exhausted)");
-                } else {
-                    hard_timeout_fate_suffix = Some(" — requeued for retry (recently active)");
-                }
-            } else if matches!(&result.outcome, PromptOutcome::Error(e) if is_auth_error(e)) {
-                // Auth errors are non-retryable: the token won't self-repair
-                // between retries, so requeueing only wastes attempt slots and
-                // delays the visible failure. Dead-letter immediately and tell
-                // the user to re-authenticate the CLI.
-                tracing::warn!(
-                    channel_id = %batch.channel_id,
-                    events = batch.events.len(),
-                    "dead-lettering batch immediately — non-retryable auth error"
-                );
-                let content = "⚠️ I couldn't process the last request: authentication failed. \
+                        spawn_failure_notice(rest_client, &dead, content);
+                        hard_timeout_fate_suffix =
+                            Some(" — dead-lettered (retry budget exhausted)");
+                    } else {
+                        hard_timeout_fate_suffix = Some(" — requeued for retry (recently active)");
+                    }
+                } else if matches!(&result.outcome, PromptOutcome::Error(e) if is_auth_error(e)) {
+                    // Auth errors are non-retryable: the token won't self-repair
+                    // between retries, so requeueing only wastes attempt slots and
+                    // delays the visible failure. Dead-letter immediately and tell
+                    // the user to re-authenticate the CLI.
+                    tracing::warn!(
+                        channel_id = %batch.channel_id,
+                        events = batch.events.len(),
+                        "dead-lettering batch immediately — non-retryable auth error"
+                    );
+                    let content = "⚠️ I couldn't process the last request: authentication failed. \
                     Please re-authenticate the CLI (e.g. run `claude /login` or `codex login`) \
                     and then re-send."
-                    .to_string();
-                spawn_failure_notice(rest_client, &batch, content);
-            } else if let Some(dead) = queue.requeue(batch) {
-                let reason = match &result.outcome {
-                    PromptOutcome::Timeout(TimeoutKind::Idle) => "the turn timed out".to_string(),
-                    PromptOutcome::Timeout(TimeoutKind::Hard { .. }) => {
-                        "the turn exceeded the maximum duration".to_string()
-                    }
-                    PromptOutcome::AgentExited => "the agent process exited".to_string(),
-                    PromptOutcome::Error(e) => format!("{e}"),
-                    _ => "repeated failures".to_string(),
-                };
-                let content = format!(
+                        .to_string();
+                    spawn_failure_notice(rest_client, &batch, content);
+                } else if let Some(dead) = queue.requeue(batch) {
+                    let reason = match &result.outcome {
+                        PromptOutcome::Timeout(TimeoutKind::Idle) => {
+                            "the turn timed out".to_string()
+                        }
+                        PromptOutcome::Timeout(TimeoutKind::Hard { .. }) => {
+                            "the turn exceeded the maximum duration".to_string()
+                        }
+                        PromptOutcome::AgentExited => "the agent process exited".to_string(),
+                        PromptOutcome::Error(e) => format!("{e}"),
+                        _ => "repeated failures".to_string(),
+                    };
+                    let content = format!(
                     "⚠️ I couldn't process the last request after multiple retries ({reason}). Please re-send if it's still needed."
                 );
-                spawn_failure_notice(rest_client, &dead, content);
+                    spawn_failure_notice(rest_client, &dead, content);
+                }
+            } else {
+                tracing::debug!(
+                    channel_id = %batch.channel_id,
+                    events = batch.events.len(),
+                    "dropping failed batch for removed channel"
+                );
+                hard_timeout_fate_suffix = Some(" — batch dropped (channel removed)");
             }
-        } else {
-            tracing::debug!(
-                channel_id = %batch.channel_id,
-                events = batch.events.len(),
-                "dropping failed batch for removed channel"
-            );
-            hard_timeout_fate_suffix = Some(" — batch dropped (channel removed)");
         }
     }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -641,6 +641,8 @@ pub struct PromptContext {
     /// the desktop keys per (agent, relay) pair, e.g. `session_config_captured`,
     /// mirroring the `managed_agent_runtime_lifecycle` frames.
     pub relay_url: String,
+    /// Default-off native job routing configuration for this harness.
+    pub native_jobs: crate::jobs::NativeJobsConfig,
 }
 
 impl AgentPool {
@@ -2281,10 +2283,13 @@ pub async fn run_prompt_task(
     // (`prompt[0].text.startsWith("/")`) fires; the wrapped Buzz context
     // follows as a second block.
     let mut slash_command: Option<String> = None;
+    if let Some(ref native_batch) = batch {
+        crate::jobs::publish_accepted(&ctx.native_jobs, &ctx.rest_client, native_batch).await;
+    }
     // Event IDs represented by this prompt. Commit only after ACP reports a
     // successful turn; failed/cancelled prompts must be retryable without loss.
     let mut pending_delivered_event_ids = HashSet::new();
-    let prompt_sections: Vec<String> = if let Some(text) = prompt_text {
+    let mut prompt_sections: Vec<String> = if let Some(text) = prompt_text {
         // Heartbeats create their session before this point, so a Goose method-not-found
         // probe has already selected the correct framing for this process.
         //
@@ -2308,77 +2313,88 @@ pub async fn run_prompt_task(
         };
         vec![text]
     } else if let Some(ref b) = batch {
-        // Build prompt from batch with context enrichment.
-        // Try startup cache first; lazy-fetch via REST for dynamic channels.
-        let channel_info = ctx.channel_info.resolve(b.channel_id).await;
-
-        let conversation_context = if ctx.context_message_limit > 0 {
-            fetch_conversation_context(b, &channel_info, &ctx).await
-        } else {
-            None
-        };
         let rendered_batch_ids: HashSet<String> = b
             .events
             .iter()
             .chain(b.cancelled_events.iter())
             .map(|event| event.event.id.to_hex())
             .collect();
-        let delivered_ids = agent
-            .state
-            .deliveries
-            .get(&b.channel_id)
-            .map(|delivery| &delivery.delivered_event_ids)
-            .cloned()
-            .unwrap_or_default();
-        let conversation_context_had_delivered_events =
-            conversation_context.as_ref().is_some_and(|context| {
-                conversation_context_event_ids(Some(context))
-                    .iter()
-                    .any(|event_id| delivered_ids.contains(event_id))
-            });
-        let conversation_context =
-            conversation_context_delta(conversation_context, &delivered_ids, &rendered_batch_ids);
-        pending_delivered_event_ids.extend(rendered_batch_ids);
-        pending_delivered_event_ids.extend(conversation_context_event_ids(
-            conversation_context.as_ref(),
-        ));
+        pending_delivered_event_ids.extend(rendered_batch_ids.iter().cloned());
 
-        let profile_lookup =
-            fetch_prompt_profile_lookup(b, conversation_context.as_ref(), &ctx.rest_client).await;
-
-        let known_names: Vec<&str> = profile_lookup
-            .iter()
-            .flat_map(|lookup| lookup.values())
-            .flat_map(|p| [p.display_name.as_deref(), p.nip05_handle.as_deref()])
+        if let Some(prompt) = ctx
+            .native_jobs
+            .enabled
+            .then(|| crate::jobs::compact_prompt(b))
             .flatten()
-            .collect();
-        slash_command = crate::queue::slash_command_for_batch(b, &known_names);
-        if let Some(ref cmd) = slash_command {
-            tracing::info!(
-                target: "pool::prompt",
-                channel = %b.channel_id,
-                command = %cmd,
-                "slash-command pass-through"
+        {
+            vec![prompt]
+        } else {
+            // Build an ordinary prompt with context enrichment.
+            let channel_info = ctx.channel_info.resolve(b.channel_id).await;
+            let conversation_context = if ctx.context_message_limit > 0 {
+                fetch_conversation_context(b, &channel_info, &ctx).await
+            } else {
+                None
+            };
+            let delivered_ids = agent
+                .state
+                .deliveries
+                .get(&b.channel_id)
+                .map(|delivery| &delivery.delivered_event_ids)
+                .cloned()
+                .unwrap_or_default();
+            let conversation_context_had_delivered_events =
+                conversation_context.as_ref().is_some_and(|context| {
+                    conversation_context_event_ids(Some(context))
+                        .iter()
+                        .any(|event_id| delivered_ids.contains(event_id))
+                });
+            let conversation_context = conversation_context_delta(
+                conversation_context,
+                &delivered_ids,
+                &rendered_batch_ids,
             );
-        }
+            pending_delivered_event_ids.extend(conversation_context_event_ids(
+                conversation_context.as_ref(),
+            ));
 
-        crate::queue::format_prompt(
-            b,
-            &crate::queue::FormatPromptArgs {
-                agent_core: standing.agent_core,
-                huddle_instructions: standing.huddle_instructions,
-                channel_info: channel_info.as_ref(),
-                conversation_context: conversation_context.as_ref(),
-                conversation_context_had_delivered_events,
-                profile_lookup: profile_lookup.as_ref(),
-                has_system_prompt_support: agent.has_system_prompt_support(),
-                base_prompt: standing.base_prompt,
-                system_prompt: standing.system_prompt,
-                team_instructions: standing.team_instructions,
-                agent_canvas: standing.agent_canvas,
-                standing_context_sent,
-            },
-        )
+            let profile_lookup =
+                fetch_prompt_profile_lookup(b, conversation_context.as_ref(), &ctx.rest_client)
+                    .await;
+            let known_names: Vec<&str> = profile_lookup
+                .iter()
+                .flat_map(|lookup| lookup.values())
+                .flat_map(|p| [p.display_name.as_deref(), p.nip05_handle.as_deref()])
+                .flatten()
+                .collect();
+            slash_command = crate::queue::slash_command_for_batch(b, &known_names);
+            if let Some(ref cmd) = slash_command {
+                tracing::info!(
+                    target: "pool::prompt",
+                    channel = %b.channel_id,
+                    command = %cmd,
+                    "slash-command pass-through"
+                );
+            }
+
+            crate::queue::format_prompt(
+                b,
+                &crate::queue::FormatPromptArgs {
+                    agent_core: standing.agent_core,
+                    huddle_instructions: standing.huddle_instructions,
+                    channel_info: channel_info.as_ref(),
+                    conversation_context: conversation_context.as_ref(),
+                    conversation_context_had_delivered_events,
+                    profile_lookup: profile_lookup.as_ref(),
+                    has_system_prompt_support: agent.has_system_prompt_support(),
+                    base_prompt: standing.base_prompt,
+                    system_prompt: standing.system_prompt,
+                    team_instructions: standing.team_instructions,
+                    agent_canvas: standing.agent_canvas,
+                    standing_context_sent,
+                },
+            )
+        }
     } else {
         // Should not happen — batch is None only for heartbeats which have prompt_text.
         // Return the agent to the pool to prevent a permanent slot leak.
@@ -2393,6 +2409,13 @@ pub async fn run_prompt_task(
         );
         return;
     };
+    if let (Some(control), Some(ordinary_batch)) =
+        (ctx.native_jobs.manager_control_prompt(), batch.as_ref())
+    {
+        if crate::jobs::compact_prompt(ordinary_batch).is_none() {
+            prompt_sections.push(control.to_string());
+        }
+    }
 
     // 💬 — fire-and-forget so the prompt fires immediately.
     // The guard's cleanup (spawned on drop) removes 💬 after the turn completes.
@@ -2700,7 +2723,7 @@ pub async fn run_prompt_task(
                 agent,
                 source,
                 PromptOutcome::Ok(stop_reason),
-                None,
+                batch,
             );
         }
         Err(AcpError::AgentExited) => {
@@ -7953,6 +7976,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             memory_enabled: false,
             harness_name: "goose".to_string(),
             relay_url: "ws://127.0.0.1:3000".to_string(),
+            native_jobs: crate::jobs::NativeJobsConfig::default(),
         }
     }
 

--- a/crates/buzz-core/src/agent_job.rs
+++ b/crates/buzz-core/src/agent_job.rs
@@ -1,0 +1,345 @@
+//! Typed payloads and validation for Buzz's native agent-job protocol.
+//!
+//! Job events are ordinary, durable Nostr events. The relay is the source of
+//! truth for recovery; harnesses keep only an in-memory projection while they
+//! are running.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Protocol version emitted by current Buzz job producers.
+pub const AGENT_JOB_VERSION: u8 = 1;
+/// Maximum serialized job-event content accepted by the relay.
+pub const MAX_AGENT_JOB_CONTENT_BYTES: usize = 16 * 1024;
+/// Maximum bytes in a delegated objective.
+pub const MAX_AGENT_JOB_OBJECTIVE_BYTES: usize = 4 * 1024;
+/// Maximum evidence references carried inline by one request or result.
+pub const MAX_AGENT_JOB_EVIDENCE_REFS: usize = 32;
+/// Maximum bytes in one evidence reference.
+pub const MAX_AGENT_JOB_EVIDENCE_REF_BYTES: usize = 1024;
+
+/// A compact reference to durable evidence; source bodies do not ride in jobs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceRef {
+    /// Stable path, URL, or application-defined evidence URI.
+    pub uri: String,
+    /// Optional revision, commit, or capture date.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<String>,
+    /// Optional section or anchor within the referenced artifact.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub section: Option<String>,
+}
+
+/// Bounded execution policy attached to a job request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JobBudget {
+    /// Absolute job deadline as an RFC3339 timestamp.
+    pub deadline_at: String,
+    /// Advisory maximum model calls for this task.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_model_calls: Option<u32>,
+    /// Maximum serialized terminal-result size.
+    pub max_output_bytes: usize,
+}
+
+/// Contract describing the compact terminal result expected from a worker.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResultContract {
+    /// Application-defined result type such as `evidence_packet`.
+    pub kind: String,
+    /// Required result field names.
+    #[serde(default)]
+    pub required: Vec<String>,
+}
+
+/// Payload for kind `43001` — delegate one bounded task to one agent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JobRequest {
+    /// Protocol version.
+    pub v: u8,
+    /// Host-generated UUID task identifier.
+    pub task_id: Uuid,
+    /// Owner-message or application root identifier.
+    pub root_task_id: String,
+    /// Optional parent task for future correlation; Phase 1.2 is sequential.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_task_id: Option<Uuid>,
+    /// Logical configured role, for example `research` or `builder`.
+    pub assigned_role: String,
+    /// One bounded objective.
+    pub objective: String,
+    /// Existing evidence the worker should reuse first.
+    #[serde(default)]
+    pub evidence_refs: Vec<EvidenceRef>,
+    /// Expected terminal result shape.
+    pub result_contract: ResultContract,
+    /// Task-specific safety and scope restrictions.
+    #[serde(default)]
+    pub constraints: Vec<String>,
+    /// Deadline and output/model budgets.
+    pub budget: JobBudget,
+    /// One-based attempt number.
+    pub attempt: u32,
+}
+
+/// Payload for kind `43002` and `43003` host-generated status events.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JobStatus {
+    /// Protocol version.
+    pub v: u8,
+    /// Task identifier.
+    pub task_id: Uuid,
+    /// Short host-generated status label.
+    pub status: String,
+    /// Optional bounded human-readable detail.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// Terminal result status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JobTerminalStatus {
+    /// The assigned objective was completed.
+    Completed,
+    /// Work cannot continue without a real external decision or dependency.
+    Blocked,
+    /// Work failed.
+    Failed,
+    /// Work was cancelled.
+    Cancelled,
+}
+
+/// Payload for kind `43004` and `43006` terminal events.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JobResult {
+    /// Protocol version.
+    pub v: u8,
+    /// Task identifier.
+    pub task_id: Uuid,
+    /// Terminal status.
+    pub status: JobTerminalStatus,
+    /// At most five concise result bullets.
+    #[serde(default)]
+    pub summary: Vec<String>,
+    /// Durable artifacts produced by the task.
+    #[serde(default)]
+    pub artifacts: Vec<String>,
+    /// Evidence references supporting the result.
+    #[serde(default)]
+    pub evidence_refs: Vec<EvidenceRef>,
+    /// Validation checks run by the worker.
+    #[serde(default)]
+    pub checks: Vec<String>,
+    /// Unresolved facts or decisions.
+    #[serde(default)]
+    pub gaps: Vec<String>,
+}
+
+/// Payload for kind `43005` cancellation events.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JobCancel {
+    /// Protocol version.
+    pub v: u8,
+    /// Task identifier.
+    pub task_id: Uuid,
+    /// Bounded reason supplied by the owner or delegator.
+    pub reason: String,
+}
+
+/// Validation failure for a native job payload.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum AgentJobError {
+    /// Serialized content is too large.
+    #[error("job content exceeds {MAX_AGENT_JOB_CONTENT_BYTES} bytes")]
+    ContentTooLarge,
+    /// JSON did not match the event-kind schema.
+    #[error("invalid job payload: {0}")]
+    InvalidJson(String),
+    /// A required or bounded field is invalid.
+    #[error("invalid job field: {0}")]
+    InvalidField(&'static str),
+}
+
+fn validate_common(version: u8, task_id: Uuid) -> Result<(), AgentJobError> {
+    if version != AGENT_JOB_VERSION {
+        return Err(AgentJobError::InvalidField("v"));
+    }
+    if task_id.is_nil() {
+        return Err(AgentJobError::InvalidField("task_id"));
+    }
+    Ok(())
+}
+
+fn validate_refs(refs: &[EvidenceRef]) -> Result<(), AgentJobError> {
+    if refs.len() > MAX_AGENT_JOB_EVIDENCE_REFS {
+        return Err(AgentJobError::InvalidField("evidence_refs"));
+    }
+    if refs.iter().any(|reference| {
+        reference.uri.trim().is_empty()
+            || reference.uri.len() > MAX_AGENT_JOB_EVIDENCE_REF_BYTES
+            || reference
+                .revision
+                .as_ref()
+                .is_some_and(|value| value.len() > 256)
+            || reference
+                .section
+                .as_ref()
+                .is_some_and(|value| value.len() > 256)
+    }) {
+        return Err(AgentJobError::InvalidField("evidence_refs"));
+    }
+    Ok(())
+}
+
+/// Parse and validate a request payload.
+pub fn parse_job_request(content: &str) -> Result<JobRequest, AgentJobError> {
+    check_size(content)?;
+    let value: JobRequest = serde_json::from_str(content)
+        .map_err(|error| AgentJobError::InvalidJson(error.to_string()))?;
+    validate_common(value.v, value.task_id)?;
+    if value.root_task_id.trim().is_empty() || value.root_task_id.len() > 256 {
+        return Err(AgentJobError::InvalidField("root_task_id"));
+    }
+    if value.assigned_role.trim().is_empty() || value.assigned_role.len() > 64 {
+        return Err(AgentJobError::InvalidField("assigned_role"));
+    }
+    if value.objective.trim().is_empty() || value.objective.len() > MAX_AGENT_JOB_OBJECTIVE_BYTES {
+        return Err(AgentJobError::InvalidField("objective"));
+    }
+    if value.result_contract.kind.trim().is_empty() || value.result_contract.kind.len() > 64 {
+        return Err(AgentJobError::InvalidField("result_contract.kind"));
+    }
+    if value.attempt == 0 || value.budget.max_output_bytes == 0 {
+        return Err(AgentJobError::InvalidField("budget/attempt"));
+    }
+    chrono::DateTime::parse_from_rfc3339(&value.budget.deadline_at)
+        .map_err(|_| AgentJobError::InvalidField("budget.deadline_at"))?;
+    validate_refs(&value.evidence_refs)?;
+    Ok(value)
+}
+
+/// Parse and validate an accepted/progress payload.
+pub fn parse_job_status(content: &str) -> Result<JobStatus, AgentJobError> {
+    check_size(content)?;
+    let value: JobStatus = serde_json::from_str(content)
+        .map_err(|error| AgentJobError::InvalidJson(error.to_string()))?;
+    validate_common(value.v, value.task_id)?;
+    if value.status.trim().is_empty() || value.status.len() > 64 {
+        return Err(AgentJobError::InvalidField("status"));
+    }
+    if value
+        .detail
+        .as_ref()
+        .is_some_and(|detail| detail.len() > 512)
+    {
+        return Err(AgentJobError::InvalidField("detail"));
+    }
+    Ok(value)
+}
+
+/// Parse and validate a terminal result/error payload.
+pub fn parse_job_result(content: &str) -> Result<JobResult, AgentJobError> {
+    check_size(content)?;
+    let value: JobResult = serde_json::from_str(content)
+        .map_err(|error| AgentJobError::InvalidJson(error.to_string()))?;
+    validate_common(value.v, value.task_id)?;
+    if value.summary.len() > 5 || value.summary.iter().any(|line| line.len() > 1024) {
+        return Err(AgentJobError::InvalidField("summary"));
+    }
+    validate_refs(&value.evidence_refs)?;
+    Ok(value)
+}
+
+/// Parse and validate a cancellation payload.
+pub fn parse_job_cancel(content: &str) -> Result<JobCancel, AgentJobError> {
+    check_size(content)?;
+    let value: JobCancel = serde_json::from_str(content)
+        .map_err(|error| AgentJobError::InvalidJson(error.to_string()))?;
+    validate_common(value.v, value.task_id)?;
+    if value.reason.trim().is_empty() || value.reason.len() > 512 {
+        return Err(AgentJobError::InvalidField("reason"));
+    }
+    Ok(value)
+}
+
+fn check_size(content: &str) -> Result<(), AgentJobError> {
+    if content.len() > MAX_AGENT_JOB_CONTENT_BYTES {
+        return Err(AgentJobError::ContentTooLarge);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request() -> JobRequest {
+        JobRequest {
+            v: AGENT_JOB_VERSION,
+            task_id: Uuid::new_v4(),
+            root_task_id: "owner-event".into(),
+            parent_task_id: None,
+            assigned_role: "research".into(),
+            objective: "Verify one fact".into(),
+            evidence_refs: vec![EvidenceRef {
+                uri: "evidence://verified/item".into(),
+                revision: Some("abc123".into()),
+                section: None,
+            }],
+            result_contract: ResultContract {
+                kind: "evidence_packet".into(),
+                required: vec!["summary".into()],
+            },
+            constraints: vec!["read-only".into()],
+            budget: JobBudget {
+                deadline_at: "2026-08-21T12:00:00Z".into(),
+                max_model_calls: Some(3),
+                max_output_bytes: 8192,
+            },
+            attempt: 1,
+        }
+    }
+
+    #[test]
+    fn request_round_trips_and_validates() {
+        let request = request();
+        let json = serde_json::to_string(&request).unwrap();
+        assert_eq!(parse_job_request(&json).unwrap(), request);
+    }
+
+    #[test]
+    fn request_rejects_unknown_fields() {
+        let mut value = serde_json::to_value(request()).unwrap();
+        value["master_prompt"] = serde_json::json!("too much context");
+        assert!(matches!(
+            parse_job_request(&value.to_string()),
+            Err(AgentJobError::InvalidJson(_))
+        ));
+    }
+
+    #[test]
+    fn request_rejects_unbounded_evidence() {
+        let mut request = request();
+        request.evidence_refs = (0..=MAX_AGENT_JOB_EVIDENCE_REFS)
+            .map(|index| EvidenceRef {
+                uri: format!("evidence://{index}"),
+                revision: None,
+                section: None,
+            })
+            .collect();
+        assert_eq!(
+            parse_job_request(&serde_json::to_string(&request).unwrap()),
+            Err(AgentJobError::InvalidField("evidence_refs"))
+        );
+    }
+}

--- a/crates/buzz-core/src/lib.rs
+++ b/crates/buzz-core/src/lib.rs
@@ -5,6 +5,8 @@
 //! Provides [`StoredEvent`], filter matching, kind constants, and event
 //! verification. All other Buzz crates depend on this one.
 
+/// Typed native agent-job payloads and validation.
+pub mod agent_job;
 /// NIP-AM: Agent Turn Metric — payload type and encrypt/decrypt helpers.
 pub mod agent_turn_metric;
 /// Channel and membership enums shared across crates.

--- a/crates/buzz-relay/CHANGELOG.md
+++ b/crates/buzz-relay/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## relay-v0.2.2-rc.1
+
+- Admit and validate BUZZ-native job request, status, result, cancellation, and failure events (kinds 43001–43006).
+
 ## relay-v0.2.1
 
 - fix(sdk): preserve self-mention p tags in message and forum event builders ([#4975](https://github.com/block/buzz/pull/4975)) ([`78c87ae20e`](https://github.com/block/buzz/commit/78c87ae20e182fffdd99744d6c9ff99df82b159c))

--- a/crates/buzz-relay/Cargo.toml
+++ b/crates/buzz-relay/Cargo.toml
@@ -4,7 +4,7 @@ default-run = "buzz-relay"
 # Independent version: buzz-relay ships as a pinnable artifact
 # (ghcr.io/block/buzz), released on its own cadence via `just release-relay`.
 # It does NOT inherit the workspace version.
-version = "0.2.1"
+version = "0.2.2-rc.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -21,20 +21,21 @@ use buzz_core::kind::{
     KIND_GIT_STATUS_CLOSED, KIND_GIT_STATUS_DRAFT, KIND_GIT_STATUS_MERGED, KIND_GIT_STATUS_OPEN,
     KIND_HUDDLE_ENDED, KIND_HUDDLE_GUIDELINES, KIND_HUDDLE_PARTICIPANT_JOINED,
     KIND_HUDDLE_PARTICIPANT_LEFT, KIND_HUDDLE_STARTED, KIND_IA_ARCHIVE_REQUEST,
-    KIND_IA_UNARCHIVE_REQUEST, KIND_LONG_FORM, KIND_MANAGED_AGENT, KIND_MEMBER_ADDED_NOTIFICATION,
-    KIND_MEMBER_REMOVED_NOTIFICATION, KIND_MODERATION_BAN, KIND_MODERATION_RESOLVE_REPORT,
-    KIND_MODERATION_TIMEOUT, KIND_MODERATION_UNBAN, KIND_MODERATION_UNTIMEOUT, KIND_MUTE_LIST,
-    KIND_NIP29_CREATE_GROUP, KIND_NIP29_DELETE_EVENT, KIND_NIP29_DELETE_GROUP,
-    KIND_NIP29_EDIT_METADATA, KIND_NIP29_JOIN_REQUEST, KIND_NIP29_LEAVE_REQUEST,
-    KIND_NIP29_PUT_USER, KIND_NIP29_REMOVE_USER, KIND_NIP43_LEAVE_REQUEST,
-    KIND_NIP65_RELAY_LIST_METADATA, KIND_PERSONA, KIND_PIN_LIST, KIND_PRESENCE_UPDATE,
-    KIND_PRIVATE_MANAGED_AGENT, KIND_PRODUCT_FEEDBACK, KIND_PROFILE, KIND_PROJECT, KIND_REACTION,
-    KIND_READ_STATE, KIND_REPORT, KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_BOOKMARKED,
-    KIND_STREAM_MESSAGE_DIFF, KIND_STREAM_MESSAGE_EDIT, KIND_STREAM_MESSAGE_PINNED,
-    KIND_STREAM_MESSAGE_SCHEDULED, KIND_STREAM_MESSAGE_V2, KIND_STREAM_REMINDER, KIND_TEAM,
-    KIND_TEAM_CATALOG, KIND_TEXT_NOTE, KIND_USER_STATUS, KIND_WORKFLOW_DEF, KIND_WORKFLOW_TRIGGER,
-    RELAY_ADMIN_ADD_MEMBER, RELAY_ADMIN_CHANGE_ROLE, RELAY_ADMIN_REMOVE_MEMBER,
-    RELAY_ADMIN_SET_WORKSPACE_PROFILE,
+    KIND_IA_UNARCHIVE_REQUEST, KIND_JOB_ACCEPTED, KIND_JOB_CANCEL, KIND_JOB_ERROR,
+    KIND_JOB_PROGRESS, KIND_JOB_REQUEST, KIND_JOB_RESULT, KIND_LONG_FORM, KIND_MANAGED_AGENT,
+    KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_MODERATION_BAN,
+    KIND_MODERATION_RESOLVE_REPORT, KIND_MODERATION_TIMEOUT, KIND_MODERATION_UNBAN,
+    KIND_MODERATION_UNTIMEOUT, KIND_MUTE_LIST, KIND_NIP29_CREATE_GROUP, KIND_NIP29_DELETE_EVENT,
+    KIND_NIP29_DELETE_GROUP, KIND_NIP29_EDIT_METADATA, KIND_NIP29_JOIN_REQUEST,
+    KIND_NIP29_LEAVE_REQUEST, KIND_NIP29_PUT_USER, KIND_NIP29_REMOVE_USER,
+    KIND_NIP43_LEAVE_REQUEST, KIND_NIP65_RELAY_LIST_METADATA, KIND_PERSONA, KIND_PIN_LIST,
+    KIND_PRESENCE_UPDATE, KIND_PRIVATE_MANAGED_AGENT, KIND_PRODUCT_FEEDBACK, KIND_PROFILE,
+    KIND_PROJECT, KIND_REACTION, KIND_READ_STATE, KIND_REPORT, KIND_STREAM_MESSAGE,
+    KIND_STREAM_MESSAGE_BOOKMARKED, KIND_STREAM_MESSAGE_DIFF, KIND_STREAM_MESSAGE_EDIT,
+    KIND_STREAM_MESSAGE_PINNED, KIND_STREAM_MESSAGE_SCHEDULED, KIND_STREAM_MESSAGE_V2,
+    KIND_STREAM_REMINDER, KIND_TEAM, KIND_TEAM_CATALOG, KIND_TEXT_NOTE, KIND_USER_STATUS,
+    KIND_WORKFLOW_DEF, KIND_WORKFLOW_TRIGGER, RELAY_ADMIN_ADD_MEMBER, RELAY_ADMIN_CHANGE_ROLE,
+    RELAY_ADMIN_REMOVE_MEMBER, RELAY_ADMIN_SET_WORKSPACE_PROFILE,
 };
 use buzz_core::tenant::TenantContext;
 use buzz_core::verification::verify_event;
@@ -153,6 +154,78 @@ fn validate_custom_emoji_tags(event: &Event) -> Result<(), IngestError> {
         })?;
         buzz_sdk::normalize_custom_emoji_shortcode(shortcode)
             .map_err(|err| IngestError::Rejected(format!("invalid: {err}")))?;
+    }
+    Ok(())
+}
+
+fn job_tag<'a>(event: &'a Event, name: &str) -> Option<&'a str> {
+    event.tags.iter().find_map(|tag| {
+        let parts = tag.as_slice();
+        (parts.first().map(String::as_str) == Some(name))
+            .then(|| parts.get(1).map(String::as_str))
+            .flatten()
+    })
+}
+
+fn validate_agent_job_event(event: &Event, kind: u32) -> Result<(), IngestError> {
+    for required in ["h", "p", "task", "root"] {
+        if job_tag(event, required).is_none() {
+            return Err(IngestError::Rejected(format!(
+                "invalid: agent job event requires {required} tag"
+            )));
+        }
+    }
+    let task_tag = job_tag(event, "task").ok_or_else(|| {
+        IngestError::Rejected("invalid: agent job event requires task tag".into())
+    })?;
+    let payload_task = match kind {
+        KIND_JOB_REQUEST => {
+            for required in ["role", "delegator"] {
+                if job_tag(event, required).is_none() {
+                    return Err(IngestError::Rejected(format!(
+                        "invalid: job request requires {required} tag"
+                    )));
+                }
+            }
+            let author = event.pubkey.to_hex();
+            if job_tag(event, "delegator") != Some(author.as_str()) {
+                return Err(IngestError::Rejected(
+                    "invalid: job request delegator must match author".into(),
+                ));
+            }
+            buzz_core::agent_job::parse_job_request(&event.content).map(|payload| payload.task_id)
+        }
+        KIND_JOB_ACCEPTED | KIND_JOB_PROGRESS => {
+            if job_tag(event, "request").is_none() {
+                return Err(IngestError::Rejected(
+                    "invalid: job status requires request tag".into(),
+                ));
+            }
+            buzz_core::agent_job::parse_job_status(&event.content).map(|payload| payload.task_id)
+        }
+        KIND_JOB_RESULT | KIND_JOB_ERROR => {
+            if job_tag(event, "request").is_none() {
+                return Err(IngestError::Rejected(
+                    "invalid: job result requires request tag".into(),
+                ));
+            }
+            buzz_core::agent_job::parse_job_result(&event.content).map(|payload| payload.task_id)
+        }
+        KIND_JOB_CANCEL => {
+            if job_tag(event, "request").is_none() {
+                return Err(IngestError::Rejected(
+                    "invalid: job cancel requires request tag".into(),
+                ));
+            }
+            buzz_core::agent_job::parse_job_cancel(&event.content).map(|payload| payload.task_id)
+        }
+        _ => return Ok(()),
+    }
+    .map_err(|error| IngestError::Rejected(format!("invalid: {error}")))?;
+    if payload_task.to_string() != task_tag {
+        return Err(IngestError::Rejected(
+            "invalid: task tag does not match payload task_id".into(),
+        ));
     }
     Ok(())
 }
@@ -481,7 +554,13 @@ fn required_scope_for_kind(kind: u32, event: &Event) -> Result<Scope, &'static s
         | KIND_STREAM_MESSAGE_DIFF
         | KIND_FORUM_POST
         | KIND_FORUM_VOTE
-        | KIND_FORUM_COMMENT => Ok(Scope::MessagesWrite),
+        | KIND_FORUM_COMMENT
+        | KIND_JOB_REQUEST
+        | KIND_JOB_ACCEPTED
+        | KIND_JOB_PROGRESS
+        | KIND_JOB_RESULT
+        | KIND_JOB_CANCEL
+        | KIND_JOB_ERROR => Ok(Scope::MessagesWrite),
         KIND_NIP29_PUT_USER | KIND_NIP29_REMOVE_USER | KIND_NIP29_DELETE_GROUP => {
             Ok(Scope::AdminChannels)
         }
@@ -716,6 +795,12 @@ pub(crate) fn requires_h_channel_scope(kind: u32) -> bool {
             | KIND_FORUM_POST
             | KIND_FORUM_VOTE
             | KIND_FORUM_COMMENT
+            | KIND_JOB_REQUEST
+            | KIND_JOB_ACCEPTED
+            | KIND_JOB_PROGRESS
+            | KIND_JOB_RESULT
+            | KIND_JOB_CANCEL
+            | KIND_JOB_ERROR
             // NIP-29 admin kinds (except CREATE_GROUP which creates the channel)
             | KIND_NIP29_PUT_USER
             | KIND_NIP29_REMOVE_USER
@@ -2250,6 +2335,17 @@ async fn ingest_event_inner(
         Ok(scope) => scope,
         Err(msg) => return Err(IngestError::Rejected(msg.into())),
     };
+    if matches!(
+        kind_u32,
+        KIND_JOB_REQUEST
+            | KIND_JOB_ACCEPTED
+            | KIND_JOB_PROGRESS
+            | KIND_JOB_RESULT
+            | KIND_JOB_CANCEL
+            | KIND_JOB_ERROR
+    ) {
+        validate_agent_job_event(&event, kind_u32)?;
+    }
     // NIP-43: relay admin commands are global — channel-scoped tokens cannot
     // issue them even if the event has no `h` tag (is_global_only_kind strips
     // channel_id, but we still need to reject the token itself).
@@ -3286,6 +3382,80 @@ mod tests {
         KIND_STREAM_MESSAGE_DIFF, KIND_TEAM, KIND_USER_STATUS,
     };
     use nostr::{EventBuilder, Kind};
+
+    fn job_request_event_with(delegator: &nostr::Keys) -> Event {
+        let assignee = nostr::Keys::generate();
+        let request = buzz_core::agent_job::JobRequest {
+            v: buzz_core::agent_job::AGENT_JOB_VERSION,
+            task_id: Uuid::new_v4(),
+            root_task_id: "owner-event".into(),
+            parent_task_id: None,
+            assigned_role: "research".into(),
+            objective: "Verify one fact".into(),
+            evidence_refs: vec![],
+            result_contract: buzz_core::agent_job::ResultContract {
+                kind: "evidence_packet".into(),
+                required: vec!["summary".into()],
+            },
+            constraints: vec!["read-only".into()],
+            budget: buzz_core::agent_job::JobBudget {
+                deadline_at: "2026-08-21T12:00:00Z".into(),
+                max_model_calls: Some(3),
+                max_output_bytes: 8192,
+            },
+            attempt: 1,
+        };
+        buzz_sdk::build_agent_job_request(
+            Uuid::new_v4(),
+            &assignee.public_key().to_hex(),
+            &delegator.public_key().to_hex(),
+            &request,
+        )
+        .unwrap()
+        .sign_with_keys(delegator)
+        .unwrap()
+    }
+
+    fn job_request_event() -> Event {
+        job_request_event_with(&nostr::Keys::generate())
+    }
+
+    #[test]
+    fn native_job_events_are_scoped_and_validated() {
+        let event = job_request_event();
+        assert_eq!(
+            required_scope_for_kind(KIND_JOB_REQUEST, &event).unwrap(),
+            Scope::MessagesWrite
+        );
+        assert!(requires_h_channel_scope(KIND_JOB_REQUEST));
+        assert!(validate_agent_job_event(&event, KIND_JOB_REQUEST).is_ok());
+    }
+
+    #[test]
+    fn native_job_rejects_task_tag_mismatch() {
+        let delegator = nostr::Keys::generate();
+        let original = job_request_event_with(&delegator);
+        let tags = original
+            .tags
+            .iter()
+            .map(|tag| {
+                let parts = tag.as_slice();
+                if parts.first().map(String::as_str) == Some("task") {
+                    nostr::Tag::parse(["task", &Uuid::new_v4().to_string()]).unwrap()
+                } else {
+                    tag.clone()
+                }
+            })
+            .collect::<Vec<_>>();
+        let event = EventBuilder::new(original.kind, original.content)
+            .tags(tags)
+            .sign_with_keys(&delegator)
+            .unwrap();
+        assert!(matches!(
+            validate_agent_job_event(&event, KIND_JOB_REQUEST),
+            Err(IngestError::Rejected(message)) if message.contains("task tag")
+        ));
+    }
 
     #[test]
     fn missing_huddle_backing_channel_is_a_client_rejection() {

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -244,6 +244,129 @@ pub fn build_message(
         .allow_self_tagging())
 }
 
+/// Build a native agent job request (kind 43001).
+pub fn build_agent_job_request(
+    channel_id: Uuid,
+    assignee_pubkey: &str,
+    delegator_pubkey: &str,
+    request: &buzz_core::agent_job::JobRequest,
+) -> Result<EventBuilder, SdkError> {
+    let assignee = check_pubkey_hex(assignee_pubkey, "assignee_pubkey")?;
+    let delegator = check_pubkey_hex(delegator_pubkey, "delegator_pubkey")?;
+    let content = serde_json::to_string(request)
+        .map_err(|error| SdkError::InvalidInput(error.to_string()))?;
+    buzz_core::agent_job::parse_job_request(&content)
+        .map_err(|error| SdkError::InvalidInput(error.to_string()))?;
+    let task_id = request.task_id.to_string();
+    let tags = vec![
+        tag(&["h", &channel_id.to_string()])?,
+        tag(&["p", &assignee])?,
+        tag(&["task", &task_id])?,
+        tag(&["root", &request.root_task_id])?,
+        tag(&["role", &request.assigned_role])?,
+        tag(&["delegator", &delegator])?,
+    ];
+    Ok(EventBuilder::new(
+        Kind::Custom(buzz_core::kind::KIND_JOB_REQUEST as u16),
+        content,
+    )
+    .tags(tags))
+}
+
+/// Build a native agent job accepted or progress event (kind 43002/43003).
+pub fn build_agent_job_status(
+    kind: u32,
+    channel_id: Uuid,
+    recipient_pubkey: &str,
+    root_task_id: &str,
+    request_event_id: &str,
+    status: &buzz_core::agent_job::JobStatus,
+) -> Result<EventBuilder, SdkError> {
+    if !matches!(
+        kind,
+        buzz_core::kind::KIND_JOB_ACCEPTED | buzz_core::kind::KIND_JOB_PROGRESS
+    ) {
+        return Err(SdkError::InvalidInput(
+            "job status kind must be 43002 or 43003".into(),
+        ));
+    }
+    let recipient = check_pubkey_hex(recipient_pubkey, "recipient_pubkey")?;
+    let content =
+        serde_json::to_string(status).map_err(|error| SdkError::InvalidInput(error.to_string()))?;
+    buzz_core::agent_job::parse_job_status(&content)
+        .map_err(|error| SdkError::InvalidInput(error.to_string()))?;
+    let task_id = status.task_id.to_string();
+    let tags = vec![
+        tag(&["h", &channel_id.to_string()])?,
+        tag(&["p", &recipient])?,
+        tag(&["task", &task_id])?,
+        tag(&["root", root_task_id])?,
+        tag(&["request", request_event_id])?,
+    ];
+    Ok(EventBuilder::new(Kind::Custom(kind as u16), content).tags(tags))
+}
+
+/// Build a native agent job result or error event (kind 43004/43006).
+pub fn build_agent_job_result(
+    kind: u32,
+    channel_id: Uuid,
+    recipient_pubkey: &str,
+    root_task_id: &str,
+    request_event_id: &str,
+    result: &buzz_core::agent_job::JobResult,
+) -> Result<EventBuilder, SdkError> {
+    if !matches!(
+        kind,
+        buzz_core::kind::KIND_JOB_RESULT | buzz_core::kind::KIND_JOB_ERROR
+    ) {
+        return Err(SdkError::InvalidInput(
+            "job terminal kind must be 43004 or 43006".into(),
+        ));
+    }
+    let recipient = check_pubkey_hex(recipient_pubkey, "recipient_pubkey")?;
+    let content =
+        serde_json::to_string(result).map_err(|error| SdkError::InvalidInput(error.to_string()))?;
+    buzz_core::agent_job::parse_job_result(&content)
+        .map_err(|error| SdkError::InvalidInput(error.to_string()))?;
+    let task_id = result.task_id.to_string();
+    let tags = vec![
+        tag(&["h", &channel_id.to_string()])?,
+        tag(&["p", &recipient])?,
+        tag(&["task", &task_id])?,
+        tag(&["root", root_task_id])?,
+        tag(&["request", request_event_id])?,
+    ];
+    Ok(EventBuilder::new(Kind::Custom(kind as u16), content).tags(tags))
+}
+
+/// Build a native agent job cancellation event (kind 43005).
+pub fn build_agent_job_cancel(
+    channel_id: Uuid,
+    recipient_pubkey: &str,
+    root_task_id: &str,
+    request_event_id: &str,
+    cancel: &buzz_core::agent_job::JobCancel,
+) -> Result<EventBuilder, SdkError> {
+    let recipient = check_pubkey_hex(recipient_pubkey, "recipient_pubkey")?;
+    let content =
+        serde_json::to_string(cancel).map_err(|error| SdkError::InvalidInput(error.to_string()))?;
+    buzz_core::agent_job::parse_job_cancel(&content)
+        .map_err(|error| SdkError::InvalidInput(error.to_string()))?;
+    let task_id = cancel.task_id.to_string();
+    let tags = vec![
+        tag(&["h", &channel_id.to_string()])?,
+        tag(&["p", &recipient])?,
+        tag(&["task", &task_id])?,
+        tag(&["root", root_task_id])?,
+        tag(&["request", request_event_id])?,
+    ];
+    Ok(EventBuilder::new(
+        Kind::Custom(buzz_core::kind::KIND_JOB_CANCEL as u16),
+        content,
+    )
+    .tags(tags))
+}
+
 /// Build an encrypted agent observer frame (kind 24200).
 ///
 /// `recipient_pubkey` is the cleartext `p` tag used by the relay for owner-only
@@ -4866,5 +4989,46 @@ mod tests {
 
         assert_eq!(accept_count, 11, "expected 11 accept cases");
         assert_eq!(reject_count, 20, "expected 20 reject cases");
+    }
+
+    #[test]
+    fn native_job_request_has_compact_routing_tags() {
+        let assignee = keys().public_key().to_hex();
+        let delegator = keys().public_key().to_hex();
+        let request = buzz_core::agent_job::JobRequest {
+            v: buzz_core::agent_job::AGENT_JOB_VERSION,
+            task_id: Uuid::new_v4(),
+            root_task_id: event_id().to_hex(),
+            parent_task_id: None,
+            assigned_role: "research".into(),
+            objective: "Verify one fact".into(),
+            evidence_refs: vec![],
+            result_contract: buzz_core::agent_job::ResultContract {
+                kind: "evidence_packet".into(),
+                required: vec!["summary".into()],
+            },
+            constraints: vec!["read-only".into()],
+            budget: buzz_core::agent_job::JobBudget {
+                deadline_at: "2026-08-21T12:00:00Z".into(),
+                max_model_calls: Some(3),
+                max_output_bytes: 8192,
+            },
+            attempt: 1,
+        };
+
+        let event = sign(build_agent_job_request(uuid(), &assignee, &delegator, &request).unwrap());
+        assert_eq!(
+            event.kind,
+            Kind::Custom(buzz_core::kind::KIND_JOB_REQUEST as u16)
+        );
+        assert!(event.tags.iter().any(|tag| {
+            let parts = tag.as_slice();
+            parts.first().map(String::as_str) == Some("task")
+                && parts.get(1).map(String::as_str) == Some(request.task_id.to_string().as_str())
+        }));
+        assert_eq!(
+            buzz_core::agent_job::parse_job_request(&event.content).unwrap(),
+            request
+        );
     }
 }

--- a/crates/buzz-test-client/tests/e2e_relay.rs
+++ b/crates/buzz-test-client/tests/e2e_relay.rs
@@ -414,6 +414,253 @@ async fn test_send_event_and_receive_via_subscription() {
     client_b.disconnect().await.expect("disconnect B");
 }
 
+/// Prove the BUZZ-native job lifecycle is admitted, correlated, and delivered
+/// exactly once without polling. These kinds are Buzz protocol events, not
+/// NIP-90 events.
+#[tokio::test]
+#[ignore]
+async fn test_native_job_request_running_result_lifecycle() {
+    use buzz_core::agent_job::{
+        JobBudget, JobRequest, JobResult, JobStatus, JobTerminalStatus, ResultContract,
+        AGENT_JOB_VERSION,
+    };
+    use buzz_core::kind::{KIND_JOB_ACCEPTED, KIND_JOB_REQUEST, KIND_JOB_RESULT};
+
+    fn tag<'a>(event: &'a nostr::Event, name: &str) -> Option<&'a str> {
+        event.tags.iter().find_map(|tag| {
+            let parts = tag.as_slice();
+            (parts.first().map(String::as_str) == Some(name))
+                .then(|| parts.get(1).map(String::as_str))
+                .flatten()
+        })
+    }
+
+    let url = relay_url();
+    let manager_keys = Keys::generate();
+    let worker_keys = Keys::generate();
+    let channel = create_test_channel(&manager_keys).await;
+    let channel_id = Uuid::parse_str(&channel).expect("channel UUID");
+    let task_id = Uuid::new_v4();
+    let root_task_id = format!("owner-{}", Uuid::new_v4());
+
+    let mut manager = BuzzTestClient::connect(&url, &manager_keys)
+        .await
+        .expect("manager connect");
+    let mut worker = BuzzTestClient::connect(&url, &worker_keys)
+        .await
+        .expect("worker connect");
+
+    let worker_sid = sub_id("native-worker");
+    let worker_filter = Filter::new()
+        .kind(Kind::Custom(KIND_JOB_REQUEST as u16))
+        .custom_tags(SingleLetterTag::lowercase(Alphabet::H), [channel.as_str()])
+        .custom_tags(
+            SingleLetterTag::lowercase(Alphabet::P),
+            [worker_keys.public_key().to_hex()],
+        );
+    worker
+        .subscribe(&worker_sid, vec![worker_filter])
+        .await
+        .expect("worker subscribe");
+    worker
+        .collect_until_eose(&worker_sid, Duration::from_secs(5))
+        .await
+        .expect("worker EOSE");
+
+    let manager_sid = sub_id("native-manager");
+    let manager_filter = Filter::new()
+        .kinds(vec![
+            Kind::Custom(KIND_JOB_ACCEPTED as u16),
+            Kind::Custom(KIND_JOB_RESULT as u16),
+        ])
+        .custom_tags(SingleLetterTag::lowercase(Alphabet::H), [channel.as_str()])
+        .custom_tags(
+            SingleLetterTag::lowercase(Alphabet::P),
+            [manager_keys.public_key().to_hex()],
+        );
+    manager
+        .subscribe(&manager_sid, vec![manager_filter.clone()])
+        .await
+        .expect("manager subscribe");
+    manager
+        .collect_until_eose(&manager_sid, Duration::from_secs(5))
+        .await
+        .expect("manager EOSE");
+
+    let request = JobRequest {
+        v: AGENT_JOB_VERSION,
+        task_id,
+        root_task_id: root_task_id.clone(),
+        parent_task_id: None,
+        assigned_role: "qa".into(),
+        objective: "Judge one harmless fixture".into(),
+        evidence_refs: vec![],
+        result_contract: ResultContract {
+            kind: "qa_result".into(),
+            required: vec!["summary".into()],
+        },
+        constraints: vec!["read-only".into(), "no delegation".into()],
+        budget: JobBudget {
+            deadline_at: (chrono::Utc::now() + chrono::Duration::minutes(5)).to_rfc3339(),
+            max_model_calls: Some(1),
+            max_output_bytes: 8192,
+        },
+        attempt: 1,
+    };
+    let request_event = buzz_sdk::build_agent_job_request(
+        channel_id,
+        &worker_keys.public_key().to_hex(),
+        &manager_keys.public_key().to_hex(),
+        &request,
+    )
+    .expect("build request")
+    .sign_with_keys(&manager_keys)
+    .expect("sign request");
+    let request_id = request_event.id.to_hex();
+    let request_ok = manager
+        .send_event(request_event.clone())
+        .await
+        .expect("send 43001");
+    assert!(
+        request_ok.accepted,
+        "43001 rejected: {}",
+        request_ok.message
+    );
+
+    let delivered_request = match worker
+        .recv_event(Duration::from_secs(5))
+        .await
+        .expect("worker receives 43001")
+    {
+        RelayMessage::Event { event, .. } => event,
+        other => panic!("expected worker 43001, got {other:?}"),
+    };
+    assert_eq!(
+        delivered_request.kind,
+        Kind::Custom(KIND_JOB_REQUEST as u16)
+    );
+    assert_eq!(delivered_request.pubkey, manager_keys.public_key());
+    assert_eq!(
+        tag(&delivered_request, "task"),
+        Some(task_id.to_string().as_str())
+    );
+    assert_eq!(tag(&delivered_request, "root"), Some(root_task_id.as_str()));
+
+    let duplicate_ok = manager
+        .send_event(request_event)
+        .await
+        .expect("replay exact 43001");
+    assert!(
+        duplicate_ok.accepted,
+        "idempotent replay acknowledgement failed: {}",
+        duplicate_ok.message
+    );
+    assert!(matches!(
+        worker.recv_event(Duration::from_millis(500)).await,
+        Err(TestClientError::Timeout)
+    ));
+
+    let running = JobStatus {
+        v: AGENT_JOB_VERSION,
+        task_id,
+        status: "running".into(),
+        detail: Some("qa running".into()),
+    };
+    let running_event = buzz_sdk::build_agent_job_status(
+        KIND_JOB_ACCEPTED,
+        channel_id,
+        &manager_keys.public_key().to_hex(),
+        &root_task_id,
+        &request_id,
+        &running,
+    )
+    .expect("build 43002")
+    .sign_with_keys(&worker_keys)
+    .expect("sign 43002");
+    let running_ok = worker.send_event(running_event).await.expect("send 43002");
+    assert!(
+        running_ok.accepted,
+        "43002 rejected: {}",
+        running_ok.message
+    );
+
+    let result = JobResult {
+        v: AGENT_JOB_VERSION,
+        task_id,
+        status: JobTerminalStatus::Completed,
+        summary: vec!["PASS".into()],
+        artifacts: vec![],
+        evidence_refs: vec![],
+        checks: vec!["fixture passed".into()],
+        gaps: vec![],
+    };
+    let result_event = buzz_sdk::build_agent_job_result(
+        KIND_JOB_RESULT,
+        channel_id,
+        &manager_keys.public_key().to_hex(),
+        &root_task_id,
+        &request_id,
+        &result,
+    )
+    .expect("build 43004")
+    .sign_with_keys(&worker_keys)
+    .expect("sign 43004");
+    let result_ok = worker.send_event(result_event).await.expect("send 43004");
+    assert!(result_ok.accepted, "43004 rejected: {}", result_ok.message);
+
+    let mut received = Vec::new();
+    while received.len() < 2 {
+        match manager
+            .recv_event(Duration::from_secs(5))
+            .await
+            .expect("manager receives native status/result")
+        {
+            RelayMessage::Event { event, .. } => received.push(event),
+            other => panic!("expected manager native event, got {other:?}"),
+        }
+    }
+    assert_eq!(received[0].kind, Kind::Custom(KIND_JOB_ACCEPTED as u16));
+    assert_eq!(received[1].kind, Kind::Custom(KIND_JOB_RESULT as u16));
+    for event in &received {
+        assert_eq!(event.pubkey, worker_keys.public_key());
+        assert_eq!(tag(event, "task"), Some(task_id.to_string().as_str()));
+        assert_eq!(tag(event, "root"), Some(root_task_id.as_str()));
+        assert_eq!(tag(event, "request"), Some(request_id.as_str()));
+    }
+
+    let audit_sid = sub_id("native-audit");
+    manager
+        .subscribe(
+            &audit_sid,
+            vec![Filter::new()
+                .kinds(vec![
+                    Kind::Custom(KIND_JOB_REQUEST as u16),
+                    Kind::Custom(KIND_JOB_ACCEPTED as u16),
+                    Kind::Custom(KIND_JOB_RESULT as u16),
+                ])
+                .custom_tags(SingleLetterTag::lowercase(Alphabet::H), [channel.as_str()])],
+        )
+        .await
+        .expect("audit subscribe");
+    let events = manager
+        .collect_until_eose(&audit_sid, Duration::from_secs(5))
+        .await
+        .expect("audit EOSE");
+    let counts = [KIND_JOB_REQUEST, KIND_JOB_ACCEPTED, KIND_JOB_RESULT].map(|kind| {
+        events
+            .iter()
+            .filter(|event| {
+                event.kind == Kind::Custom(kind as u16)
+                    && tag(event, "task") == Some(task_id.to_string().as_str())
+            })
+            .count()
+    });
+    assert_eq!(counts, [1, 1, 1]);
+
+    manager.disconnect().await.expect("manager disconnect");
+    worker.disconnect().await.expect("worker disconnect");
+}
+
 #[tokio::test]
 #[ignore]
 async fn test_large_event_frame_below_configured_limit_is_accepted() {


### PR DESCRIPTION
## Summary

- admit the complete BUZZ-native 43001-43006 job lifecycle through relay validation and authorization
- add compact native Manager, QA, Translation, and existing specialist worker contracts to buzz-acp
- preserve scoped routing, typed payload validation, duplicate protection, and bounded metrics

These are BUZZ-native custom job kinds, not NIP-90.

## Validation

- cargo fmt --all -- --check
- focused buzz-core, buzz-sdk, buzz-acp, and buzz-relay native-job tests
- cargo clippy for buzz-core, buzz-sdk, buzz-relay, and buzz-acp with warnings denied
- repository pre-push branch-skew, scope, file-size, Rust, and Desktop/Tauri gates
- git diff --check

## Rollout boundary

This PR prepares the reviewed source change only. It does not deploy the relay, replace Desktop ACP binaries, restart workers, or mutate ATLAS Media, QA, Translation, Tracker, Website, or Helpdesk content.