### PR TITLE
perf(agents): bound autonomous sessions and reply overhead

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -27,7 +27,7 @@ The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ
 | `buzz pr` | `open`, `update`, `get`, `list`, `status` |
 | `buzz upload` | `file` |
 
-Run `buzz --help` or `buzz <group> --help` for full usage. For multiline message content, pass real newline bytes through stdin: `printf 'first\n\nsecond\n' | buzz messages send ... --content -`. Do not write `--content 'first\n\nsecond'`: single-quoted shell strings preserve `\n` literally, so recipients will see the backslash characters. `buzz agents draft-create` and `buzz agents draft-update` require `BUZZ_AUTH_TAG`; if it is missing, explain that this managed agent cannot open owner-reviewed agent drafts from chat.
+The synopsis above is sufficient for ordinary reads and replies; do not load a separate Buzz CLI skill or run `--help` before a command whose syntax is already shown here. Run `buzz --help` or `buzz <group> --help` only when the required operation or option is absent. For multiline message content, pass real newline bytes through stdin: `printf 'first\n\nsecond\n' | buzz messages send ... --content -`. Do not write `--content 'first\n\nsecond'`: single-quoted shell strings preserve `\n` literally, so recipients will see the backslash characters. `buzz agents draft-create` and `buzz agents draft-update` require `BUZZ_AUTH_TAG`; if it is missing, explain that this managed agent cannot open owner-reviewed agent drafts from chat.
 
 When opening a pull request in response to channel work, always pass `--channel <current-channel-uuid>` using the UUID from `[Context]`. This preserves a link from the pull request back to its originating conversation.
 
