### PR TITLE
fix(scripts): catch a pubkey truncation the formatter wrapped

### DIFF
--- a/desktop/scripts/check-pubkey-truncation.mjs
+++ b/desktop/scripts/check-pubkey-truncation.mjs
@@ -25,7 +25,7 @@ const overrides = new Set([
   // clientId (not a pubkey) sliced in a debug log next to the real thing.
   "src/features/channels/readState/readStateManager.ts:338",
   // Array windows (first N pubkeys), not string truncation.
-  "src/features/messages/lib/threadPanel.ts:395",
+  "src/features/messages/lib/threadPanel.ts:399",
   "src/features/projects/ui/ProjectsView.tsx:166",
   "src/features/projects/ui/ProjectsOverviewPanel.tsx:209",
 ]);

--- a/scripts/check-pubkey-truncation-core.mjs
+++ b/scripts/check-pubkey-truncation-core.mjs
@@ -10,14 +10,37 @@ import path from "node:path";
  * which also offers full-key reveal + copy). Ad-hoc `pubkey.slice(0, N)`
  * display forms fragmented into five formats before this guard existed.
  *
- * It flags `.slice(` / `.substring(` / `.slice(0` template-truncations applied
- * to identifiers that look like a pubkey/npub, outside the canonical module.
+ * It flags `.slice(` / `.substring(` / `.substr(` truncations applied to
+ * identifiers that look like a pubkey/npub, outside the canonical module.
  * Non-display uses (array windows, color derivation from a key, avatar
  * initials) live in each app's `overrides` allowlist.
+ *
+ * The scan runs over whole file contents rather than a line at a time: the
+ * formatter wraps a long call as `authorPubkey\n  .slice(0, 8)`, which no
+ * single line matches.
  */
 
 const PUBKEY_SLICE_RE =
