### PR TITLE
feat(desktop): add Google Antigravity official ACP harness

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -269,9 +269,11 @@ Buzz Desktop supports registering any ACP-speaking agent tool as a selectable ru
 
 **Tier-1 — compiled-in runtimes** (Goose, Claude Code, Codex, Buzz Agent): have auto-installers, auth probes, and first-class onboarding. Their IDs (`goose`, `claude`, `codex`, `buzz-agent`) are reserved and cannot be overridden.
 
-**Tier-2 — preset catalog** (Cursor, Oh My Pi, Grok Build, OpenCode, Kimi Code, Amp, Hermes Agent, OpenClaw): static `HarnessDefinition` entries in `desktop/src-tauri/src/managed_agents/discovery.rs` (`PRESET_HARNESSES`). They are always present in the runtime catalog, PATH-probed for availability, not editable or deletable by the user. Displayed with bundled logos; if not installed, a docs link appears instead.
+**Tier-2 — preset catalog** (Cursor, Oh My Pi, Grok Build, OpenCode, Kimi Code, Amp, Hermes Agent, OpenClaw, Google Antigravity): static `HarnessDefinition` entries in `desktop/src-tauri/src/managed_agents/discovery/presets.rs` (`PRESET_HARNESSES`). They are always present in the runtime catalog, PATH-probed for availability, not editable or deletable by the user. Displayed with bundled logos; if not installed, a docs link appears instead.
 
 > **Note — OpenClaw:** `openclaw acp` is a Gateway-backed bridge; PATH availability shows "Available" even when the OpenClaw Gateway daemon is not running. This is expected tier-2 semantics (same class as a preset with unconfigured auth). The Gateway URL is configured via `OPENCLAW_GATEWAY_URL` (or the equivalent env var from OpenClaw's docs) — set it in the agent's **env vars** in Edit Agent, not in the definition env (the preset definition carries no env entries). Note that `openclaw acp` executes tools inside the Gateway daemon, not the Desktop process, so Desktop-injected `BUZZ_*` env vars do NOT reach the execution locus unless you also set them on the Gateway's own environment.
+>
+> **Note — Google Antigravity:** the `agy` CLI has no ACP stdio mode. Buzz PATH-probes Google's official ACP server (`agy_acp_server.par`, registry id `antigravity-acp`). If `agy` is on PATH but the ACP server is not, the catalog shows AdapterMissing rather than Available. Keep `localharness_external` next to the `.par` file. Sign-in is ACP-native (`oauth-personal`, `gemini-api-key`, Gemini Enterprise) — Desktop's Connect Account flow is tier-1-only, same as other presets.
 
 **Tier-3 — user custom harnesses**: JSON files in `<app-data>/custom_harnesses/` that the user can create from the Settings UI or drop in directly. Each file describes one harness — no install scripts.
 
@@ -313,10 +315,9 @@ Invalid files (bad JSON, unknown id, empty command) are skipped with a warning a
 To add a new runtime to the tier-2 gallery:
 
 1. **Verify the ACP entrypoint** from the vendor's own documentation — do not rely on a PR description alone. Test with the actual binary.
-2. **Add a `HarnessDefinition` entry** to the `PRESET_HARNESSES` slice in `desktop/src-tauri/src/managed_agents/discovery.rs`. Fill `id`, `label`, `command`, `args`, `install_instructions_url`, `install_hint`. Leave `env` empty unless the harness requires a specific env var to enable ACP mode.
-3. **Add the preset id to `BUILTIN_IDS`** in `desktop/src-tauri/src/managed_agents/custom_harnesses.rs` so custom JSON files cannot shadow it.
-4. **Add a bundled logo** (64×64 PNG or optimised SVG) to `desktop/public/harness-logos/<id>.png` and add a corresponding entry to `PRESET_LOGOS` in `desktop/src/features/onboarding/ui/RuntimeIcon.tsx`. Record the source and license in `desktop/public/harness-logos/CREDITS.md`. Only bundle a mark whose upstream license permits redistribution; skipping this step is caught by `presetLogos.test.mjs`, which asserts every `PRESET_HARNESSES` id has a mapped logo that exists on disk.
-5. Run `cargo test --lib` and `just desktop-typecheck` to verify everything compiles.
+2. **Add a `HarnessDefinition` entry** to the `PRESET_HARNESSES` slice in `desktop/src-tauri/src/managed_agents/discovery/presets.rs`. Fill `id`, `label`, `command`, `args`, `install_instructions_url`, `install_hint`. Leave `env` empty unless the harness requires a specific env var to enable ACP mode. The id is reserved automatically via `preset_harness_ids()` — do not add it to a hand-maintained `BUILTIN_IDS` list.
+3. **Add a bundled logo** (64×64 PNG or optimised SVG) to `desktop/public/harness-logos/<id>.png` mapped in `PRESET_LOGOS` in `desktop/src/features/onboarding/ui/RuntimeIcon.tsx`, **or** an inline `currentColor` mark in `RUNTIME_MARKS` in `desktop/src/features/onboarding/ui/HarnessMarks.tsx`. Record the source and license in `desktop/public/harness-logos/CREDITS.md`. Only bundle a mark whose upstream license permits redistribution; skipping this step is caught by `presetLogos.test.mjs`, which asserts every `PRESET_HARNESSES` id has a mapped logo or inline mark.
+4. Run `cargo test --lib` and `just desktop-typecheck` to verify everything compiles.
 
 The built-in `BUILTIN_IDS` set (`goose`, `claude`, `codex`, `buzz-agent`, and all current preset ids) is the reserved namespace; every other id is available for custom harnesses.
 

--- a/desktop/public/harness-logos/CREDITS.md
+++ b/desktop/public/harness-logos/CREDITS.md
@@ -26,6 +26,7 @@ Monochrome marks inlined as `currentColor` paths in
 |---|---|---|---|---|---|
 | Goose | [block/goose](https://github.com/block/goose) | `305849b71709b95b86ed9f11bd3bc939899c0aab` | Apache-2.0 © Block, Inc. | `documentation/static/img/goose.svg` | `fill="#101010"` → `currentColor`; dropped the redundant clipPath wrapper |
 | Cursor | [simple-icons](https://github.com/simple-icons/simple-icons) | `16.27.1` (slug `cursor`) | CC0-1.0 (path data); nominative use of the Cursor mark to identify Cursor's harness | `icons/cursor.svg` | `fill` → `currentColor` |
+| Google Antigravity | [agentclientprotocol/registry](https://github.com/agentclientprotocol/registry) (`antigravity-acp`) | Registry icon served 2026-08-23 (`antigravity-acp.svg`); submitted by Google LLC in [PR #542](https://github.com/agentclientprotocol/registry/pull/542) | Google trademark; nominative use of the mark Google published for ACP clients to identify the Antigravity harness | `https://cdn.agentclientprotocol.com/registry/v1/latest/antigravity-acp.svg` | Inlined the `currentColor` path; dropped the 16×16 width/height attributes (viewBox retained) |
 
 Codex deliberately has **no** bundled mark: the OpenAI blossom was removed
 from simple-icons in v16 at the vendor's request, so we do not ship it —

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -237,7 +237,7 @@ fn command_looks_like_path(command: &str) -> bool {
 
 fn executable_basename(command: &str) -> String {
     let suffix = std::env::consts::EXE_SUFFIX;
-    if suffix.is_empty() || command.ends_with(suffix) {
+    if suffix.is_empty() || command.ends_with(suffix) || command.ends_with(".par") {
         command.to_string()
     } else {
         format!("{command}{suffix}")
@@ -255,6 +255,10 @@ pub(crate) fn normalize_command_identity(command: &str) -> String {
         })
         .collect::<String>();
     let lower = lower.strip_suffix(".exe").unwrap_or(&lower).to_string();
+    // Google's Antigravity ACP server ships as `agy_acp_server.par` on
+    // macOS/Linux. Strip the suffix so a path pin and the bare command
+    // classify as the same harness.
+    let lower = lower.strip_suffix(".par").unwrap_or(&lower).to_string();
 
     if let Some(suffix) = std::env::consts::EXE_SUFFIX.strip_prefix('.') {
         return lower

--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -178,6 +178,18 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
             Gateway's own environment separately.",
         underlying_cli: None,
     },
+    PresetHarness {
+        id: "antigravity",
+        label: "Google Antigravity",
+        // Official ACP server from the Agent Client Protocol registry
+        // (agentclientprotocol/registry id `antigravity-acp`). The `agy` CLI
+        // has no ACP mode — do not spawn `agy` or `agy --acp`.
+        command: "agy_acp_server.par",
+        args: &[],
+        install_instructions_url: "https://antigravity.google/docs/ide/extensions",
+        install_hint: "Buzz talks to Google Antigravity through Google's official ACP server (`agy_acp_server.par`), not the `agy` CLI. The CLI has no ACP mode. Download the Google Antigravity agent zip from the ACP registry, keep `agy_acp_server.par` and `localharness_external` in the same directory on your PATH, then sign in with Google (oauth-personal), a Gemini API key (`GEMINI_API_KEY`), or Gemini Enterprise.",
+        underlying_cli: Some("agy"),
+    },
 ];
 
 /// Return preset definitions for the spawn/readiness registry.
@@ -325,6 +337,84 @@ mod tests {
         );
         assert!(missing_entry.command.is_none());
         assert_eq!(missing_entry.default_args, vec!["acp"]);
+    }
+
+    #[test]
+    fn antigravity_preset_uses_official_acp_server_not_agy_cli() {
+        let preset = PRESET_HARNESSES
+            .iter()
+            .find(|preset| preset.id == "antigravity")
+            .expect("Antigravity preset should be present");
+
+        assert_eq!(preset.label, "Google Antigravity");
+        assert_eq!(preset.command, "agy_acp_server.par");
+        assert!(preset.args.is_empty());
+        assert_eq!(preset.underlying_cli, Some("agy"));
+        assert_eq!(
+            preset.install_instructions_url,
+            "https://antigravity.google/docs/ide/extensions"
+        );
+        assert!(
+            !preset.install_hint.contains("agy --acp"),
+            "hint must not claim the CLI speaks ACP"
+        );
+        assert!(
+            preset.install_hint.contains("agy_acp_server.par"),
+            "hint must name the official ACP server"
+        );
+
+        let available = preset_catalog_entry(preset, |command| {
+            (command == "agy_acp_server.par")
+                .then(|| PathBuf::from("/usr/local/bin/agy_acp_server.par"))
+        });
+        assert_eq!(available.availability, AcpAvailabilityStatus::Available);
+        assert_eq!(available.command.as_deref(), Some("agy_acp_server.par"));
+        assert!(available.default_args.is_empty());
+        assert_eq!(
+            available.binary_path.as_deref(),
+            Some("/usr/local/bin/agy_acp_server.par")
+        );
+        assert_eq!(available.auth_status, AuthStatus::NotApplicable);
+        assert_eq!(available.source, HarnessSource::Preset);
+
+        let adapter_missing = preset_catalog_entry(preset, |command| {
+            (command == "agy").then(|| PathBuf::from("/usr/local/bin/agy"))
+        });
+        assert_eq!(
+            adapter_missing.availability,
+            AcpAvailabilityStatus::AdapterMissing
+        );
+        assert!(adapter_missing.command.is_none());
+        assert_eq!(
+            adapter_missing.underlying_cli_path.as_deref(),
+            Some("/usr/local/bin/agy")
+        );
+
+        let missing = preset_catalog_entry(preset, |_| None);
+        assert_eq!(missing.availability, AcpAvailabilityStatus::NotInstalled);
+        assert!(missing.command.is_none());
+        assert!(missing.default_args.is_empty());
+    }
+
+    #[test]
+    fn antigravity_preset_is_exposed_in_the_runtime_catalog() {
+        use crate::managed_agents::custom_harnesses::registry_test_lock;
+
+        let _path_guard = crate::managed_agents::lock_path_mutex();
+        let _registry_guard = registry_test_lock();
+
+        let entry = super::super::discover_acp_runtimes_from(None, true)
+            .into_iter()
+            .find(|entry| entry.id == "antigravity")
+            .expect("Antigravity preset should appear in the runtime catalog");
+
+        assert_eq!(entry.label, "Google Antigravity");
+        assert!(entry.default_args.is_empty());
+        assert_eq!(
+            entry.install_instructions_url,
+            "https://antigravity.google/docs/ide/extensions"
+        );
+        assert_eq!(entry.source, HarnessSource::Preset);
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -5,9 +5,10 @@ use super::{
     apply_agent_command_update, classify_runtime, codex_adapter_availability,
     codex_adapter_is_outdated, create_time_agent_command_override, default_agent_command,
     effective_agent_command, find_nvm_default_bin, is_login_shell_path_uninit, is_safe_nvm_tag,
-    managed_agent_avatar_url, normalize_agent_args, parse_semver_tag, probe_codex_acp_version,
-    record_agent_command, refresh_login_shell_path, try_record_agent_command,
-    BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL, GOOSE_AVATAR_URL,
+    managed_agent_avatar_url, normalize_agent_args, normalize_command_identity, parse_semver_tag,
+    probe_codex_acp_version, record_agent_command, refresh_login_shell_path,
+    try_record_agent_command, BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL,
+    GOOSE_AVATAR_URL,
 };
 use crate::managed_agents::AcpAvailabilityStatus;
 
@@ -1160,6 +1161,32 @@ fn test_command_basenames_dotted_name_no_extra_candidates() {
         candidates.len(),
         1,
         "dotted name must produce exactly one candidate"
+    );
+}
+
+#[test]
+fn command_basenames_keeps_par_suffix() {
+    let candidates = super::command_basenames("agy_acp_server.par");
+    assert_eq!(
+        candidates,
+        vec!["agy_acp_server.par"],
+        "Google's ACP server ships as a .par; do not append .exe/.cmd/.bat"
+    );
+}
+
+#[test]
+fn normalize_command_identity_strips_par_suffix() {
+    assert_eq!(
+        normalize_command_identity("agy_acp_server.par"),
+        "agy-acp-server"
+    );
+    assert_eq!(
+        normalize_command_identity("/usr/local/bin/agy_acp_server.par"),
+        "agy-acp-server"
+    );
+    assert_eq!(
+        normalize_command_identity("agy_acp_server"),
+        "agy-acp-server"
     );
 }
 

--- a/desktop/src/features/onboarding/ui/HarnessMarks.tsx
+++ b/desktop/src/features/onboarding/ui/HarnessMarks.tsx
@@ -39,11 +39,29 @@ function CursorMark({ className }: MarkProps) {
   );
 }
 
+/// Google Antigravity mark from the official ACP registry icon (16×16,
+/// `currentColor`). Google published this SVG for ACP clients to display.
+function AntigravityMark({ className }: MarkProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="currentColor"
+      role="img"
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M14.1452 14.6818C14.9937 15.3182 16.2664 14.894 15.0997 13.7273C11.5998 10.3333 12.3421 1 7.99366 1C3.64518 1 4.3876 10.3333 0.887603 13.7273C-0.385123 15 0.993664 15.3182 1.84215 14.6818C5.13002 12.4545 4.9179 8.5303 7.99366 8.5303C11.0694 8.5303 10.8573 12.4545 14.1452 14.6818Z" />
+    </svg>
+  );
+}
+
 /// Theme-adaptive inline marks, keyed by runtime/preset id. Consulted before
 /// the bitmap logo maps in `RuntimeIcon`. Codex deliberately has no entry:
 /// the OpenAI blossom was removed from simple-icons v16 at the vendor's
 /// request, so Codex renders RuntimeIcon's neutral terminal-glyph fallback.
 export const RUNTIME_MARKS: Record<string, React.FC<MarkProps>> = {
+  antigravity: AntigravityMark,
   cursor: CursorMark,
   goose: GooseMark,
 };


### PR DESCRIPTION
## Summary

Adds **Google Antigravity** as a tier-2 preset harness so Buzz can run Gemini Flash (and the rest of the Antigravity model list) through Google's **official ACP server**.

`agy` 1.1.19 has no ACP stdio mode (`agy help acp` → unknown subcommand; [google-antigravity/antigravity-cli#31](https://github.com/google-antigravity/antigravity-cli/issues/31) is still open). Google now ships a first-party ACP binary, registered 2026-08-20 as [`antigravity-acp`](https://github.com/agentclientprotocol/registry/pull/542). I verified a live `initialize` handshake against `agy_acp_server_20260818_01_RC01`; `agentInfo.name` is `antigravity-acp`. Auth methods advertised: `oauth-personal`, `oauth-business`, `gemini-api-key`, `agent-platform`.

This follows the contributor guide in `crates/buzz-acp/README.md`: a `PRESET_HARNESSES` entry, not a new tier-1 `KnownAcpRuntime`. `underlying_cli` is `agy` so a CLI-only install shows **AdapterMissing** instead of silently looking available.

Related (wrong shape — wrapping `agy`, PATH-probing `agy` as ACP, or a custom Gemini SDK loop):

- #6208, #3325, #6462, #5333
- #2393 was closed for the generic custom-harness path before Google published the official ACP server

Originating Buzz channel: `81dd3019-bd4b-4b68-8f0d-a3bb483efc4f`

## Install (until this ships in Desktop)

1. Download the Google Antigravity agent zip from the [ACP registry](https://agentclientprotocol.com/get-started/registry) (or `https://dl.google.com/agy-extensions/releases/…`).
2. Put `agy_acp_server.par` **and** `localharness_external` in the same directory on `PATH`.
3. Sign in out of band (same as other presets — Desktop Connect Account is tier-1-only): `GEMINI_API_KEY` on the agent, or `~/.gemini/antigravity-acp/settings.json` with `auth.type`.

## Validation

- Live ACP `initialize` against `agy_acp_server.par` (build `agy_acp_server_20260818_01_RC01`)
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib antigravity_preset`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib normalize_command_identity_strips_par_suffix`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib command_basenames_keeps_par_suffix`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib preset_ids_are_reserved_and_cannot_be_used_as_custom_ids`
- `node --import ./test-loader.mjs --experimental-strip-types --test src/features/onboarding/ui/presetLogos.test.mjs` (includes `preset "antigravity"`)
- `just desktop-typecheck`
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check`