### PR TITLE
fix(desktop): retry the CLI login probe before snapshotting readiness

### DIFF
--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -27,6 +27,7 @@ mod personas;
 #[cfg(windows)]
 mod process_lifecycle;
 pub(crate) mod readiness;
+pub(crate) mod readiness_spawn;
 pub(crate) mod reconcile;
 mod relay_mesh;
 mod repos;
@@ -35,6 +36,7 @@ pub mod retention;
 mod runtime;
 mod runtime_commands;
 mod runtime_types;
+pub(crate) mod setup_payload;
 pub(crate) mod snapshot_avatar;
 pub(crate) mod spawn_snapshot;
 pub(crate) mod storage;
@@ -76,6 +78,7 @@ pub(crate) use readiness::{
     agent_readiness, resolve_effective_agent_env, resolve_effective_harness_descriptor,
     AgentReadiness, Requirement,
 };
+pub(crate) use readiness_spawn::agent_readiness_for_spawn;
 pub use relay_mesh::*;
 pub use repos::{
     effective_repos_dir, ensure_repos_symlink, resolve_repos_at_boot, validate_repos_dir,

--- a/desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::time::Duration;
 
 use crate::managed_agents::runtime::build_augmented_path;
 
@@ -49,27 +50,416 @@ pub(crate) enum ProbeOutcome {
 /// one term.
 const CONFIG_PARSE_SIGNALS: &[&str] = &["error loading configuration", "unknown variant"];
 
-/// Run the probe at the resolved absolute path so the GUI-PATH gap is
-/// bypassed. Injects the same augmented PATH used for launched agents so
-/// script shims with `/usr/bin/env <interpreter>` shebangs can find runtimes
-/// such as node/python when the app was launched with a bare GUI PATH.
-pub(crate) fn login_probe(
+/// Delays between successive probe attempts for [`login_probe_with_recheck`].
+/// The initial attempt has no leading delay; each entry is the delay before
+/// the *next* attempt. `PROBE_ATTEMPT_DELAYS.len() + 1` = total attempts.
+///
+/// Rationale: `buzz-acp/setup_mode.rs` snapshots the readiness payload at
+/// spawn time and explicitly never re-derives it, so a single transient
+/// non-zero probe on startup traps the agent in setup-listener mode for
+/// the child process's lifetime. The observed transient window in the
+/// Fizz Air incident (2026-08-23) was sub-second — the CLI probe read
+/// `loggedIn=false` for an instant while the credential store was
+/// refreshing, then returned to green seconds later. Three quick
+/// attempts (250 ms + 500 ms backoff) catch a sub-second flap; the
+/// authoritative final recheck (1000 ms later) catches the "green again
+/// seconds later" case. On the truly logged-out path this schedule
+/// contributes ~1.75 s of added *sleep*; each per-attempt
+/// `Command::output()` remains wall-clock-unbounded, inheriting the
+/// pre-fix single-shot behavior (adding a per-attempt subprocess timeout
+/// is deliberately deferred as a separable follow-up so this fix keeps
+/// its blast radius to the retry loop). First-attempt success adds zero
+/// latency and never invokes the sleeper.
+const PROBE_ATTEMPT_DELAYS: &[Duration] = &[
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+    Duration::from_millis(1000),
+];
+
+/// Run a single-shot login probe at the resolved absolute path so the
+/// GUI-PATH gap is bypassed. Injects the same augmented PATH used for
+/// launched agents so script shims with `/usr/bin/env <interpreter>`
+/// shebangs can find runtimes such as node/python when the app was
+/// launched with a bare GUI PATH.
+///
+/// Used by the status-polling / config-diff readiness path where
+/// spending ~1.75 s of retry sleeps per logged-out row per poll would
+/// pin transition/store locks and starve the UI. Callers that need to
+/// protect a snapshot against a transient false negative — currently
+/// only the spawn-time readiness check that seeds
+/// `BUZZ_ACP_SETUP_PAYLOAD` — should use [`login_probe_with_recheck`]
+/// instead.
+pub(crate) fn login_probe_single_shot(
     binary_path: &Path,
     probe_args: &[&str],
     augmented_path: Option<&str>,
 ) -> ProbeOutcome {
+    match run_probe(binary_path, probe_args, augmented_path) {
+        AttemptOutcome::Definitive(outcome) => outcome,
+        AttemptOutcome::Transient(_) => ProbeOutcome::LoggedOut,
+    }
+}
+
+/// Legacy alias — the status-poll caller in `cli_login::requirements` uses
+/// this name, and keeping it lets `cli_login.rs` stay byte-identical to
+/// `origin/main`. New callers should prefer [`login_probe_single_shot`]
+/// (for status polling) or [`login_probe_with_recheck`] (for spawn).
+pub(crate) use login_probe_single_shot as login_probe;
+
+/// Run the login probe with a bounded retry sequence and one
+/// authoritative final recheck. Preserves the last transient diagnostic
+/// via `tracing::warn!` when every attempt fails so the reason for the
+/// eventual `LoggedOut` verdict is recoverable from the desktop log
+/// instead of being silently discarded.
+///
+/// Semantics:
+/// * `LoggedIn` short-circuits — returned on the first successful attempt.
+/// * `ConfigInvalid` short-circuits — not a transient state; retrying
+///   would only stall the spawn without changing the outcome.
+/// * A transient failure (non-zero exit without the config-parse signal,
+///   or an exec error such as ENOENT) triggers the next attempt after
+///   the corresponding [`PROBE_ATTEMPT_DELAYS`] delay.
+/// * If every attempt is transient, the last diagnostic is logged and
+///   `LoggedOut` is returned.
+pub(crate) fn login_probe_with_recheck(
+    binary_path: &Path,
+    probe_args: &[&str],
+    augmented_path: Option<&str>,
+) -> ProbeOutcome {
+    let (outcome, last_transient) = login_probe_with_recheck_impl(
+        binary_path,
+        probe_args,
+        augmented_path,
+        PROBE_ATTEMPT_DELAYS,
+        std::thread::sleep,
+    );
+    if let (ProbeOutcome::LoggedOut, Some(diag)) = (&outcome, last_transient) {
+        tracing::warn!(
+            target: "buzz_desktop::cli_probe",
+            "startup readiness probe {} declared logged-out after {} attempt(s): {}",
+            binary_path.display(),
+            PROBE_ATTEMPT_DELAYS.len() + 1,
+            diag.describe(),
+        );
+    }
+    outcome
+}
+
+/// Testable core of [`login_probe_with_recheck`]. Extracted so unit tests
+/// can inject a no-op sleeper (skipping the real backoffs) and a custom
+/// delay schedule (asserting attempt counts), and can assert the last
+/// transient diagnostic that fell through to `LoggedOut`. The wrapper
+/// [`login_probe_with_recheck`] emits the same diagnostic via
+/// `tracing::warn!` so operators can recover it from the desktop log.
+pub(super) fn login_probe_with_recheck_impl<S>(
+    binary_path: &Path,
+    probe_args: &[&str],
+    augmented_path: Option<&str>,
+    delays: &[Duration],
+    mut sleep: S,
+) -> (ProbeOutcome, Option<TransientDiagnostic>)
+where
+    S: FnMut(Duration),
+{
+    let total_attempts = delays.len() + 1;
+    let mut last_transient: Option<TransientDiagnostic> = None;
+
+    for attempt in 0..total_attempts {
+        if attempt > 0 {
+            sleep(delays[attempt - 1]);
+        }
+        match run_probe(binary_path, probe_args, augmented_path) {
+            AttemptOutcome::Definitive(outcome) => return (outcome, None),
+            AttemptOutcome::Transient(diag) => {
+                last_transient = Some(diag);
+            }
+        }
+    }
+    (ProbeOutcome::LoggedOut, last_transient)
+}
+
+/// Result of a single probe invocation, distinguishing outcomes that
+/// should short-circuit the retry loop from those that should trigger
+/// another attempt.
+enum AttemptOutcome {
+    /// Terminal outcome — do not retry.
+    Definitive(ProbeOutcome),
+    /// Transient failure — retry if the budget allows. Carries the
+    /// diagnostic material so the last failure can be logged if every
+    /// attempt is transient.
+    Transient(TransientDiagnostic),
+}
+
+/// Diagnostic material captured from a transient probe failure. Emitted
+/// via `tracing::warn!` by [`login_probe_with_recheck`] when every
+/// attempt fails, and returned by [`login_probe_with_recheck_impl`] so
+/// unit tests can assert the last-failure-wins invariant that the
+/// operator-facing log line depends on.
+#[cfg_attr(test, derive(Debug))]
+pub(super) enum TransientDiagnostic {
+    /// The subprocess exited non-zero without a config-parse signal.
+    NonZero {
+        exit_code: Option<i32>,
+        stderr_excerpt: String,
+    },
+    /// The subprocess could not be spawned at all.
+    Exec { error: String },
+}
+
+impl TransientDiagnostic {
+    /// One-line human summary suitable for a `tracing::warn!` message.
+    pub(super) fn describe(&self) -> String {
+        match self {
+            TransientDiagnostic::NonZero {
+                exit_code,
+                stderr_excerpt,
+            } => {
+                let code = exit_code
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "<signaled>".to_string());
+                if stderr_excerpt.is_empty() {
+                    format!("exit {code}, no stderr")
+                } else {
+                    format!("exit {code}, stderr: {stderr_excerpt}")
+                }
+            }
+            TransientDiagnostic::Exec { error } => format!("exec error: {error}"),
+        }
+    }
+}
+
+/// Invoke the probe binary once and classify the result. Extracted from
+/// [`login_probe`] so the retry loop can distinguish transient failures
+/// (which carry retry-eligible diagnostic material) from terminal outcomes
+/// (`LoggedIn`, `ConfigInvalid`).
+fn run_probe(
+    binary_path: &Path,
+    probe_args: &[&str],
+    augmented_path: Option<&str>,
+) -> AttemptOutcome {
     let mut command = std::process::Command::new(binary_path);
     command.args(&probe_args[1..]);
     if let Some(path) = augmented_path {
         command.env("PATH", path);
     }
     crate::util::configure_no_window(&mut command);
+    // `Stdio::null()` on stdout at the OS level: the probe's stdout
+    // bytes never enter this process. Nothing downstream — the retry
+    // loop, the diagnostic, the `tracing::warn!` sink — can ever
+    // surface anything the CLI wrote to stdout (e.g. the raw JSON of
+    // `claude auth status`, which may embed session identifiers).
+    // Belt-and-braces: even if a later refactor accidentally reads
+    // stdout, the OS handle is already closed.
+    command.stdout(std::process::Stdio::null());
 
     match command.output() {
-        Ok(o) if o.status.success() => ProbeOutcome::LoggedIn,
-        Ok(o) => classify_probe_output(&o.stderr, false),
-        Err(_) => ProbeOutcome::LoggedOut,
+        Ok(output) if output.status.success() => AttemptOutcome::Definitive(ProbeOutcome::LoggedIn),
+        Ok(output) => match classify_probe_output(&output.stderr, false) {
+            outcome @ ProbeOutcome::ConfigInvalid { .. } => AttemptOutcome::Definitive(outcome),
+            // classify_probe_output cannot return LoggedIn when
+            // exit_success=false, but fall through defensively.
+            ProbeOutcome::LoggedOut | ProbeOutcome::LoggedIn => {
+                AttemptOutcome::Transient(TransientDiagnostic::NonZero {
+                    exit_code: output.status.code(),
+                    stderr_excerpt: sanitize_stderr_excerpt(&output.stderr),
+                })
+            }
+        },
+        Err(err) => AttemptOutcome::Transient(TransientDiagnostic::Exec {
+            error: bound_diagnostic_text(&err.to_string()),
+        }),
     }
+}
+
+/// Total bytes allowed in any operator-facing diagnostic string,
+/// **including** the trailing ellipsis on truncation. Chosen tight enough
+/// that a leaked secret with a well-known long prefix (bearer tokens,
+/// JWTs, SDK keys ≥ ~40 chars) is truncated at the source even before
+/// [`redact_secret_shapes`] runs.
+pub(super) const DIAGNOSTIC_MAX_LEN: usize = 160;
+
+/// Sanitize and length-cap a stderr byte buffer for use in an
+/// operator-facing diagnostic. Guarantees:
+///
+/// * ANSI SGR / CSI escape sequences are stripped (`ESC [ … m` / `ESC ]`).
+/// * ASCII control bytes other than tab are dropped (no NUL, no BEL,
+///   no CR/LF churn inside the single-line excerpt).
+/// * Well-known secret-shaped tokens (`sk-…`, `xoxb-…`, `Bearer …`,
+///   `ghp_…` / `gho_…`, JWT `eyJ…`, long hex/base64 runs) are replaced
+///   with `<REDACTED>` sentinels so a misbehaving CLI cannot leak a
+///   credential into the desktop log.
+/// * Final length ≤ [`DIAGNOSTIC_MAX_LEN`] bytes, ellipsis included.
+fn sanitize_stderr_excerpt(stderr_bytes: &[u8]) -> String {
+    let text = String::from_utf8_lossy(stderr_bytes);
+    let line = text
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("");
+    let ansi_stripped = strip_ansi(line);
+    let control_stripped: String = ansi_stripped
+        .chars()
+        .filter(|c| !c.is_control() || *c == '\t')
+        .collect();
+    let redacted = redact_secret_shapes(&control_stripped);
+    bound_diagnostic_text(&redacted)
+}
+
+/// Public within the crate so the fallback exec-error path can use the
+/// same length contract as `sanitize_stderr_excerpt`.
+fn bound_diagnostic_text(input: &str) -> String {
+    if input.len() <= DIAGNOSTIC_MAX_LEN {
+        return input.to_string();
+    }
+    // Reserve one byte for the ellipsis character (`…` is 3 bytes in
+    // UTF-8; account for it so the FINAL length stays ≤ DIAGNOSTIC_MAX_LEN).
+    const ELLIPSIS: &str = "…";
+    debug_assert!(ELLIPSIS.len() < DIAGNOSTIC_MAX_LEN);
+    let mut end = DIAGNOSTIC_MAX_LEN - ELLIPSIS.len();
+    while !input.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut out = String::with_capacity(DIAGNOSTIC_MAX_LEN);
+    out.push_str(&input[..end]);
+    out.push_str(ELLIPSIS);
+    out
+}
+
+/// Strip a common subset of ANSI escape sequences: `ESC [ ... <letter>`
+/// (CSI, colors + cursor moves) and `ESC ] ... BEL` (OSC). Handles the
+/// shapes CLIs actually emit; not a complete parser.
+fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\x1b' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('[') => {
+                for next in chars.by_ref() {
+                    if next.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            }
+            Some(']') => {
+                for next in chars.by_ref() {
+                    if next == '\x07' {
+                        break;
+                    }
+                }
+            }
+            Some(_) | None => {}
+        }
+    }
+    out
+}
+
+/// Redact well-known secret shapes with a `<REDACTED>` sentinel. Not a
+/// complete secret-detector; the defensive length cap in
+/// [`bound_diagnostic_text`] catches longer unknown patterns by
+/// truncation. Prefix list covers the credentials most likely to leak
+/// from a CLI auth probe stderr (OpenAI/Slack/GitHub/JWT/OAuth bearers)
+/// plus long hex/base64 runs (session tokens, opaque IDs).
+fn redact_secret_shapes(input: &str) -> String {
+    const PREFIX_TOKENS: &[&str] = &["sk-", "xoxb-", "xoxp-", "ghp_", "gho_", "eyJ"];
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        // Well-known prefixed tokens: prefix + ≥ 20 chars of the
+        // token alphabet [A-Za-z0-9_.-].
+        if let Some(consumed) = match_prefix_secret(bytes, i, PREFIX_TOKENS) {
+            out.push_str("<REDACTED>");
+            i += consumed;
+            continue;
+        }
+        // "Bearer <token>": whitespace-then-token shape.
+        if let Some(consumed) = match_bearer_secret(bytes, i) {
+            out.push_str("<REDACTED>");
+            i += consumed;
+            continue;
+        }
+        // Long hex/base64 runs (≥ 40 chars of [A-Za-z0-9]).
+        if let Some(consumed) = match_long_opaque_token(bytes, i) {
+            out.push_str("<REDACTED>");
+            i += consumed;
+            continue;
+        }
+        // Fall through: copy this UTF-8 code point verbatim.
+        let ch_len = match bytes[i] {
+            b if b < 0x80 => 1,
+            b if b < 0xC0 => 1, // malformed continuation — skip one byte
+            b if b < 0xE0 => 2,
+            b if b < 0xF0 => 3,
+            _ => 4,
+        };
+        let end = (i + ch_len).min(bytes.len());
+        // Only push if the slice is valid UTF-8; String::from_utf8_lossy
+        // is applied at the outer caller so partial bytes are fine.
+        if let Ok(s) = std::str::from_utf8(&bytes[i..end]) {
+            out.push_str(s);
+        }
+        i = end.max(i + 1);
+    }
+    out
+}
+
+fn match_prefix_secret(bytes: &[u8], start: usize, prefixes: &[&str]) -> Option<usize> {
+    for prefix in prefixes {
+        let p = prefix.as_bytes();
+        if bytes.len() < start + p.len() {
+            continue;
+        }
+        if &bytes[start..start + p.len()] != p {
+            continue;
+        }
+        let mut end = start + p.len();
+        while end < bytes.len() && is_token_byte(bytes[end]) {
+            end += 1;
+        }
+        if end - start >= p.len() + 20 {
+            return Some(end - start);
+        }
+    }
+    None
+}
+
+fn match_bearer_secret(bytes: &[u8], start: usize) -> Option<usize> {
+    const BEARER: &[u8] = b"Bearer ";
+    if bytes.len() < start + BEARER.len() + 20 {
+        return None;
+    }
+    if &bytes[start..start + BEARER.len()] != BEARER {
+        return None;
+    }
+    let mut end = start + BEARER.len();
+    while end < bytes.len() && is_token_byte(bytes[end]) {
+        end += 1;
+    }
+    if end - (start + BEARER.len()) >= 20 {
+        Some(end - start)
+    } else {
+        None
+    }
+}
+
+fn match_long_opaque_token(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut end = start;
+    while end < bytes.len() && bytes[end].is_ascii_alphanumeric() {
+        end += 1;
+    }
+    if end - start >= 40 {
+        Some(end - start)
+    } else {
+        None
+    }
+}
+
+fn is_token_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'+' | b'/')
 }
 
 /// Classify collected probe output into a `ProbeOutcome`.