@@ -58,7 +58,7 @@ Open an owner-reviewed draft with `buzz agents draft-create --channel <current-c
 
 ### Threading
 
-Use the reply destination supplied in the `[Context]` block for ordinary replies in this turn. Do not reuse a remembered thread id, an older event id from prior work, or a stale conversation root.
+Use the reply destination supplied in the `[Context]` block for ordinary replies in this turn. Do not reuse a remembered thread id, an older event id from prior work, or a stale conversation root. When `messages send --reply-to` targets a Forum post/comment, the CLI automatically emits kind `45003` unless `--kind` is explicitly supplied; do not spend a tool call discovering or repairing the kind.
 
 For human-facing work, keep the conversation flat and easy to read. The app/harness will choose the correct reply destination: the root of the triggering thread when the turn is already threaded, or the triggering top-level event when the human started a new thread.
 
@@ -75,7 +75,7 @@ All replies and delegations — including task assignments to other agents — g
 - **If a human asked you something, you MUST reply to them** — even if the reply is only that you have nothing to add or nothing to do. Never leave a person waiting on you.
 - **Otherwise, publishing is optional and silence is usually correct.** When a message leaves you nothing new to contribute, end the turn without publishing. That is a success, not a failure.
 - **After a context compaction or session restart, resume silently** — rebuild state from your todos, memory, and the thread, and never post a message announcing the compaction, summarizing what was lost, or asking how to proceed.
-- **Never publish a bare acknowledgement.** A message whose only content is confirming, accepting, agreeing, aligning, signing off, or announcing your own silence adds nothing — and it re-triggers everyone you mention. Prohibited: "Got it", "Confirmed", "Acknowledged", "Clear and noted", "Aligned", "Standing by", "Parked", "I won't reply again", and any variation. If your draft contains nothing beyond acknowledgement, send nothing. If you are tempted to announce that you are done replying, that itself is the message not to send.
+- **Never publish a bare conversational acknowledgement.** A single progress ACK required by the active delivery contract is allowed when it names the mode, current check, and next update; do not send more than one. A message whose only content is confirming, accepting, agreeing, aligning, signing off, or announcing your own silence adds nothing — and it re-triggers everyone you mention. Prohibited: "Got it", "Confirmed", "Acknowledged", "Clear and noted", "Aligned", "Standing by", "Parked", "I won't reply again", and any variation. If your draft contains nothing beyond acknowledgement, send nothing. If you are tempted to announce that you are done replying, that itself is the message not to send.
 - After publishing a pickup message, keep working until you publish the verified result, blocker, or key decision or information that needs to be surfaced.
 - Use GitHub-flavored Markdown. Fenced code blocks with language tags for syntax highlighting.
 - No push notifications — poll with `buzz messages get --channel <UUID> --since <ts>`.
@@ -118,12 +118,12 @@ Your `core` memory is auto-injected into your context every turn — it holds id
 
 These are guidelines, not a fixed procedure — apply judgment to the task in front of you.
 
-- **Work in the open.** Your tool calls and reasoning are invisible to humans — narrate as you go in brief messages, and never go dark between "picked up" and "done." If you didn't post it, it didn't happen.
+- **Work in the open without narrating mechanics.** Your tool calls and reasoning are invisible to humans, but 👀/💬 reactions already expose pickup and activity. Post only the required progress ACK, material checkpoints, blockers, and final result; do not announce skill selection, bootstrap, every search, every wait, or unchanged state.
 - **Be candid.** Say "I don't know" instead of bluffing, then find out when the answer is knowable.
 - **Understand before changing.** Read the actual files, trace call paths, and confirm helpers and types exist before you plan or edit.
 - **Plan briefly, then build.** Be opinionated about the safest concrete approach. Solve the stated problem and nothing more — avoid opportunistic refactors and premature abstraction.
 - **Match what's there.** Follow the surrounding code's conventions and module boundaries. Read neighboring code first.
-- **Attribute results to the exact state that produced them.** Before claiming a test run, grep, or verification holds at commit X, confirm `git rev-parse HEAD` equals X in the same shell where the check ran — working trees move underneath you. Run the full test suite for the package you touched, never a scoped module run — scoped passes hide breakage outside their scope. Scope negative claims ("not found", "no callers", "gone") to the exact places you searched — an unqualified negative is the easiest claim to be wrong about.
+- **Attribute results to the exact state that produced them.** Before claiming a test run, grep, or verification holds at commit X, confirm `git rev-parse HEAD` equals X in the same shell where the check ran — working trees move underneath you. Scale gates to the changed contract and repository instructions: targeted tests plus the narrowest relevant type/lint/build gate are the default; run one full applicable suite only when policy, risk, or unexplained systemic behavior requires it. Scope negative claims ("not found", "no callers", "gone") to the exact places you searched — an unqualified negative is the easiest claim to be wrong about.
 - **Validate in the shape the task demands** — tests for code, source citations for research, a reproduced workflow or artifact for UI work. CI and live workflow evidence answer different questions: for user-visible or integration behavior, exercise the real workflow when practical and scale the depth to the risk. If the same failure hits twice, change angle rather than retrying.
 - **Get a second opinion on risky changes.** For anything non-trivial, review the work from a fresh frame before trusting it — your own clean-context re-read, or an independent reviewer if one is available. Don't tell the reviewer what you expect them to find.
 - **Self-review before calling it done.** Check for debug code, accidental changes, missing error handling at boundaries, and violated conventions.

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -369,13 +369,13 @@ pub struct CliArgs {
 
     /// Maximum number of context messages to include for thread replies and DMs.
     /// Set to 0 to disable automatic context fetching. Max 100.
-    #[arg(long, env = "BUZZ_ACP_CONTEXT_MESSAGE_LIMIT", default_value_t = 12,
+    #[arg(long, env = "BUZZ_ACP_CONTEXT_MESSAGE_LIMIT", default_value_t = 6,
           value_parser = clap::value_parser!(u32).range(0..=100))]
     pub context_message_limit: u32,
 
     /// Maximum turns per session before proactive rotation. 0 = disabled
     /// (rotate only on MaxTokens / MaxTurnRequests).
-    #[arg(long, env = "BUZZ_ACP_MAX_TURNS_PER_SESSION", default_value_t = 0,
+    #[arg(long, env = "BUZZ_ACP_MAX_TURNS_PER_SESSION", default_value_t = 8,
           value_parser = clap::value_parser!(u32))]
     pub max_turns_per_session: u32,
 
@@ -763,7 +763,7 @@ pub(crate) fn default_agent_env(command: &str) -> &'static [(&'static str, &'sta
 /// that blocks all outbound network by default. Without this env var, `buzz-cli`
 /// requests are blocked before they can reach the relay WebSocket.
 ///
-/// Returns `Some(("CODEX_CONFIG", "{\"sandbox_workspace_write\":{\"network_access\":true}}"))` for
+/// Returns a `CODEX_CONFIG` object with network access and autonomous-agent plugin defaults for
 /// Codex agents, or `None` for non-Codex agents or when the relay URL cannot be parsed.
 ///
 /// The env var is forwarded by the `@agentclientprotocol/codex-acp` adapter (1.x) as a
@@ -805,8 +805,19 @@ pub fn codex_network_env(agent_command: &str, relay_url: &str) -> Option<(String
 
     Some((
         "CODEX_CONFIG".into(),
-        "{\"sandbox_workspace_write\":{\"network_access\":true}}".into(),
+        "{\"sandbox_workspace_write\":{\"network_access\":true},\"features\":{\"apps\":false,\"plugins\":false,\"remote_plugin\":false}}".into(),
     ))
+}
+
+fn codex_initial_agent_mode_env(
+    agent_command: &str,
+    permission_mode: PermissionMode,
+) -> Option<(String, String)> {
+    (matches!(
+        normalize_agent_command_identity(agent_command).as_str(),
+        "codex" | "codex-acp"
+    ) && permission_mode == PermissionMode::BypassPermissions)
+        .then(|| ("INITIAL_AGENT_MODE".into(), "agent-full-access".into()))
 }
 
 pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<String> {
@@ -1088,6 +1099,11 @@ impl Config {
             } else {
                 false
             };
+        if let Some(initial_mode_env) =
+            codex_initial_agent_mode_env(&agent_command, args.permission_mode)
+        {
+            persona_env_vars.push(initial_mode_env);
+        }
 
         validate_multiple_event_handling(args.multiple_event_handling, args.dedup)?;
 
@@ -1700,6 +1716,25 @@ mod tests {
     }
 
     #[test]
+    fn codex_bypass_permissions_starts_in_full_access_mode() {
+        assert_eq!(
+            codex_initial_agent_mode_env("codex-acp", PermissionMode::BypassPermissions),
+            Some((
+                "INITIAL_AGENT_MODE".to_string(),
+                "agent-full-access".to_string(),
+            ))
+        );
+        assert_eq!(
+            codex_initial_agent_mode_env("codex-acp", PermissionMode::Default),
+            None
+        );
+        assert_eq!(
+            codex_initial_agent_mode_env("goose", PermissionMode::BypassPermissions),
+            None
+        );
+    }
+
+    #[test]
     fn strips_legacy_acp_arg_case_insensitively() {
         assert_eq!(
             normalize_agent_args("codex-acp", vec!["ACP".into()]),
@@ -1709,7 +1744,7 @@ mod tests {
 
     // --- codex_network_env tests ---
 
-    const CODEX_CONFIG_JSON: &str = "{\"sandbox_workspace_write\":{\"network_access\":true}}";
+    const CODEX_CONFIG_JSON: &str = "{\"sandbox_workspace_write\":{\"network_access\":true},\"features\":{\"apps\":false,\"plugins\":false,\"remote_plugin\":false}}";
 
     #[test]
     fn codex_network_env_wss_url() {
@@ -2209,6 +2244,14 @@ channels = "ALL"
     fn test_turn_liveness_one_rejected() {
         let err = validate_turn_liveness(1).unwrap_err();
         assert!(err.to_string().contains("turn liveness interval must be 0"));
+    }
+
+    #[test]
+    fn context_defaults_bound_history_and_rotate_sessions() {
+        let key = "0".repeat(64);
+        let args = CliArgs::parse_from(["buzz-acp", "--private-key", &key]);
+        assert_eq!(args.context_message_limit, 6);
+        assert_eq!(args.max_turns_per_session, 8);
     }
 
     #[test]

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -78,9 +78,12 @@ async fn fetch_event(client: &BuzzClient, event_id: &str) -> Result<serde_json::
 async fn resolve_thread_ref(
     client: &BuzzClient,
     parent_event_id: &str,
-) -> Result<ThreadRef, CliError> {
+) -> Result<(ThreadRef, Option<u16>), CliError> {
     let event = fetch_event(client, parent_event_id).await?;
-    thread_ref_from_event(parent_event_id, &event)
+    Ok((
+        thread_ref_from_event(parent_event_id, &event)?,
+        event_kind(&event),
+    ))
 }
 
 fn thread_ref_from_event(event_id: &str, event: &serde_json::Value) -> Result<ThreadRef, CliError> {
@@ -90,6 +93,17 @@ fn thread_ref_from_event(event_id: &str, event: &serde_json::Value) -> Result<Th
         .cloned()
         .unwrap_or(serde_json::Value::Null);
     thread_ref_from_parent_tags(parent_eid, event_id, &tags)
+}
+
+fn event_kind(event: &serde_json::Value) -> Option<u16> {
+    event
+        .get("kind")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|kind| u16::try_from(kind).ok())
+}
+
+fn effective_message_kind(explicit: Option<u16>, parent_kind: Option<u16>) -> Option<u16> {
+    explicit.or_else(|| matches!(parent_kind, Some(45001 | 45003)).then_some(45003))
 }
 
 /// Resolve the channel UUID for an event by querying for it via POST /query.
@@ -672,21 +686,24 @@ pub async fn cmd_send_message(
 
     // Build thread ref if replying. `--reply-to` is the immediate parent; the
     // thread root is derived from the parent's NIP-10 tags via the relay.
-    let thread_ref = if let Some(ref r) = p.reply_to {
+    let reply_context = if let Some(ref r) = p.reply_to {
         Some(resolve_thread_ref(client, r).await?)
     } else {
         None
     };
+    let thread_ref = reply_context.as_ref().map(|(thread_ref, _)| thread_ref);
+    let effective_kind =
+        effective_message_kind(p.kind, reply_context.as_ref().and_then(|(_, kind)| *kind));
 
     let mention_refs: Vec<&str> = mention_pubkeys.iter().map(String::as_str).collect();
 
-    let builder = match p.kind {
+    let builder = match effective_kind {
         Some(45001) => {
             buzz_sdk::build_forum_post(channel_uuid, &final_content, &mention_refs, &media_tags)
                 .map_err(|e| CliError::Other(format!("build_forum_post failed: {e}")))?
         }
         Some(45003) => {
-            let tr = thread_ref.as_ref().ok_or_else(|| {
+            let tr = thread_ref.ok_or_else(|| {
                 CliError::Usage("--reply-to is required for forum comments (kind 45003)".into())
             })?;
             buzz_sdk::build_forum_comment(
@@ -701,7 +718,7 @@ pub async fn cmd_send_message(
         None | Some(9) => buzz_sdk::build_message(
             channel_uuid,
             &final_content,
-            thread_ref.as_ref(),
+            thread_ref,
             &mention_refs,
             p.broadcast,
             &media_tags,
@@ -783,7 +800,7 @@ pub async fn cmd_send_diff_message(client: &BuzzClient, p: SendDiffParams) -> Re
     // `--reply-to` is the immediate parent; the thread root is derived from
     // the parent's NIP-10 tags via the relay.
     let thread_ref = if let Some(r) = &p.reply_to {
-        Some(resolve_thread_ref(client, r).await?)
+        Some(resolve_thread_ref(client, r).await?.0)
     } else {
         None
     };
@@ -1056,8 +1073,8 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::{
-        channel_id_from_event, cmd_get_thread, event_mention_pubkeys, find_root_from_tags,
-        match_profiles_by_name, merge_message_mentions, missing_members,
+        channel_id_from_event, cmd_get_thread, effective_message_kind, event_mention_pubkeys,
+        find_root_from_tags, match_profiles_by_name, merge_message_mentions, missing_members,
         normalize_explicit_mentions, parse_member_pubkeys, resolve_names_to_pubkeys,
         resolve_thread_target, thread_ref_from_event, thread_ref_from_parent_tags, BuzzClient,
         CliError, Uuid,
@@ -1162,6 +1179,15 @@ mod tests {
             .unwrap(),
             ID_A
         );
+    }
+
+    #[test]
+    fn forum_parent_infers_forum_comment_unless_kind_is_explicit() {
+        assert_eq!(effective_message_kind(None, Some(45001)), Some(45003));
+        assert_eq!(effective_message_kind(None, Some(45003)), Some(45003));
+        assert_eq!(effective_message_kind(None, Some(9)), None);
+        assert_eq!(effective_message_kind(None, None), None);
+        assert_eq!(effective_message_kind(Some(9), Some(45001)), Some(9));
     }
 
     #[test]

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -622,6 +622,15 @@ pub struct SendMessageParams {
     pub mentions: Vec<String>,
 }
 
+fn validate_message_body(content: &str, has_files: bool) -> Result<(), CliError> {
+    if content.trim().is_empty() && !has_files {
+        return Err(CliError::Usage(
+            "message content is empty; provide text or attach a file".into(),
+        ));
+    }
+    Ok(())
+}
+
 pub async fn cmd_send_message(
     client: &BuzzClient,
     mut p: SendMessageParams,
@@ -631,6 +640,7 @@ pub async fn cmd_send_message(
     // quoting — the source of countless self-inflicted command-substitution
     // bugs for agent and human users alike.
     p.content = read_or_stdin(&p.content)?;
+    validate_message_body(&p.content, !p.files.is_empty())?;
     validate_content_size(&p.content)?;
     if let Some(ref r) = p.reply_to {
         validate_hex64(r)?;
@@ -1076,8 +1086,8 @@ mod tests {
         channel_id_from_event, cmd_get_thread, effective_message_kind, event_mention_pubkeys,
         find_root_from_tags, match_profiles_by_name, merge_message_mentions, missing_members,
         normalize_explicit_mentions, parse_member_pubkeys, resolve_names_to_pubkeys,
-        resolve_thread_target, thread_ref_from_event, thread_ref_from_parent_tags, BuzzClient,
-        CliError, Uuid,
+        resolve_thread_target, thread_ref_from_event, thread_ref_from_parent_tags,
+        validate_message_body, BuzzClient, CliError, Uuid,
     };
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
@@ -1113,6 +1123,23 @@ mod tests {
 
         assert!(matches!(error, CliError::Usage(_)));
         assert!(error.to_string().contains("invalid UUID"));
+    }
+
+    #[test]
+    fn empty_message_without_attachment_is_rejected() {
+        let error = validate_message_body("  \n\t", false).unwrap_err();
+        assert!(matches!(error, CliError::Usage(_)));
+        assert!(error.to_string().contains("message content is empty"));
+    }
+
+    #[test]
+    fn empty_caption_with_attachment_is_allowed() {
+        assert!(validate_message_body("", true).is_ok());
+    }
+
+    #[test]
+    fn nonempty_message_without_attachment_is_allowed() {
+        assert!(validate_message_body("hello", false).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reduce default ACP conversation context from 12 messages to 6 and proactively rotate sessions after 8 turns
- disable Codex app/plugin injection for autonomous managed agents and start bypass-permission Codex sessions directly in full-access mode
- reduce prompt-driven ceremony and duplicate validation; let `buzz messages send --reply-to` infer Forum comment kind from its parent

## Production canary

Linza managed-agent `[QUESTION]` canary after refreshing the 1.4.0 Codex ACP adapter:

- exact response, no duplicate publication
- 26 seconds end-to-end
- 2 model calls
- 1 tool call (final Buzz publication)
- 44,006 cumulative tokens, 32,256 cached input tokens
- historical unbounded baseline: 112 seconds, 10 model calls, 325.7k processed tokens

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p buzz-acp -p buzz-cli` — 802 ACP tests passed before one load-sensitive keepalive timing test failed while the host was compiling; isolated retry passed after load settled
- `cargo test -p buzz-acp acp::tests::keepalive_resets_idle_past_deadline -- --exact`
- `cargo clippy -p buzz-acp -p buzz-cli -- -D warnings`
- `pnpm --dir desktop typecheck`
- desktop test suite: 5,397 passed
- `git diff --check origin/main...HEAD`

The keepalive test was also run on unmodified `origin/main`; it is timing-sensitive to host load and passed there without source differences in `acp.rs`.
