### PR TITLE
fix(desktop): preserve deferred upload errors

### DIFF
--- a/desktop/src/features/messages/ui/useMentionSendFlow.helpers.test.mjs
+++ b/desktop/src/features/messages/ui/useMentionSendFlow.helpers.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { mergeMentionRecipients } from "./useMentionSendFlow.helpers.ts";
+import {
+  getErrorMessage,
+  mergeMentionRecipients,
+} from "./useMentionSendFlow.helpers.ts";
+
+const fallback = "Unknown error";
 
 test("address-locked agents join explicit mentions without duplicating recipients", () => {
   const explicit = ["A".repeat(64), "b".repeat(64)];
@@ -12,4 +17,52 @@ test("address-locked agents join explicit mentions without duplicating recipient
     "b".repeat(64),
     "c".repeat(64),
   ]);
+});
+
+test("preserves an actionable raw ffmpeg error string", () => {
+  const error =
+    "ffmpeg is required for video uploads but was not found.\n\nInstall it:\n  macOS: brew install ffmpeg";
+
+  assert.equal(getErrorMessage(error, fallback), error);
+});
+
+test("preserves an ordinary Error message", () => {
+  assert.equal(
+    getErrorMessage(new Error("Video conversion failed"), fallback),
+    "Video conversion failed",
+  );
+});
+
+test("uses the fallback for empty and whitespace-only text", () => {
+  for (const error of ["", " \n\t ", new Error(""), new Error(" \n\t ")]) {
+    assert.equal(getErrorMessage(error, fallback), fallback);
+  }
+});
+
+test("uses the fallback for non-text rejection values", () => {
+  for (const error of [
+    null,
+    undefined,
+    0,
+    42,
+    false,
+    true,
+    [],
+    ["Video conversion failed"],
+    {},
+    { message: "Video conversion failed" },
+  ]) {
+    assert.equal(getErrorMessage(error, fallback), fallback);
+  }
+});
+
+test("preserves original multiline and surrounding whitespace after validation", () => {
+  const rawString = " \nVideo conversion failed\nTry another file.\n ";
+  const errorMessage = "\tVideo conversion failed\nDecoder unavailable\t";
+
+  assert.equal(getErrorMessage(rawString, fallback), rawString);
+  assert.equal(
+    getErrorMessage(new Error(errorMessage), fallback),
+    errorMessage,
+  );
 });

--- a/desktop/src/features/messages/ui/useMentionSendFlow.helpers.ts
+++ b/desktop/src/features/messages/ui/useMentionSendFlow.helpers.ts
@@ -82,7 +82,13 @@ export function mergeOutgoingTagsWithReferenceMentions(
 }
 
 export function getErrorMessage(error: unknown, fallback: string) {
-  return error instanceof Error && error.message ? error.message : fallback;
+  if (error instanceof Error) {
+    return error.message.trim().length > 0 ? error.message : fallback;
+  }
+  if (typeof error === "string") {
+    return error.trim().length > 0 ? error : fallback;
+  }
+  return fallback;
 }
 
 export function uniqueNormalizedPubkeys(pubkeys: Iterable<string>) {


### PR DESCRIPTION
## Summary

- preserve actionable primitive string errors from deferred Tauri uploads
- retain the fallback for blank strings and non-text rejection values
- add regression coverage for native error strings and the fallback boundary

## Related issue

No issue found. Originating Buzz thread: buzz://message?channel=f5853d3f-3db4-443f-9f42-d60215ed5441&id=d87e4d27c3d58c620365933ebc7d28531c4b33daa3f39e7eda609f7b24f1c0ed

## Testing

- `just desktop-test` (5,254 passed)
- `just desktop-check`
- `just ci` (passed, including 1,552 mobile tests)