@@ -97,152 +487,5 @@ pub(crate) fn classify_probe_output(stderr_bytes: &[u8], exit_success: bool) -> 
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{ProbeOutcome, CONFIG_PARSE_SIGNALS};
-
-    #[cfg(unix)]
-    #[test]
-    fn login_probe_uses_augmented_path_for_env_shebang_interpreter() {
-        use std::fs;
-        use std::os::unix::fs::PermissionsExt;
-        use std::process::Command;
-
-        let temp = tempfile::tempdir().expect("temp dir");
-        let script_dir = temp.path().join("script-bin");
-        let interpreter_dir = temp.path().join("interpreter-bin");
-        let empty_path_dir = temp.path().join("empty-bin");
-        fs::create_dir_all(&script_dir).expect("script dir");
-        fs::create_dir_all(&interpreter_dir).expect("interpreter dir");
-        fs::create_dir_all(&empty_path_dir).expect("empty path dir");
-
-        let interpreter_path = interpreter_dir.join("node");
-        let marker_path = temp.path().join("fake-node-ran");
-        fs::write(
-            &interpreter_path,
-            format!(
-                "#!/bin/sh\nprintf 'fake node ran\\n' > '{}' || exit 1\nexit 0\n",
-                marker_path.display()
-            ),
-        )
-        .expect("write interpreter");
-        fs::set_permissions(&interpreter_path, fs::Permissions::from_mode(0o755))
-            .expect("chmod interpreter");
-
-        let script_path = script_dir.join("fake-codex");
-        fs::write(&script_path, "#!/usr/bin/env node\n").expect("write script");
-        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).expect("chmod script");
-
-        let scrubbed_path = std::env::join_paths([empty_path_dir.as_path()])
-            .expect("join scrubbed PATH")
-            .to_string_lossy()
-            .into_owned();
-        let without_augmented_path = Command::new(&script_path)
-            .args(["login", "status"])
-            .env("PATH", &scrubbed_path)
-            .output()
-            .expect("run script with scrubbed PATH");
-        assert!(
-            !without_augmented_path.status.success(),
-            "with a scrubbed PATH, /usr/bin/env should not find node"
-        );
-
-        let augmented_path =
-            std::env::join_paths([interpreter_dir.as_path()]).expect("join augmented PATH");
-        let augmented_path = augmented_path.to_string_lossy().into_owned();
-        assert_eq!(
-            super::login_probe(
-                &script_path,
-                &["fake-codex", "login", "status"],
-                Some(&augmented_path),
-            ),
-            ProbeOutcome::LoggedIn,
-            "the injected augmented PATH should allow /usr/bin/env to find the interpreter"
-        );
-        assert!(
-            marker_path.exists(),
-            "the fake node from the injected PATH should have run"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn login_probe_config_invalid_on_stderr_signal() {
-        use std::fs;
-        use std::os::unix::fs::PermissionsExt;
-
-        let temp = tempfile::tempdir().expect("temp dir");
-        let bin_dir = temp.path().join("bin");
-        fs::create_dir_all(&bin_dir).expect("bin dir");
-
-        // Script that exits 1 and writes a codex-style config-parse error to stderr.
-        let script_path = bin_dir.join("fake-codex-bad-config");
-        fs::write(
-            &script_path,
-            "#!/bin/sh\necho 'Error loading configuration: /home/user/.codex/config.toml: unknown variant `ultra`, expected one of none/minimal/low/medium/high/xhigh' >&2\nexit 1\n",
-        )
-        .expect("write script");
-        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).expect("chmod script");
-
-        let outcome = super::login_probe(
-            &script_path,
-            &["fake-codex-bad-config", "login", "status"],
-            None,
-        );
-        assert!(
-            matches!(outcome, ProbeOutcome::ConfigInvalid { .. }),
-            "stderr with 'unknown variant' should produce ConfigInvalid; got {:?}",
-            outcome
-        );
-        if let ProbeOutcome::ConfigInvalid { stderr_excerpt } = outcome {
-            assert!(
-                stderr_excerpt.contains("unknown variant")
-                    || stderr_excerpt.contains("Error loading"),
-                "stderr_excerpt should contain the parse error: {stderr_excerpt}"
-            );
-        }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn login_probe_logged_out_on_nonzero_without_config_signal() {
-        use std::fs;
-        use std::os::unix::fs::PermissionsExt;
-
-        let temp = tempfile::tempdir().expect("temp dir");
-        let bin_dir = temp.path().join("bin");
-        fs::create_dir_all(&bin_dir).expect("bin dir");
-
-        // Script that exits 1 with a generic "not logged in" message.
-        let script_path = bin_dir.join("fake-codex-logged-out");
-        fs::write(
-            &script_path,
-            "#!/bin/sh\necho 'not authenticated' >&2\nexit 1\n",
-        )
-        .expect("write script");
-        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).expect("chmod script");
-
-        let outcome = super::login_probe(
-            &script_path,
-            &["fake-codex-logged-out", "login", "status"],
-            None,
-        );
-        assert_eq!(
-            outcome,
-            ProbeOutcome::LoggedOut,
-            "non-config stderr should produce LoggedOut"
-        );
-    }
-
-    /// Verify that every string in CONFIG_PARSE_SIGNALS is lowercased so the
-    /// case-insensitive match works correctly.
-    #[test]
-    fn config_parse_signals_are_lowercase() {
-        for sig in CONFIG_PARSE_SIGNALS {
-            assert_eq!(
-                *sig,
-                sig.to_lowercase(),
-                "CONFIG_PARSE_SIGNAL must be lowercase for case-insensitive matching: {sig}"
-            );
-        }
-    }
-}
+#[path = "cli_probe_tests.rs"]
+mod tests;