-  /\b[A-Za-z_$][\w$]*(?:[Pp]ubkey|[Pp]ub_key|[Nn]pub)[\w$]*\??\.(?:slice|substring)\(|\b(?:pubkey|npub)\??\.(?:slice|substring)\(/g;
+  /\b[A-Za-z_$][\w$]*(?:[Pp]ubkey|[Pp]ub_key|[Nn]pub)[\w$]*\??\s*(?:\r?\n\s*)?\.(?:slice|substring|substr)\(|\b(?:pubkey|npub)\??\s*(?:\r?\n\s*)?\.(?:slice|substring|substr)\(/g;
+
+/**
+ * Every hand-rolled truncation in `content`, as `{ line, text }` with a
+ * 1-based line number and the trimmed source line the match starts on.
+ */
+export function findPubkeyTruncations(content) {
+  const found = [];
+  PUBKEY_SLICE_RE.lastIndex = 0;
+  let match = PUBKEY_SLICE_RE.exec(content);
+  while (match !== null) {
+    const line = content.slice(0, match.index).split("\n").length;
+    found.push({
+      line,
+      text: content.split("\n")[line - 1].trim(),
+    });
+    match = PUBKEY_SLICE_RE.exec(content);
+  }
+  return found;
+}
 
 async function walkFiles(directory) {
   const entries = await fs.readdir(directory, { withFileTypes: true });
@@ -80,18 +103,13 @@ export async function runPubkeyTruncationCheck({
     }
 
     const content = await fs.readFile(filePath, "utf8");
-    const lines = content.split("\n");
-    lines.forEach((line, index) => {
-      PUBKEY_SLICE_RE.lastIndex = 0;
-      if (!PUBKEY_SLICE_RE.test(line)) {
-        return;
-      }
-      const key = `${relativePath.split(path.sep).join("/")}:${index + 1}`;
+    for (const found of findPubkeyTruncations(content)) {
+      const key = `${relativePath.split(path.sep).join("/")}:${found.line}`;
       if (overrides.has(key)) {
-        return;
+        continue;
       }
-      violations.push({ key, line: line.trim() });
-    });
+      violations.push({ key, line: found.text });
+    }
   }
 
   if (violations.length > 0) {

--- a/scripts/check-pubkey-truncation-core.test.mjs
+++ b/scripts/check-pubkey-truncation-core.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { findPubkeyTruncations } from "./check-pubkey-truncation-core.mjs";
+
+test("flags a truncation written on one line", () => {
+  const found = findPubkeyTruncations("const short = pubkey.slice(0, 8);\n");
+  assert.deepEqual(
+    found.map((entry) => entry.line),
+    [1],
+  );
+});
+
+test("flags a truncation the formatter wrapped onto the next line", () => {
+  const found = findPubkeyTruncations(
+    ["const short =", "  authorPubkey", "    .slice(0, 8);", ""].join("\n"),
+  );
+  assert.deepEqual(
+    found.map((entry) => entry.line),
+    [2],
+  );
+});
+
+test("flags substring and substr as well as slice", () => {
+  const found = findPubkeyTruncations(
+    ["a = pubkey.substring(0, 8);", "b = pubkey.substr(0, 8);", ""].join("\n"),
+  );
+  assert.deepEqual(
+    found.map((entry) => entry.line),
+    [1, 2],
+  );
+});
+
+test("flags optional-chained and suffixed pubkey identifiers", () => {
+  const found = findPubkeyTruncations(
+    ["a = npub?.slice(0, 8);", "b = recipientPubkeyHex.slice(0, 8);", ""].join(
+      "\n",
+    ),
+  );
+  assert.deepEqual(
+    found.map((entry) => entry.line),
+    [1, 2],
+  );
+});
+
+test("reports the line the identifier starts on, not the one holding the call", () => {
+  const [found] = findPubkeyTruncations(
+    ["// leading comment", "const short = authorPubkey", "  .slice(0, 8);", ""].join(
+      "\n",
+    ),
+  );
+  assert.equal(found.line, 2);
+  assert.equal(found.text, "const short = authorPubkey");
+});
+
+test("leaves unrelated identifiers alone", () => {
+  const found = findPubkeyTruncations(
+    ["a = messageId.slice(0, 8);", "b = name.substring(0, 4);", ""].join("\n"),
+  );
+  assert.deepEqual(found, []);
+});
+
+test("finds every occurrence in a file, not just the first", () => {
+  const found = findPubkeyTruncations(
+    ["a = pubkey.slice(0, 8);", "b = npub.slice(0, 8);", ""].join("\n"),
+  );
+  assert.equal(found.length, 2);
+});


### PR DESCRIPTION
`check-pubkey-truncation-core.mjs` guards against hand-rolled pubkey truncation, because a truncated prefix is forgeable by vanity-grinding and display truncation has to go through the canonical `truncatePubkey`.

It scanned **one line at a time**, so it only ever saw a truncation whose identifier and `.slice(` were on the same line. The formatter wraps a long call as

```js
const short = authorPubkey
  .slice(0, 8);
```

and that form was invisible to it. The guard therefore got weaker as call sites got longer — the opposite of a ratchet. `.substr(` was missing from the alternation too.

Both apps run this (`desktop` and `web`), so the hole was in both.

### Evidence

Three fixtures through the guard as it stands on `main`:

| form | flagged before | flagged after |
|---|---|---|
| `pubkey.slice(0, 8)` on one line | yes | yes |
| `authorPubkey` newline `.slice(0, 8)` | **no** | yes |
| `pubkey.substr(0, 8)` | **no** | yes |

Run against the real trees, the fixed guard immediately finds one occurrence `main`'s version misses: `desktop/src/features/messages/lib/threadPanel.ts:399`. That one is a legitimate array window (`participantPubkeys.slice(0, 3)`, the facepile), not string truncation — and it was **already allowlisted at `threadPanel.ts:395`**. That override had been dead since the formatter moved the call to 399, which is the same drift arriving from the other side. The override is updated to 399; `desktop` and `web` both exit 0.

`check-file-sizes-core` has tests and this one did not, so the scan is now a pure exported `findPubkeyTruncations(content)` with a test file covering the wrapped and `substr` forms, the line number reported for a wrapped call, multiple occurrences per file, and that unrelated identifiers stay unflagged.

The regex is unchanged in what it considers a pubkey-ish identifier — this only changes *where* it can see one.