### PR TITLE
feat(desktop): pop out agent activity into a window

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
         "**/observer-feed-screenshots.spec.ts",
         "**/core-memory-screenshots.spec.ts",
         "**/activity-scope-label-screenshots.spec.ts",
+        "**/agent-activity-window.spec.ts",
         "**/welcome-agent-modal-screenshots.spec.ts",
         "**/local-archive-screenshots.spec.ts",
         "**/voice-settings.spec.ts",

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main window and trusted huddle companions",
-  "windows": ["main", "huddle-*"],
+  "description": "Capability for the main window and trusted companion windows",
+  "windows": ["main", "huddle-*", "agent-activity-*"],
   "permissions": [
     "core:default",
     "core:webview:allow-set-webview-zoom",

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "core:window:allow-set-badge-label",
     "core:window:allow-request-user-attention",
     "core:window:allow-set-focus",
+    "core:window:allow-set-title",
     "core:window:allow-start-dragging",
     "core:window:allow-toggle-maximize",
     "core:window:allow-unminimize",

--- a/desktop/src-tauri/src/agent_activity_window.rs
+++ b/desktop/src-tauri/src/agent_activity_window.rs
@@ -34,6 +34,7 @@ fn activity_route(community_id: &str, channel_id: &Uuid, pubkey: &str) -> String
     let query = form_urlencoded::Serializer::new(String::new())
         .append_pair("community", community_id)
         .append_pair("agentSession", pubkey)
+        .append_pair("agentSessionChannel", &channel_id.to_string())
         .finish();
     format!("index.html#/channels/{channel_id}?{query}")
 }
@@ -111,7 +112,7 @@ mod tests {
         assert_eq!(
             activity_route("community & one", &channel_id, &pubkey),
             format!(
-                "index.html#/channels/{channel_id}?community=community+%26+one&agentSession={pubkey}"
+                "index.html#/channels/{channel_id}?community=community+%26+one&agentSession={pubkey}&agentSessionChannel={channel_id}"
             )
         );
     }

--- a/desktop/src-tauri/src/agent_activity_window.rs
+++ b/desktop/src-tauri/src/agent_activity_window.rs
@@ -1,6 +1,8 @@
 //! Native companion-window lifecycle for an agent activity feed.
 
+use sha2::{Digest, Sha256};
 use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+use url::form_urlencoded;
 use uuid::Uuid;
 
 const PUBKEY_HEX_LENGTH: usize = 64;
@@ -15,8 +17,25 @@ fn normalized_pubkey(pubkey: &str) -> Result<String, String> {
     Ok(normalized)
 }
 
