### PR TITLE
fix(deploy): run buzz-pair-relay in the Hetzner/compose stack

### DIFF
--- a/deploy/compose/Caddyfile
+++ b/deploy/compose/Caddyfile
@@ -1,5 +1,14 @@
 {$BUZZ_DOMAIN} {
-  encode zstd gzip
+	encode zstd gzip
 
-  reverse_proxy relay:3000
+	# Legacy same-host mobile pairing convention: desktop/mobile clients fall
+	# back to wss://<domain>/pair when the relay's NIP-11 doesn't advertise a
+	# dedicated pairing_relay_url. Route it to the buzz-pair-relay sidecar.
+	handle /pair* {
+		reverse_proxy pair-relay:5000
+	}
+
+	handle {
+		reverse_proxy relay:3000
+	}
 }

--- a/deploy/compose/compose.caddy.yml
+++ b/deploy/compose/compose.caddy.yml
@@ -7,6 +7,8 @@ services:
     depends_on:
       relay:
         condition: service_healthy
+      pair-relay:
+        condition: service_healthy
     environment:
       BUZZ_DOMAIN: ${BUZZ_DOMAIN:?set BUZZ_DOMAIN}
     ports:

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -48,6 +48,25 @@ services:
     networks:
       - buzz-net
 
+  pair-relay:
+    image: ${BUZZ_IMAGE:-ghcr.io/block/buzz:main}
+    entrypoint: ["/usr/local/bin/buzz-pair-relay"]
+    environment:
+      BUZZ_PAIR_RELAY_BIND_ADDR: 0.0.0.0:5000
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "bash -ec 'exec 3<>/dev/tcp/127.0.0.1/5000'",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - buzz-net
+
   postgres:
     image: postgres:17-alpine
     environment:


### PR DESCRIPTION
## Summary
- Mobile pairing fails with `WebSocket connection failed: HTTP error 404 Not Found` on the Hetzner/docker-compose deploy.
- Root cause: the relay's NIP-11 advertises NIP-43 (relay membership, on when `BUZZ_REQUIRE_RELAY_MEMBERSHIP=true`), so Buzz Desktop falls back to the legacy `wss://<domain>/pair` convention. Nothing in `deploy/compose` ran `buzz-pair-relay`, and Caddy only proxied to the main relay on `/`.
- Adds a `pair-relay` service (same published image, `buzz-pair-relay` entrypoint) to `compose.yml`, wires its healthcheck into `compose.caddy.yml`, and routes `/pair*` to it in the `Caddyfile` (everything else still goes to `relay:3000`).

## Test plan
- [x] `docker compose --env-file <test.env> -f compose.yml -f compose.caddy.yml config` renders cleanly
- [x] `caddy validate` against the updated Caddyfile passes
- [ ] End-to-end mobile pairing against a live Hetzner deploy after this lands