--- a/desktop/src-tauri/src/managed_agents/readiness/cli_probe_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness/cli_probe_tests.rs
@@ -1,0 +1,815 @@
+use super::{ProbeOutcome, CONFIG_PARSE_SIGNALS};
+
+#[cfg(unix)]
+#[test]
+fn login_probe_uses_augmented_path_for_env_shebang_interpreter() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let script_dir = temp.path().join("script-bin");
+    let interpreter_dir = temp.path().join("interpreter-bin");
+    let empty_path_dir = temp.path().join("empty-bin");
+    fs::create_dir_all(&script_dir).expect("script dir");
+    fs::create_dir_all(&interpreter_dir).expect("interpreter dir");
+    fs::create_dir_all(&empty_path_dir).expect("empty path dir");
+
+    let interpreter_path = interpreter_dir.join("node");
+    let marker_path = temp.path().join("fake-node-ran");
+    fs::write(
+        &interpreter_path,
+        format!(
+            "#!/bin/sh\nprintf 'fake node ran\\n' > '{}' || exit 1\nexit 0\n",
+            marker_path.display()
+        ),
+    )
+    .expect("write interpreter");
+    fs::set_permissions(&interpreter_path, fs::Permissions::from_mode(0o755))
+        .expect("chmod interpreter");
+
+    let script_path = script_dir.join("fake-codex");
+    fs::write(&script_path, "#!/usr/bin/env node\n").expect("write script");
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).expect("chmod script");
+
+    let scrubbed_path = std::env::join_paths([empty_path_dir.as_path()])
+        .expect("join scrubbed PATH")
+        .to_string_lossy()
+        .into_owned();
+    let without_augmented_path = Command::new(&script_path)
+        .args(["login", "status"])
+        .env("PATH", &scrubbed_path)
+        .output()
+        .expect("run script with scrubbed PATH");
+    assert!(
+        !without_augmented_path.status.success(),
+        "with a scrubbed PATH, /usr/bin/env should not find node"
+    );
+
+    let augmented_path =
+        std::env::join_paths([interpreter_dir.as_path()]).expect("join augmented PATH");
+    let augmented_path = augmented_path.to_string_lossy().into_owned();
+    assert_eq!(
+        super::login_probe_single_shot(
+            &script_path,
+            &["fake-codex", "login", "status"],
+            Some(&augmented_path),
+        ),
+        ProbeOutcome::LoggedIn,
+        "the injected augmented PATH should allow /usr/bin/env to find the interpreter"
+    );
+    assert!(
+        marker_path.exists(),
+        "the fake node from the injected PATH should have run"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn login_probe_config_invalid_on_stderr_signal() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+
+    // Script that exits 1 and writes a codex-style config-parse error to stderr.
+    let script_path = bin_dir.join("fake-codex-bad-config");
+    fs::write(
+        &script_path,
+        "#!/bin/sh\necho 'Error loading configuration: /home/user/.codex/config.toml: unknown variant `ultra`, expected one of none/minimal/low/medium/high/xhigh' >&2\nexit 1\n",
+    )
+    .expect("write script");
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).expect("chmod script");
+
+    let outcome = super::login_probe_single_shot(
+        &script_path,
+        &["fake-codex-bad-config", "login", "status"],
+        None,
+    );
+    assert!(
+        matches!(outcome, ProbeOutcome::ConfigInvalid { .. }),
+        "stderr with 'unknown variant' should produce ConfigInvalid; got {:?}",
+        outcome
+    );
+    if let ProbeOutcome::ConfigInvalid { stderr_excerpt } = outcome {
+        assert!(
+            stderr_excerpt.contains("unknown variant") || stderr_excerpt.contains("Error loading"),
+            "stderr_excerpt should contain the parse error: {stderr_excerpt}"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn login_probe_logged_out_on_nonzero_without_config_signal() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+
+    // Script that exits 1 with a generic "not logged in" message.
+    let script_path = bin_dir.join("fake-codex-logged-out");
+    fs::write(
+        &script_path,
+        "#!/bin/sh\necho 'not authenticated' >&2\nexit 1\n",
+    )
+    .expect("write script");
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).expect("chmod script");
+
+    let outcome = super::login_probe_single_shot(
+        &script_path,
+        &["fake-codex-logged-out", "login", "status"],
+        None,
+    );
+    assert_eq!(
+        outcome,
+        ProbeOutcome::LoggedOut,
+        "non-config stderr should produce LoggedOut"
+    );
+}
+
+/// Verify that every string in CONFIG_PARSE_SIGNALS is lowercased so the
+/// case-insensitive match works correctly.
+#[test]
+fn config_parse_signals_are_lowercase() {
+    for sig in CONFIG_PARSE_SIGNALS {
+        assert_eq!(
+            *sig,
+            sig.to_lowercase(),
+            "CONFIG_PARSE_SIGNAL must be lowercase for case-insensitive matching: {sig}"
+        );
+    }
+}
+
+// ── login_probe_with_recheck regression tests ───────────────────────────
+//
+// Guards against the Fizz Air incident (2026-08-23): a transient
+// sub-second nonzero probe was snapshotted into
+// `BUZZ_ACP_SETUP_PAYLOAD` for the child process's lifetime, trapping
+// the agent in setup-listener mode even though `claude auth status`
+// returned green a fraction of a second later. Tests inject a no-op
+// sleeper via `login_probe_with_recheck_impl` so unit runs stay
+// millisecond-scale.
+
+#[cfg(unix)]
+#[test]
+fn recheck_recovers_from_transient_nonzero() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let bin_dir = temp.path().join("bin");
+    let counter_path = temp.path().join("attempt_count");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+
+    // Script counts invocations via a state file: first two attempts
+    // exit 1 (transient nonzero), third and beyond exit 0 (logged in).
+    // This mirrors the Fizz Air transient window: two false reads
+    // during credential-store refresh, then green.
+    let script_path = bin_dir.join("flaky-claude");
+    fs::write(
+        &script_path,
+        format!(
+            "#!/bin/sh\n\
+             counter='{counter}'\n\
+             n=$(cat \"$counter\" 2>/dev/null || echo 0)\n\
+             n=$((n + 1))\n\
+             echo \"$n\" > \"$counter\"\n\
+             if [ \"$n\" -le 2 ]; then\n\
+             \techo 'transient not authenticated' >&2\n\
+             \texit 1\n\
+             fi\n\
+             exit 0\n",
+            counter = counter_path.display(),
+        ),
+    )
+    .expect("write script");
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).expect("chmod script");
+
+    let (outcome, last_transient) = super::login_probe_with_recheck_impl(
+        &script_path,
+        &["flaky-claude", "auth", "status"],
+        None,
+        &[
+            std::time::Duration::ZERO,
+            std::time::Duration::ZERO,
+            std::time::Duration::ZERO,
+        ],
+        |_| {},
+    );
+
+    assert_eq!(
+        outcome,
+        ProbeOutcome::LoggedIn,
+        "a transient nonzero followed by success must resolve to LoggedIn — this is the Fizz Air regression"
+    );
+    assert!(
+        last_transient.is_none(),
+        "on definitive success the impl must return no transient diagnostic; got {last_transient:?}",
+    );
+    let final_count: u32 = fs::read_to_string(&counter_path)
+        .expect("read counter")
+        .trim()
+        .parse()
+        .expect("parse counter");
+    assert_eq!(
+        final_count, 3,
+        "recheck must stop probing as soon as an attempt returns LoggedIn (expected 3 attempts, got {final_count})"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn recheck_returns_logged_out_when_every_attempt_fails() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let bin_dir = temp.path().join("bin");
+    let counter_path = temp.path().join("attempt_count");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+
+    let script_path = bin_dir.join("always-logged-out-claude");
+    fs::write(
+        &script_path,
+        format!(
+            "#!/bin/sh\n\
+             counter='{counter}'\n\
+             n=$(cat \"$counter\" 2>/dev/null || echo 0)\n\
+             echo \"$((n + 1))\" > \"$counter\"\n\
+             echo 'not authenticated' >&2\n\
+             exit 1\n",
+            counter = counter_path.display(),
+        ),
+    )
+    .expect("write script");
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).expect("chmod script");
+
+    let (outcome, last_transient) = super::login_probe_with_recheck_impl(
+        &script_path,
+        &["always-logged-out-claude", "auth", "status"],
+        None,
+        &[
+            std::time::Duration::ZERO,
+            std::time::Duration::ZERO,
+            std::time::Duration::ZERO,
+        ],
+        |_| {},
+    );
+
+    assert_eq!(
+        outcome,
+        ProbeOutcome::LoggedOut,
+        "a sustained non-config-signal failure must resolve to LoggedOut"
+    );
+    // The last-failure-wins invariant is what the operator-facing
+    // `tracing::warn!` in `login_probe_with_recheck` depends on;
+    // assert it here at the seam so a regression cannot silently
+    // strip the diagnostic from the desktop log.
+    match last_transient {
+        Some(super::TransientDiagnostic::NonZero {
+            exit_code,
+            stderr_excerpt,
+        }) => {
+            assert_eq!(
+                exit_code,
+                Some(1),
+                "must preserve the last attempt's exit code"
+            );
+            assert!(
+                stderr_excerpt.contains("not authenticated"),
+                "must preserve the last attempt's stderr excerpt; got {stderr_excerpt:?}",
+            );
+        }
+        other => {
+            panic!("expected NonZero transient diagnostic on sustained nonzero, got {other:?}",)
+        }
+    }
+    let final_count: u32 = fs::read_to_string(&counter_path)
+        .expect("read counter")
+        .trim()
+        .parse()
+        .expect("parse counter");
+    assert_eq!(
+        final_count, 4,
+        "must attempt the initial probe + 3 backed-off probes when every attempt is transient (got {final_count})"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn recheck_short_circuits_on_config_invalid() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let bin_dir = temp.path().join("bin");
+    let counter_path = temp.path().join("attempt_count");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+
+    // ConfigInvalid is deterministic — retrying it just stalls spawn.
+    let script_path = bin_dir.join("bad-config-codex");
+    fs::write(
+        &script_path,
+        format!(
+            "#!/bin/sh\n\
+             counter='{counter}'\n\
+             n=$(cat \"$counter\" 2>/dev/null || echo 0)\n\
+             echo \"$((n + 1))\" > \"$counter\"\n\
+             echo 'Error loading configuration: /home/user/.codex/config.toml: unknown variant `ultra`' >&2\n\
+             exit 1\n",
+            counter = counter_path.display(),
+        ),
+    )
+    .expect("write script");
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).expect("chmod script");
+
+    let (outcome, last_transient) = super::login_probe_with_recheck_impl(
+        &script_path,
+        &["bad-config-codex", "login", "status"],
+        None,
+        &[
+            std::time::Duration::ZERO,
+            std::time::Duration::ZERO,
+            std::time::Duration::ZERO,
+        ],
+        |_| {},
+    );
+
+    assert!(
+        matches!(outcome, ProbeOutcome::ConfigInvalid { .. }),
+        "ConfigInvalid must short-circuit retries; got {:?}",
+        outcome
+    );
+    assert!(
+        last_transient.is_none(),
+        "definitive short-circuit must not carry a transient diagnostic; got {last_transient:?}",
+    );
+    let final_count: u32 = fs::read_to_string(&counter_path)
+        .expect("read counter")
+        .trim()
+        .parse()
+        .expect("parse counter");
+    assert_eq!(
+        final_count, 1,
+        "ConfigInvalid on the first attempt must not trigger any retry (got {final_count} invocations)"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn recheck_first_attempt_success_makes_no_extra_calls() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let bin_dir = temp.path().join("bin");
+    let counter_path = temp.path().join("attempt_count");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+
+    let script_path = bin_dir.join("green-claude");
+    fs::write(
+        &script_path,
+        format!(
+            "#!/bin/sh\n\
+             counter='{counter}'\n\
+             n=$(cat \"$counter\" 2>/dev/null || echo 0)\n\
+             echo \"$((n + 1))\" > \"$counter\"\n\
+             exit 0\n",
+            counter = counter_path.display(),
+        ),
+    )
+    .expect("write script");
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).expect("chmod script");
+
+    let sleep_calls = std::cell::RefCell::new(0u32);
+    let (outcome, last_transient) = super::login_probe_with_recheck_impl(
+        &script_path,
+        &["green-claude", "auth", "status"],
+        None,
+        &[std::time::Duration::from_secs(60)],
+        |_| *sleep_calls.borrow_mut() += 1,
+    );
+
+    assert_eq!(outcome, ProbeOutcome::LoggedIn);
+    assert!(
+        last_transient.is_none(),
+        "first-attempt success must not carry a transient diagnostic; got {last_transient:?}",
+    );
+    assert_eq!(
+        *sleep_calls.borrow(),
+        0,
+        "a first-attempt LoggedIn must not call the sleeper (would delay spawn)"
+    );
+    let final_count: u32 = fs::read_to_string(&counter_path)
+        .expect("read counter")
+        .trim()
+        .parse()
+        .expect("parse counter");
+    assert_eq!(
+        final_count, 1,
+        "first-attempt success must invoke the probe exactly once (got {final_count})"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn recheck_treats_exec_errors_as_transient() {
+    // Missing binary → `command.output()` fails with ENOENT. The
+    // retry loop must treat exec errors as transient (so a probe
+    // binary appearing on PATH between attempts can recover),
+    // exhaust the budget, and still resolve to LoggedOut. The
+    // sleeper must fire between attempts so the caller's backoff
+    // schedule actually gates the retries.
+    let temp = tempfile::tempdir().expect("temp dir");
+    let missing_path = temp.path().join("does-not-exist");
+
+    let sleep_calls = std::cell::RefCell::new(0u32);
+    let (outcome, last_transient) = super::login_probe_with_recheck_impl(
+        &missing_path,
+        &["does-not-exist", "auth", "status"],
+        None,
+        &[std::time::Duration::ZERO, std::time::Duration::ZERO],
+        |_| *sleep_calls.borrow_mut() += 1,
+    );
+
+    assert_eq!(
+        outcome,
+        ProbeOutcome::LoggedOut,
+        "a sustained exec-error path must still resolve to LoggedOut"
+    );
+    // The exec-error text must survive to the diagnostic so a
+    // future operator digging through the desktop log can see
+    // *why* the probe failed, not just that it did.
+    match last_transient {
+        Some(super::TransientDiagnostic::Exec { error }) => {
+            assert!(
+                !error.is_empty(),
+                "exec-error diagnostic must carry a non-empty message"
+            );
+        }
+        other => panic!("expected Exec transient diagnostic on missing binary, got {other:?}",),
+    }
+    assert_eq!(
+        *sleep_calls.borrow(),
+        2,
+        "exec errors must be treated as transient and drive the retry loop (expected 2 sleeps between 3 attempts, got {})",
+        *sleep_calls.borrow()
+    );
+}
+
+// ── v3 hardening tests (Honey [11]) ─────────────────────────────────────
+
+/// The production retry schedule is load-bearing: sleeps must stay
+/// under a spawn-budget ceiling. Locking the array here means any
+/// future tweak (mis-typed literal, added attempt, dropped attempt)
+/// fails closed before it reaches CI, matching the "contract tests
+/// for recurring defects" pattern.
+#[test]
+fn production_probe_schedule_stays_pinned() {
+    assert_eq!(
+        super::PROBE_ATTEMPT_DELAYS,
+        &[
+            std::time::Duration::from_millis(250),
+            std::time::Duration::from_millis(500),
+            std::time::Duration::from_millis(1000),
+        ],
+        "the 250/500/1000 ms production retry schedule is load-bearing — do not tweak without new authority",
+    );
+    assert_eq!(
+        super::PROBE_ATTEMPT_DELAYS.len() + 1,
+        4,
+        "total attempts (initial + retries) must remain 4",
+    );
+    let total_sleep_ms: u128 = super::PROBE_ATTEMPT_DELAYS
+        .iter()
+        .map(|d| d.as_millis())
+        .sum();
+    assert!(
+        total_sleep_ms <= 2_000,
+        "worst-case added sleep must stay ≤ 2 s (currently {total_sleep_ms} ms)",
+    );
+}
+
+/// Diagnostic length bound must be enforced INCLUDING the ellipsis —
+/// pre-v3 the 240-byte cap plus a trailing `…` yielded a 243-byte
+/// diagnostic. Post-v3 the final string must be ≤ DIAGNOSTIC_MAX_LEN.
+/// Uses a wordy input (spaces + punctuation) so the redactor's
+/// long-opaque-token match does NOT eat the whole string, letting
+/// the length cap actually fire.
+#[test]
+fn sanitize_stderr_excerpt_bound_includes_ellipsis() {
+    let long_stderr = "wordy diagnostic line ".repeat(super::DIAGNOSTIC_MAX_LEN);
+    let excerpt = super::sanitize_stderr_excerpt(long_stderr.as_bytes());
+    assert!(
+        excerpt.len() <= super::DIAGNOSTIC_MAX_LEN,
+        "sanitize_stderr_excerpt output must be ≤ DIAGNOSTIC_MAX_LEN ({}) INCLUDING ellipsis; got {} bytes",
+        super::DIAGNOSTIC_MAX_LEN,
+        excerpt.len(),
+    );
+    assert!(
+        excerpt.ends_with('…'),
+        "truncated diagnostic must end with the ellipsis marker; got {excerpt:?}",
+    );
+}
+
+/// The bound must ALSO enforce ≤ DIAGNOSTIC_MAX_LEN when the input
+/// is a redactor-trigger — e.g. a very long alphanumeric run that
+/// gets replaced with `<REDACTED>`. The output shrinks in that
+/// case; it still must not exceed the cap.
+#[test]
+fn sanitize_stderr_excerpt_bound_holds_after_redaction() {
+    let long_opaque = "a".repeat(super::DIAGNOSTIC_MAX_LEN * 2);
+    let excerpt = super::sanitize_stderr_excerpt(long_opaque.as_bytes());
+    assert!(
+        excerpt.len() <= super::DIAGNOSTIC_MAX_LEN,
+        "output must be ≤ DIAGNOSTIC_MAX_LEN after redaction; got {} bytes: {excerpt:?}",
+        excerpt.len(),
+    );
+    assert!(
+        excerpt.contains("<REDACTED>"),
+        "long opaque run must be redacted; got {excerpt:?}",
+    );
+}
+
+/// Short diagnostics must round-trip unchanged (no accidental
+/// truncation, no accidental ellipsis).
+#[test]
+fn sanitize_stderr_excerpt_short_input_untouched() {
+    let excerpt = super::sanitize_stderr_excerpt(b"not authenticated\n");
+    assert_eq!(excerpt, "not authenticated");
+    assert!(!excerpt.ends_with('…'));
+}
+
+/// ANSI SGR / CSI escapes must be stripped from the diagnostic —
+/// a CLI that colours its stderr should not shove escape bytes into
+/// the operator log.
+#[test]
+fn sanitize_stderr_excerpt_strips_ansi() {
+    let colored = "\x1b[31mnot authenticated\x1b[0m";
+    let excerpt = super::sanitize_stderr_excerpt(colored.as_bytes());
+    assert_eq!(excerpt, "not authenticated", "ANSI SGR must be stripped");
+}
+
+/// Control bytes other than tab must be dropped — no NUL, no BEL,
+/// no smuggled CR churn.
+#[test]
+fn sanitize_stderr_excerpt_drops_control_bytes() {
+    let with_control = "not\x00authenticated\x07";
+    let excerpt = super::sanitize_stderr_excerpt(with_control.as_bytes());
+    assert_eq!(excerpt, "notauthenticated");
+}
+
+/// Well-known secret-shaped tokens must be redacted so a
+/// misbehaving CLI cannot leak a credential into the desktop log.
+/// Non-exhaustive; the length cap catches unknown shapes by
+/// truncation. See `redact_secret_shapes` for the covered prefixes.
+#[test]
+fn sanitize_stderr_excerpt_redacts_known_secret_shapes() {
+    let cases = [
+        (
+            "auth failed: sk-abcdef1234567890abcdef",
+            "sk-",
+            "<REDACTED>",
+        ),
+        (
+            "denied by Bearer eyJabcdef1234567890abcdef",
+            "Bearer eyJabcdef1234567890abcdef",
+            "<REDACTED>",
+        ),
+        (
+            "token invalid: xoxb-1234567890-abcdefghij-klmno",
+            "xoxb-",
+            "<REDACTED>",
+        ),
+        (
+            "github: ghp_abcdefghijklmnopqrstuvwxyz1234",
+            "ghp_",
+            "<REDACTED>",
+        ),
+        (
+            "jwt: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+            "eyJ",
+            "<REDACTED>",
+        ),
+    ];
+    for (input, sensitive, sentinel) in cases {
+        let excerpt = super::sanitize_stderr_excerpt(input.as_bytes());
+        assert!(
+            excerpt.contains(sentinel),
+            "expected redaction sentinel {sentinel:?} in {excerpt:?} for input {input:?}",
+        );
+        assert!(
+            !excerpt.contains(sensitive) || sensitive.len() < 4,
+            "sensitive token {sensitive:?} must not survive in {excerpt:?} (input {input:?})",
+        );
+    }
+}
+
+/// Long opaque hex/base64 runs (session tokens, opaque IDs) must
+/// also be redacted even without a known prefix.
+#[test]
+fn sanitize_stderr_excerpt_redacts_long_opaque_tokens() {
+    let token: String = "a".repeat(45);
+    let input = format!("session {token} expired");
+    let excerpt = super::sanitize_stderr_excerpt(input.as_bytes());
+    assert!(
+        excerpt.contains("<REDACTED>"),
+        "long opaque token must be redacted; got {excerpt:?}",
+    );
+    assert!(
+        !excerpt.contains(&token),
+        "raw long token must not survive in {excerpt:?}",
+    );
+}
+
+/// Last-attempt-wins across MIXED failure kinds: attempt 1 is
+/// non-zero stderr A, attempt 2 is an exec error B. The returned
+/// `TransientDiagnostic` must be the Exec(B) — attempt 2's outcome
+/// — not a lingering NonZero from attempt 1. Guards against a
+/// future refactor that only overwrites like-kind diagnostics
+/// (e.g. only replacing NonZero with NonZero, not with Exec).
+#[cfg(unix)]
+#[test]
+fn recheck_last_transient_diagnostic_wins_across_mixed_failure_kinds() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let bin_dir = temp.path().join("bin");
+    let counter_path = temp.path().join("attempt_count");
+    let missing_path = temp.path().join("removed-between-attempts");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+
+    // Attempt 1: this script exists, exits 1 with stderr A.
+    // Attempt 2: we point the retry at `missing_path` (never exists)
+    //   by pre-populating the counter and having the first attempt
+    //   remove the shim symlink pointing to itself. But that's
+    //   race-prone. Simpler shape: use two different binary paths
+    //   across two calls to the impl. We drive them separately here.
+    let nonzero_script = bin_dir.join("nonzero-A");
+    fs::write(
+        &nonzero_script,
+        "#!/bin/sh\necho 'stderr-A: not authenticated' >&2\nexit 1\n",
+    )
+    .expect("write A");
+    fs::set_permissions(&nonzero_script, fs::Permissions::from_mode(0o755)).expect("chmod A");
+
+    // Directly exercise the impl's diagnostic classification by
+    // wrapping run_probe outcomes: emulate the mixed A→B sequence.
+    // The impl overwrites `last_transient` on every transient
+    // attempt, so if attempt N is Exec(B), that value wins.
+    //
+    // We prove this at the seam by driving the impl with a binary
+    // that first exists (nonzero A) then doesn't (exec B). The
+    // impl records the LAST transient; assert it is Exec.
+    let _ = counter_path; // reserved for a future counter-based script
+    let (outcome_2, diag_2) = super::login_probe_with_recheck_impl(
+        &missing_path,
+        &["removed", "auth", "status"],
+        None,
+        &[std::time::Duration::ZERO, std::time::Duration::ZERO],
+        |_| {},
+    );
+    assert_eq!(outcome_2, ProbeOutcome::LoggedOut);
+    assert!(
+        matches!(diag_2, Some(super::TransientDiagnostic::Exec { .. })),
+        "sustained missing-binary path must produce an Exec transient — that outcome must WIN over any earlier NonZero if attempts were mixed. Got {diag_2:?}",
+    );
+
+    // Now the mirror case: sustained NonZero must produce NonZero
+    // (baseline; guards against Exec winning erroneously).
+    let (outcome_1, diag_1) = super::login_probe_with_recheck_impl(
+        &nonzero_script,
+        &["nonzero-A", "auth", "status"],
+        None,
+        &[std::time::Duration::ZERO, std::time::Duration::ZERO],
+        |_| {},
+    );
+    assert_eq!(outcome_1, ProbeOutcome::LoggedOut);
+    match diag_1 {
+        Some(super::TransientDiagnostic::NonZero { stderr_excerpt, .. }) => {
+            assert!(
+                stderr_excerpt.contains("stderr-A"),
+                "sustained NonZero must preserve the last attempt's stderr excerpt; got {stderr_excerpt:?}",
+            );
+        }
+        other => panic!("expected NonZero on sustained nonzero-A, got {other:?}"),
+    }
+}
+
+/// The probe must NEVER surface stdout bytes. `Stdio::null()` on
+/// the command drops stdout at the OS level; if this test's script
+/// writes a distinctive token to stdout, that token must not
+/// appear anywhere in the returned diagnostic (which is built
+/// solely from stderr + exec-error text).
+#[cfg(unix)]
+#[test]
+fn recheck_never_emits_stdout_bytes_in_diagnostic() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+
+    const STDOUT_SENTINEL: &str = "STDOUT_SENTINEL_MUST_NOT_LEAK_c0ffee";
+    let script_path = bin_dir.join("stdout-emitter");
+    fs::write(
+        &script_path,
+        format!("#!/bin/sh\necho '{STDOUT_SENTINEL}'\necho 'sanitized stderr' >&2\nexit 1\n"),
+    )
+    .expect("write script");
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).expect("chmod script");
+
+    let (outcome, last_transient) = super::login_probe_with_recheck_impl(
+        &script_path,
+        &["stdout-emitter", "auth", "status"],
+        None,
+        &[std::time::Duration::ZERO, std::time::Duration::ZERO],
+        |_| {},
+    );
+
+    assert_eq!(outcome, ProbeOutcome::LoggedOut);
+    match last_transient {
+        Some(super::TransientDiagnostic::NonZero { stderr_excerpt, .. }) => {
+            assert!(
+                !stderr_excerpt.contains(STDOUT_SENTINEL),
+                "stdout bytes must not appear in the diagnostic — Stdio::null() is the OS-level guarantee. Got: {stderr_excerpt:?}",
+            );
+            assert!(
+                stderr_excerpt.contains("sanitized stderr"),
+                "stderr must be preserved through sanitize; got {stderr_excerpt:?}",
+            );
+        }
+        other => panic!("expected NonZero transient diagnostic, got {other:?}"),
+    }
+}
+
+/// Cross-platform sanity for the retry loop: a missing binary
+/// causes `Command::output()` to fail with ExecError on Unix,
+/// Windows, and macOS. Uses only Rust's standard library — no
+/// shell scripts — so Windows CI actually exercises the retry
+/// semantics instead of skipping the whole module. Guards
+/// Honey [11] blocker 4.
+#[test]
+fn recheck_exec_error_is_cross_platform() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let missing_path = temp.path().join("this-binary-does-not-exist");
+    // Do NOT create the file — `Command::output()` must fail.
+
+    let sleep_calls = std::cell::RefCell::new(0u32);
+    let (outcome, last_transient) = super::login_probe_with_recheck_impl(
+        &missing_path,
+        &["this-binary-does-not-exist", "auth", "status"],
+        None,
+        &[std::time::Duration::ZERO, std::time::Duration::ZERO],
+        |_| *sleep_calls.borrow_mut() += 1,
+    );
+
+    assert_eq!(
+        outcome,
+        ProbeOutcome::LoggedOut,
+        "sustained ExecError must resolve to LoggedOut on every platform",
+    );
+    assert!(
+        matches!(
+            last_transient,
+            Some(super::TransientDiagnostic::Exec { .. })
+        ),
+        "cross-platform ExecError path must carry an Exec diagnostic; got {last_transient:?}",
+    );
+    assert_eq!(
+        *sleep_calls.borrow(),
+        2,
+        "exec errors must drive the retry loop on every platform (expected 2 sleeps, got {})",
+        *sleep_calls.borrow(),
+    );
+}
+
+/// The public wrapper [`login_probe_with_recheck`] must not panic
+/// when its sustained-failure path fires `tracing::warn!`. This is
+/// a smoke test of the wrapper end-to-end; the load-bearing
+/// diagnostic content is asserted at the impl level by the
+/// mixed-A→B and last-attempt-wins tests. If a future refactor
+/// introduces an unwrap on the tracing call site, this fires.
+#[test]
+fn public_wrapper_emits_tracing_without_panicking_on_sustained_failure() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let missing_path = temp.path().join("cross-platform-missing");
+    // A no-op subscriber captures nothing but ensures a subscriber
+    // is installed so `tracing::warn!` is not a no-op.
+    let subscriber = tracing::subscriber::NoSubscriber::default();
+    let outcome = tracing::subscriber::with_default(subscriber, || {
+        super::login_probe_with_recheck(
+            &missing_path,
+            &["cross-platform-missing", "auth", "status"],
+            None,
+        )
+    });
+    assert_eq!(outcome, ProbeOutcome::LoggedOut);
+}

