### PR TITLE
ci(docker): build image for migration-only changes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,6 +53,8 @@ on:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - "crates/**"
+      # sqlx::migrate! embeds these files in the relay binary.
+      - "migrations/**"
       - "web/**"
       - "package.json"
       - "pnpm-lock.yaml"


### PR DESCRIPTION
Adds migrations/** to Docker CI pull-request paths, ensuring migration-only changes build the relay image. Related to #6570.