### PR TITLE
fix(desktop): handle respond_to "nobody" in the agent directory and mention list

### DIFF
--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -207,10 +207,57 @@ pub struct RelayAgentInfo {
     pub channel_ids: Vec<String>,
     pub capabilities: Vec<String>,
     pub status: String,
-    #[serde(default)]
-    pub respond_to: Option<RespondTo>,
+    #[serde(default, deserialize_with = "lenient_directory_respond_to")]
+    pub respond_to: Option<DirectoryRespondTo>,
     #[serde(default)]
     pub respond_to_allowlist: Vec<String>,
+}
+
+/// `respond_to` as it appears in kind:10100 directory records on the wire.
+///
+/// A superset of [`RespondTo`]: the harness also accepts `nobody`
+/// (heartbeat-only — every inbound event is dropped; see
+/// `buzz-acp/src/config.rs`). The desktop never writes `nobody`, but it must
+/// read it: the directory is an open, member-signed surface that other
+/// writers publish into, and the frontend uses this mode to keep
+/// never-responding entries out of the mention autocomplete.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DirectoryRespondTo {
+    OwnerOnly,
+    Allowlist,
+    Anyone,
+    Nobody,
+}
+
+impl From<RespondTo> for DirectoryRespondTo {
+    /// Owner-written records carry only the three GUI modes; `nobody` is a
+    /// harness mode that reaches the directory from other writers. So this
+    /// direction is total and lossless, and the reverse deliberately does not
+    /// exist — narrowing `nobody` to a GUI mode would invent an answer.
+    fn from(value: RespondTo) -> Self {
+        match value {
+            RespondTo::OwnerOnly => DirectoryRespondTo::OwnerOnly,
+            RespondTo::Allowlist => DirectoryRespondTo::Allowlist,
+            RespondTo::Anyone => DirectoryRespondTo::Anyone,
+        }
+    }
+}
+
+/// Parse a directory record's `respond_to` without failing the batch.
+///
+/// `list_relay_agents` deserializes the whole directory as one `Vec`, so a
+/// strict parse here lets a single record with an unrecognized mode blank
+/// the agent list for every member. A mode this build does not know reads
+/// as "unset" for that record alone.
+fn lenient_directory_respond_to<'de, D>(
+    deserializer: D,
+) -> Result<Option<DirectoryRespondTo>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    Ok(serde_json::from_value::<DirectoryRespondTo>(value).ok())
 }
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ManagedAgentRecord {

--- a/desktop/src-tauri/src/nostr_convert/agent_directory.rs
+++ b/desktop/src-tauri/src/nostr_convert/agent_directory.rs
@@ -136,7 +136,7 @@ fn relay_agent_from_managed_policy(agent_pubkey: &str, event: &Event) -> Option<
         channel_ids: Vec::new(),
         capabilities: Vec::new(),
         status: "offline".to_string(),
-        respond_to: Some(content.respond_to),
+        respond_to: Some(content.respond_to.into()),
         respond_to_allowlist: content.respond_to_allowlist,
     })
 }

--- a/desktop/src-tauri/src/nostr_convert/tests.rs
+++ b/desktop/src-tauri/src/nostr_convert/tests.rs
@@ -379,7 +379,7 @@ fn agents_preserves_public_respond_to_mode_for_directory_parse() {
     assert_eq!(parsed.len(), 1);
     assert_eq!(
         parsed[0].respond_to,
-        Some(crate::managed_agents::RespondTo::Anyone)
+        Some(crate::managed_agents::DirectoryRespondTo::Anyone)
     );
 }
 
@@ -398,7 +398,7 @@ fn agents_preserves_allowlist_metadata_for_directory_parse() {
     assert_eq!(parsed.len(), 1);
     assert_eq!(
         parsed[0].respond_to,
-        Some(crate::managed_agents::RespondTo::Allowlist)
+        Some(crate::managed_agents::DirectoryRespondTo::Allowlist)
     );
     assert_eq!(parsed[0].respond_to_allowlist, vec!["a".repeat(64)]);
 }