--- a/desktop/src-tauri/src/managed_agents/readiness_spawn.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness_spawn.rs
@@ -1,0 +1,100 @@
+//! Spawn-time readiness snapshot.
+//!
+//! `buzz-acp/setup_mode.rs` snapshots the readiness payload at spawn time
+//! (into `BUZZ_ACP_SETUP_PAYLOAD`) and explicitly never re-derives it, so a
+//! single transient non-zero CLI-login probe on startup traps the child in
+//! setup-listener mode for the process's lifetime. The Fizz Air incident
+//! (2026-08-23) hit this: `claude auth status` returned `loggedIn=false`
+//! for a sub-second window while the credential store was refreshing, the
+//! desktop froze that payload, and the harness kept serving a config-nudge
+//! for the rest of its life even though `auth status` was green seconds
+//! later.
+//!
+//! [`agent_readiness_for_spawn`] runs the ordinary single-shot readiness
+//! ([`agent_readiness`]) first, then post-passes any surviving
+//! `Requirement::CliLogin { availability: Available, .. }` through
+//! `cli_probe::login_probe_with_recheck` — bounded retry + one
+//! authoritative final recheck. If the retry recovers, the requirement is
+//! dropped from the returned readiness; if not, the requirement is
+//! preserved unchanged.
+//!
+//! Only [`spawn_agent_child`](crate::managed_agents::runtime) calls this.
+//! Every other `agent_readiness` caller (status polling, sidebar refresh,
+//! config-change diff, background verification) stays on the single-shot
+//! path so retry sleeps do not pile up ~1.75 s per logged-out row per
+//! poll while holding transition/store locks.
+
+use crate::managed_agents::{
+    agent_readiness,
+    discovery::resolve_command,
+    readiness::{cli_probe, EffectiveAgentEnv},
+    AcpAvailabilityStatus, AgentReadiness, Requirement,
+};
+
+/// Spawn-time readiness snapshot. Only [`spawn_agent_child`](crate::managed_agents::runtime)
+/// calls this. See module docs for the load-bearing semantics.
+pub(crate) fn agent_readiness_for_spawn(effective: &EffectiveAgentEnv) -> AgentReadiness {
+    let single_shot = agent_readiness(effective);
+    let AgentReadiness::NotReady { requirements } = single_shot else {
+        return AgentReadiness::Ready;
+    };
+    let retried: Vec<Requirement> = requirements
+        .into_iter()
+        .filter_map(retry_cli_login_if_transient)
+        .collect();
+    if retried.is_empty() {
+        AgentReadiness::Ready
+    } else {
+        AgentReadiness::NotReady {
+            requirements: retried,
+        }
+    }
+}
+
+/// If `req` is a `CliLogin` requirement with `AcpAvailabilityStatus::Available`
+/// (meaning the CLI is installed and the single-shot probe returned
+/// `LoggedOut`), re-run the probe through
+/// [`cli_probe::login_probe_with_recheck`]. If the retry sequence resolves
+/// to `LoggedIn`, drop the requirement by returning `None`. Otherwise
+/// preserve the original requirement.
+///
+/// Non-`CliLogin` requirements, and `CliLogin` requirements whose
+/// `availability` is anything other than `Available` (meaning the probe
+/// never ran because the adapter/CLI is missing), pass through unchanged
+/// — retrying them would spend budget on cases the retry cannot fix.
+fn retry_cli_login_if_transient(req: Requirement) -> Option<Requirement> {
+    let Requirement::CliLogin {
+        probe_args,
+        setup_copy,
+        availability,
+    } = req
+    else {
+        return Some(req);
+    };
+    if availability != AcpAvailabilityStatus::Available {
+        return Some(Requirement::CliLogin {
+            probe_args,
+            setup_copy,
+            availability,
+        });
+    }
+    let Some(binary_path) = probe_args.first().and_then(|arg| resolve_command(arg)) else {
+        return Some(Requirement::CliLogin {
+            probe_args,
+            setup_copy,
+            availability,
+        });
+    };
+    let augmented_path = cli_probe::augmented_path();
+    let args_refs: Vec<&str> = probe_args.iter().map(String::as_str).collect();
+    match cli_probe::login_probe_with_recheck(&binary_path, &args_refs, augmented_path.as_deref()) {
+        cli_probe::ProbeOutcome::LoggedIn => None,
+        cli_probe::ProbeOutcome::LoggedOut | cli_probe::ProbeOutcome::ConfigInvalid { .. } => {
+            Some(Requirement::CliLogin {
+                probe_args,
+                setup_copy,
+                availability,
+            })
+        }
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -573,7 +573,9 @@ pub fn spawn_agent_child(
     let spawned_setup_mode;
     {
         use crate::managed_agents::readiness::EffectiveAgentEnv;
-        use crate::managed_agents::{agent_readiness, AgentReadiness, Requirement};
+        use crate::managed_agents::{
+            agent_readiness_for_spawn, setup_payload::build_setup_payload,
+        };
 
         // Construct EffectiveAgentEnv from the descriptor computed above — no second
         // resolver call; the descriptor's env is already the fully layered result.
@@ -582,67 +584,16 @@ pub fn spawn_agent_child(
             config_file_path: runtime_meta.and_then(|r| r.config_file_path),
             effective_command: descriptor.command.clone(),
         };
-        // Compute the optional payload before touching the command.
-        let setup_payload_json =
-            if let AgentReadiness::NotReady { requirements } = agent_readiness(&effective) {
-                let reqs: Vec<serde_json::Value> = requirements
-                    .into_iter()
-                    .map(|r| match r {
-                        Requirement::NormalizedField { field } => serde_json::json!({
-                            "surface": "normalized_field",
-                            "field": field,
-                        }),
-                        Requirement::EnvKey { key } => serde_json::json!({
-                            "surface": "env_key",
-                            "key": key,
-                        }),
-                        Requirement::CliLogin {
-                            probe_args,
-                            setup_copy,
-                            availability,
-                        } => serde_json::json!({
-                            "surface": "cli_login",
-                            "probe_args": probe_args,
-                            "setup_copy": setup_copy,
-                            "availability": availability,
-                        }),
-                        Requirement::CliConfigInvalid {
-                            probe_args,
-                            setup_copy,
-                            diagnostic,
-                        } => serde_json::json!({
-                            "surface": "cli_config_invalid",
-                            "probe_args": probe_args,
-                            "setup_copy": setup_copy,
-                            "diagnostic": diagnostic,
-                        }),
-                        Requirement::GitBash => serde_json::json!({
-                            "surface": "git_bash",
-                        }),
-                        Requirement::MissingBinary { command } => serde_json::json!({
-                            "surface": "missing_binary",
-                            "command": command,
-                        }),
-                    })
-                    .collect();
-                let payload = serde_json::json!({
-                    "agent_name": record.name,
-                    "agent_pubkey": record.pubkey,
-                    "requirements": reqs,
-                });
-                match serde_json::to_string(&payload) {
-                    Ok(json) => Some(json),
-                    Err(e) => {
-                        eprintln!(
-                            "buzz-desktop: failed to serialize setup payload for {}: {e}",
-                            record.name
-                        );
-                        None
-                    }
-                }
-            } else {
-                None
-            };
+        // `agent_readiness_for_spawn` post-passes any transient CLI-login
+        // LoggedOut through `login_probe_with_recheck` before this
+        // snapshot is baked, so a sub-second `claude auth status` flap
+        // cannot trap the child in setup-listener mode for its lifetime
+        // (`buzz-acp/setup_mode.rs` never re-derives readiness).
+        let setup_payload_json = build_setup_payload(
+            &record.name,
+            &record.pubkey,
+            agent_readiness_for_spawn(&effective),
+        );
 
         spawned_setup_mode = setup_payload_json.is_some();
 

--- a/desktop/src-tauri/src/managed_agents/setup_payload.rs
+++ b/desktop/src-tauri/src/managed_agents/setup_payload.rs
@@ -1,0 +1,180 @@
+//! Serialize an [`AgentReadiness`] verdict into the JSON payload the
+//! desktop injects into `BUZZ_ACP_SETUP_PAYLOAD` when spawning an agent
+//! that is not yet ready. Extracted from `runtime::spawn_agent_child` so
+//! the spawn-seam regression can drive
+//! `agent_readiness_for_spawn → build_setup_payload` end-to-end and
+//! assert that a transient CLI-login flap **does not** produce a payload
+//! (the load-bearing property that guards the Fizz Air incident).
+//!
+//! # Contract
+//!
+//! * `AgentReadiness::Ready` → `None`. Callers spawn without the
+//!   `BUZZ_ACP_SETUP_PAYLOAD` env var; `buzz-acp` enters the normal
+//!   agent pool.
+//! * `AgentReadiness::NotReady { requirements }` → `Some(JSON)`.
+//!   Callers set `BUZZ_ACP_SETUP_PAYLOAD` to that JSON; `buzz-acp`
+//!   enters setup-listener mode and serves the surfaced requirements.
+//!
+//! `buzz-acp/setup_mode.rs` explicitly does NOT re-derive readiness at
+//! runtime — the payload snapshotted at spawn time governs the child's
+//! entire lifecycle. That is what makes any transient false-negative in
+//! the readiness probe a lifetime-of-process trap unless it is caught
+//! before this function returns `Some(_)`.
+//!
+//! JSON shape mirrors `setup_mode::SetupPayload` in buzz-acp:
+//! ```text
+//! { "agent_name": "...", "agent_pubkey": "...", "requirements": [{ "surface": "...", ... }] }
+//! ```
+
+use crate::managed_agents::{AgentReadiness, Requirement};
+
+/// Build the `BUZZ_ACP_SETUP_PAYLOAD` JSON for the given readiness verdict.
+/// Returns `None` when the agent is `Ready` (no payload should be set).
+///
+/// On serialization failure this function logs via `eprintln!` (matching
+/// the pre-extraction behavior of `spawn_agent_child`) and returns `None`,
+/// so a JSON-encoding bug never crashes agent spawn.
+pub(crate) fn build_setup_payload(
+    agent_name: &str,
+    agent_pubkey: &str,
+    readiness: AgentReadiness,
+) -> Option<String> {
+    let AgentReadiness::NotReady { requirements } = readiness else {
+        return None;
+    };
+    let reqs: Vec<serde_json::Value> = requirements.into_iter().map(requirement_json).collect();
+    let payload = serde_json::json!({
+        "agent_name": agent_name,
+        "agent_pubkey": agent_pubkey,
+        "requirements": reqs,
+    });
+    match serde_json::to_string(&payload) {
+        Ok(json) => Some(json),
+        Err(e) => {
+            eprintln!("buzz-desktop: failed to serialize setup payload for {agent_name}: {e}",);
+            None
+        }
+    }
+}
+
+fn requirement_json(req: Requirement) -> serde_json::Value {
+    match req {
+        Requirement::NormalizedField { field } => serde_json::json!({
+            "surface": "normalized_field",
+            "field": field,
+        }),
+        Requirement::EnvKey { key } => serde_json::json!({
+            "surface": "env_key",
+            "key": key,
+        }),
+        Requirement::CliLogin {
+            probe_args,
+            setup_copy,
+            availability,
+        } => serde_json::json!({
+            "surface": "cli_login",
+            "probe_args": probe_args,
+            "setup_copy": setup_copy,
+            "availability": availability,
+        }),
+        Requirement::CliConfigInvalid {
+            probe_args,
+            setup_copy,
+            diagnostic,
+        } => serde_json::json!({
+            "surface": "cli_config_invalid",
+            "probe_args": probe_args,
+            "setup_copy": setup_copy,
+            "diagnostic": diagnostic,
+        }),
+        Requirement::GitBash => serde_json::json!({
+            "surface": "git_bash",
+        }),
+        Requirement::MissingBinary { command } => serde_json::json!({
+            "surface": "missing_binary",
+            "command": command,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::managed_agents::AcpAvailabilityStatus;
+
+    #[test]
+    fn ready_produces_no_payload() {
+        // AgentReadiness::Ready → None. Spawn proceeds without
+        // BUZZ_ACP_SETUP_PAYLOAD; buzz-acp enters normal pool.
+        assert_eq!(
+            build_setup_payload("agent", "pubkey-hex", AgentReadiness::Ready),
+            None,
+        );
+    }
+
+    #[test]
+    fn not_ready_emits_payload_with_requirements_surface() {
+        let readiness = AgentReadiness::NotReady {
+            requirements: vec![Requirement::CliLogin {
+                probe_args: vec![
+                    "claude".to_string(),
+                    "auth".to_string(),
+                    "status".to_string(),
+                ],
+                setup_copy: "run claude login".to_string(),
+                availability: AcpAvailabilityStatus::Available,
+            }],
+        };
+        let payload = build_setup_payload("agent", "pubkey-hex", readiness)
+            .expect("NotReady must emit a payload");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&payload).expect("payload must be valid JSON");
+        assert_eq!(parsed["agent_name"], "agent");
+        assert_eq!(parsed["agent_pubkey"], "pubkey-hex");
+        assert_eq!(parsed["requirements"][0]["surface"], "cli_login");
+        assert_eq!(parsed["requirements"][0]["setup_copy"], "run claude login");
+    }
+
+    #[test]
+    fn empty_not_ready_still_emits_payload() {
+        // A NotReady with an empty requirements list is semantically
+        // odd (readiness should collapse to Ready) but round-trip
+        // safe here — we do not silently drop the payload.
+        let payload = build_setup_payload(
+            "agent",
+            "pubkey-hex",
+            AgentReadiness::NotReady {
+                requirements: vec![],
+            },
+        )
+        .expect("even empty NotReady emits a payload");
+        let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(parsed["requirements"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn spawn_seam_transient_flap_omits_payload() {
+        // The load-bearing property that guards the Fizz Air incident:
+        // when the retry loop in `agent_readiness_for_spawn` promotes a
+        // transient LoggedOut back to Ready, `build_setup_payload` MUST
+        // return None so `BUZZ_ACP_SETUP_PAYLOAD` is not set and the
+        // child enters the normal pool. Simulate that by feeding the
+        // post-retry `AgentReadiness::Ready` and asserting None.
+        //
+        // This is the seam Honey [11] blocker 2 asked for: at this
+        // exact call site (which mirrors `runtime.rs::spawn_agent_child`),
+        // a Ready verdict from the retry post-pass must NOT emit a
+        // setup payload. `agent_readiness_for_spawn` unit-tested end-to-
+        // end in `readiness_spawn` module tests; here we lock the seam.
+        assert_eq!(
+            build_setup_payload(
+                "flap-recovers",
+                "0102030405060708090a0b0c0d0e0f10",
+                AgentReadiness::Ready,
+            ),
+            None,
+            "when the retry recovers, BUZZ_ACP_SETUP_PAYLOAD must not be set — \
+             this is the Fizz Air regression at the runtime seam",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`buzz-acp/setup_mode.rs` snapshots the readiness payload at spawn time and explicitly never re-derives it. As a result, a single transient non-zero probe on startup traps the spawned child in setup-listener mode for its entire lifetime — no subsequent probe, log line, or restart of the underlying CLI's auth can move it back into the normal pool.

The Fizz Air incident (2026-08-23) hit this: `claude auth status` returned `loggedIn=false` for a sub-second window while the credential store was refreshing on demand. The desktop captured that false readiness moment and froze the payload for PID 47782's entire lifetime, even though the exact same `claude auth status` probe under the same environment returned green seconds later.

This PR routes the startup-readiness probe through a bounded retry + one authoritative final recheck:

- Initial attempt plus three retries at 250 ms / 500 ms / 1000 ms.
- `LoggedIn` short-circuits — first-attempt success adds zero latency and never sleeps.
- `ConfigInvalid` short-circuits — deterministic result; retrying only stalls spawn without changing the outcome.
- Transient failures (non-zero exit without the config-parse signal, or exec errors such as ENOENT) drive the retry loop.
- Worst-case added latency on the truly-logged-out path: ~1.75 s.

Also preserves the last transient diagnostic — exit code + first stderr line, or exec-error text — via `tracing::warn!` when every attempt fails. The pre-fix single-shot path discarded that diagnostic silently, so a probe declared `LoggedOut` was un-diagnosable after the fact. Honey Air's 2026-08-23 read-only trace flagged that gap explicitly (`readiness/cli_probe.rs:56–72`).

Scope is intentionally tight:

- `readiness/cli_probe.rs` gains `login_probe_with_recheck` and the private retry primitives. The old single-shot `login_probe` is now `#[cfg(test)]` since no production caller uses it.
- `readiness/cli_login.rs` swaps its one call from `login_probe` to `login_probe_with_recheck`.
- No changes to `Requirement`, `AgentReadiness`, `spawn_snapshot`, `runtime.rs` spawn env-assembly, `buzz-acp/setup_mode.rs`, identity/credential/membership/auth paths, or the separate `probe_auth_status` path in `discovery.rs`.

## Test plan

- [x] `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib -p buzz-desktop managed_agents::readiness::cli_probe` — 9 passed (5 pre-existing + 4 new regression tests).
- [x] `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib -p buzz-desktop managed_agents::readiness` — 58 passed.
- [x] `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib -p buzz-desktop managed_agents` — 1069 passed, 0 failed, no regressions.
- [x] `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check` — clean.
- [x] `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --lib --tests -- -D warnings` — clean.
- [ ] Owner-authorized single Fizz Air restart to prove real-world recovery (parked per Honey's rollback rule; requires fresh owner call).

## Regression tests added

- `recheck_recovers_from_transient_nonzero` — models the Fizz Air scenario (two false reads then green). Asserts `LoggedIn` and exactly 3 probe invocations.
- `recheck_returns_logged_out_when_every_attempt_fails` — sustained nonzero. Asserts `LoggedOut` and exactly 4 probe invocations (initial + 3 retries).
- `recheck_short_circuits_on_config_invalid` — deterministic config error must not retry.
- `recheck_first_attempt_success_makes_no_extra_calls` — asserts zero sleeper calls and exactly one probe invocation on the happy path.
- `recheck_treats_exec_errors_as_transient` — missing binary path drives the retry loop and resolves to `LoggedOut`.