### PR TITLE
fix(acp): wake agents from self-owned workflows

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -147,6 +147,11 @@ Controls which authors' events the harness forwards to the agent. Events from di
 | `anyone` | Forward all events (no author filtering). |
 | `nobody` | Drop all inbound events. Agent only acts on heartbeat prompts. |
 
+Relay-signed workflow messages are first verified against the relay's NIP-11
+`self` key and attributed to their explicit workflow owner. A workflow owned by
+this agent may wake it in every responding mode; `nobody` remains an explicit
+proactive-only mode and still rejects workflow wakes.
+
 The gate applies to **all** inbound events — @mentions, DMs, thread replies, and any event delivered by the relay. Owner control commands are checked **before** the gate, so the owner can still manage the harness regardless of mode:
 
 | Command | Effect |

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -273,6 +273,67 @@ async fn author_allowed(
     }
 }
 
+/// Return the workflow owner attributed by a relay-signed workflow message.
+///
+/// The workflow tags alone are not authority: any ordinary event author can
+/// forge custom tags. Attribution is accepted only when the event signer
+/// matches the relay's NIP-11 `self` key, the event is a kind:9 stream
+/// message, and exactly one canonical marker and workflow-owner tag are
+/// present. Mention `p` tags are never used for attribution.
+fn verified_workflow_owner(event: &nostr::Event, relay_self: Option<&str>) -> Option<String> {
+    if event.kind.as_u16() as u32 != KIND_STREAM_MESSAGE {
+        return None;
+    }
+
+    let relay_self = nostr::PublicKey::from_hex(relay_self?).ok()?;
+    if event.pubkey != relay_self {
+        return None;
+    }
+
+    let markers: Vec<&[String]> = event
+        .tags
+        .iter()
+        .map(|tag| tag.as_slice())
+        .filter(|values| values.first().map(String::as_str) == Some("buzz:workflow"))
+        .collect();
+    if markers.len() != 1 || markers[0] != ["buzz:workflow", "true"] {
+        return None;
+    }
+
+    let owners: Vec<&[String]> = event
+        .tags
+        .iter()
+        .map(|tag| tag.as_slice())
+        .filter(|values| values.first().map(String::as_str) == Some("buzz:workflow-owner"))
+        .collect();
+    let [owner_tag] = owners.as_slice() else {
+        return None;
+    };
+    let [_, owner_value] = owner_tag else {
+        return None;
+    };
+    let owner = nostr::PublicKey::from_hex(owner_value).ok()?;
+
+    if event.verify().is_err() {
+        return None;
+    }
+
+    Some(owner.to_hex())
+}
+
+/// Return an author-gate decision only for a verified self-owned workflow.
+///
+/// `None` means the caller must apply the ordinary author policy. A self-owned
+/// workflow is the scheduled equivalent of a heartbeat, but `Nobody` remains
+/// an explicit proactive-only mode and therefore rejects it.
+fn self_owned_workflow_decision(
+    workflow_owner: Option<&str>,
+    agent_pubkey: &str,
+    respond_to: &RespondTo,
+) -> Option<bool> {
+    (workflow_owner == Some(agent_pubkey)).then_some(!matches!(respond_to, RespondTo::Nobody))
+}
+
 /// Resolve whether `channel_id` is a DM, for the inbound author gate.
 ///
 /// Resolution order:
@@ -2017,6 +2078,26 @@ async fn tokio_main() -> Result<()> {
 
     tracing::info!("connected to relay at {}", config.relay_url);
 
+    let relay_self = match relay.rest_client().relay_self().await {
+        Ok(Some(pubkey)) => {
+            tracing::info!(relay_self = %pubkey, "verified relay signing identity via NIP-11");
+            Some(pubkey)
+        }
+        Ok(None) => {
+            tracing::warn!(
+                "relay NIP-11 document has no stable `self` key; relay-authored workflow wakes will fail closed"
+            );
+            None
+        }
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "failed to verify relay signing identity; relay-authored workflow wakes will fail closed"
+            );
+            None
+        }
+    };
+
     relay
         .subscribe_membership_notifications()
         .await