@@ -439,7 +439,7 @@ fn managed_agent_directory_accepts_only_the_verified_owner_policy() {
     assert_eq!(agents[0].name, "Codex");
     assert_eq!(
         agents[0].respond_to,
-        Some(crate::managed_agents::RespondTo::Allowlist)
+        Some(crate::managed_agents::DirectoryRespondTo::Allowlist)
     );
     assert_eq!(agents[0].respond_to_allowlist, vec![viewer_pubkey]);
 }
@@ -592,7 +592,7 @@ fn relay_agent_directory_preserves_headless_profiles_and_prefers_verified_manage
         .expect("headless profile retained");
     assert_eq!(
         headless.respond_to,
-        Some(crate::managed_agents::RespondTo::Anyone)
+        Some(crate::managed_agents::DirectoryRespondTo::Anyone)
     );
     assert!(
         headless.channel_ids.is_empty(),
@@ -606,7 +606,7 @@ fn relay_agent_directory_preserves_headless_profiles_and_prefers_verified_manage
     assert_eq!(managed.name, "Codex");
     assert_eq!(
         managed.respond_to,
-        Some(crate::managed_agents::RespondTo::Allowlist)
+        Some(crate::managed_agents::DirectoryRespondTo::Allowlist)
     );
     assert_eq!(managed.respond_to_allowlist, vec![viewer_pubkey]);
 }