-fn window_label(channel_id: &Uuid, pubkey: &str) -> String {
-    format!("agent-activity-{pubkey}-{channel_id}")
+fn normalized_community_id(community_id: &str) -> Result<String, String> {
+    let normalized = community_id.trim();
+    if normalized.is_empty() {
+        return Err("community id must not be empty".to_string());
+    }
+    Ok(normalized.to_string())
+}
+
+fn window_label(community_id: &str, channel_id: &Uuid, pubkey: &str) -> String {
+    let community_scope = hex::encode(Sha256::digest(community_id.as_bytes()));
+    format!("agent-activity-{community_scope}-{pubkey}-{channel_id}")
+}
+
+fn activity_route(community_id: &str, channel_id: &Uuid, pubkey: &str) -> String {
+    let query = form_urlencoded::Serializer::new(String::new())
+        .append_pair("community", community_id)
+        .append_pair("agentSession", pubkey)
+        .finish();
+    format!("index.html#/channels/{channel_id}?{query}")
 }
 
 /// Open an agent's channel-scoped activity feed without replacing the main
@@ -24,13 +43,15 @@ fn window_label(channel_id: &Uuid, pubkey: &str) -> String {
 #[tauri::command]
 pub fn open_agent_activity_window(
     app: tauri::AppHandle,
+    community_id: String,
     channel_id: String,
     pubkey: String,
 ) -> Result<bool, String> {
+    let community_id = normalized_community_id(&community_id)?;
     let channel_id =
         Uuid::parse_str(channel_id.trim()).map_err(|_| "channel id must be a UUID".to_string())?;
     let pubkey = normalized_pubkey(&pubkey)?;
-    let label = window_label(&channel_id, &pubkey);
+    let label = window_label(&community_id, &channel_id, &pubkey);
 
     if let Some(window) = app.get_webview_window(&label) {
         window.show().map_err(|error| error.to_string())?;
@@ -38,7 +59,7 @@ pub fn open_agent_activity_window(
         return Ok(true);
     }
 
-    let route = format!("index.html#/channels/{channel_id}?agentSession={pubkey}");
+    let route = activity_route(&community_id, &channel_id, &pubkey);
     WebviewWindowBuilder::new(&app, label, WebviewUrl::App(route.into()))
         .title("Agent activity")
         .inner_size(560.0, 760.0)
@@ -50,7 +71,7 @@ pub fn open_agent_activity_window(
 
 #[cfg(test)]
 mod tests {
-    use super::{normalized_pubkey, window_label};
+    use super::{activity_route, normalized_community_id, normalized_pubkey, window_label};
     use uuid::Uuid;
 
     #[test]
@@ -66,9 +87,38 @@ mod tests {
         let second = format!("{}{}", "ab".repeat(6), "ef".repeat(26));
 
         assert_ne!(
-            window_label(&channel_id, &first),
-            window_label(&channel_id, &second)
+            window_label("community-a", &channel_id, &first),
+            window_label("community-a", &channel_id, &second)
         );
+    }
+
+    #[test]
+    fn labels_distinguish_communities() {
+        let channel_id = Uuid::nil();
+        let pubkey = "ab".repeat(32);
+
+        assert_ne!(
+            window_label("community-a", &channel_id, &pubkey),
+            window_label("community-b", &channel_id, &pubkey)
+        );
+    }
+
+    #[test]
+    fn route_carries_immutable_community_scope() {
+        let channel_id = Uuid::nil();
+        let pubkey = "ab".repeat(32);
+
+        assert_eq!(
+            activity_route("community & one", &channel_id, &pubkey),
+            format!(
+                "index.html#/channels/{channel_id}?community=community+%26+one&agentSession={pubkey}"
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_empty_community_ids() {
+        assert!(normalized_community_id("  ").is_err());
     }
 
     #[test]

--- a/desktop/src-tauri/src/agent_activity_window.rs
+++ b/desktop/src-tauri/src/agent_activity_window.rs
@@ -1,0 +1,79 @@
+//! Native companion-window lifecycle for an agent activity feed.
+
+use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+use uuid::Uuid;
+
+const PUBKEY_HEX_LENGTH: usize = 64;
+
+fn normalized_pubkey(pubkey: &str) -> Result<String, String> {
+    let normalized = pubkey.trim().to_ascii_lowercase();
+    if normalized.len() != PUBKEY_HEX_LENGTH
+        || !normalized.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err("agent pubkey must be 64 hexadecimal characters".to_string());
+    }
+    Ok(normalized)
+}
+
+fn window_label(channel_id: &Uuid, pubkey: &str) -> String {
+    format!("agent-activity-{pubkey}-{channel_id}")
+}
+
+/// Open an agent's channel-scoped activity feed without replacing the main
+/// window's thread panel. Each agent/channel pair owns one reusable window.
+#[tauri::command]
+pub fn open_agent_activity_window(
+    app: tauri::AppHandle,
+    channel_id: String,
+    pubkey: String,
+) -> Result<bool, String> {
+    let channel_id =
+        Uuid::parse_str(channel_id.trim()).map_err(|_| "channel id must be a UUID".to_string())?;
+    let pubkey = normalized_pubkey(&pubkey)?;
+    let label = window_label(&channel_id, &pubkey);
+
+    if let Some(window) = app.get_webview_window(&label) {
+        window.show().map_err(|error| error.to_string())?;
+        window.set_focus().map_err(|error| error.to_string())?;
+        return Ok(true);
+    }
+
+    let route = format!("index.html#/channels/{channel_id}?agentSession={pubkey}");
+    WebviewWindowBuilder::new(&app, label, WebviewUrl::App(route.into()))
+        .title("Agent activity")
+        .inner_size(560.0, 760.0)
+        .min_inner_size(420.0, 520.0)
+        .build()
+        .map_err(|error| error.to_string())?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalized_pubkey, window_label};
+    use uuid::Uuid;
+
+    #[test]
+    fn normalizes_valid_pubkeys() {
+        let uppercase = "AB".repeat(32);
+        assert_eq!(normalized_pubkey(&uppercase), Ok("ab".repeat(32)));
+    }
+
+    #[test]
+    fn labels_distinguish_pubkeys_with_the_same_prefix() {
+        let channel_id = Uuid::nil();
+        let first = format!("{}{}", "ab".repeat(6), "cd".repeat(26));
+        let second = format!("{}{}", "ab".repeat(6), "ef".repeat(26));
+
+        assert_ne!(
+            window_label(&channel_id, &first),
+            window_label(&channel_id, &second)
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_pubkeys() {
+        assert!(normalized_pubkey("abc").is_err());
+        assert!(normalized_pubkey(&"zz".repeat(32)).is_err());
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "256"] // Deep Tauri command futures exceed the default layout query depth.
+mod agent_activity_window;
 mod app_menu;
 mod app_state;
 mod archive;
@@ -50,6 +51,7 @@ mod unread_catch_up;
 mod util;
 #[cfg(target_os = "linux")]
 pub mod webkit_rendering;
+use agent_activity_window::open_agent_activity_window;
 use app_state::{build_app_state, resolve_persisted_identity, AppState};
 use builderlab::*;
 #[doc(hidden)]
@@ -781,6 +783,7 @@ pub fn run() {
             get_huddle_state,
             close_huddle_companion,
             open_huddle_window,
+            open_agent_activity_window,
             push_audio_pcm,
             reconnect_huddle_audio,
             start_stt_pipeline,

--- a/desktop/src-tauri/tests/csp.rs
+++ b/desktop/src-tauri/tests/csp.rs
@@ -1,4 +1,5 @@
-//! Guards on the packaged-app Content-Security-Policy in `tauri.conf.json`.
+//! Guards on packaged-app security configuration in `tauri.conf.json` and
+//! `capabilities/default.json`.
 //!
 //! The CSP is only enforced on assets Tauri itself serves, so neither
 //! `just dev` (loads the Vite `devUrl`) nor the Playwright suite (runs under
@@ -12,6 +13,25 @@
 use std::collections::HashMap;
 
 const TAURI_CONF: &str = include_str!("../tauri.conf.json");
+const DEFAULT_CAPABILITY: &str = include_str!("../capabilities/default.json");
+
+#[test]
+fn companion_windows_receive_the_default_capability() {
+    let capability: serde_json::Value =
+        serde_json::from_str(DEFAULT_CAPABILITY).expect("default capability is valid JSON");
+    let windows = capability["windows"]
+        .as_array()
+        .expect("default capability declares trusted windows");
+
+    for pattern in ["huddle-*", "agent-activity-*"] {
+        assert!(
+            windows
+                .iter()
+                .any(|window| window.as_str() == Some(pattern)),
+            "default capability must include trusted companion pattern {pattern}"
+        );
+    }
+}
 
 fn csp_directives() -> HashMap<String, Vec<String>> {
     let conf: serde_json::Value =

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -399,6 +399,7 @@ function CommunityApp({
     communityKey,
     sharedIdentity,
     isFindingCommunityAfterLeave,
+    currentCompanionWindowKind() === null,
   );
 
   const transitionCommunity = useCallback(

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -23,7 +23,10 @@ import { CommunityThemeController } from "@/shared/theme/CommunityThemeControlle
 import { useReloadShortcut } from "@/app/useReloadShortcut";
 import { useCloseWindowShortcut } from "@/app/useCloseWindowShortcut";
 import { KnownAgentPubkeysProvider } from "@/features/agents/useKnownAgentPubkeys";
-import { huddleWindowChannelId } from "@/features/huddle/lib/huddleWindow";
+import {
+  acceptsNativeDeepLinks,
+  currentCompanionWindowKind,
+} from "@/app/companionWindow";
 import { useAppOnboardingState } from "@/features/onboarding/hooks";
 import { useMachineOnboardingState } from "@/features/onboarding/machineOnboarding";
 import {
@@ -712,10 +715,12 @@ function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
     [activeCommunity, communityOnboarding.start],
   );
 
-  // Community links are app-global work. A Huddle companion loads the same
+  // Community links are app-global work. Companion windows load the same
   // React tree, but must never race the main window for the native pending-link
-  // queue or replace its dedicated transcript surface with onboarding.
-  const acceptsCommunityDeepLinks = huddleWindowChannelId() === null;
+  // queue or replace their dedicated surface with onboarding.
+  const acceptsCommunityDeepLinks = acceptsNativeDeepLinks(
+    currentCompanionWindowKind(),
+  );
   useEffect(() => {
     if (!acceptsCommunityDeepLinks) return;
 

--- a/desktop/src/app/AppHuddleShell.tsx
+++ b/desktop/src/app/AppHuddleShell.tsx
@@ -12,6 +12,7 @@ type AppHuddleShellProps = {
   isCompanionOpen: boolean;
   isDrawerOpen: boolean;
   isRoom: boolean;
+  isPassiveWindow?: boolean;
   onCompanionOpen: () => void;
   onHuddleStartPendingChange: (pending: boolean) => void;
   onHuddleStarted: (ephemeralChannelId: string) => void | Promise<void>;
@@ -48,6 +49,7 @@ export function AppHuddleShell({
   isCompanionOpen,
   isDrawerOpen,
   isRoom,
+  isPassiveWindow = false,
   onCompanionOpen,
   onHuddleStartPendingChange,
   onHuddleStarted,
@@ -57,7 +59,7 @@ export function AppHuddleShell({
 }: AppHuddleShellProps) {
   return (
     <HuddleProvider
-      ownsAudioSession={!isRoom}
+      ownsAudioSession={!isRoom && !isPassiveWindow}
       onHuddleStartPendingChange={
         isRoom ? undefined : onHuddleStartPendingChange
       }
@@ -91,7 +93,7 @@ export function AppHuddleShell({
               <BuzzTheme.GradientLayer />
               {children}
             </div>
-            {isRoom || !isCompanionOpen ? (
+            {!isPassiveWindow && (isRoom || !isCompanionOpen) ? (
               <div className="buzz-huddle-drawer-slot absolute inset-x-0 bottom-0 z-[2] h-(--buzz-huddle-drawer-height)">
                 <AppHuddleBar
                   mode={isRoom ? "room" : "main"}

--- a/desktop/src/app/AppShell.helpers.test.mjs
+++ b/desktop/src/app/AppShell.helpers.test.mjs
@@ -3,10 +3,33 @@ import test from "node:test";
 
 import {
   markAllReadSources,
+  mainOwnedEffects,
   activateDesktopNotificationTarget,
   createDesktopNotificationActivationQueue,
   shouldBounceForChannelNotification,
 } from "./AppShell.helpers.ts";
+
+const MAIN_OWNED_EFFECTS_ENABLED = {
+  agentRuntimeReconciliation: true,
+  autoRestart: true,
+  membershipNotifications: true,
+  presenceSession: true,
+  reminderNotifications: true,
+  markAsReadShortcuts: true,
+};
+
+test("primary window owns singleton and mutating app effects", () => {
+  assert.deepEqual(mainOwnedEffects(false), MAIN_OWNED_EFFECTS_ENABLED);
+});
+
+test("companion windows disable singleton and mutating app effects", () => {
+  assert.deepEqual(
+    mainOwnedEffects(true),
+    Object.fromEntries(
+      Object.keys(MAIN_OWNED_EFFECTS_ENABLED).map((effect) => [effect, false]),
+    ),
+  );
+});
 
 test("shouldBounceForChannelNotification_allowsTopLevelChannelMessages", () => {
   assert.equal(shouldBounceForChannelNotification([["h", "channel"]]), true);

--- a/desktop/src/app/AppShell.helpers.ts
+++ b/desktop/src/app/AppShell.helpers.ts
@@ -2,6 +2,27 @@ import { isThreadReply } from "@/features/messages/lib/threading";
 import type { DesktopNotificationTarget } from "@/features/notifications/lib/desktop";
 import type { SearchHit } from "@/shared/api/types";
 
+export type MainOwnedEffects = {
+  agentRuntimeReconciliation: boolean;
+  autoRestart: boolean;
+  membershipNotifications: boolean;
+  presenceSession: boolean;
+  reminderNotifications: boolean;
+  markAsReadShortcuts: boolean;
+};
+
+export function mainOwnedEffects(isCompanionWindow: boolean): MainOwnedEffects {
+  const enabled = !isCompanionWindow;
+  return {
+    agentRuntimeReconciliation: enabled,
+    autoRestart: enabled,
+    membershipNotifications: enabled,
+    presenceSession: enabled,
+    reminderNotifications: enabled,
+    markAsReadShortcuts: enabled,
+  };
+}
+
 export type AppView =
   | "home"
   | "channel"

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -44,7 +44,7 @@ import {
 } from "@/features/notifications/hooks";
 import { PreventSleepProvider } from "@/features/agents/usePreventSleep";
 import { requestOpenCreateAgent } from "@/features/agents/openCreateAgentEvent";
-import { isAgentActivityWindow } from "@/features/agents/lib/agentActivityWindow";
+import { currentCompanionWindowKind } from "@/app/companionWindow";
 import { useAgentsDataRefresh } from "@/features/agents/lib/useAgentsDataRefresh";
 import { useManagedAgentRuntimeReconciliation } from "@/features/agents/useManagedAgentRuntimeReconciliation";
 import { useAutoRestartPolicy } from "@/features/agents/lib/useAutoRestartPolicy";
@@ -126,8 +126,9 @@ export function AppShell() {
     showHuddleInMainApp,
     viewHuddleChannel,
   } = useHuddlePresentation();
-  const isActivityWindow = isAgentActivityWindow();
-  const isCompanionWindow = isHuddleRoom || isActivityWindow;
+  const companionWindowKind = currentCompanionWindowKind();
+  const isActivityWindow = companionWindowKind === "agent-activity";
+  const isCompanionWindow = companionWindowKind !== null;
   const hasCommunityRail =
     communitiesHook.communities.length > 1 && !isCompanionWindow;
   const addCommunityDialog = useAddCommunityDialogState();
@@ -354,7 +355,7 @@ export function AppShell() {
     handleThreadReplyDesktopNotification,
   } = useAppShellDesktopNotifications({
     channels,
-    enabled: !isHuddleRoom,
+    enabled: !isCompanionWindow,
     goChannel,
     goHome,
     notificationSettings: notificationSettings.settings,
@@ -391,8 +392,8 @@ export function AppShell() {
     muteThread,
     unmuteThread,
   } = useUnreadChannels(
-    isHuddleRoom ? EMPTY_CHANNELS : sidebarChannels,
-    isHuddleRoom ? null : activeChannel,
+    isCompanionWindow ? EMPTY_CHANNELS : sidebarChannels,
+    isCompanionWindow ? null : activeChannel,
     {
       pubkey: identityQuery.data?.pubkey,
       relayClient,
@@ -454,7 +455,7 @@ export function AppShell() {
       identityQuery.data?.pubkey,
       notificationSettings.settings,
       notificationSettings.setDesktopEnabled,
-      !isHuddleRoom,
+      !isCompanionWindow,
       selectedView === "home" && !settingsOpen,
       getChannelReadAt,
       readStateVersion,
@@ -658,13 +659,13 @@ export function AppShell() {
     [openSearchHit],
   );
   useAppShellLifecycleEffects({
-    desktopBadgeEnabled: !isHuddleRoom,
+    desktopBadgeEnabled: !isCompanionWindow,
     homeBadgeCountExcludingHighPriority,
     topLevelUnreadChannelIds,
     unreadChannelNotificationCount,
   });
-  // Dispatch `buzz://` deep links only from the main window; the companion is dedicated to its active Huddle route.
-  useAppDeepLinks(!isHuddleRoom);
+  // Dispatch `buzz://` deep links only from the primary window; companions own their focused route.
+  useAppDeepLinks(!isCompanionWindow);
   const handleOpenCreateChannel = React.useCallback(
     () => setIsCreateChannelOpen(true),
     [],
@@ -673,7 +674,7 @@ export function AppShell() {
     activeChannelId: selectedView === "channel" ? selectedChannelId : null,
     canSearchCurrentChannel:
       selectedView === "channel" && Boolean(activeChannel),
-    disabled: settingsOpen || isHuddleRoom,
+    disabled: settingsOpen || isCompanionWindow,
     onBrowseChannels: handleOpenBrowseChannels,
     onCreateChannel: handleOpenCreateChannel,
     onGoHome: goHome,
@@ -684,7 +685,7 @@ export function AppShell() {
   useSettingsShortcuts({
     onClose: handleCloseSettings,
     onOpenSettings: handleOpenSettings,
-    open: isHuddleRoom ? undefined : settingsOpen,
+    open: isCompanionWindow ? undefined : settingsOpen,
   });
   useMarkAsReadShortcuts({
     activeChannelId: activeChannel?.id ?? null,

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/features/notifications/hooks";
 import { PreventSleepProvider } from "@/features/agents/usePreventSleep";
 import { requestOpenCreateAgent } from "@/features/agents/openCreateAgentEvent";
+import { isAgentActivityWindow } from "@/features/agents/lib/agentActivityWindow";
 import { useAgentsDataRefresh } from "@/features/agents/lib/useAgentsDataRefresh";
 import { useManagedAgentRuntimeReconciliation } from "@/features/agents/useManagedAgentRuntimeReconciliation";
 import { useAutoRestartPolicy } from "@/features/agents/lib/useAutoRestartPolicy";
@@ -125,7 +126,10 @@ export function AppShell() {
     showHuddleInMainApp,
     viewHuddleChannel,
   } = useHuddlePresentation();
-  const hasCommunityRail = communitiesHook.communities.length > 1;
+  const isActivityWindow = isAgentActivityWindow();
+  const isCompanionWindow = isHuddleRoom || isActivityWindow;
+  const hasCommunityRail =
+    communitiesHook.communities.length > 1 && !isCompanionWindow;
   const addCommunityDialog = useAddCommunityDialogState();
   const [isChannelManagementOpen, setIsChannelManagementOpen] =
     React.useState(false);
@@ -691,7 +695,7 @@ export function AppShell() {
   });
   return (
     <PreventSleepProvider>
-      {!isHuddleRoom ? (
+      {!isCompanionWindow ? (
         <AppShellTrayMenu
           channels={channels}
           goChannel={goChannel}
@@ -743,6 +747,7 @@ export function AppShell() {
             isCompanionOpen={isHuddleCompanionOpen}
             isDrawerOpen={isHuddleDrawerOpen}
             isRoom={isHuddleRoom}
+            isPassiveWindow={isActivityWindow}
             onCompanionOpen={handleHuddleCompanionOpen}
             onHuddleStartPendingChange={handleHuddleStartPendingChange}
             onHuddleStarted={handleHuddleStarted}
@@ -750,7 +755,7 @@ export function AppShell() {
             onViewHuddleChannel={viewHuddleChannel}
             onVisibilityChange={handleHuddleVisibilityChange}
           >
-            {hasCommunityRail && !isHuddleRoom ? (
+            {hasCommunityRail ? (
               <CommunityRail
                 activeCommunityId={communitiesHook.activeCommunity?.id ?? null}
                 onAddCommunity={addCommunityDialog.openDialog}
@@ -766,7 +771,7 @@ export function AppShell() {
             >
               <AppProfilePanelProvider>
                 <AppWorkflowEditorOverlayProvider>
-                  {!settingsOpen && !isHuddleRoom ? (
+                  {!settingsOpen && !isCompanionWindow ? (
                     <AppTopChrome
                       canGoBack={canGoBack}
                       canGoForward={canGoForward}
@@ -817,7 +822,7 @@ export function AppShell() {
                     </div>
                   ) : (
                     <div className="relative flex min-h-0 flex-1 overflow-visible">
-                      {!isHuddleRoom ? (
+                      {!isCompanionWindow ? (
                         <AppSidebar
                           activeCommunity={communitiesHook.activeCommunity}
                           channels={sidebarChannels}
@@ -935,7 +940,7 @@ export function AppShell() {
                           <Outlet />
                         </AppShellChannelSurface>
                       </TerminalContextOverrideProvider>
-                      {!isHuddleRoom ? (
+                      {!isCompanionWindow ? (
                         <RelayConnectionOverlay
                           card={relayConnectionCard}
                           errorMessage={channelsErrorMessage}

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -684,10 +684,9 @@ export function AppShell() {
     open: isCompanionWindow ? undefined : settingsOpen,
   });
   useMarkAsReadShortcuts({
-    activeChannelId: ownedEffects.markAsReadShortcuts
-      ? (activeChannel?.id ?? null)
-      : null,
+    activeChannelId: activeChannel?.id ?? null,
     activeChannelLastMessageAt: activeChannel?.lastMessageAt,
+    enabled: ownedEffects.markAsReadShortcuts,
     markAllChannelsRead,
     markChannelRead,
     selectedView,

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -1,7 +1,11 @@
 import * as React from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Outlet, useLocation } from "@tanstack/react-router";
-import { deriveShellRoute, markAllReadSources } from "@/app/AppShell.helpers";
+import {
+  deriveShellRoute,
+  mainOwnedEffects,
+  markAllReadSources,
+} from "@/app/AppShell.helpers";
 import { useTerminalContext } from "@/app/useTerminalContext";
 import { AppShellProvider } from "@/app/AppShellContext";
 import { AppShellOverlays, TerminalBootstrap } from "@/app/AppShellOverlays";
@@ -129,6 +133,7 @@ export function AppShell() {
   const companionWindowKind = currentCompanionWindowKind();
   const isActivityWindow = companionWindowKind === "agent-activity";
   const isCompanionWindow = companionWindowKind !== null;
+  const ownedEffects = mainOwnedEffects(isCompanionWindow);
   const hasCommunityRail =
     communitiesHook.communities.length > 1 && !isCompanionWindow;
   const addCommunityDialog = useAddCommunityDialogState();
@@ -145,7 +150,10 @@ export function AppShell() {
   const mainInsetRef = React.useRef<HTMLElement>(null);
   const location = useLocation();
   const queryClient = useQueryClient();
-  useManagedAgentRuntimeReconciliation(communitiesHook.communities); // sync storage snapshot
+  useManagedAgentRuntimeReconciliation(
+    communitiesHook.communities,
+    ownedEffects.agentRuntimeReconciliation,
+  );
   const {
     goAgents,
     goChannel,
@@ -197,30 +205,13 @@ export function AppShell() {
     communitiesHook.activeCommunity?.relayUrl,
   );
   useAgentsDataRefresh();
-  // Chunk F: auto-restart drifted idle agents (per-agent opt-out, default ON).
-  useAutoRestartPolicy();
-  // Owner-global observer ingestion: receives + decrypts agent observer
-  // frames and keeps derived active-turn liveness in sync app-wide, so no
-  // individual screen/panel has to mount its own bridge for ingestion.
-  // Intentionally mounted without a `startupReady`/identity guard: before
-  // `currentPubkey` resolves the hook ingests managed agents only, and
-  // relay-owned agents join automatically once identity arrives. Adding a
-  // guard here would drop managed-agent coverage during startup.
+  useAutoRestartPolicy(ownedEffects.autoRestart);
   useAgentObserverIngestion();
-  // Kind 24200 is relay-ephemeral, so reconciliation runs eagerly (not
-  // deferred): seeds kind 24200 for fresh identities, no-ops for explicit
-  // opt-outs. Frames before the listener opens are permanently lost.
   const observerReconciled = useObserverArchiveReconciliation(
     identityQuery.data?.pubkey,
   );
-  // useArchiveSync must wait for reconciliation, or listeners could open
-  // before kind 24200 is guaranteed present in the subscription.
   useArchiveSync(observerReconciled);
-  // The archive batch now persists in Rust, so the agent-metrics invalidation
-  // signal arrives as a Tauri event rather than an in-process call.
   useArchiveAgentMetricsBridge();
-  // Kind 44200 is relay-persisted (durable) and stays deferred: missed
-  // startup frames can be replayed, so there's no ordering constraint.
   const deferredPubkey = startupReady ? identityQuery.data?.pubkey : undefined;
   useAgentMetricArchiveSeed(deferredPubkey);
   const profileQuery = useProfileQuery();
@@ -228,8 +219,13 @@ export function AppShell() {
   usePresenceSubscription();
   useUserStatusSubscription();
   useCommunityEmojiLiveUpdates();
-  useMembershipNotifications(identityQuery.data?.pubkey);
-  const presenceSession = usePresenceSession(deferredPubkey);
+  const mainOwnedPubkey = ownedEffects.membershipNotifications
+    ? identityQuery.data?.pubkey
+    : undefined;
+  useMembershipNotifications(mainOwnedPubkey);
+  const presenceSession = usePresenceSession(
+    startupReady && ownedEffects.presenceSession ? mainOwnedPubkey : undefined,
+  );
   const selfStatusQuery = useUserStatusQuery(
     deferredPubkey ? [deferredPubkey] : [],
   );
@@ -240,7 +236,7 @@ export function AppShell() {
   const channelsQuery = useChannelsQuery();
   const channels = channelsQuery.data ?? [];
   useReminderNotifications(
-    identityQuery.data?.pubkey,
+    ownedEffects.reminderNotifications ? mainOwnedPubkey : undefined,
     notificationSettings.settings,
     channels,
   );
@@ -688,7 +684,9 @@ export function AppShell() {
     open: isCompanionWindow ? undefined : settingsOpen,
   });
   useMarkAsReadShortcuts({
-    activeChannelId: activeChannel?.id ?? null,
+    activeChannelId: ownedEffects.markAsReadShortcuts
+      ? (activeChannel?.id ?? null)
+      : null,
     activeChannelLastMessageAt: activeChannel?.lastMessageAt,
     markAllChannelsRead,
     markChannelRead,

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -932,6 +932,7 @@ export function AppShell() {
                           hasCommunityRail={hasCommunityRail}
                           isHuddleRoom={isHuddleRoom}
                           isHuddleRoomStarting={isHuddleRoomStarting}
+                          unframed={isCompanionWindow}
                           mainInsetRef={mainInsetRef}
                           terminal={
                             <TerminalBootstrap {...effectiveTerminalContext} />

--- a/desktop/src/app/AppShellChannelSurface.tsx
+++ b/desktop/src/app/AppShellChannelSurface.tsx
@@ -11,6 +11,7 @@ type AppShellChannelSurfaceProps = {
   hasCommunityRail: boolean;
   isHuddleRoom: boolean;
   isHuddleRoomStarting: boolean;
+  unframed?: boolean;
   mainInsetRef: React.RefObject<HTMLElement | null>;
   terminal?: React.ReactNode;
 };
@@ -20,12 +21,13 @@ export function AppShellChannelSurface({
   hasCommunityRail,
   isHuddleRoom,
   isHuddleRoomStarting,
+  unframed = false,
   mainInsetRef,
   terminal,
 }: AppShellChannelSurfaceProps) {
   const { isMobile, openMobile, state: sidebarState } = useSidebar();
   const hasCollapsedSidebarGutter =
-    !isHuddleRoom &&
+    !unframed &&
     !hasCommunityRail &&
     (isMobile ? !openMobile : sidebarState === "collapsed");
 
@@ -35,11 +37,11 @@ export function AppShellChannelSurface({
         ref={mainInsetRef}
         className={cn(
           "isolate z-0 min-h-0 min-w-0 overflow-hidden",
-          isHuddleRoom ? "bg-background" : "bg-sidebar",
+          unframed ? "bg-background" : "bg-sidebar",
           hasCollapsedSidebarGutter && "pl-2",
         )}
-        data-buzz-content-surface={isHuddleRoom ? true : undefined}
-        data-buzz-content-unframed={isHuddleRoom ? true : undefined}
+        data-buzz-content-surface={unframed ? true : undefined}
+        data-buzz-content-unframed={unframed ? true : undefined}
         data-buzz-glass-inset
         data-buzz-shadow-viewport
         style={chromeCssVarDefaults as React.CSSProperties}
@@ -51,7 +53,7 @@ export function AppShellChannelSurface({
           />
         ) : null}
         {isHuddleRoom && !isHuddleRoomStarting ? <HuddleRoomHeader /> : null}
-        <BuzzTheme.ContentSurface terminal={terminal} unframed={isHuddleRoom}>
+        <BuzzTheme.ContentSurface terminal={terminal} unframed={unframed}>
           {isHuddleRoomStarting ? <HuddleStartingView /> : children}
         </BuzzTheme.ContentSurface>
       </SidebarInset>

--- a/desktop/src/app/BuzzThemeSurfaces.tsx
+++ b/desktop/src/app/BuzzThemeSurfaces.tsx
@@ -27,7 +27,7 @@ export function ContentSurface({
 }: {
   children: ReactNode;
   terminal?: ReactNode;
-  /** Used by dedicated huddle windows, which should not resemble app cards. */
+  /** Used by dedicated companion windows, which should not resemble app cards. */
   unframed?: boolean;
 }) {
   return (

--- a/desktop/src/app/companionWindow.test.mjs
+++ b/desktop/src/app/companionWindow.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   acceptsNativeDeepLinks,
+  companionCommunityBootstrap,
   companionCommunityIdForHash,
   companionWindowKindForLabel,
 } from "./companionWindow.ts";
@@ -27,6 +28,35 @@ describe("acceptsNativeDeepLinks", () => {
     assert.equal(acceptsNativeDeepLinks(null), true);
     assert.equal(acceptsNativeDeepLinks("huddle"), false);
     assert.equal(acceptsNativeDeepLinks("agent-activity"), false);
+  });
+});
+
+describe("companionCommunityBootstrap", () => {
+  it("lets huddle companions boot through normal community selection", () => {
+    assert.deepEqual(companionCommunityBootstrap("huddle", ""), {
+      initialActiveCommunityId: undefined,
+      missingRequiredCommunity: false,
+    });
+  });
+
+  it("rejects agent activity companions without community context", () => {
+    assert.deepEqual(companionCommunityBootstrap("agent-activity", ""), {
+      initialActiveCommunityId: undefined,
+      missingRequiredCommunity: true,
+    });
+  });
+
+  it("pins agent activity companions to their encoded community", () => {
+    assert.deepEqual(
+      companionCommunityBootstrap(
+        "agent-activity",
+        "#/channels/channel?community=community-one",
+      ),
+      {
+        initialActiveCommunityId: "community-one",
+        missingRequiredCommunity: false,
+      },
+    );
   });
 });
 

--- a/desktop/src/app/companionWindow.test.mjs
+++ b/desktop/src/app/companionWindow.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   acceptsNativeDeepLinks,
+  agentActivityCompanionCoordinates,
   companionCommunityBootstrap,
   companionCommunityIdForHash,
   companionWindowKindForLabel,
@@ -20,6 +21,35 @@ describe("companionWindowKindForLabel", () => {
   it("leaves primary and unrelated windows unclassified", () => {
     assert.equal(companionWindowKindForLabel("main"), null);
     assert.equal(companionWindowKindForLabel("reader-document"), null);
+  });
+});
+
+describe("agentActivityCompanionCoordinates", () => {
+  const coordinates = {
+    community: "community-one",
+    agentSession: "agent-one",
+    agentSessionChannel: "channel-one",
+  };
+
+  it("returns every immutable activity companion coordinate", () => {
+    assert.deepEqual(
+      agentActivityCompanionCoordinates("agent-activity", coordinates),
+      coordinates,
+    );
+  });
+
+  it("rejects non-activity windows and incomplete coordinates", () => {
+    assert.equal(
+      agentActivityCompanionCoordinates("huddle", coordinates),
+      undefined,
+    );
+    assert.equal(
+      agentActivityCompanionCoordinates("agent-activity", {
+        community: coordinates.community,
+        agentSession: coordinates.agentSession,
+      }),
+      undefined,
+    );
   });
 });
 

--- a/desktop/src/app/companionWindow.test.mjs
+++ b/desktop/src/app/companionWindow.test.mjs
@@ -7,6 +7,7 @@ import {
   companionCommunityBootstrap,
   companionCommunityIdForHash,
   companionWindowKindForLabel,
+  pinAgentActivityCompanionSearch,
 } from "./companionWindow.ts";
 
 describe("companionWindowKindForLabel", () => {
@@ -49,6 +50,37 @@ describe("agentActivityCompanionCoordinates", () => {
         agentSession: coordinates.agentSession,
       }),
       undefined,
+    );
+  });
+});
+
+describe("pinAgentActivityCompanionSearch", () => {
+  const coordinates = {
+    community: "community-one",
+    agentSession: "agent-one",
+    agentSessionChannel: "channel-one",
+  };
+
+  it("preserves coordinates while stripping panel-swapping state", () => {
+    assert.deepEqual(
+      pinAgentActivityCompanionSearch("agent-activity", coordinates, {
+        community: "community-two",
+        agentSession: "agent-two",
+        agentSessionChannel: "channel-two",
+        messageId: "message-one",
+        profile: "profile-one",
+        thread: "thread-one",
+        unrelated: "kept",
+      }),
+      { ...coordinates, unrelated: "kept" },
+    );
+  });
+
+  it("leaves ordinary windows unchanged", () => {
+    const nextSearch = { messageId: "message-one" };
+    assert.equal(
+      pinAgentActivityCompanionSearch(null, coordinates, nextSearch),
+      nextSearch,
     );
   });
 });

--- a/desktop/src/app/companionWindow.test.mjs
+++ b/desktop/src/app/companionWindow.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   acceptsNativeDeepLinks,
+  companionCommunityIdForHash,
   companionWindowKindForLabel,
 } from "./companionWindow.ts";
 
@@ -26,5 +27,20 @@ describe("acceptsNativeDeepLinks", () => {
     assert.equal(acceptsNativeDeepLinks(null), true);
     assert.equal(acceptsNativeDeepLinks("huddle"), false);
     assert.equal(acceptsNativeDeepLinks("agent-activity"), false);
+  });
+});
+
+describe("companionCommunityIdForHash", () => {
+  it("reads and decodes immutable community identity from the route", () => {
+    assert.equal(
+      companionCommunityIdForHash(
+        "#/channels/channel?community=community+%26+one&agentSession=agent",
+      ),
+      "community & one",
+    );
+  });
+
+  it("returns null when the bootstrap contract is absent", () => {
+    assert.equal(companionCommunityIdForHash("#/channels/channel"), null);
   });
 });

--- a/desktop/src/app/companionWindow.test.mjs
+++ b/desktop/src/app/companionWindow.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { companionWindowKindForLabel } from "./companionWindow.ts";
+import {
+  acceptsNativeDeepLinks,
+  companionWindowKindForLabel,
+} from "./companionWindow.ts";
 
 describe("companionWindowKindForLabel", () => {
   it("classifies focused companion labels", () => {
@@ -15,5 +18,13 @@ describe("companionWindowKindForLabel", () => {
   it("leaves primary and unrelated windows unclassified", () => {
     assert.equal(companionWindowKindForLabel("main"), null);
     assert.equal(companionWindowKindForLabel("reader-document"), null);
+  });
+});
+
+describe("acceptsNativeDeepLinks", () => {
+  it("reserves the pending-link queue for the main realm", () => {
+    assert.equal(acceptsNativeDeepLinks(null), true);
+    assert.equal(acceptsNativeDeepLinks("huddle"), false);
+    assert.equal(acceptsNativeDeepLinks("agent-activity"), false);
   });
 });

--- a/desktop/src/app/companionWindow.test.mjs
+++ b/desktop/src/app/companionWindow.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { companionWindowKindForLabel } from "./companionWindow.ts";
+
+describe("companionWindowKindForLabel", () => {
+  it("classifies focused companion labels", () => {
+    assert.equal(
+      companionWindowKindForLabel("agent-activity-deadbeef-channel"),
+      "agent-activity",
+    );
+    assert.equal(companionWindowKindForLabel("huddle-channel-id"), "huddle");
+  });
+
+  it("leaves primary and unrelated windows unclassified", () => {
+    assert.equal(companionWindowKindForLabel("main"), null);
+    assert.equal(companionWindowKindForLabel("reader-document"), null);
+  });
+});

--- a/desktop/src/app/companionWindow.ts
+++ b/desktop/src/app/companionWindow.ts
@@ -24,6 +24,42 @@ export function currentCompanionWindowKind(): CompanionWindowKind | null {
   }
 }
 
+export type AgentActivityCompanionCoordinates = {
+  community: string;
+  agentSession: string;
+  agentSessionChannel: string;
+};
+
+export function agentActivityCompanionCoordinates(
+  companionKind: CompanionWindowKind | null,
+  search: Record<string, unknown>,
+): AgentActivityCompanionCoordinates | undefined {
+  if (
+    companionKind !== "agent-activity" ||
+    typeof search.community !== "string" ||
+    typeof search.agentSession !== "string" ||
+    typeof search.agentSessionChannel !== "string"
+  ) {
+    return undefined;
+  }
+
+  return {
+    community: search.community,
+    agentSession: search.agentSession,
+    agentSessionChannel: search.agentSessionChannel,
+  };
+}
+
+/** Return the immutable route coordinates owned by this activity companion. */
+export function currentAgentActivityCompanionCoordinates(
+  search: Record<string, unknown>,
+): AgentActivityCompanionCoordinates | undefined {
+  return agentActivityCompanionCoordinates(
+    currentCompanionWindowKind(),
+    search,
+  );
+}
+
 /** Community encoded into a companion bootstrap hash. */
 export function companionCommunityIdForHash(hash: string): string | null {
   const query = hash.indexOf("?");

--- a/desktop/src/app/companionWindow.ts
+++ b/desktop/src/app/companionWindow.ts
@@ -60,6 +60,49 @@ export function currentAgentActivityCompanionCoordinates(
   );
 }
 
+/** Search keys that replace the dedicated feed with another channel panel. */
+const AGENT_ACTIVITY_COMPANION_PANEL_KEYS = [
+  "autoSend",
+  "channelManagement",
+  "messageId",
+  "profile",
+  "profileTab",
+  "profileView",
+  "thread",
+  "threadRootId",
+] as const;
+
+/** Keep a dedicated feed on its immutable coordinates and activity panel. */
+export function pinAgentActivityCompanionSearch(
+  companionKind: CompanionWindowKind | null,
+  currentSearch: Record<string, unknown>,
+  nextSearch: Record<string, unknown>,
+): Record<string, unknown> {
+  const coordinates = agentActivityCompanionCoordinates(
+    companionKind,
+    currentSearch,
+  );
+  if (!coordinates) return nextSearch;
+
+  const pinnedSearch = { ...nextSearch };
+  for (const key of AGENT_ACTIVITY_COMPANION_PANEL_KEYS) {
+    delete pinnedSearch[key];
+  }
+  return { ...pinnedSearch, ...coordinates };
+}
+
+/** Apply the dedicated-feed search invariant for this native window. */
+export function pinCurrentAgentActivityCompanionSearch(
+  currentSearch: Record<string, unknown>,
+  nextSearch: Record<string, unknown>,
+): Record<string, unknown> {
+  return pinAgentActivityCompanionSearch(
+    currentCompanionWindowKind(),
+    currentSearch,
+    nextSearch,
+  );
+}
+
 /** Community encoded into a companion bootstrap hash. */
 export function companionCommunityIdForHash(hash: string): string | null {
   const query = hash.indexOf("?");

--- a/desktop/src/app/companionWindow.ts
+++ b/desktop/src/app/companionWindow.ts
@@ -24,6 +24,13 @@ export function currentCompanionWindowKind(): CompanionWindowKind | null {
   }
 }
 
+/** Whether this realm owns the native pending deep-link queue. */
+export function acceptsNativeDeepLinks(
+  companionKind: CompanionWindowKind | null,
+): boolean {
+  return companionKind === null;
+}
+
 /** Whether this webview is a focused companion rather than the primary app. */
 export function isCompanionWindow(): boolean {
   return currentCompanionWindowKind() !== null;

--- a/desktop/src/app/companionWindow.ts
+++ b/desktop/src/app/companionWindow.ts
@@ -24,6 +24,21 @@ export function currentCompanionWindowKind(): CompanionWindowKind | null {
   }
 }
 
+/** Community encoded into a companion bootstrap hash. */
+export function companionCommunityIdForHash(hash: string): string | null {
+  const query = hash.indexOf("?");
+  if (query === -1) return null;
+  return new URLSearchParams(hash.slice(query + 1)).get("community");
+}
+
+/** Immutable community selected by a native companion's bootstrap URL. */
+export function companionCommunityId(
+  hash: string = typeof window === "undefined" ? "" : window.location.hash,
+): string | null | undefined {
+  if (currentCompanionWindowKind() === null) return undefined;
+  return companionCommunityIdForHash(hash);
+}
+
 /** Whether this realm owns the native pending deep-link queue. */
 export function acceptsNativeDeepLinks(
   companionKind: CompanionWindowKind | null,

--- a/desktop/src/app/companionWindow.ts
+++ b/desktop/src/app/companionWindow.ts
@@ -1,0 +1,30 @@
+import { isTauri } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+export type CompanionWindowKind = "agent-activity" | "huddle";
+
+/** Classify native companion surfaces that reuse the main application shell. */
+export function companionWindowKindForLabel(
+  label: string,
+): CompanionWindowKind | null {
+  if (label.startsWith("agent-activity-")) return "agent-activity";
+  if (label.startsWith("huddle-")) return "huddle";
+  return null;
+}
+
+/** Return this webview's companion kind, or null for the primary app window. */
+export function currentCompanionWindowKind(): CompanionWindowKind | null {
+  if (!isTauri()) return null;
+
+  try {
+    return companionWindowKindForLabel(getCurrentWindow().label);
+  } catch {
+    // Browser previews can expose the Tauri IPC mock without window metadata.
+    return null;
+  }
+}
+
+/** Whether this webview is a focused companion rather than the primary app. */
+export function isCompanionWindow(): boolean {
+  return currentCompanionWindowKind() !== null;
+}

--- a/desktop/src/app/companionWindow.ts
+++ b/desktop/src/app/companionWindow.ts
@@ -31,12 +31,27 @@ export function companionCommunityIdForHash(hash: string): string | null {
   return new URLSearchParams(hash.slice(query + 1)).get("community");
 }
 
-/** Immutable community selected by a native companion's bootstrap URL. */
-export function companionCommunityId(
-  hash: string = typeof window === "undefined" ? "" : window.location.hash,
-): string | null | undefined {
-  if (currentCompanionWindowKind() === null) return undefined;
-  return companionCommunityIdForHash(hash);
+export type CompanionCommunityBootstrap = {
+  initialActiveCommunityId: string | undefined;
+  missingRequiredCommunity: boolean;
+};
+
+/** Agent activity windows pin their origin community; huddles use normal selection. */
+export function companionCommunityBootstrap(
+  companionKind: CompanionWindowKind | null,
+  hash: string,
+): CompanionCommunityBootstrap {
+  if (companionKind !== "agent-activity") {
+    return {
+      initialActiveCommunityId: undefined,
+      missingRequiredCommunity: false,
+    };
+  }
+  const communityId = companionCommunityIdForHash(hash);
+  return {
+    initialActiveCommunityId: communityId ?? undefined,
+    missingRequiredCommunity: communityId === null,
+  };
 }
 
 /** Whether this realm owns the native pending deep-link queue. */

--- a/desktop/src/app/navigation/useAppNavigation.ts
+++ b/desktop/src/app/navigation/useAppNavigation.ts
@@ -50,6 +50,16 @@ export function useAppNavigation() {
             search: { ...next.search, ...companionCoordinates },
           }
         : next;
+
+      if (
+        companionCoordinates &&
+        (destination.to !== "/channels/$channelId" ||
+          destination.params?.channelId !==
+            companionCoordinates.agentSessionChannel)
+      ) {
+        return false;
+      }
+
       const nextLocation = router.buildLocation(destination as never);
 
       if (location.href === nextLocation.href && !behavior.force) {

--- a/desktop/src/app/navigation/useAppNavigation.ts
+++ b/desktop/src/app/navigation/useAppNavigation.ts
@@ -25,10 +25,12 @@ export function useAppNavigation() {
   const companionCoordinates =
     currentCompanionWindowKind() === "agent-activity" &&
     typeof companionSearch.community === "string" &&
-    typeof companionSearch.agentSession === "string"
+    typeof companionSearch.agentSession === "string" &&
+    typeof companionSearch.agentSessionChannel === "string"
       ? {
           community: companionSearch.community,
           agentSession: companionSearch.agentSession,
+          agentSessionChannel: companionSearch.agentSessionChannel,
         }
       : undefined;
 

--- a/desktop/src/app/navigation/useAppNavigation.ts
+++ b/desktop/src/app/navigation/useAppNavigation.ts
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-router";
 
 import { openSearchHitWithNavigation } from "@/app/navigation/searchHitNavigation";
+import { currentCompanionWindowKind } from "@/app/companionWindow";
 import type { SearchHit } from "@/shared/api/types";
 
 type NavigationBehavior = {
@@ -20,6 +21,16 @@ export function useAppNavigation() {
   const navigate = useNavigate();
   const location = useLocation();
   const canGoBack = useCanGoBack();
+  const companionSearch = location.search as Record<string, unknown>;
+  const companionCoordinates =
+    currentCompanionWindowKind() === "agent-activity" &&
+    typeof companionSearch.community === "string" &&
+    typeof companionSearch.agentSession === "string"
+      ? {
+          community: companionSearch.community,
+          agentSession: companionSearch.agentSession,
+        }
+      : undefined;
 
   const commitNavigation = React.useCallback(
     async (
@@ -31,20 +42,26 @@ export function useAppNavigation() {
       },
       behavior: NavigationBehavior = {},
     ) => {
-      const nextLocation = router.buildLocation(next as never);
+      const destination = companionCoordinates
+        ? {
+            ...next,
+            search: { ...next.search, ...companionCoordinates },
+          }
+        : next;
+      const nextLocation = router.buildLocation(destination as never);
 
       if (location.href === nextLocation.href && !behavior.force) {
         return false;
       }
 
       await navigate({
-        ...next,
+        ...destination,
         replace: behavior.replace,
         resetScroll: behavior.resetScroll,
       } as never);
       return true;
     },
-    [location.href, navigate, router],
+    [companionCoordinates, location.href, navigate, router],
   );
 
   const goHome = React.useCallback(

--- a/desktop/src/app/navigation/useAppNavigation.ts
+++ b/desktop/src/app/navigation/useAppNavigation.ts
@@ -7,7 +7,10 @@ import {
 } from "@tanstack/react-router";
 
 import { openSearchHitWithNavigation } from "@/app/navigation/searchHitNavigation";
-import { currentAgentActivityCompanionCoordinates } from "@/app/companionWindow";
+import {
+  currentAgentActivityCompanionCoordinates,
+  pinCurrentAgentActivityCompanionSearch,
+} from "@/app/companionWindow";
 import type { SearchHit } from "@/shared/api/types";
 
 type NavigationBehavior = {
@@ -38,7 +41,10 @@ export function useAppNavigation() {
       const destination = companionCoordinates
         ? {
             ...next,
-            search: { ...next.search, ...companionCoordinates },
+            search: pinCurrentAgentActivityCompanionSearch(
+              location.search as Record<string, unknown>,
+              next.search ?? {},
+            ),
           }
         : next;
 
@@ -64,7 +70,7 @@ export function useAppNavigation() {
       } as never);
       return true;
     },
-    [companionCoordinates, location.href, navigate, router],
+    [companionCoordinates, location.href, location.search, navigate, router],
   );
 
   const goHome = React.useCallback(

--- a/desktop/src/app/navigation/useAppNavigation.ts
+++ b/desktop/src/app/navigation/useAppNavigation.ts
@@ -7,7 +7,7 @@ import {
 } from "@tanstack/react-router";
 
 import { openSearchHitWithNavigation } from "@/app/navigation/searchHitNavigation";
-import { currentCompanionWindowKind } from "@/app/companionWindow";
+import { currentAgentActivityCompanionCoordinates } from "@/app/companionWindow";
 import type { SearchHit } from "@/shared/api/types";
 
 type NavigationBehavior = {
@@ -21,18 +21,9 @@ export function useAppNavigation() {
   const navigate = useNavigate();
   const location = useLocation();
   const canGoBack = useCanGoBack();
-  const companionSearch = location.search as Record<string, unknown>;
-  const companionCoordinates =
-    currentCompanionWindowKind() === "agent-activity" &&
-    typeof companionSearch.community === "string" &&
-    typeof companionSearch.agentSession === "string" &&
-    typeof companionSearch.agentSessionChannel === "string"
-      ? {
-          community: companionSearch.community,
-          agentSession: companionSearch.agentSession,
-          agentSessionChannel: companionSearch.agentSessionChannel,
-        }
-      : undefined;
+  const companionCoordinates = currentAgentActivityCompanionCoordinates(
+    location.search as Record<string, unknown>,
+  );
 
   const commitNavigation = React.useCallback(
     async (

--- a/desktop/src/app/routes/channels.$channelId.tsx
+++ b/desktop/src/app/routes/channels.$channelId.tsx
@@ -13,6 +13,8 @@ import { ViewLoadingFallback } from "@/shared/ui/ViewLoadingFallback";
 
 type ChannelRouteSearch = {
   agentSession?: string;
+  /** Immutable origin community carried by dedicated activity windows. */
+  community?: string;
   /**
    * When set, the composer on mount will auto-submit its loaded draft once,
    * then clear this param. Value is the draft key that was loaded so the
@@ -36,6 +38,7 @@ function validateChannelSearch(
 ): ChannelRouteSearch {
   return {
     agentSession: nonEmptyString(search.agentSession),
+    community: nonEmptyString(search.community),
     autoSend: nonEmptyString(search.autoSend),
     messageId: nonEmptyString(search.messageId),
     profile: nonEmptyString(search.profile),

--- a/desktop/src/app/routes/channels.$channelId.tsx
+++ b/desktop/src/app/routes/channels.$channelId.tsx
@@ -13,6 +13,8 @@ import { ViewLoadingFallback } from "@/shared/ui/ViewLoadingFallback";
 
 type ChannelRouteSearch = {
   agentSession?: string;
+  /** Immutable channel scope carried by dedicated activity windows. */
+  agentSessionChannel?: string;
   /** Immutable origin community carried by dedicated activity windows. */
   community?: string;
   /**
@@ -38,6 +40,7 @@ function validateChannelSearch(
 ): ChannelRouteSearch {
   return {
     agentSession: nonEmptyString(search.agentSession),
+    agentSessionChannel: nonEmptyString(search.agentSessionChannel),
     community: nonEmptyString(search.community),
     autoSend: nonEmptyString(search.autoSend),
     messageId: nonEmptyString(search.messageId),

--- a/desktop/src/app/useMarkAsReadShortcuts.test.mjs
+++ b/desktop/src/app/useMarkAsReadShortcuts.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { after, afterEach, before, test } from "node:test";
+
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+before(() => {
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    KeyboardEvent: dom.window.KeyboardEvent,
+    window: dom.window,
+  });
+});
+
+afterEach(async () => {
+  const { cleanup } = await import("@testing-library/react");
+  cleanup();
+});
+
+after(() => dom.window.close());
+
+async function renderShortcuts(enabled) {
+  const { renderHook } = await import("@testing-library/react");
+  const { useMarkAsReadShortcuts } = await import(
+    "./useMarkAsReadShortcuts.ts"
+  );
+  const calls = [];
+  const view = renderHook(() =>
+    useMarkAsReadShortcuts({
+      activeChannelId: "general",
+      activeChannelLastMessageAt: "2026-08-24T00:00:00.000Z",
+      enabled,
+      markAllChannelsRead: () => calls.push("all"),
+      markChannelRead: () => calls.push("channel"),
+      selectedView: "channel",
+    }),
+  );
+  return { calls, view };
+}
+
+function pressEscape({ shiftKey = false } = {}) {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Escape",
+      shiftKey,
+    }),
+  );
+}
+
+test("disabled shortcuts ignore Escape and Shift+Escape", async () => {
+  const { calls } = await renderShortcuts(false);
+
+  pressEscape();
+  pressEscape({ shiftKey: true });
+
+  assert.deepEqual(calls, []);
+});
+
+test("enabled shortcuts preserve channel and all-channel actions", async () => {
+  const { calls } = await renderShortcuts(true);
+
+  pressEscape();
+  pressEscape({ shiftKey: true });
+
+  assert.deepEqual(calls, ["channel", "all"]);
+});

--- a/desktop/src/app/useMarkAsReadShortcuts.ts
+++ b/desktop/src/app/useMarkAsReadShortcuts.ts
@@ -9,6 +9,7 @@ export function useMarkAsReadShortcuts({
   markAllChannelsRead,
   markChannelRead,
   selectedView,
+  enabled = true,
 }: {
   activeChannelId: string | null;
   activeChannelLastMessageAt: string | null | undefined;
@@ -18,8 +19,11 @@ export function useMarkAsReadShortcuts({
     lastMessageAt: string | null | undefined,
   ) => void;
   selectedView: string;
+  enabled?: boolean;
 }) {
   React.useEffect(() => {
+    if (!enabled) return;
+
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key !== "Escape") return;
       if (event.defaultPrevented) return;
@@ -51,6 +55,7 @@ export function useMarkAsReadShortcuts({
   }, [
     activeChannelId,
     activeChannelLastMessageAt,
+    enabled,
     markAllChannelsRead,
     markChannelRead,
     selectedView,

--- a/desktop/src/features/agents/lib/agentActivityWindow.test.mjs
+++ b/desktop/src/features/agents/lib/agentActivityWindow.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { agentActivityWindowTitle } from "./agentActivityWindow.ts";
+
+describe("agentActivityWindowTitle", () => {
+  it("names both the agent and channel", () => {
+    assert.equal(
+      agentActivityWindowTitle("Mongo", "buzz-inline-chip-wrap"),
+      "Mongo · #buzz-inline-chip-wrap",
+    );
+  });
+
+  it("does not duplicate a supplied channel hash", () => {
+    assert.equal(
+      agentActivityWindowTitle(" Mongo ", " #design "),
+      "Mongo · #design",
+    );
+  });
+});

--- a/desktop/src/features/agents/lib/agentActivityWindow.ts
+++ b/desktop/src/features/agents/lib/agentActivityWindow.ts
@@ -15,3 +15,26 @@ export function isAgentActivityWindow(): boolean {
     return false;
   }
 }
+
+/** Build the concise native title for a channel-scoped activity window. */
+export function agentActivityWindowTitle(
+  agentName: string,
+  channelName: string,
+): string {
+  const normalizedAgentName = agentName.trim() || "Agent";
+  const normalizedChannelName = channelName.trim().replace(/^#+/, "");
+  return `${normalizedAgentName} · #${normalizedChannelName}`;
+}
+
+/** Keep a companion window's native title aligned with its resolved scope. */
+export async function setAgentActivityWindowTitle(
+  agentName: string,
+  channelName: string,
+): Promise<boolean> {
+  if (!isAgentActivityWindow() || !channelName.trim()) return false;
+
+  await getCurrentWindow().setTitle(
+    agentActivityWindowTitle(agentName, channelName),
+  );
+  return true;
+}

--- a/desktop/src/features/agents/lib/agentActivityWindow.ts
+++ b/desktop/src/features/agents/lib/agentActivityWindow.ts
@@ -1,19 +1,9 @@
-import { isTauri } from "@tauri-apps/api/core";
+import { currentCompanionWindowKind } from "@/app/companionWindow";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-
-const AGENT_ACTIVITY_WINDOW_LABEL_PREFIX = "agent-activity-";
 
 /** Whether this webview is dedicated to an agent activity feed. */
 export function isAgentActivityWindow(): boolean {
-  if (!isTauri()) return false;
-
-  try {
-    return getCurrentWindow().label.startsWith(
-      AGENT_ACTIVITY_WINDOW_LABEL_PREFIX,
-    );
-  } catch {
-    return false;
-  }
+  return currentCompanionWindowKind() === "agent-activity";
 }
 
 /** Build the concise native title for a channel-scoped activity window. */

--- a/desktop/src/features/agents/lib/agentActivityWindow.ts
+++ b/desktop/src/features/agents/lib/agentActivityWindow.ts
@@ -1,0 +1,17 @@
+import { isTauri } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+const AGENT_ACTIVITY_WINDOW_LABEL_PREFIX = "agent-activity-";
+
+/** Whether this webview is dedicated to an agent activity feed. */
+export function isAgentActivityWindow(): boolean {
+  if (!isTauri()) return false;
+
+  try {
+    return getCurrentWindow().label.startsWith(
+      AGENT_ACTIVITY_WINDOW_LABEL_PREFIX,
+    );
+  } catch {
+    return false;
+  }
+}

--- a/desktop/src/features/agents/lib/useAutoRestartPolicy.ts
+++ b/desktop/src/features/agents/lib/useAutoRestartPolicy.ts
@@ -35,7 +35,7 @@ const POLICY_TICK_MS = 15_000;
  * on the backend store lock, so a cross-window double-fire is benign (and
  * further shrunk by the pre-fire summary re-fetch).
  */
-export function useAutoRestartPolicy() {
+export function useAutoRestartPolicy(enabled = true) {
   const queryClient = useQueryClient();
   const agents: ManagedAgent[] | undefined = useManagedAgentsQuery().data;
   const edgesRef = React.useRef(new Map<string, AutoRestartEdgeState>());
@@ -46,17 +46,17 @@ export function useAutoRestartPolicy() {
   // Re-evaluate on an interval so the quiescence clock advances even when
   // summaries and observer stores are quiet.
   React.useEffect(() => {
-    if (!documentVisible) return;
+    if (!enabled || !documentVisible) return;
 
     setTick((t) => t + 1);
     const timer = setInterval(() => setTick((t) => t + 1), POLICY_TICK_MS);
     return () => clearInterval(timer);
-  }, [documentVisible]);
+  }, [documentVisible, enabled]);
 
   // No dependency array by design: the tick pattern re-runs this effect
   // every render so it reads live store state; all mutation is ref-local.
   React.useEffect(() => {
-    if (!agents) return;
+    if (!enabled || !agents) return;
     const now = Date.now();
     const edges = edgesRef.current;
 

--- a/desktop/src/features/agents/ui/AgentSessionToolItem/CompactMessageSummary.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem/CompactMessageSummary.tsx
@@ -164,6 +164,7 @@ export function CompactMessageSummary({
             {...bubbleLinkProps}
           >
             <Markdown
+              blockCode
               className={isCompactPreview ? "text-xs leading-4" : "leading-5"}
               content={resolvedContent || "Message content unavailable."}
               interactive={activityWindowMarkdownInteractive()}

--- a/desktop/src/features/agents/ui/AgentSessionToolItem/CompactMessageSummary.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem/CompactMessageSummary.tsx
@@ -55,7 +55,7 @@ export function CompactMessageSummary({
   const { openProfilePanel } = useProfilePanel();
   const isCompactPreview = variant === "compactPreview";
   const isDedicatedActivityWindow = isAgentActivityWindow();
-  const shouldClampBubble = !isCompactPreview;
+  const shouldClampBubble = !isCompactPreview && !isDedicatedActivityWindow;
   const effectiveMessageLink = isDedicatedActivityWindow ? null : messageLink;
   const [bubbleRef, hasBubbleOverflow] =
     useTranscriptBubbleOverflow(shouldClampBubble);

--- a/desktop/src/features/agents/ui/AgentSessionToolItem/CompactMessageSummary.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem/CompactMessageSummary.tsx
@@ -7,6 +7,8 @@ import { useProfilePanel } from "@/shared/context/ProfilePanelContext";
 import { Markdown } from "@/shared/ui/markdown";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import { useAgentSessionTranscriptVariant } from "../agentSessionTranscriptContext";
+import { activityWindowMarkdownInteractive } from "../activityRenderClasses/activityWindowPresentation";
+import { isAgentActivityWindow } from "../../lib/agentActivityWindow";
 import { MessageLinkHoverCue } from "../activityRenderClasses/MessageLinkHoverCue";
 import { TranscriptTimestamp } from "../activityRenderClasses/TranscriptTimestamp";
 import { useTranscriptBubbleOverflow } from "../activityRenderClasses/useTranscriptBubbleOverflow";
@@ -52,10 +54,12 @@ export function CompactMessageSummary({
   const { goChannel } = useAppNavigation();
   const { openProfilePanel } = useProfilePanel();
   const isCompactPreview = variant === "compactPreview";
+  const isDedicatedActivityWindow = isAgentActivityWindow();
   const shouldClampBubble = !isCompactPreview;
+  const effectiveMessageLink = isDedicatedActivityWindow ? null : messageLink;
   const [bubbleRef, hasBubbleOverflow] =
     useTranscriptBubbleOverflow(shouldClampBubble);
-  const canOpenMessage = shouldClampBubble && messageLink !== null;
+  const canOpenMessage = shouldClampBubble && effectiveMessageLink !== null;
   const mutedTone = compactSummaryTone();
   const avatarClassName = cn(
     "mr-2 mt-1 shrink-0",
@@ -63,19 +67,19 @@ export function CompactMessageSummary({
   );
   const handleBubbleClick = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      if (!messageLink || isNestedInteractiveTarget(event)) return;
+      if (!effectiveMessageLink || isNestedInteractiveTarget(event)) return;
       event.preventDefault();
       event.stopPropagation();
-      void goChannel(messageLink.channelId, {
-        messageId: messageLink.messageId,
+      void goChannel(effectiveMessageLink.channelId, {
+        messageId: effectiveMessageLink.messageId,
       });
     },
-    [goChannel, messageLink],
+    [effectiveMessageLink, goChannel],
   );
   const handleBubbleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       if (
-        !messageLink ||
+        !effectiveMessageLink ||
         isNestedInteractiveTarget(event) ||
         (event.key !== "Enter" && event.key !== " ")
       ) {
@@ -84,11 +88,11 @@ export function CompactMessageSummary({
 
       event.preventDefault();
       event.stopPropagation();
-      void goChannel(messageLink.channelId, {
-        messageId: messageLink.messageId,
+      void goChannel(effectiveMessageLink.channelId, {
+        messageId: effectiveMessageLink.messageId,
       });
     },
-    [goChannel, messageLink],
+    [effectiveMessageLink, goChannel],
   );
   const bubbleLinkProps = canOpenMessage
     ? {
@@ -101,7 +105,7 @@ export function CompactMessageSummary({
   return (
     <>
       <div className="flex max-w-full flex-row items-start justify-start">
-        {openProfilePanel && !isCompactPreview ? (
+        {openProfilePanel && !isCompactPreview && !isDedicatedActivityWindow ? (
           <button
             aria-label={`Open ${displayName} profile`}
             className={cn(
@@ -162,6 +166,7 @@ export function CompactMessageSummary({
             <Markdown
               className={isCompactPreview ? "text-xs leading-4" : "leading-5"}
               content={resolvedContent || "Message content unavailable."}
+              interactive={activityWindowMarkdownInteractive()}
             />
             {hasBubbleOverflow ? (
               <span
@@ -179,7 +184,7 @@ export function CompactMessageSummary({
           </div>
           <div className="inline-flex max-w-full items-center gap-1.5 px-1">
             <TranscriptTimestamp
-              messageLink={messageLink}
+              messageLink={effectiveMessageLink}
               timestamp={timestamp}
             />
             <button

--- a/desktop/src/features/agents/ui/activityRenderClasses/MessageActivity.tsx
+++ b/desktop/src/features/agents/ui/activityRenderClasses/MessageActivity.tsx
@@ -1,5 +1,6 @@
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { Markdown } from "@/shared/ui/markdown";
+import { activityWindowMarkdownInteractive } from "./activityWindowPresentation";
 import { useAgentSessionTranscriptVariant } from "../agentSessionTranscriptContext";
 import { formatTranscriptTimestampTitle } from "../agentSessionUtils";
 import type { TranscriptItem } from "../agentSessionTypes";
@@ -65,6 +66,7 @@ function MessageItem({
           <Markdown
             className={isCompactPreview ? "text-xs leading-4" : "leading-5"}
             content={text || " "}
+            interactive={activityWindowMarkdownInteractive()}
           />
         </div>
       </div>

--- a/desktop/src/features/agents/ui/activityRenderClasses/MessageActivity.tsx
+++ b/desktop/src/features/agents/ui/activityRenderClasses/MessageActivity.tsx
@@ -64,6 +64,7 @@ function MessageItem({
           title={formatTranscriptTimestampTitle(item.timestamp)}
         >
           <Markdown
+            blockCode
             className={isCompactPreview ? "text-xs leading-4" : "leading-5"}
             content={text || " "}
             interactive={activityWindowMarkdownInteractive()}

--- a/desktop/src/features/agents/ui/activityRenderClasses/PlanActivity.tsx
+++ b/desktop/src/features/agents/ui/activityRenderClasses/PlanActivity.tsx
@@ -1,4 +1,5 @@
 import { Markdown } from "@/shared/ui/markdown";
+import { activityWindowMarkdownInteractive } from "./activityWindowPresentation";
 import {
   ActivityRow,
   ActivityRowContent,
@@ -41,6 +42,7 @@ export function PlanActivity(props: ActivityRenderClassItemProps) {
         <Markdown
           className="leading-5"
           content={props.item.text.trim() || "No plan details."}
+          interactive={activityWindowMarkdownInteractive()}
         />
       </ActivityRowContent>
     </ActivityRow>

--- a/desktop/src/features/agents/ui/activityRenderClasses/PlanActivity.tsx
+++ b/desktop/src/features/agents/ui/activityRenderClasses/PlanActivity.tsx
@@ -40,6 +40,7 @@ export function PlanActivity(props: ActivityRenderClassItemProps) {
       <ActivityRowLabel object="plan" openToneScope="tool" verb="Updated" />
       <ActivityRowContent className="pt-1 pb-1.5 text-sm leading-5 text-muted-foreground">
         <Markdown
+          blockCode
           className="leading-5"
           content={props.item.text.trim() || "No plan details."}
           interactive={activityWindowMarkdownInteractive()}

--- a/desktop/src/features/agents/ui/activityRenderClasses/ThoughtActivity.tsx
+++ b/desktop/src/features/agents/ui/activityRenderClasses/ThoughtActivity.tsx
@@ -1,4 +1,5 @@
 import { Markdown } from "@/shared/ui/markdown";
+import { activityWindowMarkdownInteractive } from "./activityWindowPresentation";
 import {
   ActivityRow,
   ActivityRowContent,
@@ -26,6 +27,7 @@ export function ThoughtActivity(props: ActivityRenderClassItemProps) {
         <Markdown
           className="leading-5"
           content={props.item.text.trim() || " "}
+          interactive={activityWindowMarkdownInteractive()}
         />
       </ActivityRowContent>
     </ActivityRow>

--- a/desktop/src/features/agents/ui/activityRenderClasses/ThoughtActivity.tsx
+++ b/desktop/src/features/agents/ui/activityRenderClasses/ThoughtActivity.tsx
@@ -25,6 +25,7 @@ export function ThoughtActivity(props: ActivityRenderClassItemProps) {
       <ActivityRowLabel openToneScope="tool" verb={props.item.title} />
       <ActivityRowContent className="pt-1 pb-1.5 text-sm leading-5 text-muted-foreground">
         <Markdown
+          blockCode
           className="leading-5"
           content={props.item.text.trim() || " "}
           interactive={activityWindowMarkdownInteractive()}

--- a/desktop/src/features/agents/ui/activityRenderClasses/TranscriptTimestamp.tsx
+++ b/desktop/src/features/agents/ui/activityRenderClasses/TranscriptTimestamp.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { buildMessageLink } from "@/features/messages/lib/messageLink";
+import { isAgentActivityWindow } from "@/features/agents/lib/agentActivityWindow";
 import { cn } from "@/shared/lib/cn";
 import {
   formatTranscriptTime,
@@ -24,17 +25,20 @@ export function TranscriptTimestamp({
 }) {
   const formatted = formatTranscriptTime(timestamp);
   const { goChannel } = useAppNavigation();
-  const href = messageLink ? buildMessageLink(messageLink) : null;
+  const effectiveMessageLink = isAgentActivityWindow() ? null : messageLink;
+  const href = effectiveMessageLink
+    ? buildMessageLink(effectiveMessageLink)
+    : null;
   const openMessage = React.useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>) => {
-      if (!messageLink) return;
+      if (!effectiveMessageLink) return;
       event.preventDefault();
       event.stopPropagation();
-      void goChannel(messageLink.channelId, {
-        messageId: messageLink.messageId,
+      void goChannel(effectiveMessageLink.channelId, {
+        messageId: effectiveMessageLink.messageId,
       });
     },
-    [goChannel, messageLink],
+    [effectiveMessageLink, goChannel],
   );
 
   if (!formatted) return null;

--- a/desktop/src/features/agents/ui/activityRenderClasses/UserMessageBubble.tsx
+++ b/desktop/src/features/agents/ui/activityRenderClasses/UserMessageBubble.tsx
@@ -36,7 +36,7 @@ export function UserMessageBubble({
   const { openProfilePanel } = useProfilePanel();
   const isCompactPreview = variant === "compactPreview";
   const isDedicatedActivityWindow = isAgentActivityWindow();
-  const shouldClampBubble = !isCompactPreview;
+  const shouldClampBubble = !isCompactPreview && !isDedicatedActivityWindow;
   const [bubbleRef, hasBubbleOverflow] =
     useTranscriptBubbleOverflow(shouldClampBubble);
   const text = item.text.trim();

--- a/desktop/src/features/agents/ui/activityRenderClasses/UserMessageBubble.tsx
+++ b/desktop/src/features/agents/ui/activityRenderClasses/UserMessageBubble.tsx
@@ -156,6 +156,7 @@ export function UserMessageBubble({
           <Markdown
             className={isCompactPreview ? "text-xs leading-4" : "leading-5"}
             content={text || " "}
+            blockCode
             interactive={activityWindowMarkdownInteractive()}
             mediaInset
           />

--- a/desktop/src/features/agents/ui/activityRenderClasses/UserMessageBubble.tsx
+++ b/desktop/src/features/agents/ui/activityRenderClasses/UserMessageBubble.tsx
@@ -8,9 +8,11 @@ import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { cn } from "@/shared/lib/cn";
 import { useProfilePanel } from "@/shared/context/ProfilePanelContext";
 import { Markdown } from "@/shared/ui/markdown";
+import { activityWindowMarkdownInteractive } from "./activityWindowPresentation";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import { useAgentSessionTranscriptVariant } from "../agentSessionTranscriptContext";
 import type { TranscriptItem } from "../agentSessionTypes";
+import { isAgentActivityWindow } from "../../lib/agentActivityWindow";
 import { MessageLinkHoverCue } from "./MessageLinkHoverCue";
 import { useTranscriptBubbleOverflow } from "./useTranscriptBubbleOverflow";
 
@@ -33,12 +35,16 @@ export function UserMessageBubble({
   const { goChannel } = useAppNavigation();
   const { openProfilePanel } = useProfilePanel();
   const isCompactPreview = variant === "compactPreview";
+  const isDedicatedActivityWindow = isAgentActivityWindow();
   const shouldClampBubble = !isCompactPreview;
   const [bubbleRef, hasBubbleOverflow] =
     useTranscriptBubbleOverflow(shouldClampBubble);
   const text = item.text.trim();
   const messageLink =
-    shouldClampBubble && item.channelId && item.messageId
+    shouldClampBubble &&
+    !isDedicatedActivityWindow &&
+    item.channelId &&
+    item.messageId
       ? { channelId: item.channelId, messageId: item.messageId }
       : null;
   const authorProfile = item.authorPubkey
@@ -98,7 +104,9 @@ export function UserMessageBubble({
       data-role="user-message"
       data-testid="transcript-user-message"
     >
-      {isCompactPreview ? null : item.authorPubkey && openProfilePanel ? (
+      {isCompactPreview ? null : item.authorPubkey &&
+        openProfilePanel &&
+        !isDedicatedActivityWindow ? (
         <button
           aria-label={`Open ${authorLabel} profile`}
           className="pointer-events-auto order-last ml-2 mt-1 size-7 shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -148,6 +156,7 @@ export function UserMessageBubble({
           <Markdown
             className={isCompactPreview ? "text-xs leading-4" : "leading-5"}
             content={text || " "}
+            interactive={activityWindowMarkdownInteractive()}
             mediaInset
           />
           {children}

--- a/desktop/src/features/agents/ui/activityRenderClasses/activityWindowPresentation.ts
+++ b/desktop/src/features/agents/ui/activityRenderClasses/activityWindowPresentation.ts
@@ -1,0 +1,6 @@
+import { currentCompanionWindowKind } from "@/app/companionWindow";
+
+/** Dedicated feeds render navigation targets as readable, non-clickable content. */
+export function activityWindowMarkdownInteractive(): boolean {
+  return currentCompanionWindowKind() !== "agent-activity";
+}

--- a/desktop/src/features/agents/useManagedAgentRuntimeReconciliation.ts
+++ b/desktop/src/features/agents/useManagedAgentRuntimeReconciliation.ts
@@ -29,6 +29,7 @@ import { reconcileManagedAgentRuntimes } from "@/shared/api/tauriManagedAgents";
  */
 export function useManagedAgentRuntimeReconciliation(
   communities: readonly { relayUrl: string }[],
+  enabled = true,
 ): void {
   const queryClient = useQueryClient();
   // Canonical relay URLs that have reconciled cleanly — never re-hit.
@@ -42,6 +43,7 @@ export function useManagedAgentRuntimeReconciliation(
   );
 
   React.useEffect(() => {
+    if (!enabled) return;
     let cancelled = false;
 
     const clearRetryTimer = () => {
@@ -131,5 +133,5 @@ export function useManagedAgentRuntimeReconciliation(
       cancelled = true;
       clearRetryTimer();
     };
-  }, [communities, queryClient]);
+  }, [communities, enabled, queryClient]);
 }

--- a/desktop/src/features/agents/useOpenAgentActivity.ts
+++ b/desktop/src/features/agents/useOpenAgentActivity.ts
@@ -5,7 +5,6 @@ import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { useChannelReferences } from "@/features/channels/openChannelDirectory";
 import { useAgentSession } from "@/shared/context/AgentSessionContext";
 import type { Channel } from "@/shared/api/types";
-import { openAgentActivityWindow } from "@/shared/api/agentActivityWindow";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { getAgentWorkingState } from "./agentWorkingSignal";
 import { useRelayAgentsQuery } from "./hooks";
@@ -55,11 +54,23 @@ export function resolveOpenableActivityChannelId({
 }
 
 /**
- * Universal ingress for opening an agent's activity feed.
+ * Universal ingress for opening an agent's activity pane.
  *
- * The selected channel is still resolved and authorized in the current
- * webview, but Tauri presents the existing channel-scoped feed in a dedicated
- * companion window. Browser builds keep the previous in-app route fallback.
+ * Inside a channel screen the AgentSessionContext handler opens the pane in
+ * place. Everywhere else (agents page, home profile panel, popovers reached
+ * from non-channel routes) there is no provider, so we navigate to a channel
+ * with the `agentSession` search param instead — preferring a channel the
+ * agent is currently working in (unified working signal), then falling back
+ * to the first channel the agent is a member of.
+ *
+ * Navigation only ever targets channels the viewer can actually open
+ * (joined, or open visibility). Owner-global ingestion means the working
+ * signal can report activity in rooms the viewer can't access; deep-linking
+ * there would land on a screen they can't read. In that case we surface a
+ * safe warning instead of navigating — no channel content, no trap-door.
+ *
+ * The separate pop-out actions invoke the native companion window explicitly;
+ * ordinary activity entry points preserve the existing in-app behavior.
  */
 export function useOpenAgentActivity() {
   const { onOpenAgentSession } = useAgentSession();
@@ -138,22 +149,6 @@ export function useOpenAgentActivity() {
     [areChannelsReady, onOpenAgentSession, resolveChannelId],
   );
 
-  const openActivityDestination = React.useCallback(
-    (pubkey: string, channelId: string): void => {
-      void openAgentActivityWindow(channelId, pubkey)
-        .then((openedNativeWindow) => {
-          if (!openedNativeWindow) {
-            void goChannel(channelId, { agentSession: pubkey });
-          }
-        })
-        .catch((error) => {
-          console.error("Failed to open agent activity window:", error);
-          toast.error("Couldn't open the agent activity window.");
-        });
-    },
-    [goChannel],
-  );
-
   const openAgentActivity = React.useCallback(
     (pubkey: string, options?: { channelId?: string | null }): boolean => {
       // An explicit channel target (e.g. clicking a "Working in #channel"
@@ -167,18 +162,22 @@ export function useOpenAgentActivity() {
             toast.warning(INACCESSIBLE_ACTIVITY_MESSAGE);
             return false;
           }
-          openActivityDestination(pubkey, options.channelId);
+          void goChannel(options.channelId, { agentSession: pubkey });
           return true;
         }
         // A channel-scoped AgentSessionProvider belongs to the channel view
         // already authorized by its route. Do not reject its own current
         // channel while the member/reference query is still settling.
-        openActivityDestination(pubkey, options.channelId);
+        onOpenAgentSession(pubkey, options.channelId);
+        return true;
+      }
+      if (onOpenAgentSession) {
+        onOpenAgentSession(pubkey);
         return true;
       }
       const channelId = resolveChannelId(pubkey);
       if (channelId) {
-        openActivityDestination(pubkey, channelId);
+        void goChannel(channelId, { agentSession: pubkey });
         return true;
       }
       // The agent may be working somewhere, just nowhere the viewer can open.
@@ -189,12 +188,7 @@ export function useOpenAgentActivity() {
       }
       return false;
     },
-    [
-      findOpenableChannel,
-      onOpenAgentSession,
-      openActivityDestination,
-      resolveChannelId,
-    ],
+    [findOpenableChannel, goChannel, onOpenAgentSession, resolveChannelId],
   );
 
   return { canOpenAgentActivity, openAgentActivity };

--- a/desktop/src/features/agents/useOpenAgentActivity.ts
+++ b/desktop/src/features/agents/useOpenAgentActivity.ts
@@ -5,6 +5,7 @@ import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { useChannelReferences } from "@/features/channels/openChannelDirectory";
 import { useAgentSession } from "@/shared/context/AgentSessionContext";
 import type { Channel } from "@/shared/api/types";
+import { openAgentActivityWindow } from "@/shared/api/agentActivityWindow";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { getAgentWorkingState } from "./agentWorkingSignal";
 import { useRelayAgentsQuery } from "./hooks";
@@ -54,23 +55,11 @@ export function resolveOpenableActivityChannelId({
 }
 
 /**
- * Universal ingress for opening an agent's activity pane.
+ * Universal ingress for opening an agent's activity feed.
  *
- * Inside a channel screen the AgentSessionContext handler opens the pane in
- * place. Everywhere else (agents page, home profile panel, popovers reached
- * from non-channel routes) there is no provider, so we navigate to a channel
- * with the `agentSession` search param instead — preferring a channel the
- * agent is currently working in (unified working signal), then falling back
- * to the first channel the agent is a member of.
- *
- * Navigation only ever targets channels the viewer can actually open
- * (joined, or open visibility). Owner-global ingestion means the working
- * signal can report activity in rooms the viewer can't access; deep-linking
- * there would land on a screen they can't read. In that case we surface a
- * safe warning instead of navigating — no channel content, no trap-door.
- *
- * This replaces the old behavior where "View activity log" silently
- * disappeared on routes without an AgentSessionProvider.
+ * The selected channel is still resolved and authorized in the current
+ * webview, but Tauri presents the existing channel-scoped feed in a dedicated
+ * companion window. Browser builds keep the previous in-app route fallback.
  */
 export function useOpenAgentActivity() {
   const { onOpenAgentSession } = useAgentSession();
@@ -149,6 +138,22 @@ export function useOpenAgentActivity() {
     [areChannelsReady, onOpenAgentSession, resolveChannelId],
   );
 
+  const openActivityDestination = React.useCallback(
+    (pubkey: string, channelId: string): void => {
+      void openAgentActivityWindow(channelId, pubkey)
+        .then((openedNativeWindow) => {
+          if (!openedNativeWindow) {
+            void goChannel(channelId, { agentSession: pubkey });
+          }
+        })
+        .catch((error) => {
+          console.error("Failed to open agent activity window:", error);
+          toast.error("Couldn't open the agent activity window.");
+        });
+    },
+    [goChannel],
+  );
+
   const openAgentActivity = React.useCallback(
     (pubkey: string, options?: { channelId?: string | null }): boolean => {
       // An explicit channel target (e.g. clicking a "Working in #channel"
@@ -162,22 +167,18 @@ export function useOpenAgentActivity() {
             toast.warning(INACCESSIBLE_ACTIVITY_MESSAGE);
             return false;
           }
-          void goChannel(options.channelId, { agentSession: pubkey });
+          openActivityDestination(pubkey, options.channelId);
           return true;
         }
         // A channel-scoped AgentSessionProvider belongs to the channel view
         // already authorized by its route. Do not reject its own current
         // channel while the member/reference query is still settling.
-        onOpenAgentSession(pubkey, options.channelId);
-        return true;
-      }
-      if (onOpenAgentSession) {
-        onOpenAgentSession(pubkey);
+        openActivityDestination(pubkey, options.channelId);
         return true;
       }
       const channelId = resolveChannelId(pubkey);
       if (channelId) {
-        void goChannel(channelId, { agentSession: pubkey });
+        openActivityDestination(pubkey, channelId);
         return true;
       }
       // The agent may be working somewhere, just nowhere the viewer can open.
@@ -188,7 +189,12 @@ export function useOpenAgentActivity() {
       }
       return false;
     },
-    [findOpenableChannel, goChannel, onOpenAgentSession, resolveChannelId],
+    [
+      findOpenableChannel,
+      onOpenAgentSession,
+      openActivityDestination,
+      resolveChannelId,
+    ],
   );
 
   return { canOpenAgentActivity, openAgentActivity };

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -336,7 +336,7 @@ export function AgentSessionThreadPanel({
                 }}
               >
                 <SquareArrowOutUpRight className="text-muted-foreground" />
-                <span>Open in external window</span>
+                <span>Pop-out window</span>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
             </>

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -4,6 +4,7 @@ import {
   Octagon,
   Settings,
   Sparkles,
+  SquareArrowOutUpRight,
   TerminalSquare,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -29,6 +30,7 @@ import {
 import { useAnchoredScroll } from "@/features/messages/ui/useAnchoredScroll";
 import { useStableArrayShallow } from "@/shared/hooks/useStableReference";
 import { cancelManagedAgentTurn } from "@/shared/api/agentControl";
+import { openAgentActivityWindow } from "@/shared/api/agentActivityWindow";
 import type { Channel } from "@/shared/api/types";
 import { useEscapeKey } from "@/shared/hooks/useEscapeKey";
 import { useIsThreadPanelOverlay } from "@/shared/hooks/use-mobile";
@@ -257,6 +259,27 @@ export function AgentSessionThreadPanel({
   const headerScopeLabel = `${viewLabel} · ${scopeLabel}`;
   const animateActivity = useTranscriptAnimationEnabled();
   const showTimestamps = useTranscriptTimestampsEnabled();
+  async function handleOpenExternalWindow() {
+    if (!sessionChannelId || isDedicatedActivityWindow) {
+      return;
+    }
+
+    try {
+      const openedNativeWindow = await openAgentActivityWindow(
+        sessionChannelId,
+        agent.pubkey,
+      );
+      if (!openedNativeWindow) {
+        toast.error(
+          "External activity windows are only available in the desktop app.",
+        );
+      }
+    } catch (error) {
+      console.error("Failed to open agent activity window:", error);
+      toast.error("Couldn't open the agent activity window.");
+    }
+  }
+
   async function handleInterruptTurn() {
     if (!channel) {
       return;
@@ -278,152 +301,164 @@ export function AgentSessionThreadPanel({
 
   const agentHeaderActions = (
     <AuxiliaryPanelHeaderActions>
-      {isLive ? (
-        <DropdownMenu modal={false}>
-          <DropdownMenuTrigger asChild>
-            <Button
-              aria-label="Open activity settings"
-              className="relative"
-              data-testid="agent-session-settings-menu-trigger"
-              size="icon"
-              title="Activity settings"
-              type="button"
-              variant="ghost"
-            >
-              <Settings />
-              {canStopCurrentTurn ? (
-                <span
-                  aria-hidden="true"
-                  className="absolute right-1 bottom-1 h-2 w-2 rounded-full bg-primary ring-2 ring-background"
-                  data-testid="agent-session-settings-live-badge"
-                />
-              ) : null}
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="end"
-            className="min-w-56"
-            onCloseAutoFocus={(event) => event.preventDefault()}
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            aria-label="Open activity settings"
+            className="relative"
+            data-testid="agent-session-settings-menu-trigger"
+            size="icon"
+            title="Activity settings"
+            type="button"
+            variant="ghost"
           >
-            <DropdownMenuItem
-              className="items-start gap-3"
-              data-testid="agent-session-toggle-raw-feed"
-              onSelect={(event) => {
-                event.preventDefault();
-                handleRawFeedChange(!showRawFeed);
-              }}
-              title={
-                showRawFeed
-                  ? "Hide raw JSON-RPC payloads."
-                  : channel
-                    ? "Show raw JSON-RPC payloads for this channel."
-                    : "Show raw JSON-RPC payloads for this agent."
-              }
-            >
-              <span className="min-w-0 flex-1">
-                <span className="flex items-center gap-2 text-sm font-medium">
-                  <TerminalSquare className="h-4 w-4 text-muted-foreground" />
-                  Raw
-                </span>
+            <Settings />
+            {canStopCurrentTurn ? (
+              <span
+                aria-hidden="true"
+                className="absolute right-1 bottom-1 h-2 w-2 rounded-full bg-primary ring-2 ring-background"
+                data-testid="agent-session-settings-live-badge"
+              />
+            ) : null}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          className="min-w-56"
+          onCloseAutoFocus={(event) => event.preventDefault()}
+        >
+          {!isDedicatedActivityWindow && sessionChannelId ? (
+            <>
+              <DropdownMenuItem
+                data-testid="agent-session-open-external-window"
+                onSelect={() => {
+                  void handleOpenExternalWindow();
+                }}
+              >
+                <SquareArrowOutUpRight className="text-muted-foreground" />
+                <span>Open in external window</span>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          ) : null}
+          <DropdownMenuItem
+            className="items-start gap-3"
+            data-testid="agent-session-toggle-raw-feed"
+            onSelect={(event) => {
+              event.preventDefault();
+              handleRawFeedChange(!showRawFeed);
+            }}
+            title={
+              showRawFeed
+                ? "Hide raw JSON-RPC payloads."
+                : channel
+                  ? "Show raw JSON-RPC payloads for this channel."
+                  : "Show raw JSON-RPC payloads for this agent."
+            }
+          >
+            <span className="min-w-0 flex-1">
+              <span className="flex items-center gap-2 text-sm font-medium">
+                <TerminalSquare className="h-4 w-4 text-muted-foreground" />
+                Raw
+              </span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                Show raw JSON-RPC activity.
+              </span>
+            </span>
+            <Switch
+              aria-hidden="true"
+              checked={showRawFeed}
+              className="pointer-events-none mt-0.5"
+              tabIndex={-1}
+            />
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="items-start gap-3"
+            data-testid="agent-session-toggle-animate-activity"
+            disabled={showRawFeed}
+            onSelect={(event) => {
+              event.preventDefault();
+              setTranscriptAnimationEnabled(!animateActivity);
+            }}
+            title={
+              showRawFeed
+                ? "Raw activity rows don't animate in."
+                : animateActivity
+                  ? "Stop animating new activity rows."
+                  : "Animate new activity rows as they arrive."
+            }
+          >
+            <span className="min-w-0 flex-1">
+              <span className="flex items-center gap-2 text-sm font-medium">
+                <Sparkles className="h-4 w-4 text-muted-foreground" />
+                Show Animations
+              </span>
+            </span>
+            <Switch
+              aria-hidden="true"
+              checked={animateActivity && !showRawFeed}
+              className="pointer-events-none mt-0.5"
+              tabIndex={-1}
+            />
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="items-start gap-3"
+            data-testid="agent-session-toggle-show-timestamps"
+            onSelect={(event) => {
+              event.preventDefault();
+              setTranscriptTimestampsEnabled(!showTimestamps);
+            }}
+            title={
+              showTimestamps
+                ? "Hide per-row activity timestamps."
+                : "Show a timestamp under each activity row."
+            }
+          >
+            <span className="min-w-0 flex-1">
+              <span className="flex items-center gap-2 text-sm font-medium">
+                <Clock3 className="h-4 w-4 text-muted-foreground" />
+                Show Timestamps
+              </span>
+            </span>
+            <Switch
+              aria-hidden="true"
+              checked={showTimestamps}
+              className="pointer-events-none mt-0.5"
+              tabIndex={-1}
+            />
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="items-start gap-3"
+            data-testid="agent-session-stop-turn"
+            disabled={!canStopCurrentTurn}
+            onSelect={() => {
+              void handleInterruptTurn();
+            }}
+            title={
+              canStopCurrentTurn
+                ? "Interrupt the current ACP turn without stopping the agent process."
+                : isWorking
+                  ? "Only locally managed agents can be interrupted from this community."
+                  : "Available while the agent is working."
+            }
+          >
+            <Octagon className="mt-0.5 h-4 w-4 text-muted-foreground" />
+            <span className="min-w-0 flex-1">
+              <span className="block text-sm font-medium">
+                Stop current turn
+              </span>
+              {!canStopCurrentTurn ? (
                 <span className="mt-0.5 block text-xs text-muted-foreground">
-                  Show raw JSON-RPC activity.
+                  {isWorking
+                    ? "Only available for locally managed agents."
+                    : "Available while the agent is working."}
                 </span>
-              </span>
-              <Switch
-                aria-hidden="true"
-                checked={showRawFeed}
-                className="pointer-events-none mt-0.5"
-                tabIndex={-1}
-              />
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="items-start gap-3"
-              data-testid="agent-session-toggle-animate-activity"
-              disabled={showRawFeed}
-              onSelect={(event) => {
-                event.preventDefault();
-                setTranscriptAnimationEnabled(!animateActivity);
-              }}
-              title={
-                showRawFeed
-                  ? "Raw activity rows don't animate in."
-                  : animateActivity
-                    ? "Stop animating new activity rows."
-                    : "Animate new activity rows as they arrive."
-              }
-            >
-              <span className="min-w-0 flex-1">
-                <span className="flex items-center gap-2 text-sm font-medium">
-                  <Sparkles className="h-4 w-4 text-muted-foreground" />
-                  Show Animations
-                </span>
-              </span>
-              <Switch
-                aria-hidden="true"
-                checked={animateActivity && !showRawFeed}
-                className="pointer-events-none mt-0.5"
-                tabIndex={-1}
-              />
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="items-start gap-3"
-              data-testid="agent-session-toggle-show-timestamps"
-              onSelect={(event) => {
-                event.preventDefault();
-                setTranscriptTimestampsEnabled(!showTimestamps);
-              }}
-              title={
-                showTimestamps
-                  ? "Hide per-row activity timestamps."
-                  : "Show a timestamp under each activity row."
-              }
-            >
-              <span className="min-w-0 flex-1">
-                <span className="flex items-center gap-2 text-sm font-medium">
-                  <Clock3 className="h-4 w-4 text-muted-foreground" />
-                  Show Timestamps
-                </span>
-              </span>
-              <Switch
-                aria-hidden="true"
-                checked={showTimestamps}
-                className="pointer-events-none mt-0.5"
-                tabIndex={-1}
-              />
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              className="items-start gap-3"
-              data-testid="agent-session-stop-turn"
-              disabled={!canStopCurrentTurn}
-              onSelect={() => {
-                void handleInterruptTurn();
-              }}
-              title={
-                canStopCurrentTurn
-                  ? "Interrupt the current ACP turn without stopping the agent process."
-                  : isWorking
-                    ? "Only locally managed agents can be interrupted from this community."
-                    : "Available while the agent is working."
-              }
-            >
-              <Octagon className="mt-0.5 h-4 w-4 text-muted-foreground" />
-              <span className="min-w-0 flex-1">
-                <span className="block text-sm font-medium">
-                  Stop current turn
-                </span>
-                {!canStopCurrentTurn ? (
-                  <span className="mt-0.5 block text-xs text-muted-foreground">
-                    {isWorking
-                      ? "Only available for locally managed agents."
-                      : "Available while the agent is working."}
-                  </span>
-                ) : null}
-              </span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      ) : null}
+              ) : null}
+            </span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </AuxiliaryPanelHeaderActions>
   );
 

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -284,12 +284,12 @@ export function AgentSessionThreadPanel({
   }
 
   async function handleInterruptTurn() {
-    if (!channel) {
+    if (!sessionChannelId) {
       return;
     }
 
     try {
-      await cancelManagedAgentTurn(agent.pubkey, channel.id);
+      await cancelManagedAgentTurn(agent.pubkey, sessionChannelId);
       toast.success(
         `Stop signal sent to ${agent.name}. It may take a moment to respond.`,
       );
@@ -354,7 +354,7 @@ export function AgentSessionThreadPanel({
             title={
               showRawFeed
                 ? "Hide raw JSON-RPC payloads."
-                : channel
+                : sessionChannelId
                   ? "Show raw JSON-RPC payloads for this channel."
                   : "Show raw JSON-RPC payloads for this agent."
             }

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -67,6 +67,7 @@ import { useLoadArchivedObserverEvents } from "@/features/agents/ui/useObserverE
 import { useLoadOlderOnScroll } from "@/features/messages/ui/useLoadOlderOnScroll";
 import type { ChannelAgentSessionAgent } from "./useChannelAgentSessions";
 import { useChannelReference } from "@/features/channels/openChannelDirectory";
+import { useCommunities } from "@/features/communities/useCommunities";
 
 type AgentSessionThreadPanelProps = {
   agent: ChannelAgentSessionAgent;
@@ -102,6 +103,7 @@ export function AgentSessionThreadPanel({
   widthPx,
   transparentChrome = false,
 }: AgentSessionThreadPanelProps) {
+  const { activeCommunity } = useCommunities();
   const isDedicatedActivityWindow = isAgentActivityWindow();
   const isLive = isManagedAgentActive(agent);
   const isOverlay = useIsThreadPanelOverlay();
@@ -260,12 +262,13 @@ export function AgentSessionThreadPanel({
   const animateActivity = useTranscriptAnimationEnabled();
   const showTimestamps = useTranscriptTimestampsEnabled();
   async function handleOpenExternalWindow() {
-    if (!sessionChannelId || isDedicatedActivityWindow) {
+    if (!sessionChannelId || !activeCommunity || isDedicatedActivityWindow) {
       return;
     }
 
     try {
       const openedNativeWindow = await openAgentActivityWindow(
+        activeCommunity.id,
         sessionChannelId,
         agent.pubkey,
       );

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -9,6 +9,10 @@ import {
 import { toast } from "sonner";
 
 import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
+import {
+  isAgentActivityWindow,
+  setAgentActivityWindowTitle,
+} from "@/features/agents/lib/agentActivityWindow";
 import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import {
   mergeObserverEventWindows,
@@ -96,6 +100,7 @@ export function AgentSessionThreadPanel({
   widthPx,
   transparentChrome = false,
 }: AgentSessionThreadPanelProps) {
+  const isDedicatedActivityWindow = isAgentActivityWindow();
   const isLive = isManagedAgentActive(agent);
   const isOverlay = useIsThreadPanelOverlay();
   const sessionChannelId = channelId ?? channel?.id ?? null;
@@ -106,7 +111,10 @@ export function AgentSessionThreadPanel({
     sessionChannelId,
   );
   const canStopCurrentTurn = isWorking && canInterruptTurn;
-  useEscapeKey(onClose, isOverlay || isSinglePanelView);
+  useEscapeKey(
+    onClose,
+    (isOverlay || isSinglePanelView) && !isDedicatedActivityWindow,
+  );
 
   const scrollRef = React.useRef<HTMLDivElement>(null);
   const contentRef = React.useRef<HTMLDivElement>(null);
@@ -236,6 +244,15 @@ export function AgentSessionThreadPanel({
     profiles,
     preferResolvedSelfLabel: true,
   });
+  React.useEffect(() => {
+    if (!scopeChannelName) return;
+
+    void setAgentActivityWindowTitle(agentLabel, scopeChannelName).catch(
+      (error) => {
+        console.error("Failed to update agent activity window title:", error);
+      },
+    );
+  }, [agentLabel, scopeChannelName]);
   const viewLabel = showRawFeed ? "Raw ACP activity" : "Activity";
   const headerScopeLabel = `${viewLabel} · ${scopeLabel}`;
   const animateActivity = useTranscriptAnimationEnabled();
@@ -469,6 +486,7 @@ export function AgentSessionThreadPanel({
           backdrop={layout !== "split" && !isOverlay}
           backdropSurface="soft"
           inset={layout !== "split" ? "wide" : "default"}
+          showCloseAction={!isDedicatedActivityWindow}
         >
           {agentHeaderContent}
         </AuxiliaryPanelHeader>

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Loader2 } from "lucide-react";
+import { ExternalLink, Loader2 } from "lucide-react";
 
 import { useAgentTranscript } from "@/features/agents/ui/useObserverEvents";
 import {
@@ -10,6 +10,12 @@ import {
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ManagedAgent } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/shared/ui/context-menu";
 import {
   DEFAULT_POPOVER_HOVER_OPEN_DELAY_MS,
   Popover,
@@ -25,6 +31,10 @@ type BotActivityBarProps = {
   agents: BotActivityAgent[];
   channelId?: string | null;
   onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
+  onOpenAgentSessionExternal: (
+    pubkey: string,
+    channelId?: string | null,
+  ) => void;
   openAgentSessionPubkey: string | null;
   profiles?: UserProfileLookup;
   workingBotPubkeys: string[];
@@ -38,6 +48,7 @@ export function BotActivityComposerAction({
   agents,
   channelId = null,
   onOpenAgentSession,
+  onOpenAgentSessionExternal,
   openAgentSessionPubkey,
   profiles,
   workingBotPubkeys,
@@ -161,116 +172,147 @@ export function BotActivityComposerAction({
       : `${workingAgents[0]?.name ?? "Agent"} +${workingAgents.length - 1}`;
 
   return (
-    <Popover onOpenChange={setOpen} open={open}>
-      <PopoverTrigger asChild>
-        <button
-          aria-label={`${triggerLabel}. View activity.`}
-          className={cn(
-            "inline-flex items-center justify-center rounded-full border border-border/60 bg-background font-medium text-muted-foreground transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary",
-            isInline
-              ? "min-w-0 gap-1.5 overflow-visible border-transparent bg-transparent px-0 text-xs font-normal leading-normal shadow-none hover:border-transparent hover:bg-transparent data-[state=open]:border-transparent data-[state=open]:bg-transparent"
-              : "h-9 min-w-9 gap-1.5 px-2 text-xs",
-          )}
-          data-testid="bot-activity-composer-trigger"
-          onBlur={closeWithDelay}
-          onClick={() => {
-            clearHoverTimer();
-            setOpen((current) => !current);
-          }}
-          onFocus={() => setOpen(true)}
-          onMouseEnter={openWithDelay}
-          onMouseLeave={closeWithDelay}
-          type="button"
-        >
-          <span className="flex h-4.5 items-center overflow-visible -space-x-1">
-            {workingAgents.slice(0, 2).map((agent) => (
-              <UserAvatar
-                avatarUrl={agentAvatarUrl(agent)}
-                className={cn(
-                  "border border-background",
-                  isInline ? "!h-4.5 !w-4.5 text-3xs" : "shrink-0",
-                )}
-                displayName={agent.name}
-                fallbackDelayMs={isInline ? 0 : undefined}
-                key={agent.pubkey}
-                size="xs"
-              />
-            ))}
-          </span>
-          {workingAgents.length > 2 ? (
-            <span className="text-2xs leading-none">
-              +{workingAgents.length - 2}
-            </span>
-          ) : null}
-          <span
-            className={cn(
-              isInline
-                ? "flex h-4.5 min-w-0 flex-1 items-center overflow-visible leading-none"
-                : "sr-only",
-            )}
-          >
-            {isInline ? (
-              <Shimmer className="-my-px truncate py-px">
-                {visibleStatusLabel}
-              </Shimmer>
-            ) : (
-              "working"
-            )}
-          </span>
-          {isInline ? null : (
-            <Loader2 className="h-4 w-4 shrink-0 animate-spin opacity-70" />
-          )}
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        align={isInline ? "start" : "end"}
-        className="w-64 p-1"
-        onMouseEnter={keepOpen}
-        onMouseLeave={closeWithDelay}
-        onOpenAutoFocus={(event) => event.preventDefault()}
-        side="top"
-        sideOffset={8}
-      >
-        <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
-          Agents working
-        </div>
-        <div className="mt-1 flex flex-col gap-1">
-          {workingAgents.map((agent) => {
-            const isSelected = selectedPubkey === agent.pubkey.toLowerCase();
-
-            return (
-              <button
-                className={cn(
-                  "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors",
-                  isSelected
-                    ? "bg-primary/10 text-primary"
-                    : "text-foreground hover:bg-accent hover:text-accent-foreground",
-                )}
-                data-testid={`bot-activity-composer-item-${agent.pubkey}`}
-                key={agent.pubkey}
-                onClick={() => {
-                  clearHoverTimer();
-                  setOpen(false);
-                  onOpenAgentSession(agent.pubkey, channelId);
-                }}
-                type="button"
-              >
-                <UserAvatar
-                  avatarUrl={agentAvatarUrl(agent)}
-                  className="shrink-0"
-                  displayName={agent.name}
-                  size="sm"
-                />
-                <span className="min-w-0 flex-1 truncate">{agent.name}</span>
-                <span className="shrink-0 whitespace-nowrap text-xs font-medium opacity-80">
-                  View activity
+    <ContextMenu>
+      <Popover onOpenChange={setOpen} open={open}>
+        <PopoverTrigger asChild>
+          <ContextMenuTrigger asChild>
+            <button
+              aria-label={`${triggerLabel}. View activity.`}
+              className={cn(
+                "inline-flex items-center justify-center rounded-full border border-border/60 bg-background font-medium text-muted-foreground transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary",
+                isInline
+                  ? "min-w-0 gap-1.5 overflow-visible border-transparent bg-transparent px-0 text-xs font-normal leading-normal shadow-none hover:border-transparent hover:bg-transparent data-[state=open]:border-transparent data-[state=open]:bg-transparent"
+                  : "h-9 min-w-9 gap-1.5 px-2 text-xs",
+              )}
+              data-testid="bot-activity-composer-trigger"
+              onBlur={closeWithDelay}
+              onClick={() => {
+                clearHoverTimer();
+                setOpen((current) => !current);
+              }}
+              onContextMenu={() => {
+                clearHoverTimer();
+                setOpen(false);
+              }}
+              onFocus={() => setOpen(true)}
+              onMouseEnter={openWithDelay}
+              onMouseLeave={closeWithDelay}
+              type="button"
+            >
+              <span className="flex h-4.5 items-center overflow-visible -space-x-1">
+                {workingAgents.slice(0, 2).map((agent) => (
+                  <UserAvatar
+                    avatarUrl={agentAvatarUrl(agent)}
+                    className={cn(
+                      "border border-background",
+                      isInline ? "!h-4.5 !w-4.5 text-3xs" : "shrink-0",
+                    )}
+                    displayName={agent.name}
+                    fallbackDelayMs={isInline ? 0 : undefined}
+                    key={agent.pubkey}
+                    size="xs"
+                  />
+                ))}
+              </span>
+              {workingAgents.length > 2 ? (
+                <span className="text-2xs leading-none">
+                  +{workingAgents.length - 2}
                 </span>
-                <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground/70" />
-              </button>
-            );
-          })}
-        </div>
-      </PopoverContent>
-    </Popover>
+              ) : null}
+              <span
+                className={cn(
+                  isInline
+                    ? "flex h-4.5 min-w-0 flex-1 items-center overflow-visible leading-none"
+                    : "sr-only",
+                )}
+              >
+                {isInline ? (
+                  <Shimmer className="-my-px truncate py-px">
+                    {visibleStatusLabel}
+                  </Shimmer>
+                ) : (
+                  "working"
+                )}
+              </span>
+              {isInline ? null : (
+                <Loader2 className="h-4 w-4 shrink-0 animate-spin opacity-70" />
+              )}
+            </button>
+          </ContextMenuTrigger>
+        </PopoverTrigger>
+        <PopoverContent
+          align={isInline ? "start" : "end"}
+          className="w-64 p-1"
+          onMouseEnter={keepOpen}
+          onMouseLeave={closeWithDelay}
+          onOpenAutoFocus={(event) => event.preventDefault()}
+          side="top"
+          sideOffset={8}
+        >
+          <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
+            Agents working
+          </div>
+          <div className="mt-1 flex flex-col gap-1">
+            {workingAgents.map((agent) => {
+              const isSelected = selectedPubkey === agent.pubkey.toLowerCase();
+
+              return (
+                <button
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors",
+                    isSelected
+                      ? "bg-primary/10 text-primary"
+                      : "text-foreground hover:bg-accent hover:text-accent-foreground",
+                  )}
+                  data-testid={`bot-activity-composer-item-${agent.pubkey}`}
+                  key={agent.pubkey}
+                  onClick={() => {
+                    clearHoverTimer();
+                    setOpen(false);
+                    onOpenAgentSession(agent.pubkey, channelId);
+                  }}
+                  type="button"
+                >
+                  <UserAvatar
+                    avatarUrl={agentAvatarUrl(agent)}
+                    className="shrink-0"
+                    displayName={agent.name}
+                    size="sm"
+                  />
+                  <span className="min-w-0 flex-1 truncate">{agent.name}</span>
+                  <span className="shrink-0 whitespace-nowrap text-xs font-medium opacity-80">
+                    View activity
+                  </span>
+                  <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground/70" />
+                </button>
+              );
+            })}
+          </div>
+        </PopoverContent>
+      </Popover>
+      <ContextMenuContent className="min-w-56">
+        {workingAgents.map((agent) => (
+          <ContextMenuItem
+            data-testid={`bot-activity-open-external-${agent.pubkey}`}
+            key={agent.pubkey}
+            onSelect={() => {
+              clearHoverTimer();
+              setOpen(false);
+              onOpenAgentSessionExternal(agent.pubkey, channelId);
+            }}
+          >
+            <ExternalLink />
+            <span className="min-w-0 flex-1">
+              <span className="block">Open in external window</span>
+              {workingAgents.length > 1 ? (
+                <span className="block truncate text-xs text-muted-foreground">
+                  {agent.name}
+                </span>
+              ) : null}
+            </span>
+          </ContextMenuItem>
+        ))}
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -303,7 +303,7 @@ export function BotActivityComposerAction({
           >
             <ExternalLink />
             <span className="min-w-0 flex-1">
-              <span className="block">Open in external window</span>
+              <span className="block">Pop-out window</span>
               {workingAgents.length > 1 ? (
                 <span className="block truncate text-xs text-muted-foreground">
                   {agent.name}

--- a/desktop/src/features/channels/ui/ChannelComposerActivityAccessory.tsx
+++ b/desktop/src/features/channels/ui/ChannelComposerActivityAccessory.tsx
@@ -13,6 +13,9 @@ type ChannelComposerActivityAccessoryProps = {
   onOpenAgentSession: ComponentProps<
     typeof BotActivityComposerAction
   >["onOpenAgentSession"];
+  onOpenAgentSessionExternal: ComponentProps<
+    typeof BotActivityComposerAction
+  >["onOpenAgentSessionExternal"];
   openAgentSessionPubkey: ComponentProps<
     typeof BotActivityComposerAction
   >["openAgentSessionPubkey"];
@@ -27,6 +30,7 @@ export function ChannelComposerActivityAccessory({
   channel,
   currentPubkey,
   onOpenAgentSession,
+  onOpenAgentSessionExternal,
   openAgentSessionPubkey,
   profiles,
   typingPubkeys,
@@ -48,6 +52,7 @@ export function ChannelComposerActivityAccessory({
               agents={agents}
               channelId={channel?.id ?? null}
               onOpenAgentSession={onOpenAgentSession}
+              onOpenAgentSessionExternal={onOpenAgentSessionExternal}
               openAgentSessionPubkey={openAgentSessionPubkey}
               profiles={profiles}
               workingBotPubkeys={workingBotPubkeys}

--- a/desktop/src/features/channels/ui/ChannelPane.helpers.test.mjs
+++ b/desktop/src/features/channels/ui/ChannelPane.helpers.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldShowAgentSessionUnavailable } from "./ChannelPane.helpers.ts";
+
+test("unavailable activity state is exclusive to dedicated windows", () => {
+  const unresolvedSession = {
+    openAgentSessionPubkey: "agent-pubkey",
+    selectedAgent: null,
+  };
+
+  assert.equal(
+    shouldShowAgentSessionUnavailable({
+      ...unresolvedSession,
+      isDedicatedActivityWindow: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldShowAgentSessionUnavailable({
+      ...unresolvedSession,
+      isDedicatedActivityWindow: false,
+    }),
+    false,
+  );
+});

--- a/desktop/src/features/channels/ui/ChannelPane.helpers.ts
+++ b/desktop/src/features/channels/ui/ChannelPane.helpers.ts
@@ -57,6 +57,22 @@ export function isChannelCreatedSystemMessage(message: TimelineMessage) {
   }
 }
 
+export function shouldShowAgentSessionUnavailable({
+  isDedicatedActivityWindow,
+  openAgentSessionPubkey,
+  selectedAgent,
+}: {
+  isDedicatedActivityWindow: boolean;
+  openAgentSessionPubkey: string | null;
+  selectedAgent: unknown;
+}): boolean {
+  return (
+    isDedicatedActivityWindow &&
+    openAgentSessionPubkey !== null &&
+    selectedAgent == null
+  );
+}
+
 export function mentionsKnownAgent(
   mentionPubkeys: string[],
   knownAgentPubkeys: ReadonlySet<string>,

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Hash, LogIn } from "lucide-react";
+import { Hash, LoaderCircle, LogIn } from "lucide-react";
 import { AnimatePresence } from "motion/react";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { useMediaUpload } from "@/features/messages/lib/useMediaUpload";
@@ -87,6 +87,7 @@ export const ChannelPane = React.memo(function ChannelPane({
   isMessageUnreadById,
   isJoining = false,
   isSinglePanelView = false,
+  isAgentSessionLoading = false,
   isSending,
   isTimelineLoading,
   entranceMessageId = null,
@@ -914,6 +915,30 @@ export const ChannelPane = React.memo(function ChannelPane({
             );
             return wrapAux(panel, "agent-session-thread-panel");
           })()
+        ) : isSinglePanelView && openAgentSessionPubkey ? (
+          <div
+            className="flex min-h-0 flex-1 items-center justify-center p-8 text-center"
+            data-testid="agent-session-unavailable"
+          >
+            <div className="max-w-sm space-y-2">
+              {isAgentSessionLoading ? (
+                <LoaderCircle
+                  aria-hidden="true"
+                  className="mx-auto h-5 w-5 animate-spin text-muted-foreground"
+                />
+              ) : null}
+              <h1 className="text-lg font-semibold">
+                {isAgentSessionLoading
+                  ? "Loading agent activity…"
+                  : "Agent activity unavailable"}
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                {isAgentSessionLoading
+                  ? "Buzz is finding this agent."
+                  : "This agent is no longer available in this community. You can close this window and open another activity feed from Buzz."}
+              </p>
+            </div>
+          </div>
         ) : profilePanelPubkey ? (
           (() => {
             const panel = (

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -44,7 +44,10 @@ import {
   WelcomeComposerGuidanceLayer,
 } from "@/features/channels/ui/WelcomeComposerBanner";
 import { useWelcomeComposerBanner } from "@/features/channels/ui/useWelcomeComposerBanner";
-import { mentionsKnownAgent } from "@/features/channels/ui/ChannelPane.helpers";
+import {
+  mentionsKnownAgent,
+  shouldShowAgentSessionUnavailable,
+} from "@/features/channels/ui/ChannelPane.helpers";
 import { HuddleStartingView, HuddleTranscriptIntro } from "@/features/huddle";
 import { useChannelIntro } from "@/features/channels/ui/useChannelIntro";
 import type { ChannelPaneProps } from "@/features/channels/ui/ChannelPane.types";
@@ -81,6 +84,7 @@ export const ChannelPane = React.memo(function ChannelPane({
   historyExhausted,
   isFetchingOlder,
   isHuddleTranscript = false,
+  isDedicatedActivityWindow = false,
   followThreadById,
   isFollowingThread,
   isFollowingThreadById,
@@ -915,7 +919,11 @@ export const ChannelPane = React.memo(function ChannelPane({
             );
             return wrapAux(panel, "agent-session-thread-panel");
           })()
-        ) : isSinglePanelView && openAgentSessionPubkey ? (
+        ) : shouldShowAgentSessionUnavailable({
+            isDedicatedActivityWindow,
+            openAgentSessionPubkey,
+            selectedAgent,
+          }) ? (
           <div
             className="flex min-h-0 flex-1 items-center justify-center p-8 text-center"
             data-testid="agent-session-unavailable"

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -880,15 +880,16 @@ export const ChannelPane = React.memo(function ChannelPane({
           })()
         ) : activeChannel && selectedAgent ? (
           (() => {
-            // When the panel was opened from a different channel than the
-            // currently active one, re-scope it to the active channel so
-            // that both the content/header AND channel-backed actions (e.g.
-            // Stop current turn) operate on the same channel object.
+            // In normal app navigation, re-scope a panel opened from another
+            // channel so its content and channel-backed actions stay aligned.
+            // A dedicated activity companion has an immutable channel scope,
+            // even when one of its links navigates the underlying route.
             const effectiveAgentSessionChannelId =
-              openAgentSessionChannelId &&
-              activeChannel.id !== openAgentSessionChannelId
-                ? activeChannelId
-                : openAgentSessionChannelId;
+              isDedicatedActivityWindow ||
+              !openAgentSessionChannelId ||
+              activeChannel.id === openAgentSessionChannelId
+                ? openAgentSessionChannelId
+                : activeChannelId;
             const panel = (
               <AgentSessionThreadPanel
                 agent={selectedAgent}

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -118,6 +118,7 @@ export const ChannelPane = React.memo(function ChannelPane({
   onExpandThreadReplies,
   onJoinChannel,
   onOpenAgentSession,
+  onOpenAgentSessionExternal,
   onOpenDm,
   onOpenMembers,
   onOpenProfilePanel,
@@ -743,6 +744,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                     channel={activeChannel}
                     currentPubkey={currentPubkey}
                     onOpenAgentSession={onOpenAgentSession}
+                    onOpenAgentSessionExternal={onOpenAgentSessionExternal}
                     openAgentSessionPubkey={openAgentSessionPubkey}
                     profiles={profiles}
                     typingPubkeys={typingPubkeys}
@@ -845,6 +847,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                       agents={activityAgents}
                       channelId={activeChannel?.id ?? null}
                       onOpenAgentSession={onOpenAgentSession}
+                      onOpenAgentSessionExternal={onOpenAgentSessionExternal}
                       openAgentSessionPubkey={openAgentSessionPubkey}
                       profiles={profiles}
                       workingBotPubkeys={threadComposerBotTypingPubkeys}

--- a/desktop/src/features/channels/ui/ChannelPane.types.ts
+++ b/desktop/src/features/channels/ui/ChannelPane.types.ts
@@ -96,6 +96,10 @@ export type ChannelPaneProps = {
   onExpandThreadReplies: (message: TimelineMessage) => void;
   onJoinChannel?: () => Promise<void>;
   onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
+  onOpenAgentSessionExternal: (
+    pubkey: string,
+    channelId?: string | null,
+  ) => void;
   onOpenDm?: (pubkeys: string[]) => Promise<void> | void;
   onOpenMembers?: () => void;
   onOpenProfilePanel: (

--- a/desktop/src/features/channels/ui/ChannelPane.types.ts
+++ b/desktop/src/features/channels/ui/ChannelPane.types.ts
@@ -52,6 +52,7 @@ export type ChannelPaneProps = {
   isFetchingOlder?: boolean;
   /** A companion huddle window presents the channel only as a transcript. */
   isHuddleTranscript?: boolean;
+  isDedicatedActivityWindow?: boolean;
   isJoining?: boolean;
   isSinglePanelView?: boolean;
   isAgentSessionLoading?: boolean;

--- a/desktop/src/features/channels/ui/ChannelPane.types.ts
+++ b/desktop/src/features/channels/ui/ChannelPane.types.ts
@@ -54,6 +54,7 @@ export type ChannelPaneProps = {
   isHuddleTranscript?: boolean;
   isJoining?: boolean;
   isSinglePanelView?: boolean;
+  isAgentSessionLoading?: boolean;
   isSending: boolean;
   isTimelineLoading: boolean;
   /** Newly-created message that should receive the one-shot conversation arrival motion. */

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -257,6 +257,7 @@ export function ChannelScreen({
     activeChannelId,
     activeChannelIsMember: activeChannel?.isMember,
     isHuddleTranscript,
+    enabled: !isDedicatedActivityWindow,
     markChannelRead,
     messages: messagesQuery.data,
     resolvedMessages,
@@ -701,8 +702,6 @@ export function ChannelScreen({
   const isNarrowPanelViewport =
     channelContentWidthPx > 0 &&
     channelContentWidthPx < AUXILIARY_PANEL_SINGLE_COLUMN_BREAKPOINT_PX;
-  // A dedicated activity window is the panel itself, not a responsive channel
-  // view. Keep the channel timeline out of that window at every width.
   const isSinglePanelView =
     isDedicatedActivityWindow ||
     (isNarrowPanelViewport &&
@@ -871,6 +870,7 @@ export function ChannelScreen({
                   onOpenMembers={handleOpenMembersSidebar}
                   isFetchingOlder={isFetchingOlder}
                   isHuddleTranscript={isHuddleTranscript}
+                  isDedicatedActivityWindow={isDedicatedActivityWindow}
                   entranceMessageId={welcomeEntranceMessageId}
                   onEntranceMessageComplete={handleWelcomeEntranceComplete}
                   welcomeKickoffStage={welcomeKickoffStage}

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { toast } from "sonner";
 import { useAppShell } from "@/app/AppShellContext";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { useActiveChannelHeader } from "@/features/channels/useActiveChannelHeader";
@@ -57,6 +58,8 @@ import type { TimelineMessage } from "@/features/messages/types";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { useRelaySelfQuery } from "@/features/moderation/hooks";
 import type { RelayEvent, RespondToMode } from "@/shared/api/types";
+import { openAgentActivityWindow } from "@/shared/api/agentActivityWindow";
+import { isAgentActivityWindow } from "@/features/agents/lib/agentActivityWindow";
 import { ChannelScreenLoadingFallback } from "@/features/channels/ui/ChannelScreenLoadingFallback";
 import {
   useHuddleChannelMessages,
@@ -583,6 +586,29 @@ export function ChannelScreen({
     setThreadReplyTargetId,
     setThreadScrollTargetId,
   });
+  const handleOpenAgentActivity = React.useCallback(
+    (pubkey: string, channelId?: string | null) => {
+      const destinationChannelId = channelId ?? activeChannelId;
+      if (!destinationChannelId) return;
+
+      if (isAgentActivityWindow()) {
+        handleOpenAgentSession(pubkey, destinationChannelId);
+        return;
+      }
+
+      void openAgentActivityWindow(destinationChannelId, pubkey)
+        .then((openedNativeWindow) => {
+          if (!openedNativeWindow) {
+            handleOpenAgentSession(pubkey, destinationChannelId);
+          }
+        })
+        .catch((error) => {
+          console.error("Failed to open agent activity window:", error);
+          toast.error("Couldn't open the agent activity window.");
+        });
+    },
+    [activeChannelId, handleOpenAgentSession],
+  );
   const { handleOpenProfilePanel, handleCloseProfilePanel, handleOpenDm } =
     useChannelProfilePanel({
       closeAgentSession: handleCloseAgentSession,
@@ -772,7 +798,7 @@ export function ChannelScreen({
     ],
   );
   return (
-    <AgentSessionProvider onOpenAgentSession={handleOpenAgentSession}>
+    <AgentSessionProvider onOpenAgentSession={handleOpenAgentActivity}>
       <ProfilePanelProvider onOpenProfilePanel={handleOpenProfilePanel}>
         <WelcomeAgentCreateDialog
           guideName={welcomeGuideAgent?.name ?? "your welcome guide"}
@@ -911,7 +937,7 @@ export function ChannelScreen({
                   onMarkUnread={handleMessageMarkUnread}
                   onMarkRead={handleMessageMarkRead}
                   onExpandThreadReplies={handleExpandThreadReplies}
-                  onOpenAgentSession={handleOpenAgentSession}
+                  onOpenAgentSession={handleOpenAgentActivity}
                   onOpenDm={handleOpenDm}
                   onOpenProfilePanel={handleOpenProfilePanel}
                   onResetThreadPanelWidth={handleThreadPanelWidthReset}
@@ -969,7 +995,7 @@ export function ChannelScreen({
           currentPubkey={currentPubkey}
           open={isMembersSidebarOpen}
           onOpenChange={setIsMembersSidebarOpen}
-          onViewActivity={handleOpenAgentSession}
+          onViewActivity={handleOpenAgentActivity}
           relayUrl={activeCommunity?.relayUrl}
         />
       </ProfilePanelProvider>

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -306,6 +306,10 @@ export function ChannelScreen({
     welcomeGuideAgent,
   });
   const relayAgentsQuery = useRelayAgentsQuery();
+  const agentsLoading =
+    channelMembersQuery.isLoading ||
+    managedAgentsQuery.isLoading ||
+    relayAgentsQuery.isLoading;
   const relayAgents = relayAgentsQuery.data ?? [];
   const knownAgentPubkeys = React.useMemo(
     () =>
@@ -568,16 +572,14 @@ export function ChannelScreen({
   } = useChannelAgentSessions({
     activeChannel,
     activeChannelId,
-    agentsLoaded:
-      !channelMembersQuery.isLoading &&
-      !managedAgentsQuery.isLoading &&
-      !relayAgentsQuery.isLoading,
+    agentsLoaded: !agentsLoading,
     channelMembers,
     handleOpenThread,
     managedAgents: agentSessionCandidates,
     openAgentSessionPubkey,
     openThreadHeadId: effectiveOpenThreadHeadId,
     profilePanelPubkey,
+    preserveUnresolvedSession: isDedicatedActivityWindow,
     setChannelManagementOpen,
     setExpandedThreadReplyIds,
     setOpenAgentSessionChannelId,
@@ -890,6 +892,7 @@ export function ChannelScreen({
                   isMessageUnreadById={isMessageUnread}
                   isFollowingThread={isNotifiedForEffectiveThread}
                   isSending={sendMessageMutation.isPending}
+                  isAgentSessionLoading={agentsLoading}
                   isSinglePanelView={isSinglePanelView}
                   isTimelineLoading={isTimelineLoading}
                   messages={timelineMessages}

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -217,6 +217,7 @@ export function ChannelScreen({
     activeChannelId,
     activeChannel?.isMember,
     activeReadAt,
+    !isDedicatedActivityWindow,
   );
   React.useEffect(() => {
     if (!activeChannelId) {

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -589,7 +589,11 @@ export function ChannelScreen({
   const {
     openInApp: handleOpenAgentActivity,
     openInExternalWindow: handleOpenAgentActivityExternal,
-  } = useOpenAgentActivityActions(activeChannelId, handleOpenAgentSession);
+  } = useOpenAgentActivityActions(
+    activeCommunity?.id ?? null,
+    activeChannelId,
+    handleOpenAgentSession,
+  );
   const { handleOpenProfilePanel, handleCloseProfilePanel, handleOpenDm } =
     useChannelProfilePanel({
       closeAgentSession: handleCloseAgentSession,

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -587,7 +587,7 @@ export function ChannelScreen({
     setThreadReplyTargetId,
     setThreadScrollTargetId,
   });
-  const handleOpenAgentActivity = React.useCallback(
+  const handleOpenAgentActivityExternal = React.useCallback(
     (pubkey: string, channelId?: string | null) => {
       const destinationChannelId = channelId ?? activeChannelId;
       if (!destinationChannelId) return;
@@ -607,6 +607,12 @@ export function ChannelScreen({
           console.error("Failed to open agent activity window:", error);
           toast.error("Couldn't open the agent activity window.");
         });
+    },
+    [activeChannelId, handleOpenAgentSession],
+  );
+  const handleOpenAgentActivity = React.useCallback(
+    (pubkey: string, channelId?: string | null) => {
+      handleOpenAgentSession(pubkey, channelId ?? activeChannelId);
     },
     [activeChannelId, handleOpenAgentSession],
   );
@@ -943,6 +949,7 @@ export function ChannelScreen({
                   onMarkRead={handleMessageMarkRead}
                   onExpandThreadReplies={handleExpandThreadReplies}
                   onOpenAgentSession={handleOpenAgentActivity}
+                  onOpenAgentSessionExternal={handleOpenAgentActivityExternal}
                   onOpenDm={handleOpenDm}
                   onOpenProfilePanel={handleOpenProfilePanel}
                   onResetThreadPanelWidth={handleThreadPanelWidthReset}

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -98,6 +98,7 @@ export function ChannelScreen({
   targetMessageEvents,
   targetMessageId,
 }: ChannelScreenProps) {
+  const isDedicatedActivityWindow = isAgentActivityWindow();
   const { goHome } = useAppNavigation();
   const { activeCommunity } = useCommunities();
   const {
@@ -713,10 +714,13 @@ export function ChannelScreen({
   const isNarrowPanelViewport =
     channelContentWidthPx > 0 &&
     channelContentWidthPx < AUXILIARY_PANEL_SINGLE_COLUMN_BREAKPOINT_PX;
+  // A dedicated activity window is the panel itself, not a responsive channel
+  // view. Keep the channel timeline out of that window at every width.
   const isSinglePanelView =
-    isNarrowPanelViewport &&
-    activeChannel?.channelType !== "forum" &&
-    hasAuxiliaryPanel;
+    isDedicatedActivityWindow ||
+    (isNarrowPanelViewport &&
+      activeChannel?.channelType !== "forum" &&
+      hasAuxiliaryPanel);
   const shouldCompactHeaderActions =
     hasAuxiliaryPanel &&
     channelContentWidthPx > 0 &&
@@ -853,6 +857,7 @@ export function ChannelScreen({
               <React.Suspense
                 fallback={
                   <ChannelScreenLoadingFallback
+                    includeHeader={!isDedicatedActivityWindow}
                     isHuddleTranscript={isHuddleTranscript}
                   />
                 }

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { toast } from "sonner";
 import { useAppShell } from "@/app/AppShellContext";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { useActiveChannelHeader } from "@/features/channels/useActiveChannelHeader";
@@ -58,7 +57,6 @@ import type { TimelineMessage } from "@/features/messages/types";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { useRelaySelfQuery } from "@/features/moderation/hooks";
 import type { RelayEvent, RespondToMode } from "@/shared/api/types";
-import { openAgentActivityWindow } from "@/shared/api/agentActivityWindow";
 import { isAgentActivityWindow } from "@/features/agents/lib/agentActivityWindow";
 import { ChannelScreenLoadingFallback } from "@/features/channels/ui/ChannelScreenLoadingFallback";
 import {
@@ -79,6 +77,7 @@ import { normalizePubkey } from "@/shared/lib/pubkey";
 import { useChannelActivityTyping } from "./useChannelActivityTyping";
 import { useChannelAgentSessions } from "./useChannelAgentSessions";
 import { useMessageProfiles } from "./useMessageProfiles";
+import { useOpenAgentActivityActions } from "./useOpenAgentActivityActions";
 import { useChannelPanelHistoryState } from "./useChannelPanelHistoryState";
 import { useChannelProfilePanel } from "./useChannelProfilePanel";
 import { useChannelRouteTarget } from "./useChannelRouteTarget";
@@ -587,35 +586,10 @@ export function ChannelScreen({
     setThreadReplyTargetId,
     setThreadScrollTargetId,
   });
-  const handleOpenAgentActivityExternal = React.useCallback(
-    (pubkey: string, channelId?: string | null) => {
-      const destinationChannelId = channelId ?? activeChannelId;
-      if (!destinationChannelId) return;
-
-      if (isAgentActivityWindow()) {
-        handleOpenAgentSession(pubkey, destinationChannelId);
-        return;
-      }
-
-      void openAgentActivityWindow(destinationChannelId, pubkey)
-        .then((openedNativeWindow) => {
-          if (!openedNativeWindow) {
-            handleOpenAgentSession(pubkey, destinationChannelId);
-          }
-        })
-        .catch((error) => {
-          console.error("Failed to open agent activity window:", error);
-          toast.error("Couldn't open the agent activity window.");
-        });
-    },
-    [activeChannelId, handleOpenAgentSession],
-  );
-  const handleOpenAgentActivity = React.useCallback(
-    (pubkey: string, channelId?: string | null) => {
-      handleOpenAgentSession(pubkey, channelId ?? activeChannelId);
-    },
-    [activeChannelId, handleOpenAgentSession],
-  );
+  const {
+    openInApp: handleOpenAgentActivity,
+    openInExternalWindow: handleOpenAgentActivityExternal,
+  } = useOpenAgentActivityActions(activeChannelId, handleOpenAgentSession);
   const { handleOpenProfilePanel, handleCloseProfilePanel, handleOpenDm } =
     useChannelProfilePanel({
       closeAgentSession: handleCloseAgentSession,

--- a/desktop/src/features/channels/ui/ChannelScreenLoadingFallback.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreenLoadingFallback.tsx
@@ -2,13 +2,15 @@ import { HuddleStartingView } from "@/features/huddle/components/HuddleStartingV
 import { ViewLoadingFallback } from "@/shared/ui/ViewLoadingFallback";
 
 export function ChannelScreenLoadingFallback({
+  includeHeader = true,
   isHuddleTranscript,
 }: {
+  includeHeader?: boolean;
   isHuddleTranscript: boolean;
 }) {
   return isHuddleTranscript ? (
     <HuddleStartingView />
   ) : (
-    <ViewLoadingFallback includeHeader kind="channel" />
+    <ViewLoadingFallback includeHeader={includeHeader} kind="channel" />
   );
 }

--- a/desktop/src/features/channels/ui/useChannelAgentSessions.test.mjs
+++ b/desktop/src/features/channels/ui/useChannelAgentSessions.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldClearUnresolvedAgentSession } from "./useChannelAgentSessions.ts";
+
+const unresolvedSession = {
+  agentSessionAgents: [],
+  agentsLoaded: true,
+  openAgentSessionPubkey: "agent-pubkey",
+  profilePanelPubkey: null,
+};
+
+test("dedicated activity windows preserve unresolved sessions for an empty state", () => {
+  assert.equal(
+    shouldClearUnresolvedAgentSession({
+      ...unresolvedSession,
+      preserveUnresolvedSession: true,
+    }),
+    false,
+  );
+});
+
+test("the in-app panel still clears stale unresolved sessions", () => {
+  assert.equal(
+    shouldClearUnresolvedAgentSession({
+      ...unresolvedSession,
+      preserveUnresolvedSession: false,
+    }),
+    true,
+  );
+});

--- a/desktop/src/features/channels/ui/useChannelAgentSessions.ts
+++ b/desktop/src/features/channels/ui/useChannelAgentSessions.ts
@@ -39,6 +39,7 @@ type UseChannelAgentSessionsOptions = {
   openAgentSessionPubkey: string | null;
   openThreadHeadId: string | null;
   profilePanelPubkey?: string | null;
+  preserveUnresolvedSession?: boolean;
   setChannelManagementOpen: (open: boolean) => void;
   setExpandedThreadReplyIds: (value: Set<string>) => void;
   setOpenAgentSessionChannelId: PanelValueSetter;
@@ -163,6 +164,33 @@ export function getChannelAgentSessionAgents({
   });
 }
 
+export function shouldClearUnresolvedAgentSession({
+  agentSessionAgents,
+  agentsLoaded,
+  openAgentSessionPubkey,
+  preserveUnresolvedSession,
+  profilePanelPubkey,
+}: {
+  agentSessionAgents: ChannelAgentSessionAgent[];
+  agentsLoaded: boolean;
+  openAgentSessionPubkey: string | null;
+  preserveUnresolvedSession: boolean;
+  profilePanelPubkey: string | null;
+}): boolean {
+  return Boolean(
+    openAgentSessionPubkey &&
+      !preserveUnresolvedSession &&
+      agentsLoaded &&
+      normalizePubkey(profilePanelPubkey ?? "") !==
+        normalizePubkey(openAgentSessionPubkey) &&
+      !agentSessionAgents.some(
+        (agent) =>
+          normalizePubkey(agent.pubkey) ===
+          normalizePubkey(openAgentSessionPubkey),
+      ),
+  );
+}
+
 export function useChannelAgentSessions({
   activeChannel,
   activeChannelId,
@@ -173,6 +201,7 @@ export function useChannelAgentSessions({
   openAgentSessionPubkey,
   openThreadHeadId,
   profilePanelPubkey = null,
+  preserveUnresolvedSession = false,
   setChannelManagementOpen,
   setExpandedThreadReplyIds,
   setOpenAgentSessionChannelId,
@@ -298,15 +327,13 @@ export function useChannelAgentSessions({
     // agent queries have settled. Once loaded, a channel that legitimately has
     // zero agents will still auto-close a stale param.
     if (
-      openAgentSessionPubkey &&
-      agentsLoaded &&
-      normalizePubkey(profilePanelPubkey ?? "") !==
-        normalizePubkey(openAgentSessionPubkey) &&
-      !agentSessionAgents.some(
-        (agent) =>
-          normalizePubkey(agent.pubkey) ===
-          normalizePubkey(openAgentSessionPubkey),
-      )
+      shouldClearUnresolvedAgentSession({
+        agentSessionAgents,
+        agentsLoaded,
+        openAgentSessionPubkey,
+        preserveUnresolvedSession,
+        profilePanelPubkey,
+      })
     ) {
       returnTarget.clear();
       setOpenAgentSessionPubkey(null, { replace: true });
@@ -315,6 +342,7 @@ export function useChannelAgentSessions({
     agentSessionAgents,
     agentsLoaded,
     openAgentSessionPubkey,
+    preserveUnresolvedSession,
     profilePanelPubkey,
     returnTarget,
     setOpenAgentSessionPubkey,

--- a/desktop/src/features/channels/ui/useChannelOpenReadState.test.mjs
+++ b/desktop/src/features/channels/ui/useChannelOpenReadState.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getTopLevelInboxUnreadOverrideIds } from "./useChannelOpenReadState.ts";
+import {
+  getTopLevelInboxUnreadOverrideIds,
+  shouldAdvanceChannelReadState,
+} from "./useChannelOpenReadState.ts";
 
 test("opening a channel clears only its top-level Inbox overrides", () => {
   assert.deepEqual(
@@ -21,5 +24,24 @@ test("opening a channel clears only its top-level Inbox overrides", () => {
       "general",
     ),
     ["top-level"],
+  );
+});
+
+test("passive activity companions never advance synced read state", () => {
+  assert.equal(
+    shouldAdvanceChannelReadState({
+      activeChannelId: "general",
+      enabled: false,
+      isChannelMember: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldAdvanceChannelReadState({
+      activeChannelId: "general",
+      enabled: true,
+      isChannelMember: true,
+    }),
+    true,
   );
 });

--- a/desktop/src/features/channels/ui/useChannelOpenReadState.ts
+++ b/desktop/src/features/channels/ui/useChannelOpenReadState.ts
@@ -17,16 +17,29 @@ export function getTopLevelInboxUnreadOverrideIds(
   );
 }
 
+export function shouldAdvanceChannelReadState({
+  activeChannelId,
+  enabled,
+  isChannelMember,
+}: {
+  activeChannelId: string | null;
+  enabled: boolean;
+  isChannelMember: boolean | undefined;
+}): boolean {
+  return enabled && activeChannelId !== null && isChannelMember !== false;
+}
+
 export function useChannelOpenReadState(
   activeChannelId: string | null,
   isChannelMember: boolean | undefined,
   activeReadAt: string | null,
+  enabled = true,
 ) {
   const { feedItemState, locallyUnreadFeedItems, markChannelRead } =
     useAppShell();
 
   React.useEffect(() => {
-    if (!activeChannelId || isChannelMember === false) return;
+    if (!activeChannelId || !enabled || isChannelMember === false) return;
     for (const itemId of getTopLevelInboxUnreadOverrideIds(
       locallyUnreadFeedItems,
       activeChannelId,
@@ -37,6 +50,7 @@ export function useChannelOpenReadState(
   }, [
     activeChannelId,
     activeReadAt,
+    enabled,
     feedItemState.undoUnread,
     isChannelMember,
     locallyUnreadFeedItems,

--- a/desktop/src/features/channels/ui/useChannelOpenReadState.ts
+++ b/desktop/src/features/channels/ui/useChannelOpenReadState.ts
@@ -39,7 +39,16 @@ export function useChannelOpenReadState(
     useAppShell();
 
   React.useEffect(() => {
-    if (!activeChannelId || !enabled || isChannelMember === false) return;
+    if (
+      !shouldAdvanceChannelReadState({
+        activeChannelId,
+        enabled,
+        isChannelMember,
+      }) ||
+      !activeChannelId
+    ) {
+      return;
+    }
     for (const itemId of getTopLevelInboxUnreadOverrideIds(
       locallyUnreadFeedItems,
       activeChannelId,

--- a/desktop/src/features/channels/ui/useHuddleReadMarker.test.mjs
+++ b/desktop/src/features/channels/ui/useHuddleReadMarker.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { after, afterEach, before, test } from "node:test";
+
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+before(() => {
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    window: dom.window,
+  });
+});
+
+afterEach(async () => {
+  const { cleanup } = await import("@testing-library/react");
+  cleanup();
+});
+
+after(() => dom.window.close());
+
+const topLevelMessage = {
+  content: "message",
+  created_at: 1_724_457_600,
+  id: "message-id",
+  kind: 9,
+  pubkey: "author",
+  sig: "signature",
+  tags: [["h", "general"]],
+};
+
+async function mountReadMarker(enabled) {
+  const { renderHook } = await import("@testing-library/react");
+  const { useHuddleReadMarker } = await import("./useHuddleReadMarker.ts");
+  const calls = [];
+  const view = renderHook(() =>
+    useHuddleReadMarker({
+      activeChannelId: "general",
+      activeChannelIsMember: true,
+      enabled,
+      isHuddleTranscript: false,
+      markChannelRead: (...args) => calls.push(args),
+      messages: [topLevelMessage],
+      resolvedMessages: [topLevelMessage],
+    }),
+  );
+  return { calls, view };
+}
+
+test("disabled activity companions do not advance the huddle read marker", async () => {
+  const { calls } = await mountReadMarker(false);
+  assert.deepEqual(calls, []);
+});
+
+test("enabled channel screens retain the top-level read marker", async () => {
+  const { calls } = await mountReadMarker(true);
+  assert.deepEqual(calls, [
+    ["general", "2024-08-24T00:00:00.000Z", { topLevelOnly: true }],
+  ]);
+});

--- a/desktop/src/features/channels/ui/useHuddleReadMarker.ts
+++ b/desktop/src/features/channels/ui/useHuddleReadMarker.ts
@@ -13,6 +13,7 @@ type HuddleReadMarkerOptions = {
   activeChannelId: string | null;
   activeChannelIsMember: boolean | undefined;
   isHuddleTranscript: boolean;
+  enabled?: boolean;
   markChannelRead: MarkChannelRead;
   messages: RelayEvent[] | undefined;
   resolvedMessages: RelayEvent[];
@@ -22,6 +23,7 @@ export function useHuddleReadMarker({
   activeChannelId,
   activeChannelIsMember,
   isHuddleTranscript,
+  enabled = true,
   markChannelRead,
   messages,
   resolvedMessages,
@@ -65,7 +67,7 @@ export function useHuddleReadMarker({
   const lastHuddleReadKeyRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
-    if (!activeChannelId || activeChannelIsMember === false) return;
+    if (!enabled || !activeChannelId || activeChannelIsMember === false) return;
     const huddleReadKey = hasFlattenedHuddleReplies
       ? `${activeChannelId}:${huddleReadAt}`
       : null;
@@ -82,6 +84,7 @@ export function useHuddleReadMarker({
   }, [
     activeChannelId,
     activeChannelIsMember,
+    enabled,
     hasFlattenedHuddleReplies,
     huddleReadAt,
     markChannelRead,

--- a/desktop/src/features/channels/ui/useOpenAgentActivityActions.ts
+++ b/desktop/src/features/channels/ui/useOpenAgentActivityActions.ts
@@ -7,20 +7,25 @@ import { openAgentActivityWindow } from "@/shared/api/agentActivityWindow";
 type OpenAgentSession = (pubkey: string, channelId?: string | null) => void;
 
 export function useOpenAgentActivityActions(
+  activeCommunityId: string | null,
   activeChannelId: string | null,
   openAgentSession: OpenAgentSession,
 ) {
   const openInExternalWindow = React.useCallback(
     (pubkey: string, channelId?: string | null) => {
       const destinationChannelId = channelId ?? activeChannelId;
-      if (!destinationChannelId) return;
+      if (!destinationChannelId || !activeCommunityId) return;
 
       if (isAgentActivityWindow()) {
         openAgentSession(pubkey, destinationChannelId);
         return;
       }
 
-      void openAgentActivityWindow(destinationChannelId, pubkey)
+      void openAgentActivityWindow(
+        activeCommunityId,
+        destinationChannelId,
+        pubkey,
+      )
         .then((openedNativeWindow) => {
           if (!openedNativeWindow) {
             openAgentSession(pubkey, destinationChannelId);
@@ -31,7 +36,7 @@ export function useOpenAgentActivityActions(
           toast.error("Couldn't open the agent activity window.");
         });
     },
-    [activeChannelId, openAgentSession],
+    [activeChannelId, activeCommunityId, openAgentSession],
   );
   const openInApp = React.useCallback(
     (pubkey: string, channelId?: string | null) => {

--- a/desktop/src/features/channels/ui/useOpenAgentActivityActions.ts
+++ b/desktop/src/features/channels/ui/useOpenAgentActivityActions.ts
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { toast } from "sonner";
+
+import { isAgentActivityWindow } from "@/features/agents/lib/agentActivityWindow";
+import { openAgentActivityWindow } from "@/shared/api/agentActivityWindow";
+
+type OpenAgentSession = (pubkey: string, channelId?: string | null) => void;
+
+export function useOpenAgentActivityActions(
+  activeChannelId: string | null,
+  openAgentSession: OpenAgentSession,
+) {
+  const openInExternalWindow = React.useCallback(
+    (pubkey: string, channelId?: string | null) => {
+      const destinationChannelId = channelId ?? activeChannelId;
+      if (!destinationChannelId) return;
+
+      if (isAgentActivityWindow()) {
+        openAgentSession(pubkey, destinationChannelId);
+        return;
+      }
+
+      void openAgentActivityWindow(destinationChannelId, pubkey)
+        .then((openedNativeWindow) => {
+          if (!openedNativeWindow) {
+            openAgentSession(pubkey, destinationChannelId);
+          }
+        })
+        .catch((error) => {
+          console.error("Failed to open agent activity window:", error);
+          toast.error("Couldn't open the agent activity window.");
+        });
+    },
+    [activeChannelId, openAgentSession],
+  );
+  const openInApp = React.useCallback(
+    (pubkey: string, channelId?: string | null) => {
+      openAgentSession(pubkey, channelId ?? activeChannelId);
+    },
+    [activeChannelId, openAgentSession],
+  );
+
+  return { openInApp, openInExternalWindow };
+}

--- a/desktop/src/features/communities/useCommunities.tsx
+++ b/desktop/src/features/communities/useCommunities.tsx
@@ -154,8 +154,14 @@ export type UseCommunitiesReturn = {
 
 const CommunitiesContext = createContext<UseCommunitiesReturn | null>(null);
 
-export function CommunitiesProvider({ children }: { children: ReactNode }) {
-  const value = useCommunitiesInternal();
+export function CommunitiesProvider({
+  children,
+  initialActiveCommunityId,
+}: {
+  children: ReactNode;
+  initialActiveCommunityId?: string | null;
+}) {
+  const value = useCommunitiesInternal(initialActiveCommunityId);
   return (
     <CommunitiesContext.Provider value={value}>
       {children}
@@ -171,19 +177,26 @@ export function useCommunities(): UseCommunitiesReturn {
   return ctx;
 }
 
-function useCommunitiesInternal(): UseCommunitiesReturn {
+function useCommunitiesInternal(
+  initialActiveCommunityId?: string | null,
+): UseCommunitiesReturn {
   const [communities, setCommunitiesState] =
     useState<Community[]>(loadCommunities);
-  const [activeId, setActiveId] = useState<string | null>(
-    loadActiveCommunityId,
+  const [activeId, setActiveId] = useState<string | null>(() =>
+    initialActiveCommunityId === undefined
+      ? loadActiveCommunityId()
+      : initialActiveCommunityId,
   );
   const [reinitKey, setReinitKey] = useState(0);
   const communitiesRef = useRef(communities);
   communitiesRef.current = communities;
 
   const activeCommunity = useMemo(
-    () => communities.find((w) => w.id === activeId) ?? communities[0] ?? null,
-    [communities, activeId],
+    () =>
+      communities.find((community) => community.id === activeId) ??
+      (initialActiveCommunityId === undefined ? communities[0] : null) ??
+      null,
+    [activeId, communities, initialActiveCommunityId],
   );
 
   const addCommunity = useCallback((community: Community): string => {

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -106,6 +106,7 @@ export function useCommunityInit(
   communityKey: string,
   isSharedIdentity: boolean,
   suppressAutoConnect = false,
+  applyBackend = true,
 ): CommunityInitResult {
   const [result, setResult] = useState<CommunityInitResult>({
     isReady: false,
@@ -289,13 +290,15 @@ export function useCommunityInit(
       // imported key. `loadCommunities()` strips lingering `nsec` fields from
       // legacy entries; this site refuses to apply one even if present.
       try {
-        await applyCommunity(
-          activeCommunity.relayUrl,
-          undefined,
-          activeCommunity.token,
-          activeCommunity.reposDir,
-          getOverrides().agentManagedProfiles === true,
-        );
+        if (applyBackend) {
+          await applyCommunity(
+            activeCommunity.relayUrl,
+            undefined,
+            activeCommunity.token,
+            activeCommunity.reposDir,
+            getOverrides().agentManagedProfiles === true,
+          );
+        }
       } catch (error) {
         // A bad `repos_dir` no longer reaches here — `apply_workspace` treats
         // it as non-fatal (relay/keys apply, bad value not persisted, REPOS
@@ -356,6 +359,7 @@ export function useCommunityInit(
     activeCommunity?.relayUrl,
     activeCommunity?.token,
     activeCommunity?.reposDir,
+    applyBackend,
     isSharedIdentity,
     suppressAutoConnect,
     communityKey,

--- a/desktop/src/features/local-archive/useArchiveSync.test.mjs
+++ b/desktop/src/features/local-archive/useArchiveSync.test.mjs
@@ -75,7 +75,7 @@ function mountGate({
     },
     // `getCurrentWindow()` reads exactly this path (api/window.js:85), and
     // `isTauri()` reads `globalThis.isTauri` (api/core.js:280). Both are what
-    // `huddleWindowChannelId` uses to tell a companion realm from the main one.
+    // `isCompanionWindow` uses to tell a companion realm from the main one.
     metadata: { currentWindow: { label: windowLabel } },
     transformCallback: () => Math.random(),
   };
@@ -265,25 +265,28 @@ describe("archive sync lifecycle leases", () => {
 // commands at all.
 
 describe("archive sync realm ownership", () => {
-  it("issues no archive lifecycle commands from a companion window", async () => {
-    const gate = mountGate({
-      windowLabel: "huddle-11111111-2222-3333-4444-555555555555",
-    });
-    await gate.mount();
-    await gate.settleGate();
-    await gate.unmount();
+  for (const windowLabel of [
+    "huddle-test-channel-do-not-use",
+    "agent-activity-test-agent-do-not-use-test-channel-do-not-use",
+  ]) {
+    it(`issues no archive lifecycle commands from ${windowLabel}`, async () => {
+      const gate = mountGate({ windowLabel });
+      await gate.mount();
+      await gate.settleGate();
+      await gate.unmount();
 
-    assert.deepEqual(
-      gate.invoked.filter(
-        (cmd) =>
-          cmd.endsWith("_archive_sync") ||
-          cmd === "announce_archive_sync_epoch",
-      ),
-      [],
-      "a companion realm must not announce or run lifecycle commands — its " +
-        "cleanup would cancel the main window's live sync task",
-    );
-  });
+      assert.deepEqual(
+        gate.invoked.filter(
+          (cmd) =>
+            cmd.endsWith("_archive_sync") ||
+            cmd === "announce_archive_sync_epoch",
+        ),
+        [],
+        "a companion realm must not announce or run lifecycle commands — its " +
+          "cleanup would cancel the main window's live sync task",
+      );
+    });
+  }
 
   it("still runs the lifecycle in the main window", async () => {
     const gate = mountGate({ windowLabel: "main" });

--- a/desktop/src/features/local-archive/useArchiveSync.ts
+++ b/desktop/src/features/local-archive/useArchiveSync.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { huddleWindowChannelId } from "@/features/huddle/lib/huddleWindow";
+import { isCompanionWindow } from "@/app/companionWindow";
 import {
   announceArchiveSyncEpoch,
   nextArchiveSyncLease,
@@ -60,7 +60,7 @@ export function useArchiveSync(ready: boolean): void {
   React.useEffect(() => {
     if (!ready) return;
     // Companion realms do not participate; see the ownership rule above.
-    if (huddleWindowChannelId() !== null) return;
+    if (isCompanionWindow()) return;
 
     const lease = nextArchiveSyncLease();
     let stopped = false;

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -13,7 +13,11 @@ import { UpdaterProvider } from "@/features/settings/hooks/UpdaterProvider";
 import { migrateLegacyCommunityStorageBeforeRender } from "@/features/communities/legacyCommunityStorage";
 import { loadCommunities } from "@/features/communities/communityStorage";
 import { CommunitiesProvider } from "@/features/communities/useCommunities";
-import { companionCommunityId, isCompanionWindow } from "@/app/companionWindow";
+import {
+  companionCommunityBootstrap,
+  currentCompanionWindowKind,
+  isCompanionWindow,
+} from "@/app/companionWindow";
 import { CommunityOnboardingProvider } from "@/features/onboarding/communityOnboarding";
 import { ThemeProvider } from "@/shared/theme/ThemeProvider";
 import { EmojiBurstProvider } from "@/shared/ui/EmojiBurstProvider";
@@ -99,17 +103,22 @@ function renderCompanionBootstrapError(message: string) {
 }
 
 function renderApp() {
-  const companion = isCompanionWindow();
-  const companionCommunity = companionCommunityId();
-  if (companion && !companionCommunity) {
+  const companionKind = currentCompanionWindowKind();
+  const companionCommunity = companionCommunityBootstrap(
+    companionKind,
+    window.location.hash,
+  );
+  if (companionCommunity.missingRequiredCommunity) {
     renderCompanionBootstrapError(
       "This window is missing its community context. Close it and try again.",
     );
     return;
   }
   if (
-    companionCommunity &&
-    !loadCommunities().some(({ id }) => id === companionCommunity)
+    companionCommunity.initialActiveCommunityId &&
+    !loadCommunities().some(
+      ({ id }) => id === companionCommunity.initialActiveCommunityId,
+    )
   ) {
     renderCompanionBootstrapError(
       "This community is no longer available. Close this window and open activity again from Buzz.",
@@ -122,7 +131,9 @@ function renderApp() {
       {/* block/buzz#5078 — catch any uncaught render error so a WebKit
           SecurityError from localStorage can't blank the whole window. */}
       <RootErrorBoundary>
-        <CommunitiesProvider initialActiveCommunityId={companionCommunity}>
+        <CommunitiesProvider
+          initialActiveCommunityId={companionCommunity.initialActiveCommunityId}
+        >
           <CommunityOnboardingProvider enabled={!isCompanionWindow()}>
             <ThemeProvider defaultTheme="buzz">
               <TooltipProvider>

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -1,3 +1,4 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "@/app/App";
@@ -10,8 +11,9 @@ import "@fontsource/jetbrains-mono/700.css";
 import "@/shared/styles/globals.css";
 import { UpdaterProvider } from "@/features/settings/hooks/UpdaterProvider";
 import { migrateLegacyCommunityStorageBeforeRender } from "@/features/communities/legacyCommunityStorage";
+import { loadCommunities } from "@/features/communities/communityStorage";
 import { CommunitiesProvider } from "@/features/communities/useCommunities";
-import { isCompanionWindow } from "@/app/companionWindow";
+import { companionCommunityId, isCompanionWindow } from "@/app/companionWindow";
 import { CommunityOnboardingProvider } from "@/features/onboarding/communityOnboarding";
 import { ThemeProvider } from "@/shared/theme/ThemeProvider";
 import { EmojiBurstProvider } from "@/shared/ui/EmojiBurstProvider";
@@ -78,13 +80,49 @@ function configureDevE2eBridgeFromUrl() {
   );
 }
 
+function renderCompanionBootstrapError(message: string) {
+  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+    <main className="grid h-screen place-items-center bg-background p-8 text-center text-foreground">
+      <div className="max-w-sm space-y-3">
+        <h1 className="text-lg font-semibold">Couldn’t open activity</h1>
+        <p className="text-sm text-muted-foreground">{message}</p>
+        <button
+          className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+          onClick={() => void getCurrentWindow().close()}
+          type="button"
+        >
+          Close window
+        </button>
+      </div>
+    </main>,
+  );
+}
+
 function renderApp() {
+  const companion = isCompanionWindow();
+  const companionCommunity = companionCommunityId();
+  if (companion && !companionCommunity) {
+    renderCompanionBootstrapError(
+      "This window is missing its community context. Close it and try again.",
+    );
+    return;
+  }
+  if (
+    companionCommunity &&
+    !loadCommunities().some(({ id }) => id === companionCommunity)
+  ) {
+    renderCompanionBootstrapError(
+      "This community is no longer available. Close this window and open activity again from Buzz.",
+    );
+    return;
+  }
+
   ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>
       {/* block/buzz#5078 — catch any uncaught render error so a WebKit
           SecurityError from localStorage can't blank the whole window. */}
       <RootErrorBoundary>
-        <CommunitiesProvider>
+        <CommunitiesProvider initialActiveCommunityId={companionCommunity}>
           <CommunityOnboardingProvider enabled={!isCompanionWindow()}>
             <ThemeProvider defaultTheme="buzz">
               <TooltipProvider>

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -12,6 +12,7 @@ import { UpdaterProvider } from "@/features/settings/hooks/UpdaterProvider";
 import { migrateLegacyCommunityStorageBeforeRender } from "@/features/communities/legacyCommunityStorage";
 import { CommunitiesProvider } from "@/features/communities/useCommunities";
 import { huddleWindowChannelId } from "@/features/huddle/lib/huddleWindow";
+import { isAgentActivityWindow } from "@/features/agents/lib/agentActivityWindow";
 import { CommunityOnboardingProvider } from "@/features/onboarding/communityOnboarding";
 import { ThemeProvider } from "@/shared/theme/ThemeProvider";
 import { EmojiBurstProvider } from "@/shared/ui/EmojiBurstProvider";
@@ -86,7 +87,9 @@ function renderApp() {
       <RootErrorBoundary>
         <CommunitiesProvider>
           <CommunityOnboardingProvider
-            enabled={huddleWindowChannelId() === null}
+            enabled={
+              huddleWindowChannelId() === null && !isAgentActivityWindow()
+            }
           >
             <ThemeProvider defaultTheme="buzz">
               <TooltipProvider>

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -11,8 +11,7 @@ import "@/shared/styles/globals.css";
 import { UpdaterProvider } from "@/features/settings/hooks/UpdaterProvider";
 import { migrateLegacyCommunityStorageBeforeRender } from "@/features/communities/legacyCommunityStorage";
 import { CommunitiesProvider } from "@/features/communities/useCommunities";
-import { huddleWindowChannelId } from "@/features/huddle/lib/huddleWindow";
-import { isAgentActivityWindow } from "@/features/agents/lib/agentActivityWindow";
+import { isCompanionWindow } from "@/app/companionWindow";
 import { CommunityOnboardingProvider } from "@/features/onboarding/communityOnboarding";
 import { ThemeProvider } from "@/shared/theme/ThemeProvider";
 import { EmojiBurstProvider } from "@/shared/ui/EmojiBurstProvider";
@@ -86,11 +85,7 @@ function renderApp() {
           SecurityError from localStorage can't blank the whole window. */}
       <RootErrorBoundary>
         <CommunitiesProvider>
-          <CommunityOnboardingProvider
-            enabled={
-              huddleWindowChannelId() === null && !isAgentActivityWindow()
-            }
-          >
+          <CommunityOnboardingProvider enabled={!isCompanionWindow()}>
             <ThemeProvider defaultTheme="buzz">
               <TooltipProvider>
                 <EmojiBurstProvider>

--- a/desktop/src/shared/api/agentActivityWindow.ts
+++ b/desktop/src/shared/api/agentActivityWindow.ts
@@ -2,9 +2,14 @@ import { invoke, isTauri } from "@tauri-apps/api/core";
 
 /** Opens a channel-scoped agent activity feed in its native companion window. */
 export async function openAgentActivityWindow(
+  communityId: string,
   channelId: string,
   pubkey: string,
 ): Promise<boolean> {
   if (!isTauri()) return false;
-  return invoke<boolean>("open_agent_activity_window", { channelId, pubkey });
+  return invoke<boolean>("open_agent_activity_window", {
+    communityId,
+    channelId,
+    pubkey,
+  });
 }

--- a/desktop/src/shared/api/agentActivityWindow.ts
+++ b/desktop/src/shared/api/agentActivityWindow.ts
@@ -1,0 +1,10 @@
+import { invoke, isTauri } from "@tauri-apps/api/core";
+
+/** Opens a channel-scoped agent activity feed in its native companion window. */
+export async function openAgentActivityWindow(
+  channelId: string,
+  pubkey: string,
+): Promise<boolean> {
+  if (!isTauri()) return false;
+  return invoke<boolean>("open_agent_activity_window", { channelId, pubkey });
+}

--- a/desktop/src/shared/hooks/useHistorySearchState.ts
+++ b/desktop/src/shared/hooks/useHistorySearchState.ts
@@ -1,4 +1,4 @@
-import { currentAgentActivityCompanionCoordinates } from "@/app/companionWindow";
+import { pinCurrentAgentActivityCompanionSearch } from "@/app/companionWindow";
 import * as React from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 
@@ -86,10 +86,10 @@ export function useHistorySearchState<K extends string>(keys: readonly K[]) {
                 nextSearch[key] = value;
               }
             }
-            return {
-              ...nextSearch,
-              ...currentAgentActivityCompanionCoordinates(previousSearch),
-            };
+            return pinCurrentAgentActivityCompanionSearch(
+              previousSearch,
+              nextSearch,
+            );
           },
           replace: flush.replace,
           resetScroll: false,

--- a/desktop/src/shared/hooks/useHistorySearchState.ts
+++ b/desktop/src/shared/hooks/useHistorySearchState.ts
@@ -1,3 +1,4 @@
+import { currentAgentActivityCompanionCoordinates } from "@/app/companionWindow";
 import * as React from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 
@@ -85,7 +86,10 @@ export function useHistorySearchState<K extends string>(keys: readonly K[]) {
                 nextSearch[key] = value;
               }
             }
-            return nextSearch;
+            return {
+              ...nextSearch,
+              ...currentAgentActivityCompanionCoordinates(previousSearch),
+            };
           },
           replace: flush.replace,
           resetScroll: false,

--- a/desktop/src/shared/layout/AuxiliaryPanelHeader.tsx
+++ b/desktop/src/shared/layout/AuxiliaryPanelHeader.tsx
@@ -19,6 +19,7 @@ type AuxiliaryPanelHeaderProps = Omit<
   inset?: "default" | "wide";
   mode?: AuxiliaryPanelMode;
   resizeBorder?: boolean;
+  showCloseAction?: boolean;
   surface?: AuxiliaryPanelSurface;
   /** Render header content without its own backdrop for a shared parent chrome. */
   transparent?: boolean;
@@ -113,6 +114,7 @@ export function AuxiliaryPanelHeader({
   inset = "default",
   mode,
   resizeBorder = false,
+  showCloseAction = true,
   surface = "default",
   transparent,
   ...props
@@ -159,7 +161,7 @@ export function AuxiliaryPanelHeader({
           data-tauri-drag-region
           {...props}
         >
-          {renderAuxiliaryPanelHeaderContent(children)}
+          {renderAuxiliaryPanelHeaderContent(children, showCloseAction)}
         </div>
       </>
     );
@@ -181,15 +183,21 @@ export function AuxiliaryPanelHeader({
         data-tauri-drag-region
       >
         <div className="flex h-9 min-w-0 items-center gap-2.5">
-          {renderAuxiliaryPanelHeaderContent(children)}
+          {renderAuxiliaryPanelHeaderContent(children, showCloseAction)}
         </div>
       </div>
     </div>
   );
 }
 
-function renderAuxiliaryPanelHeaderContent(children: React.ReactNode) {
-  const { foundActions, content } = attachCloseActionToHeaderActions(children);
+function renderAuxiliaryPanelHeaderContent(
+  children: React.ReactNode,
+  showCloseAction: boolean,
+) {
+  const { foundActions, content } = attachCloseActionToHeaderActions(
+    children,
+    showCloseAction,
+  );
 
   if (foundActions) {
     return content;
@@ -198,12 +206,15 @@ function renderAuxiliaryPanelHeaderContent(children: React.ReactNode) {
   return (
     <>
       {children}
-      <AuxiliaryPanelHeaderActions includeCloseAction />
+      <AuxiliaryPanelHeaderActions includeCloseAction={showCloseAction} />
     </>
   );
 }
 
-function attachCloseActionToHeaderActions(children: React.ReactNode): {
+function attachCloseActionToHeaderActions(
+  children: React.ReactNode,
+  includeCloseAction: boolean,
+): {
   content: React.ReactNode;
   foundActions: boolean;
 } {
@@ -216,11 +227,14 @@ function attachCloseActionToHeaderActions(children: React.ReactNode): {
 
     if (child.type === AuxiliaryPanelHeaderActions) {
       foundActions = true;
-      return React.cloneElement(child, { includeCloseAction: true });
+      return React.cloneElement(child, { includeCloseAction });
     }
 
     if (child.type === React.Fragment) {
-      const nested = attachCloseActionToHeaderActions(child.props.children);
+      const nested = attachCloseActionToHeaderActions(
+        child.props.children,
+        includeCloseAction,
+      );
 
       if (!nested.foundActions) {
         return child;

--- a/desktop/src/shared/layout/auxiliaryPanelContext.test.mjs
+++ b/desktop/src/shared/layout/auxiliaryPanelContext.test.mjs
@@ -8,6 +8,7 @@ import { AuxiliaryPanel } from "./AuxiliaryPanel/index.ts";
 import { AuxiliaryPanelBody } from "./AuxiliaryPanel/index.ts";
 import {
   AuxiliaryPanelHeader,
+  AuxiliaryPanelHeaderActions,
   AuxiliaryPanelHeaderGroup,
 } from "./AuxiliaryPanel/index.ts";
 import {
@@ -175,6 +176,33 @@ test("AuxiliaryPanelHeader renders a generic close action from context", () => {
 
   assert.match(html, /aria-label="Close panel"/);
   assert.match(html, /data-testid="auxiliary-panel-close"/);
+});
+
+test("AuxiliaryPanelHeader can suppress its close action", () => {
+  const html = render(
+    React.createElement(
+      AuxiliaryPanel,
+      {
+        header: React.createElement(
+          AuxiliaryPanelHeader,
+          { showCloseAction: false },
+          React.createElement(AuxiliaryPanelHeaderGroup, null, "Title"),
+          React.createElement(
+            AuxiliaryPanelHeaderActions,
+            null,
+            React.createElement("button", { type: "button" }, "Settings"),
+          ),
+        ),
+        onClose: () => {},
+        widthPx: 420,
+      },
+      "Panel",
+    ),
+  );
+
+  assert.match(html, />Settings</);
+  assert.doesNotMatch(html, /aria-label="Close panel"/);
+  assert.doesNotMatch(html, /data-testid="auxiliary-panel-close"/);
 });
 
 test("AuxiliaryPanelHeader keeps resize border in single-panel mode when requested", () => {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -11238,6 +11238,10 @@ export function maybeInstallE2eTauriMocks() {
           await emitMockHuddleState();
         }
         return null;
+      case "open_agent_activity_window":
+        // Browser E2E keeps the in-app fallback so existing interaction specs
+        // can inspect the feed without a second native webview.
+        return false;
       case "open_huddle_window":
         if ((activeConfig?.mock?.openHuddleWindowDelayMs ?? 0) > 0) {
           await new Promise((resolve) =>

--- a/desktop/tests/e2e/agent-activity-window.spec.ts
+++ b/desktop/tests/e2e/agent-activity-window.spec.ts
@@ -60,6 +60,25 @@ test("keeps dedicated activity windows pinned to their original channel", async 
           {
             seq: 2,
             timestamp: new Date().toISOString(),
+            kind: "acp_read",
+            agentIndex: 0,
+            channelId,
+            sessionId: "session-user-message",
+            turnId: "turn-user-message",
+            payload: {
+              method: "session/update",
+              params: {
+                update: {
+                  sessionUpdate: "user_message_chunk",
+                  authorPubkey: repositoryOwnerPubkey,
+                  content: { type: "text", text: "Please inspect the feed" },
+                },
+              },
+            },
+          },
+          {
+            seq: 3,
+            timestamp: new Date().toISOString(),
             kind: "turn_started",
             agentIndex: 0,
             channelId,
@@ -68,7 +87,7 @@ test("keeps dedicated activity windows pinned to their original channel", async 
             payload: { source: "channel", triggeringEventIds: [] },
           },
           {
-            seq: 3,
+            seq: 4,
             timestamp: new Date().toISOString(),
             kind: "acp_read",
             agentIndex: 0,
@@ -104,27 +123,25 @@ test("keeps dedicated activity windows pinned to their original channel", async 
     "Other channel activity must stay hidden",
   );
 
-  const channelReference = panel.getByRole("button", {
-    name: "Open channel general",
-  });
-  await expect(channelReference).toBeVisible();
+  const channelReference = panel.locator("[data-channel-link]");
+  await expect(channelReference).toContainText("general");
+  await expect(
+    panel.getByRole("button", { name: "Open channel general" }),
+  ).toHaveCount(0);
   const activityWindowUrl = page.url();
-  await channelReference.click();
 
-  await expect(page).toHaveURL(activityWindowUrl);
+  await expect(
+    panel.getByRole("button", { name: "Open alice profile" }),
+  ).toHaveCount(0);
   await expect(panel).toBeVisible();
-  await expect(panel).toContainText("Activity · #agents");
-  await expect(panel).not.toContainText(
-    "Other channel activity must stay hidden",
-  );
+  await expect(page).toHaveURL(/agentSession=/);
+  await expect(page).toHaveURL(/agentSessionChannel=/);
 
-  const repositoryChip = panel.getByRole("button", {
-    name: "Open repository relay-tools",
-  });
-  await expect(repositoryChip).toBeVisible();
-  await repositoryChip.click();
+  await expect(panel).toContainText("relay-tools");
+  await expect(
+    panel.getByRole("button", { name: "Open repository relay-tools" }),
+  ).toHaveCount(0);
   await expect(page).toHaveURL(activityWindowUrl);
-  await expect(panel).toBeVisible();
 
   await page.getByTestId("agent-session-settings-menu-trigger").click();
   const rawFeedToggle = page.getByTestId("agent-session-toggle-raw-feed");

--- a/desktop/tests/e2e/agent-activity-window.spec.ts
+++ b/desktop/tests/e2e/agent-activity-window.spec.ts
@@ -79,6 +79,38 @@ test("keeps dedicated activity windows pinned to their original channel", async 
           {
             seq: 3,
             timestamp: new Date().toISOString(),
+            kind: "acp_read",
+            agentIndex: 0,
+            channelId,
+            sessionId: "session-sent-message",
+            turnId: "turn-sent-message",
+            payload: {
+              method: "session/update",
+              params: {
+                update: {
+                  sessionUpdate: "tool_call_update",
+                  toolCallId: "sent-message-activity-window",
+                  status: "completed",
+                  title: "send_message",
+                  toolName: "send_message",
+                  rawInput: {
+                    channel_id: channelId,
+                    content: "Sent update for #general",
+                  },
+                  content: {
+                    type: "text",
+                    text: JSON.stringify({
+                      accepted: true,
+                      event_id: "mock-agents-charlie",
+                    }),
+                  },
+                },
+              },
+            },
+          },
+          {
+            seq: 4,
+            timestamp: new Date().toISOString(),
             kind: "turn_started",
             agentIndex: 0,
             channelId,
@@ -87,7 +119,7 @@ test("keeps dedicated activity windows pinned to their original channel", async 
             payload: { source: "channel", triggeringEventIds: [] },
           },
           {
-            seq: 4,
+            seq: 5,
             timestamp: new Date().toISOString(),
             kind: "acp_read",
             agentIndex: 0,
@@ -123,7 +155,9 @@ test("keeps dedicated activity windows pinned to their original channel", async 
     "Other channel activity must stay hidden",
   );
 
-  const channelReference = panel.locator("[data-channel-link]");
+  const channelReference = panel
+    .getByTestId("transcript-assistant-message")
+    .locator("[data-channel-link]");
   await expect(channelReference).toContainText("general");
   await expect(
     panel.getByRole("button", { name: "Open channel general" }),
@@ -141,6 +175,26 @@ test("keeps dedicated activity windows pinned to their original channel", async 
   await expect(
     panel.getByRole("button", { name: "Open repository relay-tools" }),
   ).toHaveCount(0);
+  await expect(page).toHaveURL(activityWindowUrl);
+
+  const sentMessage = panel.getByTestId("transcript-tool-message-preview");
+  await expect(sentMessage).toContainText("Sent update for");
+  await expect(sentMessage).not.toHaveAttribute("role", "link");
+  await expect(
+    panel.getByRole("button", { name: "Open Observer Agent profile" }),
+  ).toHaveCount(0);
+  await expect(
+    sentMessage.getByRole("button", { name: "Open channel general" }),
+  ).toHaveCount(0);
+  await expect(sentMessage.locator("[data-channel-link]")).toContainText(
+    "general",
+  );
+  await expect(panel.getByTestId("transcript-open-message-link")).toHaveCount(
+    0,
+  );
+  await sentMessage.click();
+  await expect(panel).toBeVisible();
+  await expect(page.getByTestId("message-thread-panel")).toHaveCount(0);
   await expect(page).toHaveURL(activityWindowUrl);
 
   await page.getByTestId("agent-session-settings-menu-trigger").click();

--- a/desktop/tests/e2e/agent-activity-window.spec.ts
+++ b/desktop/tests/e2e/agent-activity-window.spec.ts
@@ -70,6 +70,7 @@ test("keeps dedicated activity windows pinned to their original channel", async 
               params: {
                 update: {
                   sessionUpdate: "user_message_chunk",
+                  messageId: "b".repeat(64),
                   authorPubkey: repositoryOwnerPubkey,
                   content: { type: "text", text: "Please inspect the feed" },
                 },
@@ -189,9 +190,20 @@ test("keeps dedicated activity windows pinned to their original channel", async 
   await expect(sentMessage.locator("[data-channel-link]")).toContainText(
     "general",
   );
+  const userMessage = panel.getByTestId("transcript-user-message");
+  const userTimestamp = userMessage.locator("span[title]").last();
+  await expect(userTimestamp).toBeVisible();
+  await expect(userTimestamp).toHaveCSS("cursor", "default");
   await expect(panel.getByTestId("transcript-open-message-link")).toHaveCount(
     0,
   );
+  const openedPage = page
+    .context()
+    .waitForEvent("page", { timeout: 500 })
+    .then(() => true)
+    .catch(() => false);
+  await userTimestamp.click({ button: "middle" });
+  expect(await openedPage).toBe(false);
   await sentMessage.click();
   await expect(panel).toBeVisible();
   await expect(page.getByTestId("message-thread-panel")).toHaveCount(0);

--- a/desktop/tests/e2e/agent-activity-window.spec.ts
+++ b/desktop/tests/e2e/agent-activity-window.spec.ts
@@ -56,6 +56,16 @@ test("keeps dedicated activity windows connected when opening a channel referenc
           {
             seq: 2,
             timestamp: new Date().toISOString(),
+            kind: "turn_started",
+            agentIndex: 0,
+            channelId,
+            sessionId: "session-original-channel",
+            turnId: "turn-original-channel",
+            payload: { source: "channel", triggeringEventIds: [] },
+          },
+          {
+            seq: 3,
+            timestamp: new Date().toISOString(),
             kind: "acp_read",
             agentIndex: 0,
             channelId: generalChannelId,
@@ -105,5 +115,40 @@ test("keeps dedicated activity windows connected when opening a channel referenc
   await expect(panel).not.toContainText(
     "Other channel activity must stay hidden",
   );
+
+  await page.getByTestId("agent-session-settings-menu-trigger").click();
+  const rawFeedToggle = page.getByTestId("agent-session-toggle-raw-feed");
+  await expect(rawFeedToggle).toHaveAttribute(
+    "title",
+    "Show raw JSON-RPC payloads for this channel.",
+  );
+  const stopTurn = page.getByTestId("agent-session-stop-turn");
+  await expect(stopTurn).toBeEnabled();
+
+  await page.evaluate(() => {
+    const tauri = window.__TAURI_INTERNALS__;
+    const invoke = tauri?.invoke;
+    if (!tauri || !invoke)
+      throw new Error("Mock invoke bridge is unavailable.");
+    window.__BUZZ_E2E_ACTIVITY_CONTROL_REQUESTS__ = [];
+    tauri.invoke = async (command, payload) => {
+      if (command === "build_observer_control_event") {
+        window.__BUZZ_E2E_ACTIVITY_CONTROL_REQUESTS__?.push(payload);
+        throw new Error("Control request captured by the E2E test.");
+      }
+      return invoke(command, payload);
+    };
+  });
+  await stopTurn.click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => window.__BUZZ_E2E_ACTIVITY_CONTROL_REQUESTS__?.[0] ?? null,
+      ),
+    )
+    .toMatchObject({
+      agentPubkey: AGENT_PUBKEY,
+      payload: { type: "cancel_turn", channelId: AGENTS_CHANNEL_ID },
+    });
   await expect(page.locator("body")).not.toBeEmpty();
 });

--- a/desktop/tests/e2e/agent-activity-window.spec.ts
+++ b/desktop/tests/e2e/agent-activity-window.spec.ts
@@ -23,7 +23,7 @@ test("keeps dedicated activity windows connected when opening a channel referenc
   });
 
   await page.goto(
-    `/#/channels/${AGENTS_CHANNEL_ID}?community=${COMMUNITY_ID}&agentSession=${AGENT_PUBKEY}`,
+    `/#/channels/${AGENTS_CHANNEL_ID}?community=${COMMUNITY_ID}&agentSession=${AGENT_PUBKEY}&agentSessionChannel=${AGENTS_CHANNEL_ID}`,
   );
   const panel = page.getByTestId("agent-session-thread-panel");
   await expect(panel).toBeVisible({ timeout: 10_000 });
@@ -31,7 +31,7 @@ test("keeps dedicated activity windows connected when opening a channel referenc
     () => typeof window.__BUZZ_E2E_SEED_OBSERVER_EVENTS__ === "function",
   );
   await page.evaluate(
-    ({ agentPubkey, channelId }) => {
+    ({ agentPubkey, channelId, generalChannelId }) => {
       window.__BUZZ_E2E_SEED_OBSERVER_EVENTS__?.({
         agentPubkey,
         events: [
@@ -53,10 +53,40 @@ test("keeps dedicated activity windows connected when opening a channel referenc
               },
             },
           },
+          {
+            seq: 2,
+            timestamp: new Date().toISOString(),
+            kind: "acp_read",
+            agentIndex: 0,
+            channelId: generalChannelId,
+            sessionId: "session-other-channel",
+            turnId: "turn-other-channel",
+            payload: {
+              method: "session/update",
+              params: {
+                update: {
+                  sessionUpdate: "agent_message_chunk",
+                  content: {
+                    type: "text",
+                    text: "Other channel activity must stay hidden",
+                  },
+                },
+              },
+            },
+          },
         ],
       });
     },
-    { agentPubkey: AGENT_PUBKEY, channelId: AGENTS_CHANNEL_ID },
+    {
+      agentPubkey: AGENT_PUBKEY,
+      channelId: AGENTS_CHANNEL_ID,
+      generalChannelId: GENERAL_CHANNEL_ID,
+    },
+  );
+
+  await expect(panel).toContainText("Activity · #agents");
+  await expect(panel).not.toContainText(
+    "Other channel activity must stay hidden",
   );
 
   const channelReference = panel.getByRole("button", {
@@ -67,9 +97,13 @@ test("keeps dedicated activity windows connected when opening a channel referenc
 
   await expect(page).toHaveURL(
     new RegExp(
-      `#/channels/${GENERAL_CHANNEL_ID}\\?.*community=${COMMUNITY_ID}`,
+      `#/channels/${GENERAL_CHANNEL_ID}\\?.*community=${COMMUNITY_ID}.*agentSessionChannel=${AGENTS_CHANNEL_ID}`,
     ),
   );
   await expect(panel).toBeVisible();
+  await expect(panel).toContainText("Activity · #agents");
+  await expect(panel).not.toContainText(
+    "Other channel activity must stay hidden",
+  );
   await expect(page.locator("body")).not.toBeEmpty();
 });

--- a/desktop/tests/e2e/agent-activity-window.spec.ts
+++ b/desktop/tests/e2e/agent-activity-window.spec.ts
@@ -73,7 +73,10 @@ test("keeps dedicated activity windows pinned to their original channel", async 
                   sessionUpdate: "user_message_chunk",
                   messageId: "b".repeat(64),
                   authorPubkey: repositoryOwnerPubkey,
-                  content: { type: "text", text: "Please inspect the feed" },
+                  content: {
+                    type: "text",
+                    text: `${Array.from({ length: 11 }, (_, index) => `Prompt line ${index + 1}: inspect every detail in the dedicated activity feed.`).join("\n\n")}\n\nPrompt line 12: FINAL-PROMPT-LINE`,
+                  },
                 },
               },
             },
@@ -210,6 +213,42 @@ test("keeps dedicated activity windows pinned to their original channel", async 
     "general",
   );
   const userMessage = panel.getByTestId("transcript-user-message");
+  const userBubble = userMessage.locator(":scope > div > div").first();
+  await expect(userBubble).toContainText("FINAL-PROMPT-LINE");
+  const promptTailGeometry = await userBubble.evaluate((bubble) => {
+    const walker = document.createTreeWalker(bubble, NodeFilter.SHOW_TEXT);
+    let tailNode: Text | null = null;
+    while (walker.nextNode()) {
+      const node = walker.currentNode as Text;
+      if (node.data.includes("FINAL-PROMPT-LINE")) {
+        tailNode = node;
+        break;
+      }
+    }
+    if (!tailNode)
+      throw new Error("Final prompt line text node was not found.");
+
+    const tailStart = tailNode.data.indexOf("FINAL-PROMPT-LINE");
+    const range = document.createRange();
+    range.setStart(tailNode, tailStart);
+    range.setEnd(tailNode, tailStart + "FINAL-PROMPT-LINE".length);
+    const bubbleRect = bubble.getBoundingClientRect();
+    const tailRect = range.getBoundingClientRect();
+    return {
+      bubbleBottom: bubbleRect.bottom,
+      bubbleTop: bubbleRect.top,
+      overflowY: getComputedStyle(bubble).overflowY,
+      tailBottom: tailRect.bottom,
+      tailTop: tailRect.top,
+    };
+  });
+  expect(promptTailGeometry.overflowY).toBe("visible");
+  expect(promptTailGeometry.tailTop).toBeGreaterThanOrEqual(
+    promptTailGeometry.bubbleTop,
+  );
+  expect(promptTailGeometry.tailBottom).toBeLessThanOrEqual(
+    promptTailGeometry.bubbleBottom + 1,
+  );
   const userTimestamp = userMessage.locator("span[title]").last();
   await expect(userTimestamp).toBeVisible();
   await expect(userTimestamp).toHaveCSS("cursor", "default");

--- a/desktop/tests/e2e/agent-activity-window.spec.ts
+++ b/desktop/tests/e2e/agent-activity-window.spec.ts
@@ -3,11 +3,12 @@ import { expect, test } from "@playwright/test";
 import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
 
 const AGENT_PUBKEY = TEST_IDENTITIES.tyler.pubkey;
+const REPOSITORY_OWNER_PUBKEY = TEST_IDENTITIES.alice.pubkey;
 const AGENTS_CHANNEL_ID = "94a444a4-c0a3-5966-ab05-530c6ddc2301";
 const GENERAL_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
 const COMMUNITY_ID = "e2e-default-community";
 
-test("keeps dedicated activity windows connected when opening a channel reference", async ({
+test("keeps dedicated activity windows pinned to their original channel", async ({
   page,
 }) => {
   await installMockBridge(page, {
@@ -31,7 +32,7 @@ test("keeps dedicated activity windows connected when opening a channel referenc
     () => typeof window.__BUZZ_E2E_SEED_OBSERVER_EVENTS__ === "function",
   );
   await page.evaluate(
-    ({ agentPubkey, channelId, generalChannelId }) => {
+    ({ agentPubkey, channelId, generalChannelId, repositoryOwnerPubkey }) => {
       window.__BUZZ_E2E_SEED_OBSERVER_EVENTS__?.({
         agentPubkey,
         events: [
@@ -48,7 +49,10 @@ test("keeps dedicated activity windows connected when opening a channel referenc
               params: {
                 update: {
                   sessionUpdate: "agent_message_chunk",
-                  content: { type: "text", text: "Continue in #general" },
+                  content: {
+                    type: "text",
+                    text: `Continue in #general or open <buzz://repo?owner=${repositoryOwnerPubkey}&d=relay-tools>`,
+                  },
                 },
               },
             },
@@ -91,6 +95,7 @@ test("keeps dedicated activity windows connected when opening a channel referenc
       agentPubkey: AGENT_PUBKEY,
       channelId: AGENTS_CHANNEL_ID,
       generalChannelId: GENERAL_CHANNEL_ID,
+      repositoryOwnerPubkey: REPOSITORY_OWNER_PUBKEY,
     },
   );
 
@@ -103,18 +108,23 @@ test("keeps dedicated activity windows connected when opening a channel referenc
     name: "Open channel general",
   });
   await expect(channelReference).toBeVisible();
+  const activityWindowUrl = page.url();
   await channelReference.click();
 
-  await expect(page).toHaveURL(
-    new RegExp(
-      `#/channels/${GENERAL_CHANNEL_ID}\\?.*community=${COMMUNITY_ID}.*agentSessionChannel=${AGENTS_CHANNEL_ID}`,
-    ),
-  );
+  await expect(page).toHaveURL(activityWindowUrl);
   await expect(panel).toBeVisible();
   await expect(panel).toContainText("Activity · #agents");
   await expect(panel).not.toContainText(
     "Other channel activity must stay hidden",
   );
+
+  const repositoryChip = panel.getByRole("button", {
+    name: "Open repository relay-tools",
+  });
+  await expect(repositoryChip).toBeVisible();
+  await repositoryChip.click();
+  await expect(page).toHaveURL(activityWindowUrl);
+  await expect(panel).toBeVisible();
 
   await page.getByTestId("agent-session-settings-menu-trigger").click();
   const rawFeedToggle = page.getByTestId("agent-session-toggle-raw-feed");

--- a/desktop/tests/e2e/agent-activity-window.spec.ts
+++ b/desktop/tests/e2e/agent-activity-window.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+const AGENT_PUBKEY = TEST_IDENTITIES.tyler.pubkey;
+const AGENTS_CHANNEL_ID = "94a444a4-c0a3-5966-ab05-530c6ddc2301";
+const GENERAL_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const COMMUNITY_ID = "e2e-default-community";
+
+test("keeps dedicated activity windows connected when opening a channel reference", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    windowLabel: `agent-activity-${AGENT_PUBKEY}-${AGENTS_CHANNEL_ID}`,
+    managedAgents: [
+      {
+        pubkey: AGENT_PUBKEY,
+        name: "Observer Agent",
+        status: "running",
+        channelNames: ["agents"],
+      },
+    ],
+  });
+
+  await page.goto(
+    `/#/channels/${AGENTS_CHANNEL_ID}?community=${COMMUNITY_ID}&agentSession=${AGENT_PUBKEY}`,
+  );
+  const panel = page.getByTestId("agent-session-thread-panel");
+  await expect(panel).toBeVisible({ timeout: 10_000 });
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_SEED_OBSERVER_EVENTS__ === "function",
+  );
+  await page.evaluate(
+    ({ agentPubkey, channelId }) => {
+      window.__BUZZ_E2E_SEED_OBSERVER_EVENTS__?.({
+        agentPubkey,
+        events: [
+          {
+            seq: 1,
+            timestamp: new Date().toISOString(),
+            kind: "acp_read",
+            agentIndex: 0,
+            channelId,
+            sessionId: "session-activity-window",
+            turnId: "turn-activity-window",
+            payload: {
+              method: "session/update",
+              params: {
+                update: {
+                  sessionUpdate: "agent_message_chunk",
+                  content: { type: "text", text: "Continue in #general" },
+                },
+              },
+            },
+          },
+        ],
+      });
+    },
+    { agentPubkey: AGENT_PUBKEY, channelId: AGENTS_CHANNEL_ID },
+  );
+
+  const channelReference = panel.getByRole("button", {
+    name: "Open channel general",
+  });
+  await expect(channelReference).toBeVisible();
+  await channelReference.click();
+
+  await expect(page).toHaveURL(
+    new RegExp(
+      `#/channels/${GENERAL_CHANNEL_ID}\\?.*community=${COMMUNITY_ID}`,
+    ),
+  );
+  await expect(panel).toBeVisible();
+  await expect(page.locator("body")).not.toBeEmpty();
+});

--- a/desktop/tests/e2e/agent-activity-window.spec.ts
+++ b/desktop/tests/e2e/agent-activity-window.spec.ts
@@ -11,6 +11,7 @@ const COMMUNITY_ID = "e2e-default-community";
 test("keeps dedicated activity windows pinned to their original channel", async ({
   page,
 }) => {
+  await page.setViewportSize({ width: 560, height: 760 });
   await installMockBridge(page, {
     windowLabel: `agent-activity-${AGENT_PUBKEY}-${AGENTS_CHANNEL_ID}`,
     managedAgents: [
@@ -51,7 +52,7 @@ test("keeps dedicated activity windows pinned to their original channel", async 
                   sessionUpdate: "agent_message_chunk",
                   content: {
                     type: "text",
-                    text: `Continue in #general or open <buzz://repo?owner=${repositoryOwnerPubkey}&d=relay-tools>`,
+                    text: `Continue in #general or open <buzz://repo?owner=${repositoryOwnerPubkey}&d=relay-tools>\n\n\`\`\`text\nverification-${"x".repeat(120)}-END\n\`\`\``,
                   },
                 },
               },
@@ -163,6 +164,24 @@ test("keeps dedicated activity windows pinned to their original channel", async 
   await expect(
     panel.getByRole("button", { name: "Open channel general" }),
   ).toHaveCount(0);
+  const codeBlock = panel
+    .getByTestId("transcript-assistant-message")
+    .locator("pre");
+  await expect(codeBlock).toHaveCount(1);
+  await expect(codeBlock).toContainText("-END");
+  const codeOverflow = await codeBlock.evaluate((element) => ({
+    clientWidth: element.clientWidth,
+    overflowX: getComputedStyle(element).overflowX,
+    scrollWidth: element.scrollWidth,
+  }));
+  expect(codeOverflow.overflowX).toBe("auto");
+  expect(codeOverflow.scrollWidth).toBeGreaterThan(codeOverflow.clientWidth);
+  await codeBlock.evaluate((element) => {
+    element.scrollLeft = element.scrollWidth;
+  });
+  await expect
+    .poll(() => codeBlock.evaluate((element) => element.scrollLeft))
+    .toBeGreaterThan(0);
   const activityWindowUrl = page.url();
 
   await expect(

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2083,7 +2083,7 @@ test("shows and clears activity indicators for active channel agents", async ({
   await page.getByTestId("agent-session-settings-menu-trigger").click();
   await expect(
     page.getByTestId("agent-session-open-external-window"),
-  ).toContainText("Open in external window");
+  ).toContainText("Pop-out window");
   await expect(page.getByTestId("agent-session-stop-turn")).toBeVisible();
   await expect(page.getByTestId("agent-session-stop-turn")).toBeDisabled();
   await page.keyboard.press("Escape");
@@ -2099,7 +2099,7 @@ test("shows and clears activity indicators for active channel agents", async ({
     page.getByTestId(
       `bot-activity-open-external-${TEST_IDENTITIES.alice.pubkey}`,
     ),
-  ).toContainText("Open in external window");
+  ).toContainText("Pop-out window");
   await page.keyboard.press("Escape");
 
   await page.evaluate((pubkey) => {

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2081,6 +2081,9 @@ test("shows and clears activity indicators for active channel agents", async ({
   await expect(page.getByTestId("auxiliary-panel-close")).toBeVisible();
   await expect(page.getByTestId("agent-transcript-now-summary")).toHaveCount(0);
   await page.getByTestId("agent-session-settings-menu-trigger").click();
+  await expect(
+    page.getByTestId("agent-session-open-external-window"),
+  ).toContainText("Open in external window");
   await expect(page.getByTestId("agent-session-stop-turn")).toBeVisible();
   await expect(page.getByTestId("agent-session-stop-turn")).toBeDisabled();
   await page.keyboard.press("Escape");
@@ -2088,6 +2091,16 @@ test("shows and clears activity indicators for active channel agents", async ({
     "No ACP activity yet",
   );
   await expect(page.getByTestId("message-typing-indicator")).toHaveCount(0);
+  await page.getByTestId("auxiliary-panel-close").click();
+  await page
+    .getByTestId("bot-activity-composer-trigger")
+    .click({ button: "right" });
+  await expect(
+    page.getByTestId(
+      `bot-activity-open-external-${TEST_IDENTITIES.alice.pubkey}`,
+    ),
+  ).toContainText("Open in external window");
+  await page.keyboard.press("Escape");
 
   await page.evaluate((pubkey) => {
     window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({


### PR DESCRIPTION
**Category:** new-feature
**User Impact:** Users can keep an agent’s live activity visible in a separate desktop window while continuing to work in Buzz.

**Problem:** Agent activity is useful while work is in progress, but the in-app panel competes with the channel and disappears as users navigate. Making every activity entry point open a new window would be disruptive, so the existing in-app flow needs to remain the default.

**Solution:** Add an explicit **Pop-out window** action to the activity feed settings and the in-progress chip’s context menu. The companion window reuses Buzz’s authenticated app runtime and live data connections, while normal activity clicks continue to open the in-app panel.

<details>
<summary>File changes</summary>

**desktop/src-tauri/capabilities/default.json**
Allows the dedicated activity webview to use the existing desktop capabilities it needs.

**desktop/src-tauri/src/agent_activity_window.rs**
Creates or focuses a stable channel-and-agent-scoped native window using an encoded Buzz route.

**desktop/src-tauri/src/lib.rs**
Registers the activity-window command with the Tauri application.

**desktop/src-tauri/tests/csp.rs**
Keeps capability coverage aligned with the new companion-window label.

**desktop/src/app/AppHuddleShell.tsx**
Treats activity windows as passive companion surfaces rather than rendering unrelated huddle chrome.

**desktop/src/app/AppShell.tsx**
Removes primary-window rails, overlays, notifications, shortcuts, and deep-link ownership from companion windows.

**desktop/src/app/AppShellChannelSurface.tsx**
Lets the activity window render as an unframed focused surface.

**desktop/src/app/BuzzThemeSurfaces.tsx**
Generalizes the unframed surface description from huddle-only to companion windows.

**desktop/src/app/companionWindow.ts**
Centralizes native window-label classification for activity and huddle companions.

**desktop/src/app/companionWindow.test.mjs**
Pins companion-window label classification and primary-window exclusion.

**desktop/src/features/agents/lib/agentActivityWindow.ts**
Detects the activity companion and keeps its native title synchronized with agent and channel context.

**desktop/src/features/agents/lib/agentActivityWindow.test.mjs**
Covers concise activity-window title formatting.

**desktop/src/features/agents/useOpenAgentActivity.ts**
Preserves the established in-app panel/navigation behavior for ordinary activity entry points.

**desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx**
Adds **Pop-out window** to activity settings and adapts panel controls for a dedicated window.

**desktop/src/features/channels/ui/BotActivityBar.tsx**
Adds the in-progress chip context menu while retaining the normal click-to-open-in-app flow.

**desktop/src/features/channels/ui/ChannelComposerActivityAccessory.tsx**
Passes the explicit pop-out action into the composer activity chip.

**desktop/src/features/channels/ui/ChannelPane.tsx**
Connects channel and thread activity chips to the external-window action.

**desktop/src/features/channels/ui/ChannelPane.types.ts**
Defines the separate in-app and external activity handlers.

**desktop/src/features/channels/ui/ChannelScreen.tsx**
Recognizes dedicated activity-window layout and wires both activity destinations.

**desktop/src/features/channels/ui/useOpenAgentActivityActions.ts**
Owns the distinct in-app and native-window opening behavior outside the oversized channel screen.

**desktop/src/features/channels/ui/ChannelScreenLoadingFallback.tsx**
Suppresses the normal channel header while the focused activity window loads.

**desktop/src/main.tsx**
Disables onboarding overlays in companion windows.

**desktop/src/shared/api/agentActivityWindow.ts**
Provides the typed frontend command for opening an activity window.

**desktop/src/shared/layout/AuxiliaryPanelHeader.tsx**
Allows focused panels to omit the in-app close action without changing other header behavior.

**desktop/src/shared/layout/auxiliaryPanelContext.test.mjs**
Covers explicit close-action suppression.

**desktop/src/testing/e2eBridge.ts**
Keeps browser E2E on the in-app fallback because it cannot create a native Tauri webview.

**desktop/tests/e2e/channels.spec.ts**
Covers both **Pop-out window** entry points while confirming normal activity clicks remain in app.

</details>

## Reproduction steps

1. Run the desktop app and open a channel where an agent is actively working.
2. Click the in-progress chip below the composer and confirm the activity feed opens in Buzz’s existing side panel.
3. Right-click the in-progress chip and choose **Pop-out window**; confirm a separate window opens for that agent and channel.
4. Open the in-app activity feed, open its settings menu, and choose **Pop-out window**; confirm it focuses the same scoped window rather than creating duplicates.
5. Navigate elsewhere in the main app and confirm the pop-out keeps receiving live activity.
6. Stop the agent and confirm archived activity and settings remain available in the pop-out.

## Screenshots / demos

Native companion-window capture is pending; the draft is open for implementation review first.