@@ -2866,21 +2947,36 @@ async fn tokio_main() -> Result<()> {
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
                             {
-                                let author = buzz_event.event.pubkey.to_hex();
                                 // DM hardening: resolve channel type (fail-closed
                                 // to DM) so allowlist/anyone modes cannot be
                                 // exercised by non-owner authors inside DMs.
                                 let is_dm =
                                     is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
-                                let allowed = author_allowed(
+                                let raw_author = buzz_event.event.pubkey.to_hex();
+                                let workflow_owner = verified_workflow_owner(
+                                    &buzz_event.event,
+                                    relay_self.as_deref(),
+                                );
+                                let allowed = match self_owned_workflow_decision(
+                                    workflow_owner.as_deref(),
+                                    &pubkey_hex,
                                     &config.respond_to,
-                                    &config.respond_to_allowlist,
-                                    &author,
-                                    is_dm,
-                                    &owner_cache,
-                                    &ctx.rest_client,
-                                )
-                                .await;
+                                ) {
+                                    Some(decision) => decision,
+                                    None => {
+                                        author_allowed(
+                                            &config.respond_to,
+                                            &config.respond_to_allowlist,
+                                            workflow_owner
+                                                .as_deref()
+                                                .unwrap_or(raw_author.as_str()),
+                                            is_dm,
+                                            &owner_cache,
+                                            &ctx.rest_client,
+                                        )
+                                        .await
+                                    }
+                                };
                                 if !allowed {
                                     tracing::debug!(
                                         channel_id = %buzz_event.channel_id,
@@ -5333,6 +5429,153 @@ mod owner_cache_tests {
 #[cfg(test)]
 mod author_gate_tests {
     use super::*;
+
+    #[test]
+    fn test_verified_workflow_owner_accepts_relay_signed_workflow_message() {
+        let relay_keys = nostr::Keys::generate();
+        let workflow_owner = nostr::Keys::generate().public_key().to_hex();
+        let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "run")
+            .tags([
+                nostr::Tag::parse(["buzz:workflow", "true"]).unwrap(),
+                nostr::Tag::parse(["buzz:workflow-owner", workflow_owner.as_str()]).unwrap(),
+            ])
+            .sign_with_keys(&relay_keys)
+            .unwrap();
+
+        assert_eq!(
+            verified_workflow_owner(&event, Some(&relay_keys.public_key().to_hex())),
+            Some(workflow_owner)
+        );
+    }
+
+    #[test]
+    fn test_verified_workflow_owner_rejects_forged_workflow_tags() {
+        let relay_keys = nostr::Keys::generate();
+        let stranger_keys = nostr::Keys::generate();
+        let workflow_owner = nostr::Keys::generate().public_key().to_hex();
+        let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "run")
+            .tags([
+                nostr::Tag::parse(["buzz:workflow", "true"]).unwrap(),
+                nostr::Tag::parse(["buzz:workflow-owner", workflow_owner.as_str()]).unwrap(),
+            ])
+            .sign_with_keys(&stranger_keys)
+            .unwrap();
+
+        assert_eq!(
+            verified_workflow_owner(&event, Some(&relay_keys.public_key().to_hex())),
+            None
+        );
+    }
+
+    #[test]
+    fn test_verified_workflow_owner_rejects_tampered_relay_event() {
+        let relay_keys = nostr::Keys::generate();
+        let workflow_owner = nostr::Keys::generate().public_key().to_hex();
+        let mut event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "run")
+            .tags([
+                nostr::Tag::parse(["buzz:workflow", "true"]).unwrap(),
+                nostr::Tag::parse(["buzz:workflow-owner", workflow_owner.as_str()]).unwrap(),
+            ])
+            .sign_with_keys(&relay_keys)
+            .unwrap();
+        event.content = "tampered".into();
+
+        assert_eq!(
+            verified_workflow_owner(&event, Some(&relay_keys.public_key().to_hex())),
+            None
+        );
+    }
+
+    #[test]
+    fn test_verified_workflow_owner_rejects_ambiguous_tags() {
+        let relay_keys = nostr::Keys::generate();
+        let workflow_owner = nostr::Keys::generate().public_key().to_hex();
+        for duplicate_tag in [
+            nostr::Tag::parse(["buzz:workflow", "true"]).unwrap(),
+            nostr::Tag::parse(["buzz:workflow-owner", workflow_owner.as_str()]).unwrap(),
+        ] {
+            let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "run")
+                .tags([
+                    nostr::Tag::parse(["buzz:workflow", "true"]).unwrap(),
+                    nostr::Tag::parse(["buzz:workflow-owner", workflow_owner.as_str()]).unwrap(),
+                    duplicate_tag,
+                ])
+                .sign_with_keys(&relay_keys)
+                .unwrap();
+
+            assert_eq!(
+                verified_workflow_owner(&event, Some(&relay_keys.public_key().to_hex())),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn test_verified_workflow_owner_rejects_wrong_kind() {
+        let relay_keys = nostr::Keys::generate();
+        let workflow_owner = nostr::Keys::generate().public_key().to_hex();
+        let event = nostr::EventBuilder::new(nostr::Kind::Custom(1), "run")
+            .tags([
+                nostr::Tag::parse(["buzz:workflow", "true"]).unwrap(),
+                nostr::Tag::parse(["buzz:workflow-owner", workflow_owner.as_str()]).unwrap(),
+            ])
+            .sign_with_keys(&relay_keys)
+            .unwrap();
+
+        assert_eq!(
+            verified_workflow_owner(&event, Some(&relay_keys.public_key().to_hex())),
+            None
+        );
+    }
+
+    #[test]
+    fn test_owner_only_accepts_self_owned_relay_workflow() {
+        let relay_keys = nostr::Keys::generate();
+        let agent_keys = nostr::Keys::generate();
+        let agent_pubkey = agent_keys.public_key().to_hex();
+        let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "run")
+            .tags([
+                nostr::Tag::parse(["buzz:workflow", "true"]).unwrap(),
+                nostr::Tag::parse(["buzz:workflow-owner", agent_pubkey.as_str()]).unwrap(),
+            ])
+            .sign_with_keys(&relay_keys)
+            .unwrap();
+
+        let workflow_owner =
+            verified_workflow_owner(&event, Some(&relay_keys.public_key().to_hex()));
+        assert_eq!(
+            self_owned_workflow_decision(
+                workflow_owner.as_deref(),
+                &agent_pubkey,
+                &RespondTo::OwnerOnly,
+            ),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn test_nobody_rejects_self_owned_relay_workflow() {
+        let relay_keys = nostr::Keys::generate();
+        let agent_pubkey = nostr::Keys::generate().public_key().to_hex();
+        let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "run")
+            .tags([
+                nostr::Tag::parse(["buzz:workflow", "true"]).unwrap(),
+                nostr::Tag::parse(["buzz:workflow-owner", agent_pubkey.as_str()]).unwrap(),
+            ])
+            .sign_with_keys(&relay_keys)
+            .unwrap();
+
+        let workflow_owner =
+            verified_workflow_owner(&event, Some(&relay_keys.public_key().to_hex()));
+        assert_eq!(
+            self_owned_workflow_decision(
+                workflow_owner.as_deref(),
+                &agent_pubkey,
+                &RespondTo::Nobody,
+            ),
+            Some(false)
+        );
+    }
 
     /// A `RestClient` for tests. The author-gate decisions exercised here all
     /// resolve from the owner pubkey or sibling cache before any HTTP call, so

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -277,6 +277,44 @@ fn unix_now_secs() -> u64 {
 }
 
 impl RestClient {
+    /// Fetch the relay's stable signing identity from its NIP-11 document.
+    ///
+    /// Relay-authored workflow messages are trusted only when their event
+    /// signer matches this key. Missing, malformed, or unavailable identity
+    /// data fails closed by returning an error/`None` to the caller.
+    pub async fn relay_self(&self) -> Result<Option<String>, RelayError> {
+        let url = format!("{}/info", self.base_url);
+        let response = tokio::time::timeout(
+            Duration::from_secs(5),
+            self.http
+                .get(&url)
+                .header(reqwest::header::ACCEPT, "application/nostr+json")
+                .send(),
+        )
+        .await
+        .map_err(|_| RelayError::Timeout)?
+        .map_err(|error| RelayError::Http(error.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(RelayError::Http(format!(
+                "GET /info returned HTTP {}",
+                response.status()
+            )));
+        }
+
+        let document: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|error| RelayError::Http(format!("invalid NIP-11 document: {error}")))?;
+        let Some(relay_self) = document.get("self").and_then(serde_json::Value::as_str) else {
+            return Ok(None);
+        };
+        let relay_self = nostr::PublicKey::from_hex(relay_self)
+            .map_err(|error| RelayError::Http(format!("invalid NIP-11 self pubkey: {error}")))?
+            .to_hex();
+        Ok(Some(relay_self))
+    }
+
     /// Sign a NIP-98 HTTP Auth event (kind:27235) for the given method/URL/body.
     ///
     /// Returns the `Authorization: Nostr <base64>` header value (without the

--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -257,6 +257,8 @@ impl ActionSink for RelayActionSink {
             //    - `p` tag attributes the message to the workflow owner
             //    - `h` tag scopes to the channel (NIP-29, canonical UUID)
             //    - `buzz:workflow` tag prevents recursive workflow triggering
+            //    - `buzz:workflow-owner` lets harnesses apply the owner's
+            //      inbound-author policy after verifying the relay signature
             //    - one `p` tag per `@Name` that resolves to a channel member,
             //      so mentioned agents are woken (wake is `p`-tag gated)
             let mut tags = vec![
@@ -266,6 +268,8 @@ impl ActionSink for RelayActionSink {
                     .map_err(|e| ActionSinkError::EventBuild(format!("h tag: {e}")))?,
                 Tag::parse(["buzz:workflow", "true"])
                     .map_err(|e| ActionSinkError::EventBuild(format!("workflow tag: {e}")))?,
+                Tag::parse(["buzz:workflow-owner", &author_pubkey_hex])
+                    .map_err(|e| ActionSinkError::EventBuild(format!("workflow owner tag: {e}")))?,
             ];
 
             // Resolve thread ancestry when this is a threaded reply, so the
@@ -774,6 +778,18 @@ mod integration_tests {
         assert!(
             p_tag_targets.contains(&agent_hex.as_str()),
             "mentioned member {agent_hex} must be p-tagged so it wakes; got {p_tag_targets:?}"
+        );
+
+        let owner_tag = stored
+            .event
+            .tags
+            .iter()
+            .find(|tag| tag.as_slice().first().map(String::as_str) == Some("buzz:workflow-owner"))
+            .and_then(|tag| tag.as_slice().get(1).map(String::as_str));
+        assert_eq!(
+            owner_tag,
+            Some(author_hex.as_str()),
+            "workflow owner must be explicit so consumers never infer it from p-tag order"
         );
     }
 


### PR DESCRIPTION
## Problem

Relay workflow messages are signed by the relay and attributed to their workflow owner. When an agent owns its own workflow, the default `owner-only` ACP author gate still rejects that agent pubkey because it is neither the registered human owner nor a sibling.

The result is a visible workflow message with a valid agent mention, but no agent turn.

## Fix

- verify relay workflow attribution against NIP-11 `self`, event signature, kind, and canonical workflow tags
- treat a verified workflow owned by the receiving agent as a trusted scheduled self-wake in every responding mode
- preserve `respond-to=nobody` as an explicit proactive-only mode
- emit and test the explicit workflow-owner tag in the relay sink
- document the behavior

## Verification

- regression tests cover self-owned `owner-only` acceptance and `nobody` rejection
- security tests cover forged signatures, tampering, duplicate attribution tags, and wrong event kinds
- fork CI on exact commit `b7731b34` passed workspace unit tests, Rust format + Clippy, security, both Linux server cross-compiles, and Windows workspace Clippy/check
- CI receipt: https://github.com/lionelndong/buzz/actions/runs/32729000759
- the upstream external-contributor workflow still requires maintainer approval before its checks appear on this PR
