### PR TITLE
feat(mobile): rename a community from the switcher's edit mode

### DIFF
--- a/mobile/lib/features/channels/channels_page.dart
+++ b/mobile/lib/features/channels/channels_page.dart
@@ -54,6 +54,7 @@ import 'unread_badge/observed_unread_event.dart';
 
 part 'channels_page/body.dart';
 part 'channels_page/sections.dart';
+part 'channels_page/name_input_dialog.dart';
 part 'channels_page/channel_tile.dart';
 part 'channels_page/sheets.dart';
 part 'channels_page/badges.dart';

--- a/mobile/lib/features/channels/channels_page/body.dart
+++ b/mobile/lib/features/channels/channels_page/body.dart
@@ -281,7 +281,7 @@ class _SliverChannelsList extends HookConsumerWidget {
                 onRename: () async {
                   final name = await showBuzzDialog<String>(
                     context: context,
-                    builder: (_) => _SectionNameDialog(
+                    builder: (_) => _NameInputDialog(
                       title: 'Rename Section',
                       confirmLabel: 'Rename',
                       initialValue: section.name,

--- a/mobile/lib/features/channels/channels_page/community.dart
+++ b/mobile/lib/features/channels/channels_page/community.dart
@@ -67,7 +67,11 @@ class _CommunitySwitcherSheet extends HookConsumerWidget {
                           isActive: communities[index].id == activeId,
                           isEditing: isEditing.value,
                           onTap: isEditing.value
-                              ? null
+                              ? () => _promptRenameCommunity(
+                                  context,
+                                  ref,
+                                  communities[index],
+                                )
                               : () async {
                                   final community = communities[index];
                                   if (community.id != activeId) {
@@ -119,6 +123,7 @@ class _CommunitySwitcherSheet extends HookConsumerWidget {
 }
 
 const double _communitySwitcherAvatarSize = 36;
+const double _communitySwitcherRenameIconSize = 14;
 
 class _CommunitySwitcherDivider extends StatelessWidget {
   const _CommunitySwitcherDivider();
@@ -178,15 +183,35 @@ class _CommunitySwitcherTile extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(
-                    community.name,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: context.textTheme.bodyLarge?.copyWith(
-                      fontWeight: isActive
-                          ? FontWeight.w600
-                          : FontWeight.normal,
-                    ),
+                  Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          community.name,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: context.textTheme.bodyLarge?.copyWith(
+                            fontWeight: isActive
+                                ? FontWeight.w600
+                                : FontWeight.normal,
+                          ),
+                        ),
+                      ),
+                      if (isEditing) ...[
+                        const SizedBox(width: Grid.xxs),
+                        Semantics(
+                          label: 'Rename ${community.name}',
+                          child: Icon(
+                            LucideIcons.pencil,
+                            key: Key(
+                              'community-switcher-rename-${community.id}',
+                            ),
+                            size: _communitySwitcherRenameIconSize,
+                            color: context.colors.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ],
                   ),
                   const SizedBox(height: Grid.quarter),
                   Text(
@@ -374,6 +399,25 @@ class _AddCommunityTile extends StatelessWidget {
       ),
     );
   }
+}
+
+Future<void> _promptRenameCommunity(
+  BuildContext context,
+  WidgetRef ref,
+  Community community,
+) async {
+  final name = await showBuzzDialog<String>(
+    context: context,
+    builder: (_) => _NameInputDialog(
+      title: 'Rename Community',
+      confirmLabel: 'Rename',
+      initialValue: community.name,
+    ),
+  );
+  if (name == null || name.isEmpty || name == community.name) return;
+  await ref
+      .read(communityListProvider.notifier)
+      .renameCommunity(community.id, name);
 }
 
 Future<void> _confirmRemoveCommunity(

--- a/mobile/lib/features/channels/channels_page/name_input_dialog.dart
+++ b/mobile/lib/features/channels/channels_page/name_input_dialog.dart
@@ -1,0 +1,42 @@
+part of '../channels_page.dart';
+
+/// Single-field dialog for naming or renaming something (a section, a
+/// community). Pops the trimmed name, or null when cancelled.
+class _NameInputDialog extends HookWidget {
+  final String title;
+  final String confirmLabel;
+  final String initialValue;
+
+  const _NameInputDialog({
+    required this.title,
+    required this.confirmLabel,
+    this.initialValue = '',
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = useTextEditingController(text: initialValue);
+
+    void confirm() {
+      final name = controller.text.trim();
+      if (name.isNotEmpty) Navigator.of(context).pop(name);
+    }
+
+    return AlertDialog(
+      title: Text(title),
+      content: TextField(
+        controller: controller,
+        autofocus: true,
+        decoration: const InputDecoration(labelText: 'Name'),
+        onSubmitted: (_) => confirm(),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        TextButton(onPressed: confirm, child: Text(confirmLabel)),
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/channels/channels_page/sections.dart
+++ b/mobile/lib/features/channels/channels_page/sections.dart
@@ -294,45 +294,6 @@ CustomEmoji? _resolveCustomEmoji(String icon, List<CustomEmoji> palette) {
   return null;
 }
 
-class _SectionNameDialog extends HookWidget {
-  final String title;
-  final String confirmLabel;
-  final String initialValue;
-
-  const _SectionNameDialog({
-    required this.title,
-    required this.confirmLabel,
-    this.initialValue = '',
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final controller = useTextEditingController(text: initialValue);
-
-    void confirm() {
-      final name = controller.text.trim();
-      if (name.isNotEmpty) Navigator.of(context).pop(name);
-    }
-
-    return AlertDialog(
-      title: Text(title),
-      content: TextField(
-        controller: controller,
-        autofocus: true,
-        decoration: const InputDecoration(labelText: 'Name'),
-        onSubmitted: (_) => confirm(),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: const Text('Cancel'),
-        ),
-        TextButton(onPressed: confirm, child: Text(confirmLabel)),
-      ],
-    );
-  }
-}
-
 const _kSortRecentMenuValue = 'sort_recent';
 const _kSortAlphaMenuValue = 'sort_alpha';
 

--- a/mobile/test/features/channels/channels_page_test.dart
+++ b/mobile/test/features/channels/channels_page_test.dart
@@ -1081,6 +1081,76 @@ void main() {
     );
   });
 
+  testWidgets('community switcher renames a community from edit mode', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final communities = [
+      Community(
+        id: 'alpha',
+        name: 'Alpha',
+        relayUrl: 'wss://alpha.example.com',
+        addedAt: DateTime(2025),
+      ),
+      Community(
+        id: 'bravo',
+        name: 'Bravo',
+        relayUrl: 'wss://bravo.example.com',
+        addedAt: DateTime(2025),
+      ),
+    ];
+    final communityNotifier = _FakeCommunityListNotifier(communities);
+
+    await tester.pumpWidget(
+      buildTestable(
+        overrides: [
+          channelsProvider.overrideWith(() => _FakeNotifier(testChannels)),
+          communityListProvider.overrideWith(() => communityNotifier),
+          activeCommunityProvider.overrideWith(
+            (ref) async => communities.first,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Alpha'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('community-switcher-rename-bravo')),
+      findsNothing,
+    );
+
+    await tester.tap(find.text('Edit'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('community-switcher-rename-bravo')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('community-switcher-row-bravo')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Rename Community'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), '  Bangkok Venues  ');
+    await tester.tap(find.widgetWithText(TextButton, 'Rename'));
+    await tester.pumpAndSettle();
+
+    expect(communityNotifier.renames, [('bravo', 'Bangkok Venues')]);
+    expect(find.text('Bangkok Venues'), findsOneWidget);
+    expect(find.text('Bravo'), findsNothing);
+    // Renaming keeps the sheet open and does not switch communities.
+    expect(find.text('Switch Community'), findsOneWidget);
+    expect(find.text('Done'), findsOneWidget);
+  });
+
   testWidgets('opening the community switcher refreshes visible icons', (
     tester,
   ) async {
@@ -2026,9 +2096,22 @@ class _FakeCommunityListNotifier extends CommunityListNotifier {
 
   List<Community> _communities;
   final List<String> removedIds = [];
+  final List<(String, String)> renames = [];
 
   @override
   Future<List<Community>> build() async => _communities;
+
+  @override
+  Future<void> renameCommunity(String id, String name) async {
+    renames.add((id, name));
+    _communities = _communities
+        .map(
+          (community) =>
+              community.id == id ? community.copyWith(name: name) : community,
+        )
+        .toList();
+    state = AsyncData(_communities);
+  }
 
   @override
   Future<void> removeCommunity(String id) async {


### PR DESCRIPTION
## Summary

Mobile derives a community's display name from the first label of its relay hostname (`Community.nameFromUrl`) and never offers a way to change it. `CommunityListNotifier.renameCommunity` already exists but has no caller anywhere in `mobile/lib`, so the name is effectively fixed on device.

That is fine for `relay.example.com`, but a self-hosted deployment that serves several communities from `buzz.<domain>` hosts renders every one of them as **"buzz"**, with only the grey host sub-line to tell them apart:

| relay | shown as |
| --- | --- |
| `wss://buzz.33labs.xyz` | buzz |
| `wss://buzz.fieldspark.co` | buzz |
| `wss://buzz.getnifty.xyz` | buzz |

This wires the existing method up to the community switcher. The sheet already had an Edit toggle whose rows were inert (`onTap: null`) while the trash button did the work, so edit mode now gives each row a pencil affordance and opens a rename dialog on tap. Removal keeps its own trash button, and normal mode still switches communities.

The single-field name dialog moves out of `sections.dart` into its own part as `_NameInputDialog`, so the section rename and the community rename share one implementation instead of duplicating it.

The name stays device-local, matching current behaviour.

### Related issue

No duplicate issue or PR found for renaming a community on mobile.

Related but not fixed here: #2797 asks for the community name to be canonical state synced from the relay rather than device-local; this change does not alter where the name lives, it just lets you set it. #4165 makes the relay's NIP-11 `name` configurable, which mobile does not read today (it reads only `icon` from NIP-11).

### Testing

- New widget test in `mobile/test/features/channels/channels_page_test.dart`: opens the switcher, asserts no pencil before Edit, taps Edit, taps the row, renames via the dialog, and asserts `renameCommunity` was called with the trimmed name, the list re-renders with it, and the sheet stays open in edit mode.
- `flutter test` (full mobile suite): 1662 tests, all passing.
- `flutter analyze`: No issues found.
- `dart format --output=none --set-exit-if-changed .`: clean.

Screenshots below are rendered from the widget test with the app's bundled fonts, using three communities that all derive the name "buzz".

**Before** (edit mode: rows are inert, only removal is offered)

<img src="https://raw.githubusercontent.com/NiftyPickle/buzz/media/rename-community-shots/before-edit-mode.png" width="320">

**After** (edit mode: pencil affordance, row taps to rename)

<img src="https://raw.githubusercontent.com/NiftyPickle/buzz/media/rename-community-shots/edit-mode.png" width="320">

**After** (rename dialog, pre-filled with the current name)

<img src="https://raw.githubusercontent.com/NiftyPickle/buzz/media/rename-community-shots/rename-dialog.png" width="320">

**After** (renamed, sheet stays open)

<img src="https://raw.githubusercontent.com/NiftyPickle/buzz/media/rename-community-shots/renamed.png" width="320">