@@ -759,4 +759,48 @@ fn timestamp_to_iso_known_value() {
     assert_eq!(timestamp_to_iso(1_609_459_200), "2021-01-01T00:00:00Z");
     // Epoch
     assert_eq!(timestamp_to_iso(0), "1970-01-01T00:00:00Z");
+
+    #[test]
+    fn agents_tolerate_heartbeat_only_respond_to_for_directory_parse() {
+        // `nobody` is a real harness mode (buzz-acp: heartbeat-only, all
+        // inbound events dropped). One such record must not fail the whole
+        // directory batch.
+        let nobody = ev(10100, r#"{"name":"Beacon","respond_to":"nobody"}"#, vec![]);
+        let anyone = ev(10100, r#"{"name":"Scout","respond_to":"anyone"}"#, vec![]);
+        let v = agents_from_events(&[nobody, anyone]);
+        let agents = v.get("agents").cloned().unwrap();
+        let parsed: Vec<crate::managed_agents::RelayAgentInfo> =
+            serde_json::from_value(agents).unwrap();
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(
+            parsed[0].respond_to,
+            Some(crate::managed_agents::DirectoryRespondTo::Nobody)
+        );
+        assert_eq!(
+            parsed[1].respond_to,
+            Some(crate::managed_agents::DirectoryRespondTo::Anyone)
+        );
+    }
+
+    #[test]
+    fn agents_degrade_unknown_respond_to_without_dropping_the_record() {
+        // The directory is an open surface: a mode this build has never
+        // heard of reads as "unset" for that record alone, and the rest of
+        // the batch is unaffected.
+        let unknown = ev(10100, r#"{"name":"Odd","respond_to":"sometimes"}"#, vec![]);
+        let anyone = ev(10100, r#"{"name":"Scout","respond_to":"anyone"}"#, vec![]);
+        let v = agents_from_events(&[unknown, anyone]);
+        let agents = v.get("agents").cloned().unwrap();
+        let parsed: Vec<crate::managed_agents::RelayAgentInfo> =
+            serde_json::from_value(agents).unwrap();
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].name, "Odd");
+        assert_eq!(parsed[0].respond_to, None);
+        assert_eq!(
+            parsed[1].respond_to,
+            Some(crate::managed_agents::DirectoryRespondTo::Anyone)
+        );
+    }
 }

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -12,6 +12,7 @@ import {
   isAgentMentionChannelType,
   relayAgentCanRespondInChannel,
   relayAgentIsSharedWithUser,
+  relayAgentRespondsToNobody,
   shouldHideAgentFromMentions,
   uniqueAutocompleteLabels,
 } from "./agentAutocompleteEligibility.ts";
@@ -128,6 +129,58 @@ test("relayAgentIsSharedWithUser: accepts allowlist agents for the current user"
     ),
     false,
   );
+});
+
+test("relayAgentRespondsToNobody: flags only the heartbeat-only directory mode", () => {
+  assert.equal(relayAgentRespondsToNobody({ respondTo: "nobody" }), true);
+  assert.equal(relayAgentRespondsToNobody({ respondTo: "anyone" }), false);
+  assert.equal(relayAgentRespondsToNobody({ respondTo: "owner-only" }), false);
+  assert.equal(relayAgentRespondsToNobody({ respondTo: null }), false);
+});
+
+test("relayAgentIsSharedWithUser: never accepts a nobody record, even with a matching allowlist", () => {
+  const sharedChannelIds = new Set(["general"]);
+
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      {
+        respondTo: "nobody",
+        respondToAllowlist: [CURRENT_PUBKEY],
+        channelIds: ["general"],
+      },
+      sharedChannelIds,
+      CURRENT_PUBKEY,
+    ),
+    false,
+  );
+});
+
+test("getMentionableAgentPubkeys: excludes a nobody directory entry and keeps a responding agent", () => {
+  const result = getMentionableAgentPubkeys({
+    eligibilityScope: { type: "community" },
+    managedAgentPubkeys: [],
+    currentPubkey: CURRENT_PUBKEY,
+    relayAgents: [
+      // A responding agent sharing a channel with the viewer stays.
+      {
+        pubkey: PUB_B,
+        respondTo: "anyone",
+        respondToAllowlist: [],
+        channelIds: ["general"],
+      },
+      // A heartbeat-only record is never a mention target, even when it
+      // shares a channel and names the viewer in a stale allowlist.
+      {
+        pubkey: PUB_C,
+        respondTo: "nobody",
+        respondToAllowlist: [CURRENT_PUBKEY],
+        channelIds: ["general"],
+      },
+    ],
+    sharedChannelIds: new Set(["general"]),
+  });
+
+  assert.deepEqual(result, new Set([PUB_B]));
 });
 
 test("relayAgentCanRespondInChannel: requires exact channel membership and viewer access", () => {

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -9,6 +9,24 @@ export function getSharedChannelIds(channels: readonly Channel[] | undefined) {
   );
 }
 
+/**
+ * True when a directory (kind:10100) record declares it never responds to
+ * mentions — `respond_to: "nobody"`, the harness's heartbeat-only mode
+ * (every inbound event is dropped; see `buzz-acp/src/config.rs`).
+ *
+ * Such records describe identities that publish into the directory but are
+ * not mention targets: proactive/heartbeat-only agents, and infrastructure
+ * identities some deployments announce alongside their agents. Offering one
+ * in the mention list is offering a mention that can never be answered, so
+ * callers building mention candidates must exclude these entries regardless
+ * of anything else the record carries.
+ */
+export function relayAgentRespondsToNobody(
+  agent: Pick<RelayAgent, "respondTo">,
+): boolean {
+  return agent.respondTo === "nobody";
+}
+
 export function relayAgentIsSharedWithUser(
   agent: Pick<
     RelayAgent,
@@ -17,6 +35,12 @@ export function relayAgentIsSharedWithUser(
   sharedChannelIds: ReadonlySet<string>,
   currentPubkey?: string | null,
 ) {
+  // Explicit, not fall-through: a never-responding record is not invocable
+  // even if it also carries a (stale) allowlist naming the current user.
+  if (relayAgentRespondsToNobody(agent)) {
+    return false;
+  }
+
   const normalizedCurrentPubkey = currentPubkey
     ? normalizePubkey(currentPubkey)
     : null;

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -22,6 +22,7 @@ import {
   getSharedChannelIds,
   isAgentMentionChannelType,
   rememberSelectedAgentPubkeys,
+  relayAgentRespondsToNobody,
   shouldHideAgentFromMentions,
   uniqueAutocompleteLabels,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
@@ -331,6 +332,11 @@ export function useMentions(
       });
     }
     for (const agent of relayAgentsQuery.data ?? []) {
+      // A record that declares it never responds (`respond_to: "nobody"`)
+      // is not a mention target, whatever else the record carries.
+      if (relayAgentRespondsToNobody(agent)) {
+        continue;
+      }
       const pubkey = normalizePubkey(agent.pubkey);
       addCandidate({
         kind: "identity",

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -271,7 +271,7 @@ export type RelayAgent = {
   channelIds: string[];
   capabilities: string[];
   status: "online" | "away" | "offline";
-  respondTo: RespondToMode | null;
+  respondTo: DirectoryRespondToMode | null;
   respondToAllowlist: string[];
 };
 
@@ -375,6 +375,14 @@ export type ManagedAgent = {
 
 /** Inbound author gate mode. Mirrors buzz-acp's --respond-to CLI flag. */
 export type RespondToMode = "owner-only" | "allowlist" | "anyone";
+
+/**
+ * `respond_to` as it appears in kind:10100 directory records. A superset of
+ * {@link RespondToMode}: the harness also accepts `nobody` (heartbeat-only —
+ * every inbound event is dropped), a mode the desktop never writes but must
+ * read, because the directory is an open surface other writers publish into.
+ */
+export type DirectoryRespondToMode = RespondToMode | "nobody";
 
 export type BackendProviderCandidate = {
   id: string;


### PR DESCRIPTION
## The bug

`kind:10100` directory records can carry `respond_to: "nobody"` — the
heartbeat-only mode `buzz-acp` already accepts, where every inbound event is
dropped (`buzz-acp/src/config.rs`). The desktop never writes that mode, but
the directory is an open, member-signed surface that other writers publish
into, so it has to read it. Today it fails twice.

**1 · Backend — one bad record empties the whole directory.**
`list_relay_agents` deserializes the directory as one `Vec<RelayAgentInfo>`,
and `RespondTo` only knows the three GUI modes. A single `"nobody"` record
fails the entire batch with `unknown variant`, so *every* agent disappears
from the pickers, and mention autocomplete loses the directory signal it uses
to tell agents from people.

**2 · Frontend — a never-responding agent is offered as a mention.**
Eligibility treats unrecognized modes as silent fall-through, so a record
that will never answer is suggested like any other.

## The change

- `DirectoryRespondTo` — the wire enum for directory records: a superset of
  `RespondTo` that adds `Nobody`. `RelayAgentInfo.respond_to` now uses it.
- A lenient deserializer: an unknown mode degrades that **one record** to
  `None` instead of failing the batch. The directory is an open surface, so a
  mode this build has never heard of must not be able to blank the pickers.
- `From<RespondTo> for DirectoryRespondTo` for owner-written `kind:30177`
  records, which only ever carry the three GUI modes. Deliberately one-way —
  narrowing `nobody` to a GUI mode would invent an answer.
- Frontend: `relayAgentRespondsToNobody` keeps never-responding entries out of
  mention autocomplete, and states the rule rather than falling through.

## Tests

- 2 Rust tests: a `"nobody"` record parses alongside a normal one, and an
  unknown mode degrades that record only.
- 34 frontend eligibility tests pass, including the new autocomplete cases.

```
cargo test --lib nostr_convert     54 passed, 0 failed
cargo build --lib                  clean
pnpm typecheck                     clean
node --import ./test-loader.mjs --test \
  src/features/agents/lib/agentAutocompleteEligibility.test.mjs
                                   34 passed, 0 failed
```

## Notes

Rebased on `main` at `e23632941`. The rebase crossed the `nostr_convert` test
split, so the two new tests live in `nostr_convert/tests.rs`, and upstream
assertions on `RelayAgentInfo.respond_to` were updated to the widened enum —
same field and same values, wider type.
