### PR TITLE
Fix channel template persistence and member auto-add

### DIFF
--- a/desktop/src-tauri/src/commands/channel_templates.rs
+++ b/desktop/src-tauri/src/commands/channel_templates.rs
@@ -43,6 +43,20 @@ fn validate_visibility(value: &str) -> Result<(), String> {
     }
 }
 
+fn validate_member_roles(members: &[crate::templates::TemplateMemberEntry]) -> Result<(), String> {
+    for member in members {
+        match member.role.as_str() {
+            "admin" | "member" | "guest" => {}
+            role => {
+                return Err(format!(
+                    "invalid template member role: {role:?} (expected \"admin\", \"member\", or \"guest\")"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn list_channel_templates(app: AppHandle) -> Result<Vec<ChannelTemplateRecord>, String> {
     tokio::task::spawn_blocking(move || {
@@ -70,6 +84,7 @@ pub async fn create_channel_template(
         let visibility = input.visibility.unwrap_or_else(|| "open".to_string());
         validate_channel_type(&channel_type)?;
         validate_visibility(&visibility)?;
+        validate_member_roles(&input.members)?;
         let now = now_iso();
 
         let state = app.state::<AppState>();
@@ -87,6 +102,7 @@ pub async fn create_channel_template(
             visibility,
             canvas_template,
             agents: input.agents,
+            members: input.members,
             is_builtin: false,
             created_at: now.clone(),
             updated_at: now,
@@ -113,6 +129,7 @@ pub async fn update_channel_template(
         let visibility = input.visibility.unwrap_or_else(|| "open".to_string());
         validate_channel_type(&channel_type)?;
         validate_visibility(&visibility)?;
+        validate_member_roles(&input.members)?;
 
         let state = app.state::<AppState>();
         let _store_guard = state
@@ -131,6 +148,7 @@ pub async fn update_channel_template(
         template.visibility = visibility;
         template.canvas_template = canvas_template;
         template.agents = input.agents;
+        template.members = input.members;
         template.updated_at = now_iso();
 
         let updated = template.clone();

--- a/desktop/src-tauri/src/templates/storage.rs
+++ b/desktop/src-tauri/src/templates/storage.rs
@@ -2,8 +2,10 @@ use std::{fs, path::PathBuf};
 
 use tauri::AppHandle;
 use tauri::Manager;
+use uuid::Uuid;
 
 use crate::templates::ChannelTemplateRecord;
+use crate::util::now_iso;
 
 fn channel_templates_base_dir(app: &AppHandle) -> Result<PathBuf, String> {
     let dir = app
@@ -30,6 +32,28 @@ pub fn sort_channel_templates(records: &mut [ChannelTemplateRecord]) {
     });
 }
 
+fn migrate_missing_identity_fields(
+    records: &mut [ChannelTemplateRecord],
+    migration_timestamp: &str,
+) -> bool {
+    let mut migrated = false;
+    for record in records {
+        if record.id.trim().is_empty() {
+            record.id = Uuid::new_v4().to_string();
+            migrated = true;
+        }
+        if record.created_at.trim().is_empty() {
+            record.created_at = migration_timestamp.to_string();
+            migrated = true;
+        }
+        if record.updated_at.trim().is_empty() {
+            record.updated_at.clone_from(&record.created_at);
+            migrated = true;
+        }
+    }
+    migrated
+}
+
 pub fn load_channel_templates(app: &AppHandle) -> Result<Vec<ChannelTemplateRecord>, String> {
     let path = channel_templates_store_path(app)?;
 
@@ -41,6 +65,10 @@ pub fn load_channel_templates(app: &AppHandle) -> Result<Vec<ChannelTemplateReco
     } else {
         Vec::new()
     };
+
+    if migrate_missing_identity_fields(&mut records, &now_iso()) {
+        save_channel_templates(app, &records)?;
+    }
 
     sort_channel_templates(&mut records);
     Ok(records)
@@ -69,7 +97,7 @@ pub fn validate_channel_template_deletion(template: &ChannelTemplateRecord) -> R
 
 #[cfg(test)]
 mod tests {
-    use super::sort_channel_templates;
+    use super::{migrate_missing_identity_fields, sort_channel_templates};
     use crate::templates::{
         validate_channel_template_deletion, ChannelTemplateRecord, TemplateAgentRoster,
     };
@@ -83,6 +111,7 @@ mod tests {
             visibility: "open".to_string(),
             canvas_template: None,
             agents: TemplateAgentRoster::default(),
+            members: Vec::new(),
             is_builtin: false,
             created_at: "2026-05-11T00:00:00Z".to_string(),
             updated_at: "2026-05-11T00:00:00Z".to_string(),
@@ -134,7 +163,9 @@ mod tests {
 
     #[test]
     fn serialization_round_trip() {
-        use crate::templates::{TemplateAgentEntry, TemplateBackend, TemplateTeamEntry};
+        use crate::templates::{
+            TemplateAgentEntry, TemplateBackend, TemplateMemberEntry, TemplateTeamEntry,
+        };
 
         let original = ChannelTemplateRecord {
             id: "t1".to_string(),
@@ -160,6 +191,10 @@ mod tests {
                     }),
                 }],
             },
+            members: vec![TemplateMemberEntry {
+                pubkey: "member-1".to_string(),
+                role: "guest".to_string(),
+            }],
             is_builtin: false,
             created_at: "2026-05-11T00:00:00Z".to_string(),
             updated_at: "2026-05-11T00:00:00Z".to_string(),
@@ -179,6 +214,8 @@ mod tests {
         assert_eq!(parsed.agents.personas[0].persona_id, "builtin:fizz");
         assert_eq!(parsed.agents.personas[0].runtime.as_deref(), Some("claude"));
         assert_eq!(parsed.agents.teams[0].team_id, "team-1");
+        assert_eq!(parsed.members[0].pubkey, "member-1");
+        assert_eq!(parsed.members[0].role, "guest");
         assert!(!parsed.is_builtin);
     }
 
@@ -194,6 +231,42 @@ mod tests {
         assert!(parsed.canvas_template.is_none());
         assert!(parsed.agents.personas.is_empty());
         assert!(parsed.agents.teams.is_empty());
+        assert!(parsed.members.is_empty());
+    }
+
+    #[test]
+    fn deserializes_live_legacy_record_without_identity_fields() {
+        let json = r#"{
+          "name": "Code Team",
+          "description": "Coding collaboration",
+          "channel_type": "stream",
+          "visibility": "private",
+          "canvas_template": "",
+          "agents": {
+            "teams": [],
+            "personas": [{ "personaId": "persona-1" }]
+          }
+        }"#;
+
+        let mut parsed: ChannelTemplateRecord = serde_json::from_str(json).unwrap();
+
+        assert!(parsed.id.is_empty());
+        assert!(parsed.created_at.is_empty());
+        assert!(parsed.updated_at.is_empty());
+        assert_eq!(parsed.agents.personas[0].persona_id, "persona-1");
+        assert!(parsed.members.is_empty());
+
+        assert!(migrate_missing_identity_fields(
+            std::slice::from_mut(&mut parsed),
+            "2026-08-23T19:30:00Z",
+        ));
+        assert!(uuid::Uuid::parse_str(&parsed.id).is_ok());
+        assert_eq!(parsed.created_at, "2026-08-23T19:30:00Z");
+        assert_eq!(parsed.updated_at, parsed.created_at);
+        assert!(!migrate_missing_identity_fields(
+            std::slice::from_mut(&mut parsed),
+            "2026-08-24T00:00:00Z",
+        ));
     }
 
     #[test]

--- a/desktop/src-tauri/src/templates/types.rs
+++ b/desktop/src-tauri/src/templates/types.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChannelTemplateRecord {
+    #[serde(default)]
     pub id: String,
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -14,9 +15,13 @@ pub struct ChannelTemplateRecord {
     pub canvas_template: Option<String>,
     #[serde(default)]
     pub agents: TemplateAgentRoster,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub members: Vec<TemplateMemberEntry>,
     #[serde(default)]
     pub is_builtin: bool,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
 }
 
@@ -56,6 +61,14 @@ pub struct TemplateTeamEntry {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TemplateMemberEntry {
+    pub pubkey: String,
+    #[serde(default = "default_member_role")]
+    pub role: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TemplateBackend {
     Local,
@@ -70,6 +83,10 @@ fn default_visibility() -> String {
     "open".to_string()
 }
 
+fn default_member_role() -> String {
+    "member".to_string()
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateChannelTemplateRequest {
@@ -80,6 +97,8 @@ pub struct CreateChannelTemplateRequest {
     pub canvas_template: Option<String>,
     #[serde(default)]
     pub agents: TemplateAgentRoster,
+    #[serde(default)]
+    pub members: Vec<TemplateMemberEntry>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -93,4 +112,6 @@ pub struct UpdateChannelTemplateRequest {
     pub canvas_template: Option<String>,
     #[serde(default)]
     pub agents: TemplateAgentRoster,
+    #[serde(default)]
+    pub members: Vec<TemplateMemberEntry>,
 }

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -502,7 +502,7 @@ export function AppShell() {
 
   const createChannelMutation = useCreateChannelMutation(),
     createForumMutation = useCreateChannelMutation();
-  const { applyCanvas, applyAgents } = useApplyTemplate();
+  const { applyCanvas, applyAgents, applyMembers } = useApplyTemplate();
   const openDmMutation = useOpenDmMutation();
   const hideDmMutation = useHideDmMutation();
   const {
@@ -556,9 +556,12 @@ export function AppShell() {
       await applyCanvas(templateId, createdChannel.id, name);
       await goChannel(createdChannel.id);
       onCreated?.(createdChannel.id);
-      void applyAgents(templateId, createdChannel.id);
+      void Promise.allSettled([
+        applyMembers(templateId, createdChannel.id),
+        applyAgents(templateId, createdChannel.id),
+      ]);
     },
-    [applyAgents, applyCanvas, createChannelMutation, goChannel],
+    [applyAgents, applyCanvas, applyMembers, createChannelMutation, goChannel],
   );
   const handleCreateForum = React.useCallback(
     async ({
@@ -584,9 +587,12 @@ export function AppShell() {
 
       await applyCanvas(templateId, createdForum.id, name);
       await goChannel(createdForum.id);
-      void applyAgents(templateId, createdForum.id);
+      void Promise.allSettled([
+        applyMembers(templateId, createdForum.id),
+        applyAgents(templateId, createdForum.id),
+      ]);
     },
-    [applyAgents, applyCanvas, createForumMutation, goChannel],
+    [applyAgents, applyCanvas, applyMembers, createForumMutation, goChannel],
   );
 
   // The channel browser can create either a stream or a forum depending on

--- a/desktop/src/features/channel-templates/useApplyTemplate.ts
+++ b/desktop/src/features/channel-templates/useApplyTemplate.ts
@@ -13,7 +13,8 @@ import { resolvePersonaRuntime } from "@/features/agents/lib/resolvePersonaRunti
 import { resolveTeamPersonas } from "@/features/agents/lib/teamPersonas";
 import { useLastRuntime } from "@/features/agents/lib/useLastRuntime";
 import { useChannelTemplatesQuery } from "@/features/channel-templates/hooks";
-import { setCanvas } from "@/shared/api/tauri";
+import { channelMembersQueryKey } from "@/features/channels/rosterFreshness";
+import { addChannelMembers, setCanvas } from "@/shared/api/tauri";
 import type { ChannelTemplate } from "@/shared/api/types";
 
 /**
@@ -153,5 +154,63 @@ export function useApplyTemplate() {
     }
   }
 
-  return { applyCanvas, applyAgents };
+  async function applyMembers(
+    templateId: string | undefined,
+    channelId: string,
+  ) {
+    if (!templateId) return;
+    const template = channelTemplatesQuery.data?.find(
+      (candidate) => candidate.id === templateId,
+    );
+    if (!template || template.members.length === 0) return;
+
+    const membersByRole = new Map<
+      ChannelTemplate["members"][number]["role"],
+      string[]
+    >();
+    const seenPubkeys = new Set<string>();
+    for (const member of template.members) {
+      const normalizedPubkey = member.pubkey.trim().toLowerCase();
+      if (!normalizedPubkey || seenPubkeys.has(normalizedPubkey)) continue;
+      seenPubkeys.add(normalizedPubkey);
+      const pubkeys = membersByRole.get(member.role) ?? [];
+      pubkeys.push(normalizedPubkey);
+      membersByRole.set(member.role, pubkeys);
+    }
+
+    const failures: string[] = [];
+    for (const [role, pubkeys] of membersByRole) {
+      try {
+        const result = await addChannelMembers({
+          channelId,
+          pubkeys,
+          role,
+        });
+        failures.push(...result.errors.map((error) => error.pubkey));
+      } catch {
+        failures.push(...pubkeys);
+      }
+    }
+
+    if (failures.length > 0) {
+      const { toast } = await import("sonner");
+      toast.warning(
+        failures.length === 1
+          ? "1 member from the template could not be added"
+          : `${failures.length} members from the template could not be added`,
+      );
+    }
+
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: channelMembersQueryKey(channelId),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: ["channels"],
+        refetchType: "none",
+      }),
+    ]);
+  }
+
+  return { applyCanvas, applyAgents, applyMembers };
 }

--- a/desktop/src/features/settings/ui/ChannelTemplatesSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ChannelTemplatesSettingsCard.tsx
@@ -1,10 +1,12 @@
 import {
   Bot,
+  Check,
   Copy,
   MessageSquare,
   MoreHorizontal,
   Pencil,
   Plus,
+  Search,
   Trash2,
   Users,
 } from "lucide-react";
@@ -16,6 +18,7 @@ import {
   usePersonasQuery,
   useTeamsQuery,
 } from "@/features/agents/hooks";
+import { useRelayMembersQuery } from "@/features/community-members/hooks";
 import {
   useChannelTemplatesQuery,
   useCreateChannelTemplateMutation,
@@ -24,7 +27,9 @@ import {
   useUpdateChannelTemplateMutation,
 } from "@/features/channel-templates/hooks";
 import { AddChannelBotPersonasSection } from "@/features/channels/ui/AddChannelBotPersonasSection";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
+import { useIdentityQuery } from "@/shared/api/hooks";
 import type {
   AcpRuntime,
   AgentPersona,
@@ -34,6 +39,7 @@ import type {
   UpdateChannelTemplateInput,
 } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
+import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
 import { SettingsOptionGroup } from "./SettingsOptionGroup";
 import { SettingsSectionHeader } from "./SettingsSectionHeader";
 import {
@@ -208,6 +214,7 @@ function TemplateRow({
 }) {
   const personaCount = template.agents.personas.length;
   const teamCount = template.agents.teams.length;
+  const memberCount = template.members.length;
 
   return (
     <div className="group flex items-center gap-3 rounded-lg px-3 py-2.5 hover:bg-muted/50">
@@ -242,6 +249,12 @@ function TemplateRow({
             <span className="flex items-center gap-1">
               <Users className="h-4 w-4" />
               {teamCount} {teamCount === 1 ? "team" : "teams"}
+            </span>
+          ) : null}
+          {memberCount > 0 ? (
+            <span className="flex items-center gap-1">
+              <Users className="h-4 w-4" />
+              {memberCount} {memberCount === 1 ? "member" : "members"}
             </span>
           ) : null}
           {template.canvasTemplate ? (
@@ -305,6 +318,16 @@ export function TemplateFormDialog({
   const personasQuery = usePersonasQuery();
   const teamsQuery = useTeamsQuery();
   const providersQuery = useAvailableAcpRuntimes();
+  const relayMembersQuery = useRelayMembersQuery(open);
+  const identityQuery = useIdentityQuery();
+  const relayMembers = React.useMemo(
+    () => relayMembersQuery.data ?? [],
+    [relayMembersQuery.data],
+  );
+  const memberProfilesQuery = useUsersBatchQuery(
+    relayMembers.map((member) => member.pubkey),
+    { enabled: open && relayMembers.length > 0 },
+  );
   const runtimes = providersQuery.data ?? [];
 
   const [name, setName] = React.useState("");
@@ -314,6 +337,9 @@ export function TemplateFormDialog({
     [],
   );
   const [selectedTeamIds, setSelectedTeamIds] = React.useState<string[]>([]);
+  const [selectedMemberPubkeys, setSelectedMemberPubkeys] = React.useState<
+    string[]
+  >([]);
   const [personaRuntimes, setPersonaRuntimes] = React.useState<
     Record<string, string>
   >({});
@@ -331,6 +357,7 @@ export function TemplateFormDialog({
       setCanvasTemplate(template.canvasTemplate ?? "");
       setSelectedPersonaIds(template.agents.personas.map((p) => p.personaId));
       setSelectedTeamIds(template.agents.teams.map((t) => t.teamId));
+      setSelectedMemberPubkeys(template.members.map((member) => member.pubkey));
       const pRuntimes: Record<string, string> = {};
       for (const p of template.agents.personas) {
         if (p.runtime) pRuntimes[p.personaId] = p.runtime;
@@ -347,6 +374,7 @@ export function TemplateFormDialog({
       setCanvasTemplate("");
       setSelectedPersonaIds([]);
       setSelectedTeamIds([]);
+      setSelectedMemberPubkeys([]);
       setPersonaRuntimes({});
       setTeamRuntimes({});
     }
@@ -372,6 +400,16 @@ export function TemplateFormDialog({
         backend: null,
       })),
     };
+    const existingMemberRoles = new Map(
+      template?.members.map((member) => [
+        normalizePubkey(member.pubkey),
+        member.role,
+      ]),
+    );
+    const members = selectedMemberPubkeys.map((pubkey) => ({
+      pubkey,
+      role: existingMemberRoles.get(normalizePubkey(pubkey)) ?? "member",
+    }));
 
     if (isEditing) {
       const input: UpdateChannelTemplateInput = {
@@ -380,6 +418,7 @@ export function TemplateFormDialog({
         description: description.trim() || undefined,
         canvasTemplate: canvasTemplate.trim() || undefined,
         agents,
+        members,
       };
 
       updateMutation.mutate(input, {
@@ -399,6 +438,7 @@ export function TemplateFormDialog({
         description: description.trim() || undefined,
         canvasTemplate: canvasTemplate.trim() || undefined,
         agents,
+        members,
       };
 
       createMutation.mutate(input, {
@@ -443,6 +483,36 @@ export function TemplateFormDialog({
       return [...prev, teamId];
     });
   }
+
+  function handleToggleMember(pubkey: string) {
+    const normalizedPubkey = normalizePubkey(pubkey);
+    setSelectedMemberPubkeys((current) =>
+      current.some(
+        (candidate) => normalizePubkey(candidate) === normalizedPubkey,
+      )
+        ? current.filter(
+            (candidate) => normalizePubkey(candidate) !== normalizedPubkey,
+          )
+        : [...current, normalizedPubkey],
+    );
+  }
+
+  const currentPubkey = identityQuery.data?.pubkey
+    ? normalizePubkey(identityQuery.data.pubkey)
+    : null;
+  const memberProfiles = memberProfilesQuery.data?.profiles;
+  const memberOptions = relayMembers
+    .filter((member) => normalizePubkey(member.pubkey) !== currentPubkey)
+    .map((member) => {
+      const profile = memberProfiles?.[normalizePubkey(member.pubkey)];
+      return {
+        avatarUrl: profile?.avatarUrl ?? null,
+        displayName:
+          profile?.displayName?.trim() || truncatePubkey(member.pubkey),
+        pubkey: normalizePubkey(member.pubkey),
+      };
+    })
+    .sort((left, right) => left.displayName.localeCompare(right.displayName));
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
@@ -570,6 +640,19 @@ export function TemplateFormDialog({
             isLoading={teamsQuery.isLoading}
           />
 
+          <TemplateMemberSelector
+            errorMessage={
+              relayMembersQuery.error instanceof Error
+                ? relayMembersQuery.error.message
+                : null
+            }
+            isLoading={relayMembersQuery.isLoading}
+            isPending={isPending}
+            members={memberOptions}
+            onToggleMember={handleToggleMember}
+            selectedMemberPubkeys={selectedMemberPubkeys}
+          />
+
           {/* Runtime assignments */}
           <RuntimeAssignments
             isPending={isPending}
@@ -654,6 +737,128 @@ function TemplateTeamSelector({
           );
         })}
       </div>
+    </div>
+  );
+}
+
+function TemplateMemberSelector({
+  errorMessage,
+  isLoading,
+  isPending,
+  members,
+  onToggleMember,
+  selectedMemberPubkeys,
+}: {
+  errorMessage: string | null;
+  isLoading: boolean;
+  isPending: boolean;
+  members: Array<{
+    avatarUrl: string | null;
+    displayName: string;
+    pubkey: string;
+  }>;
+  onToggleMember: (pubkey: string) => void;
+  selectedMemberPubkeys: readonly string[];
+}) {
+  const [search, setSearch] = React.useState("");
+  const normalizedSelection = new Set(
+    selectedMemberPubkeys.map(normalizePubkey),
+  );
+  const normalizedSearch = search.trim().toLowerCase();
+  const filteredMembers = normalizedSearch
+    ? members.filter(
+        (member) =>
+          member.displayName.toLowerCase().includes(normalizedSearch) ||
+          member.pubkey.includes(normalizedSearch),
+      )
+    : members;
+
+  return (
+    <div className="space-y-3" data-testid="template-member-selector">
+      <div>
+        <div className="text-sm font-medium">Members</div>
+        <p
+          className="text-sm font-normal text-muted-foreground/70"
+          data-settings-subcopy
+        >
+          Add selected community members whenever this template is used.
+        </p>
+      </div>
+
+      {errorMessage ? (
+        <p className="text-sm text-destructive">{errorMessage}</p>
+      ) : isLoading ? (
+        <p className="text-sm text-muted-foreground">
+          Loading community members…
+        </p>
+      ) : members.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No other community members are available.
+        </p>
+      ) : (
+        <>
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              className="pl-9"
+              data-testid="template-member-search"
+              disabled={isPending}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search community members"
+              value={search}
+            />
+          </div>
+          <div className="max-h-48 space-y-1 overflow-y-auto rounded-lg border border-border/80 p-1">
+            {filteredMembers.length === 0 ? (
+              <p className="px-3 py-4 text-center text-sm text-muted-foreground">
+                No members match your search.
+              </p>
+            ) : (
+              filteredMembers.map((member) => {
+                const isSelected = normalizedSelection.has(member.pubkey);
+                return (
+                  <button
+                    aria-pressed={isSelected}
+                    className={cn(
+                      "flex w-full items-center gap-3 rounded-md px-2.5 py-2 text-left transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+                      isSelected
+                        ? "bg-accent text-accent-foreground"
+                        : "hover:bg-accent/60",
+                      isPending && "cursor-not-allowed opacity-50",
+                    )}
+                    data-testid={`template-member-${member.pubkey}`}
+                    disabled={isPending}
+                    key={member.pubkey}
+                    onClick={() => onToggleMember(member.pubkey)}
+                    type="button"
+                  >
+                    <ProfileAvatar
+                      avatarUrl={member.avatarUrl}
+                      className="h-8 w-8 shrink-0 text-xs"
+                      iconClassName="h-4 w-4"
+                      label={member.displayName}
+                    />
+                    <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                      {member.displayName}
+                    </span>
+                    <span
+                      aria-hidden
+                      className={cn(
+                        "flex h-5 w-5 shrink-0 items-center justify-center rounded border",
+                        isSelected
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-border bg-background",
+                      )}
+                    >
+                      {isSelected ? <Check className="h-4 w-4" /> : null}
+                    </span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/desktop/src/features/sidebar/ui/CreateChannelFormFields.tsx
+++ b/desktop/src/features/sidebar/ui/CreateChannelFormFields.tsx
@@ -49,6 +49,7 @@ export function CreateChannelFormFields({
   const selectedTemplatePersonaCount =
     selectedTemplate?.agents.personas.length ?? 0;
   const selectedTemplateTeamCount = selectedTemplate?.agents.teams.length ?? 0;
+  const selectedTemplateMemberCount = selectedTemplate?.members.length ?? 0;
   const selectedTemplateSummary = selectedTemplate
     ? [
         form.visibility === "private" ? "Private" : "Open",
@@ -58,6 +59,9 @@ export function CreateChannelFormFields({
           : null,
         selectedTemplateTeamCount > 0
           ? `${selectedTemplateTeamCount} ${selectedTemplateTeamCount === 1 ? "team" : "teams"}`
+          : null,
+        selectedTemplateMemberCount > 0
+          ? `${selectedTemplateMemberCount} ${selectedTemplateMemberCount === 1 ? "member" : "members"}`
           : null,
       ]
         .filter(Boolean)

--- a/desktop/src/shared/api/channelTemplateTypes.ts
+++ b/desktop/src/shared/api/channelTemplateTypes.ts
@@ -1,0 +1,67 @@
+export type TemplateBackend =
+  | { type: "local" }
+  | { type: "provider"; id: string };
+
+export type TemplateAgentEntry = {
+  personaId: string;
+  runtime: string | null;
+  model: string | null;
+  role: string | null;
+  backend: TemplateBackend | null;
+};
+
+export type TemplateTeamEntry = {
+  teamId: string;
+  runtime: string | null;
+  model: string | null;
+  backend: TemplateBackend | null;
+};
+
+export type TemplateMemberEntry = {
+  pubkey: string;
+  role: "admin" | "member" | "guest";
+};
+
+export type ChannelTemplate = {
+  id: string;
+  name: string;
+  description: string | null;
+  channelType: "stream" | "forum";
+  visibility: "open" | "private";
+  canvasTemplate: string | null;
+  agents: {
+    personas: TemplateAgentEntry[];
+    teams: TemplateTeamEntry[];
+  };
+  members: TemplateMemberEntry[];
+  isBuiltin: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreateChannelTemplateInput = {
+  name: string;
+  description?: string;
+  channelType?: string;
+  visibility?: string;
+  canvasTemplate?: string;
+  agents?: {
+    personas: TemplateAgentEntry[];
+    teams: TemplateTeamEntry[];
+  };
+  members?: TemplateMemberEntry[];
+};
+
+export type UpdateChannelTemplateInput = {
+  id: string;
+  name: string;
+  description?: string;
+  channelType?: string;
+  visibility?: string;
+  canvasTemplate?: string;
+  agents?: {
+    personas: TemplateAgentEntry[];
+    teams: TemplateTeamEntry[];
+  };
+  members?: TemplateMemberEntry[];
+};

--- a/desktop/src/shared/api/tauriChannelTemplates.ts
+++ b/desktop/src/shared/api/tauriChannelTemplates.ts
@@ -27,6 +27,10 @@ type RawChannelTemplate = {
       backend?: { type: "local" } | { type: "provider"; id: string } | null;
     }>;
   };
+  members?: Array<{
+    pubkey: string;
+    role?: "admin" | "member" | "guest" | null;
+  }>;
   is_builtin: boolean;
   created_at: string;
   updated_at: string;
@@ -55,6 +59,10 @@ function fromRawChannelTemplate(raw: RawChannelTemplate): ChannelTemplate {
         backend: t.backend ?? null,
       })),
     },
+    members: (raw.members ?? []).map((member) => ({
+      pubkey: member.pubkey,
+      role: member.role ?? "member",
+    })),
     isBuiltin: raw.is_builtin,
     createdAt: raw.created_at,
     updatedAt: raw.updated_at,
@@ -79,6 +87,7 @@ export async function createChannelTemplate(
         visibility: input.visibility,
         canvasTemplate: input.canvasTemplate,
         agents: input.agents ?? { personas: [], teams: [] },
+        members: input.members ?? [],
       },
     }),
   );
@@ -97,6 +106,7 @@ export async function updateChannelTemplate(
         visibility: input.visibility,
         canvasTemplate: input.canvasTemplate,
         agents: input.agents ?? { personas: [], teams: [] },
+        members: input.members ?? [],
       },
     }),
   );

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -821,67 +821,15 @@ export type UpdateTeamInput = {
   instructions?: string;
   personaIds: string[];
 };
-// ── Channel Template types ─────────────────────────────────────────────────────
-
-export type TemplateBackend =
-  | { type: "local" }
-  | { type: "provider"; id: string };
-
-export type TemplateAgentEntry = {
-  personaId: string;
-  runtime: string | null;
-  model: string | null;
-  role: string | null;
-  backend: TemplateBackend | null;
-};
-
-export type TemplateTeamEntry = {
-  teamId: string;
-  runtime: string | null;
-  model: string | null;
-  backend: TemplateBackend | null;
-};
-
-export type ChannelTemplate = {
-  id: string;
-  name: string;
-  description: string | null;
-  channelType: "stream" | "forum";
-  visibility: "open" | "private";
-  canvasTemplate: string | null;
-  agents: {
-    personas: TemplateAgentEntry[];
-    teams: TemplateTeamEntry[];
-  };
-  isBuiltin: boolean;
-  createdAt: string;
-  updatedAt: string;
-};
-
-export type CreateChannelTemplateInput = {
-  name: string;
-  description?: string;
-  channelType?: string;
-  visibility?: string;
-  canvasTemplate?: string;
-  agents?: {
-    personas: TemplateAgentEntry[];
-    teams: TemplateTeamEntry[];
-  };
-};
-
-export type UpdateChannelTemplateInput = {
-  id: string;
-  name: string;
-  description?: string;
-  channelType?: string;
-  visibility?: string;
-  canvasTemplate?: string;
-  agents?: {
-    personas: TemplateAgentEntry[];
-    teams: TemplateTeamEntry[];
-  };
-};
+export type {
+  ChannelTemplate,
+  CreateChannelTemplateInput,
+  TemplateAgentEntry,
+  TemplateBackend,
+  TemplateMemberEntry,
+  TemplateTeamEntry,
+  UpdateChannelTemplateInput,
+} from "./channelTemplateTypes";
 
 export type {
   ApprovalActionResponse,

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -12802,6 +12802,7 @@ export function maybeInstallE2eTauriMocks() {
           visibility: template.visibility,
           canvas_template: template.canvasTemplate,
           agents: template.agents,
+          members: template.members,
           is_builtin: template.isBuiltin,
           created_at: template.createdAt,
           updated_at: template.updatedAt,
@@ -12815,6 +12816,7 @@ export function maybeInstallE2eTauriMocks() {
             visibility?: "open" | "private";
             canvasTemplate?: string;
             agents?: ChannelTemplate["agents"];
+            members?: ChannelTemplate["members"];
           };
         };
         const timestamp = new Date().toISOString();
@@ -12826,6 +12828,7 @@ export function maybeInstallE2eTauriMocks() {
           visibility: input.visibility ?? "open",
           canvasTemplate: input.canvasTemplate ?? null,
           agents: input.agents ?? { personas: [], teams: [] },
+          members: input.members ?? [],
           isBuiltin: false,
           createdAt: timestamp,
           updatedAt: timestamp,
@@ -12845,6 +12848,7 @@ export function maybeInstallE2eTauriMocks() {
           visibility: created.visibility,
           canvas_template: created.canvasTemplate,
           agents: created.agents,
+          members: created.members,
           is_builtin: created.isBuiltin,
           created_at: created.createdAt,
           updated_at: created.updatedAt,

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1435,6 +1435,7 @@ test("create channel template selector matches the lifecycle controls", async ({
             },
           ],
         },
+        members: [],
         isBuiltin: false,
         createdAt: "2026-07-23T00:00:00Z",
         updatedAt: "2026-07-23T00:00:00Z",
@@ -1515,6 +1516,64 @@ test("create channel exposes templates when the library is empty", async ({
   await expect(page.getByTestId("create-channel-description")).toHaveValue(
     "Plan the next week.",
   );
+});
+
+test("channel templates save and apply selected community members", async ({
+  page,
+}) => {
+  await installMockBridge(page, { channelTemplates: [] });
+  await page.goto("/");
+  await openCreateChannelDialog(page);
+
+  await page.getByTestId("create-channel-template").click();
+  await page
+    .getByRole("menuitem", { name: "Create new channel template…" })
+    .click();
+
+  await page.locator("#template-name").fill("Project crew");
+  await page
+    .getByTestId(`template-member-${TEST_IDENTITIES.bob.pubkey}`)
+    .click();
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+
+  await expect
+    .poll(async () => {
+      const command = (await readCommandPayloadLog(page)).find(
+        (entry) => entry.command === "create_channel_template",
+      );
+      return (
+        command?.payload as
+          | {
+              input?: {
+                members?: Array<{ pubkey: string; role: string }>;
+              };
+            }
+          | undefined
+      )?.input?.members;
+    })
+    .toEqual([{ pubkey: TEST_IDENTITIES.bob.pubkey, role: "member" }]);
+
+  await expect(page.getByTestId("create-channel-template-summary")).toHaveText(
+    "Open · 1 member",
+  );
+  await page.getByTestId("create-channel-name").fill("project-crew-room");
+  await page.getByTestId("create-channel-submit").click();
+
+  await expect
+    .poll(async () => {
+      const command = (await readCommandPayloadLog(page)).find(
+        (entry) =>
+          entry.command === "add_channel_members" &&
+          (
+            entry.payload as { pubkeys?: string[]; role?: string } | undefined
+          )?.pubkeys?.includes(TEST_IDENTITIES.bob.pubkey),
+      );
+      return command?.payload;
+    })
+    .toMatchObject({
+      pubkeys: [TEST_IDENTITIES.bob.pubkey],
+      role: "member",
+    });
 });
 
 test("create ephemeral stream shows sidebar and header affordances", async ({


### PR DESCRIPTION
## Summary

- migrate legacy channel-template records that predate generated IDs and timestamps, so one old record can no longer make the entire template store unreadable
- persist selected community members in channel templates and show member counts in the template UI
- automatically add saved members after creating a stream or forum, with partial-failure warnings and roster cache refreshes

## Root cause

The installed app's existing template file contains the older record shape without `id`, `created_at`, or `updated_at`. The current Rust model required all three fields, so deserializing one legacy entry failed the entire store. Human members were also never represented in the template schema.

## Verification

- `pnpm --dir desktop test` — 5,397 passed
- `source ./bin/activate-hermit && just desktop-tauri-test` — complete workspace passed
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop check`
- `source ./bin/activate-hermit && just desktop-tauri-fmt-check`
- `pnpm --dir desktop build:e2e`
- `pnpm --dir desktop exec playwright test tests/e2e/channels.spec.ts --project=smoke --grep 'channel templates save and apply selected community members'` — 1 passed
