### PR TITLE
fix(desktop): re-render Markdown when its link-preview props change

### DIFF
--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -1899,11 +1899,6 @@ function MarkdownInner({
   );
 }
 
-export const Markdown = React.memo(
-  MarkdownInner,
-  (prev, next) =>
-    markdownPropsAreEqual(prev, next) &&
-    prev.leadingInlineContent === next.leadingInlineContent,
-);
+export const Markdown = React.memo(MarkdownInner, markdownPropsAreEqual);
 Markdown.displayName = "Markdown";
 export { SyntaxHighlightedCode } from "./markdown/CodeBlock";

--- a/desktop/src/shared/ui/markdownUtils.test.mjs
+++ b/desktop/src/shared/ui/markdownUtils.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  markdownPropsAreEqual,
+  shallowArrayEqual,
+  shallowRecordEqual,
+} from "./markdownUtils.ts";
+
+const base = {
+  content: "hello",
+  className: "prose",
+  customEmoji: [],
+  hardLineBreaks: true,
+  interactive: true,
+  blockCode: false,
+  mediaInset: false,
+  agentMentionPubkeysByName: { bot: "aa" },
+  mentionPubkeysByName: { alice: "bb" },
+  mentionNames: ["alice"],
+  channelNames: ["general"],
+  imetaByUrl: new Map(),
+  configNudgeAuthorPubkey: null,
+  searchQuery: "",
+  snapshotSharedBy: undefined,
+  videoReviewContext: undefined,
+  messageId: "evt-1",
+  linkPreviewsSuppressed: false,
+  linkPreviewTags: [["r", "https://example.com"]],
+  leadingInlineContent: undefined,
+  onRemoveLinkPreviewsForEveryone: undefined,
+};
+
+/** A different value for every prop the renderer reads. */
+const changed = {
+  content: "goodbye",
+  className: "prose-sm",
+  customEmoji: [],
+  hardLineBreaks: false,
+  interactive: false,
+  blockCode: true,
+  mediaInset: true,
+  agentMentionPubkeysByName: { bot: "cc" },
+  mentionPubkeysByName: { alice: "cc" },
+  mentionNames: ["bob"],
+  channelNames: ["random"],
+  imetaByUrl: new Map(),
+  configNudgeAuthorPubkey: "dd",
+  searchQuery: "term",
+  snapshotSharedBy: "alice",
+  videoReviewContext: {},
+  messageId: "evt-2",
+  linkPreviewsSuppressed: true,
+  linkPreviewTags: [["r", "https://other.example"]],
+  leadingInlineContent: "prefix",
+  onRemoveLinkPreviewsForEveryone: async () => {},
+};
+
+describe("markdownPropsAreEqual", () => {
+  it("treats identical props as equal", () => {
+    assert.equal(markdownPropsAreEqual(base, { ...base }), true);
+  });
+
+  for (const key of Object.keys(changed)) {
+    it(`observes a change to ${key}`, () => {
+      assert.equal(
+        markdownPropsAreEqual(base, { ...base, [key]: changed[key] }),
+        false,
+      );
+    });
+  }
+
+  it("compares mention maps by value, not identity", () => {
+    assert.equal(
+      markdownPropsAreEqual(base, {
+        ...base,
+        mentionPubkeysByName: { ...base.mentionPubkeysByName },
+      }),
+      true,
+    );
+  });
+
+  it("compares name lists by value, not identity", () => {
+    assert.equal(
+      markdownPropsAreEqual(base, {
+        ...base,
+        mentionNames: [...base.mentionNames],
+      }),
+      true,
+    );
+  });
+});
+
+describe("shallowArrayEqual", () => {
+  it("handles missing sides", () => {
+    assert.equal(shallowArrayEqual(undefined, undefined), true);
+    assert.equal(shallowArrayEqual(["a"], undefined), false);
+  });
+
+  it("compares element-wise", () => {
+    assert.equal(shallowArrayEqual(["a", "b"], ["a", "b"]), true);
+    assert.equal(shallowArrayEqual(["a", "b"], ["b", "a"]), false);
+    assert.equal(shallowArrayEqual(["a"], ["a", "b"]), false);
+  });
+});
+
+describe("shallowRecordEqual", () => {
+  it("handles missing sides", () => {
+    assert.equal(shallowRecordEqual(undefined, undefined), true);
+    assert.equal(shallowRecordEqual({ a: "1" }, undefined), false);
+  });
+
+  it("compares entry-wise", () => {
+    assert.equal(shallowRecordEqual({ a: "1" }, { a: "1" }), true);
+    assert.equal(shallowRecordEqual({ a: "1" }, { a: "2" }), false);
+    assert.equal(shallowRecordEqual({ a: "1" }, { a: "1", b: "2" }), false);
+  });
+});

--- a/desktop/src/shared/ui/markdownUtils.ts
+++ b/desktop/src/shared/ui/markdownUtils.ts
@@ -101,6 +101,12 @@ export function shallowRecordEqual(
   return true;
 }
 
+/**
+ * Memo comparator for `Markdown`. Every prop the renderer reads has to be
+ * listed here: anything omitted cannot re-render the subtree on its own, so a
+ * message whose only change is, say, link-preview suppression keeps rendering
+ * its old previews.
+ */
 export function markdownPropsAreEqual(
   prev: MarkdownProps,
   next: MarkdownProps,
@@ -124,6 +130,13 @@ export function markdownPropsAreEqual(
     prev.configNudgeAuthorPubkey === next.configNudgeAuthorPubkey &&
     prev.searchQuery === next.searchQuery &&
     prev.snapshotSharedBy === next.snapshotSharedBy &&
-    prev.videoReviewContext === next.videoReviewContext
+    prev.videoReviewContext === next.videoReviewContext &&
+    prev.messageId === next.messageId &&
+    prev.linkPreviewsSuppressed === next.linkPreviewsSuppressed &&
+    // Callers pass the event's own tag array, so identity is stable per event.
+    prev.linkPreviewTags === next.linkPreviewTags &&
+    prev.leadingInlineContent === next.leadingInlineContent &&
+    prev.onRemoveLinkPreviewsForEveryone ===
+      next.onRemoveLinkPreviewsForEveryone
   );
 }


### PR DESCRIPTION
`markdownPropsAreEqual` is the memo comparator for `Markdown`, and it did not observe four of the props the renderer reads:

- `linkPreviewsSuppressed`
- `linkPreviewTags`
- `messageId`
- `onRemoveLinkPreviewsForEveryone`

Those four are exactly the ones that change on their own. Callers derive them from the event's tags — `linkPreviewsSuppressed={hasLinkPreviewSuppression(post.tags)}` in `ForumPostCard`, `ForumThreadPanel`, `InboxMessageRow`, `FeedSection`, and `linkPreviewTags={message.tags}` in `MessageRow`. So when a message gains link-preview suppression, its `content`, `className`, mention maps and everything else the comparator checks are unchanged, the comparator answers "equal", and the subtree keeps rendering the previews it was just told to drop. `useMessageLinkPreviews` has the right dependencies; it simply never gets to run.

`messageId` is the `key` on `LinkPreviewList`, so a changed key cannot remount, and a stale `onRemoveLinkPreviewsForEveryone` means "remove for everyone" can call the previous closure.

`leadingInlineContent` was being compared at the memo call site instead of in the helper. That split is what let the other four go missing — the helper looked complete. It is folded in and the call site now passes `markdownPropsAreEqual` directly.

`linkPreviewTags` is compared by identity, like `imetaByUrl`: every caller passes the event's own tag array, which is stable per event. That can only cause an extra render, never a missing one.

### Evidence

`markdownUtils` had no tests. The new file walks every prop the renderer reads and asserts the comparator observes a change to it — the four above fail against `main` — plus the by-value comparison of the mention maps and name lists, so a prop added to `MarkdownProps` without a line in the comparator now fails here rather than silently freezing the subtree.

Full desktop suite, measured both sides:

- `main`: 5397 tests, 0 failures
- this branch: 5425 tests, 0 failures

The delta is exactly the 28 tests added. `pnpm typecheck` and `pnpm check` are clean.

I have not exercised the suppression flow in the running app — the evidence here is the comparator's own contract, not a UI recording.