### PR TITLE
feat(workflows): discover trigger filter values

### DIFF
--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -396,13 +396,31 @@ pub async fn get_channel_messages_before(
     })
 }
 
+const GET_EVENT_KINDS: [u32; 15] = [
+    0,
+    1,
+    3,
+    5,
+    7,
+    9,
+    30078,
+    40002,
+    40003,
+    40008,
+    40099,
+    40100,
+    45001,
+    45003,
+    buzz_core_pkg::kind::KIND_HUDDLE_STARTED,
+];
+
 #[tauri::command]
 pub async fn get_event(event_id: String, state: State<'_, AppState>) -> Result<String, String> {
     let events = query_relay(
         &state,
         &[serde_json::json!({
             "ids": [event_id],
-            "kinds": [0, 1, 3, 5, 7, 9, 30078, 40002, 40003, 40008, 40099, 40100, 45001, 45003, buzz_core_pkg::kind::KIND_HUDDLE_STARTED],
+            "kinds": GET_EVENT_KINDS,
             "limit": 1
         })],
     )
@@ -412,6 +430,35 @@ pub async fn get_event(event_id: String, state: State<'_, AppState>) -> Result<S
         .first()
         .ok_or_else(|| "event not found".to_string())?;
     serde_json::to_string(ev).map_err(|e| format!("serialize event: {e}"))
+}
+
+/// Resolve many exact event IDs with one relay request. Callers still validate
+/// event kind, channel scope, and requested ID before using presentation data.
+#[tauri::command]
+pub async fn get_events(
+    event_ids: Vec<String>,
+    state: State<'_, AppState>,
+) -> Result<Vec<serde_json::Value>, String> {
+    if event_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let events = query_relay(
+        &state,
+        &[serde_json::json!({
+            "ids": event_ids,
+            "kinds": GET_EVENT_KINDS,
+            "limit": event_ids.len()
+        })],
+    )
+    .await?;
+
+    events
+        .iter()
+        .map(|event| {
+            serde_json::to_value(event).map_err(|error| format!("serialize event: {error}"))
+        })
+        .collect()
 }
 
 // ── Writes ──────────────────────────────────────────────────────────────────

--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -396,70 +396,8 @@ pub async fn get_channel_messages_before(
     })
 }
 
-const GET_EVENT_KINDS: [u32; 15] = [
-    0,
-    1,
-    3,
-    5,
-    7,
-    9,
-    30078,
-    40002,
-    40003,
-    40008,
-    40099,
-    40100,
-    45001,
-    45003,
-    buzz_core_pkg::kind::KIND_HUDDLE_STARTED,
-];
-
-#[tauri::command]
-pub async fn get_event(event_id: String, state: State<'_, AppState>) -> Result<String, String> {
-    let events = query_relay(
-        &state,
-        &[serde_json::json!({
-            "ids": [event_id],
-            "kinds": GET_EVENT_KINDS,
-            "limit": 1
-        })],
-    )
-    .await?;
-
-    let ev = events
-        .first()
-        .ok_or_else(|| "event not found".to_string())?;
-    serde_json::to_string(ev).map_err(|e| format!("serialize event: {e}"))
-}
-
-/// Resolve many exact event IDs with one relay request. Callers still validate
-/// event kind, channel scope, and requested ID before using presentation data.
-#[tauri::command]
-pub async fn get_events(
-    event_ids: Vec<String>,
-    state: State<'_, AppState>,
-) -> Result<Vec<serde_json::Value>, String> {
-    if event_ids.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let events = query_relay(
-        &state,
-        &[serde_json::json!({
-            "ids": event_ids,
-            "kinds": GET_EVENT_KINDS,
-            "limit": event_ids.len()
-        })],
-    )
-    .await?;
-
-    events
-        .iter()
-        .map(|event| {
-            serde_json::to_value(event).map_err(|error| format!("serialize event: {error}"))
-        })
-        .collect()
-}
+mod event_batch;
+pub use event_batch::{get_event, get_events};
 
 // ── Writes ──────────────────────────────────────────────────────────────────
 

--- a/desktop/src-tauri/src/commands/messages/event_batch.rs
+++ b/desktop/src-tauri/src/commands/messages/event_batch.rs
@@ -1,0 +1,68 @@
+use tauri::State;
+
+use crate::{app_state::AppState, relay::query_relay};
+
+const GET_EVENT_KINDS: [u32; 15] = [
+    0,
+    1,
+    3,
+    5,
+    7,
+    9,
+    30078,
+    40002,
+    40003,
+    40008,
+    40099,
+    40100,
+    45001,
+    45003,
+    buzz_core_pkg::kind::KIND_HUDDLE_STARTED,
+];
+
+#[tauri::command]
+pub async fn get_event(event_id: String, state: State<'_, AppState>) -> Result<String, String> {
+    let events = query_relay(
+        &state,
+        &[serde_json::json!({
+            "ids": [event_id],
+            "kinds": GET_EVENT_KINDS,
+            "limit": 1
+        })],
+    )
+    .await?;
+
+    let event = events
+        .first()
+        .ok_or_else(|| "event not found".to_string())?;
+    serde_json::to_string(event).map_err(|error| format!("serialize event: {error}"))
+}
+
+/// Resolve many exact event IDs with one relay request. Callers still validate
+/// event kind, channel scope, and requested ID before using presentation data.
+#[tauri::command]
+pub async fn get_events(
+    event_ids: Vec<String>,
+    state: State<'_, AppState>,
+) -> Result<Vec<serde_json::Value>, String> {
+    if event_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let events = query_relay(
+        &state,
+        &[serde_json::json!({
+            "ids": event_ids,
+            "kinds": GET_EVENT_KINDS,
+            "limit": event_ids.len()
+        })],
+    )
+    .await?;
+
+    events
+        .iter()
+        .map(|event| {
+            serde_json::to_value(event).map_err(|error| format!("serialize event: {error}"))
+        })
+        .collect()
+}

--- a/desktop/src-tauri/src/commands/messages/event_batch.rs
+++ b/desktop/src-tauri/src/commands/messages/event_batch.rs
@@ -1,6 +1,12 @@
+use std::collections::HashSet;
+
 use tauri::State;
 
 use crate::{app_state::AppState, relay::query_relay};
+
+// The relay clamps a single filter to this many events. Keep exact-ID reads in
+// chunks so a large workflow list cannot silently lose late presentations.
+const EVENT_QUERY_CHUNK_SIZE: usize = 1_000;
 
 const GET_EVENT_KINDS: [u32; 15] = [
     0,
@@ -38,31 +44,85 @@ pub async fn get_event(event_id: String, state: State<'_, AppState>) -> Result<S
     serde_json::to_string(event).map_err(|error| format!("serialize event: {error}"))
 }
 
-/// Resolve many exact event IDs with one relay request. Callers still validate
+/// Resolve many exact event IDs in relay-sized chunks. Callers still validate
 /// event kind, channel scope, and requested ID before using presentation data.
+fn normalized_event_id_chunks(event_ids: Vec<String>) -> Vec<Vec<String>> {
+    let mut seen_ids = HashSet::new();
+    let event_ids = event_ids
+        .into_iter()
+        .map(|event_id| event_id.trim().to_ascii_lowercase())
+        .filter(|event_id| event_id.len() == 64 && event_id.chars().all(|c| c.is_ascii_hexdigit()))
+        .filter(|event_id| seen_ids.insert(event_id.clone()))
+        .collect::<Vec<_>>();
+    event_ids
+        .chunks(EVENT_QUERY_CHUNK_SIZE)
+        .map(<[String]>::to_vec)
+        .collect()
+}
+
 #[tauri::command]
 pub async fn get_events(
     event_ids: Vec<String>,
     state: State<'_, AppState>,
 ) -> Result<Vec<serde_json::Value>, String> {
-    if event_ids.is_empty() {
+    let event_id_chunks = normalized_event_id_chunks(event_ids);
+    if event_id_chunks.is_empty() {
         return Ok(Vec::new());
     }
 
-    let events = query_relay(
-        &state,
-        &[serde_json::json!({
-            "ids": event_ids,
-            "kinds": GET_EVENT_KINDS,
-            "limit": event_ids.len()
-        })],
-    )
-    .await?;
+    let mut events_by_id = std::collections::HashMap::new();
+    for event_ids in event_id_chunks {
+        let events = query_relay(
+            &state,
+            &[serde_json::json!({
+                "ids": event_ids,
+                "kinds": GET_EVENT_KINDS,
+                "limit": event_ids.len()
+            })],
+        )
+        .await?;
+        for event in events {
+            events_by_id.entry(event.id).or_insert(event);
+        }
+    }
 
-    events
-        .iter()
+    events_by_id
+        .into_values()
         .map(|event| {
             serde_json::to_value(event).map_err(|error| format!("serialize event: {error}"))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_exact_relay_ceiling_in_one_chunk() {
+        let chunks = normalized_event_id_chunks(
+            (0..EVENT_QUERY_CHUNK_SIZE)
+                .map(|index| format!("{index:064x}"))
+                .collect(),
+        );
+
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].len(), EVENT_QUERY_CHUNK_SIZE);
+    }
+
+    #[test]
+    fn normalizes_deduplicates_and_keeps_ids_beyond_relay_ceiling() {
+        let last_id = format!("{:064x}", EVENT_QUERY_CHUNK_SIZE);
+        let mut event_ids = (0..=EVENT_QUERY_CHUNK_SIZE)
+            .map(|index| format!("{index:064X}"))
+            .collect::<Vec<_>>();
+        event_ids.extend(["not-an-event-id".to_string(), format!(" {last_id} ")]);
+
+        let chunks = normalized_event_id_chunks(event_ids);
+
+        assert_eq!(chunks.iter().map(Vec::len).sum::<usize>(), 1_001);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].len(), EVENT_QUERY_CHUNK_SIZE);
+        assert_eq!(chunks[1], [last_id]);
+    }
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -652,6 +652,7 @@ pub fn run() {
             add_reaction,
             remove_reaction,
             get_event,
+            get_events,
             show_native_notification,
             #[cfg(target_os = "macos")]
             macos_notifications::take_pending_activations,

--- a/desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx
@@ -15,6 +15,7 @@ import { Input } from "@/shared/ui/input";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import {
   enrichAuthorCandidates,
+  filterAuthorCandidatePage,
   mergeAuthorCandidateSources,
   parseDirectAuthorInput,
   type WorkflowAuthorCandidate,
@@ -56,9 +57,9 @@ export function WorkflowAuthorPicker({
   const baseCandidates = React.useMemo(
     () =>
       mergeAuthorCandidateSources([
-        channelMembersQuery.data ?? [],
         normalizedValue ? [{ pubkey: normalizedValue }] : [],
         directPubkey ? [{ pubkey: directPubkey }] : [],
+        channelMembersQuery.data ?? [],
         relayMembersQuery.data ?? [],
         directoryResults,
       ]),
@@ -70,26 +71,25 @@ export function WorkflowAuthorPicker({
       relayMembersQuery.data,
     ],
   );
+  const candidatePage = React.useMemo(
+    () =>
+      filterAuthorCandidatePage(
+        baseCandidates,
+        deferredQuery,
+        directPubkey,
+        PAGE_SIZE,
+      ),
+    [baseCandidates, deferredQuery, directPubkey],
+  );
   const profileQuery = useUsersBatchQuery(
-    baseCandidates.map(({ pubkey }) => pubkey),
+    candidatePage.map(({ pubkey }) => pubkey),
   );
   const candidates = React.useMemo(
     () =>
-      enrichAuthorCandidates(baseCandidates, profileQuery.data?.profiles ?? {}),
-    [baseCandidates, profileQuery.data?.profiles],
+      enrichAuthorCandidates(candidatePage, profileQuery.data?.profiles ?? {}),
+    [candidatePage, profileQuery.data?.profiles],
   );
-  const visibleCandidates = React.useMemo(() => {
-    if (directPubkey) {
-      return candidates.filter(({ pubkey }) => pubkey === directPubkey);
-    }
-    if (!deferredQuery) return candidates;
-    const needle = deferredQuery.toLowerCase();
-    return candidates.filter((candidate) =>
-      [candidate.displayName, candidate.nip05Handle, candidate.pubkey].some(
-        (field) => field?.toLowerCase().includes(needle),
-      ),
-    );
-  }, [candidates, deferredQuery, directPubkey]);
+  const visibleCandidates = candidates;
   const listId = `${id}-list`;
 
   React.useEffect(() => {

--- a/desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx
@@ -40,7 +40,7 @@ export function WorkflowAuthorPicker({
   const pickerRef = React.useRef<HTMLDivElement>(null);
   const optionRefs = React.useRef(new Map<string, HTMLButtonElement>());
   const [query, setQuery] = React.useState("");
-  const [activeIndex, setActiveIndex] = React.useState(0);
+  const [activeIndex, setActiveIndex] = React.useState<number | null>(null);
   const [columnCount, setColumnCount] = React.useState(2);
   const deferredQuery = React.useDeferredValue(query.trim());
   const normalizedValue = parseDirectAuthorInput(value);
@@ -93,8 +93,10 @@ export function WorkflowAuthorPicker({
   const listId = `${id}-list`;
 
   React.useEffect(() => {
-    if (activeIndex >= visibleCandidates.length) {
-      setActiveIndex(Math.max(visibleCandidates.length - 1, 0));
+    if (activeIndex !== null && activeIndex >= visibleCandidates.length) {
+      setActiveIndex(
+        visibleCandidates.length > 0 ? visibleCandidates.length - 1 : null,
+      );
     }
   }, [activeIndex, visibleCandidates.length]);
 
@@ -110,6 +112,7 @@ export function WorkflowAuthorPicker({
   }, []);
 
   React.useEffect(() => {
+    if (activeIndex === null) return;
     const candidate = visibleCandidates[activeIndex];
     if (!candidate) return;
     optionRefs.current
@@ -129,10 +132,13 @@ export function WorkflowAuthorPicker({
 
   function moveActive(delta: number) {
     if (visibleCandidates.length === 0) return;
-    setActiveIndex(
-      (current) =>
-        (current + delta + visibleCandidates.length) % visibleCandidates.length,
-    );
+    setActiveIndex((current) => {
+      const startingIndex = current ?? -1;
+      return (
+        (startingIndex + delta + visibleCandidates.length) %
+        visibleCandidates.length
+      );
+    });
   }
 
   return (
@@ -145,7 +151,7 @@ export function WorkflowAuthorPicker({
         <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           aria-activedescendant={
-            visibleCandidates[activeIndex]
+            activeIndex !== null && visibleCandidates[activeIndex]
               ? `${listId}-${visibleCandidates[activeIndex].pubkey}`
               : undefined
           }
@@ -156,11 +162,12 @@ export function WorkflowAuthorPicker({
           autoComplete="off"
           autoCorrect="off"
           className="h-11 rounded-none border-0 bg-transparent pl-9 focus-visible:ring-0"
+          data-workflow-filter-picker-search="true"
           disabled={disabled}
           id={id}
           onChange={(event) => {
             setQuery(event.target.value);
-            setActiveIndex(0);
+            setActiveIndex(null);
           }}
           onKeyDown={(event) => {
             const delta =
@@ -178,16 +185,16 @@ export function WorkflowAuthorPicker({
               moveActive(delta);
             } else if (
               event.key === "Enter" &&
-              visibleCandidates[activeIndex]
+              visibleCandidates[activeIndex ?? 0]
             ) {
               event.preventDefault();
-              onChange(visibleCandidates[activeIndex].pubkey);
+              onChange(visibleCandidates[activeIndex ?? 0].pubkey);
             } else if (event.key === "Escape") {
               event.preventDefault();
               event.stopPropagation();
               if (query) {
                 setQuery("");
-                setActiveIndex(0);
+                setActiveIndex(null);
               } else {
                 onEscape?.();
               }
@@ -222,12 +229,15 @@ export function WorkflowAuthorPicker({
       >
         {visibleCandidates.map((candidate, index) => (
           <AuthorOption
-            active={index === activeIndex}
+            active={activeIndex !== null && index === activeIndex}
             candidate={candidate}
             disabled={disabled}
             id={`${listId}-${candidate.pubkey}`}
             key={candidate.pubkey}
-            onSelect={() => onChange(candidate.pubkey)}
+            onSelect={() => {
+              setActiveIndex(null);
+              onChange(candidate.pubkey);
+            }}
             optionRef={(node) => {
               if (node) optionRefs.current.set(candidate.pubkey, node);
               else optionRefs.current.delete(candidate.pubkey);
@@ -315,7 +325,7 @@ function AuthorOption({
         selected
           ? "border-primary bg-primary/10"
           : "border-border hover:bg-accent",
-        active && "ring-2 ring-ring ring-offset-1",
+        active && "ring-1 ring-ring",
       )}
       disabled={disabled}
       id={id}

--- a/desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx
@@ -1,0 +1,347 @@
+import { Check, LoaderCircle, Search } from "lucide-react";
+import * as React from "react";
+
+import { useChannelMembersQuery } from "@/features/channels/hooks";
+import { useRelayMembersQuery } from "@/features/community-members/hooks";
+import {
+  useFlattenedUserSearchResults,
+  useInfiniteUserSearchQuery,
+  useUsersBatchQuery,
+} from "@/features/profile/hooks";
+import { resolveUserLabel } from "@/features/profile/lib/identity";
+import { cn } from "@/shared/lib/cn";
+import { truncatePubkey } from "@/shared/lib/pubkey";
+import { Input } from "@/shared/ui/input";
+import { UserAvatar } from "@/shared/ui/UserAvatar";
+import {
+  enrichAuthorCandidates,
+  mergeAuthorCandidateSources,
+  parseDirectAuthorInput,
+  type WorkflowAuthorCandidate,
+} from "./workflowAuthorCandidates";
+
+const PAGE_SIZE = 50;
+
+export function WorkflowAuthorPicker({
+  channelId,
+  disabled,
+  id,
+  onChange,
+  onEscape,
+  value,
+}: {
+  channelId?: string | null;
+  disabled?: boolean;
+  id: string;
+  onChange: (pubkey: string) => void;
+  onEscape?: () => void;
+  value: string;
+}) {
+  const pickerRef = React.useRef<HTMLDivElement>(null);
+  const optionRefs = React.useRef(new Map<string, HTMLButtonElement>());
+  const [query, setQuery] = React.useState("");
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const [columnCount, setColumnCount] = React.useState(2);
+  const deferredQuery = React.useDeferredValue(query.trim());
+  const normalizedValue = parseDirectAuthorInput(value);
+  const channelMembersQuery = useChannelMembersQuery(channelId ?? null);
+  const relayMembersQuery = useRelayMembersQuery(true);
+  const directoryQuery = useInfiniteUserSearchQuery(deferredQuery, {
+    allowEmpty: true,
+    limit: PAGE_SIZE,
+  });
+  const directoryResults = useFlattenedUserSearchResults(directoryQuery.data);
+  const directPubkey = parseDirectAuthorInput(deferredQuery);
+
+  const baseCandidates = React.useMemo(
+    () =>
+      mergeAuthorCandidateSources([
+        channelMembersQuery.data ?? [],
+        normalizedValue ? [{ pubkey: normalizedValue }] : [],
+        directPubkey ? [{ pubkey: directPubkey }] : [],
+        relayMembersQuery.data ?? [],
+        directoryResults,
+      ]),
+    [
+      channelMembersQuery.data,
+      directPubkey,
+      directoryResults,
+      normalizedValue,
+      relayMembersQuery.data,
+    ],
+  );
+  const profileQuery = useUsersBatchQuery(
+    baseCandidates.map(({ pubkey }) => pubkey),
+  );
+  const candidates = React.useMemo(
+    () =>
+      enrichAuthorCandidates(baseCandidates, profileQuery.data?.profiles ?? {}),
+    [baseCandidates, profileQuery.data?.profiles],
+  );
+  const visibleCandidates = React.useMemo(() => {
+    if (directPubkey) {
+      return candidates.filter(({ pubkey }) => pubkey === directPubkey);
+    }
+    if (!deferredQuery) return candidates;
+    const needle = deferredQuery.toLowerCase();
+    return candidates.filter((candidate) =>
+      [candidate.displayName, candidate.nip05Handle, candidate.pubkey].some(
+        (field) => field?.toLowerCase().includes(needle),
+      ),
+    );
+  }, [candidates, deferredQuery, directPubkey]);
+  const listId = `${id}-list`;
+
+  React.useEffect(() => {
+    if (activeIndex >= visibleCandidates.length) {
+      setActiveIndex(Math.max(visibleCandidates.length - 1, 0));
+    }
+  }, [activeIndex, visibleCandidates.length]);
+
+  React.useEffect(() => {
+    const picker = pickerRef.current;
+    if (!picker) return;
+    const updateColumnCount = () =>
+      setColumnCount(picker.clientWidth >= 544 ? 3 : 2);
+    updateColumnCount();
+    const observer = new ResizeObserver(updateColumnCount);
+    observer.observe(picker);
+    return () => observer.disconnect();
+  }, []);
+
+  React.useEffect(() => {
+    const candidate = visibleCandidates[activeIndex];
+    if (!candidate) return;
+    optionRefs.current
+      .get(candidate.pubkey)
+      ?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [activeIndex, visibleCandidates]);
+
+  const loading =
+    (channelMembersQuery.isLoading ||
+      relayMembersQuery.isLoading ||
+      directoryQuery.isLoading) &&
+    visibleCandidates.length === 0;
+  const failed =
+    channelMembersQuery.isError ||
+    relayMembersQuery.isError ||
+    directoryQuery.isError;
+
+  function moveActive(delta: number) {
+    if (visibleCandidates.length === 0) return;
+    setActiveIndex(
+      (current) =>
+        (current + delta + visibleCandidates.length) % visibleCandidates.length,
+    );
+  }
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-border/70 bg-background/35"
+      data-testid="workflow-author-picker"
+      ref={pickerRef}
+    >
+      <div className="relative shrink-0 border-b border-border/70">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          aria-activedescendant={
+            visibleCandidates[activeIndex]
+              ? `${listId}-${visibleCandidates[activeIndex].pubkey}`
+              : undefined
+          }
+          aria-controls={listId}
+          aria-label="Search authors or paste a public key"
+          aria-expanded="true"
+          autoCapitalize="none"
+          autoComplete="off"
+          autoCorrect="off"
+          className="h-11 rounded-none border-0 bg-transparent pl-9 focus-visible:ring-0"
+          disabled={disabled}
+          id={id}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setActiveIndex(0);
+          }}
+          onKeyDown={(event) => {
+            const delta =
+              event.key === "ArrowDown"
+                ? columnCount
+                : event.key === "ArrowUp"
+                  ? -columnCount
+                  : event.key === "ArrowRight"
+                    ? 1
+                    : event.key === "ArrowLeft"
+                      ? -1
+                      : 0;
+            if (delta) {
+              event.preventDefault();
+              moveActive(delta);
+            } else if (
+              event.key === "Enter" &&
+              visibleCandidates[activeIndex]
+            ) {
+              event.preventDefault();
+              onChange(visibleCandidates[activeIndex].pubkey);
+            } else if (event.key === "Escape") {
+              event.preventDefault();
+              event.stopPropagation();
+              if (query) {
+                setQuery("");
+                setActiveIndex(0);
+              } else {
+                onEscape?.();
+              }
+            }
+          }}
+          placeholder="Search people or paste a public key…"
+          role="combobox"
+          spellCheck={false}
+          value={query}
+        />
+      </div>
+
+      <div
+        aria-label="Authors"
+        className={cn(
+          "grid min-h-0 flex-1 gap-2 overflow-y-auto overscroll-contain p-2",
+          columnCount === 3 ? "grid-cols-3" : "grid-cols-2",
+        )}
+        data-testid="workflow-author-picker-results"
+        id={listId}
+        onScroll={(event) => {
+          const list = event.currentTarget;
+          if (
+            list.scrollHeight - list.scrollTop - list.clientHeight < 64 &&
+            directoryQuery.hasNextPage &&
+            !directoryQuery.isFetchingNextPage
+          ) {
+            void directoryQuery.fetchNextPage();
+          }
+        }}
+        role="listbox"
+      >
+        {visibleCandidates.map((candidate, index) => (
+          <AuthorOption
+            active={index === activeIndex}
+            candidate={candidate}
+            disabled={disabled}
+            id={`${listId}-${candidate.pubkey}`}
+            key={candidate.pubkey}
+            onSelect={() => onChange(candidate.pubkey)}
+            optionRef={(node) => {
+              if (node) optionRefs.current.set(candidate.pubkey, node);
+              else optionRefs.current.delete(candidate.pubkey);
+            }}
+            selected={candidate.pubkey === normalizedValue}
+          />
+        ))}
+        {loading ? (
+          <p
+            className="col-span-full flex items-center justify-center gap-2 px-3 py-8 text-sm text-muted-foreground"
+            role="status"
+          >
+            <LoaderCircle className="h-4 w-4 animate-spin" /> Loading authors…
+          </p>
+        ) : visibleCandidates.length === 0 ? (
+          <p className="col-span-full px-3 py-8 text-center text-sm text-muted-foreground">
+            {failed ? "Couldn’t load authors." : "No authors found."}
+          </p>
+        ) : null}
+        {failed ? (
+          <button
+            className="col-span-full rounded-md px-3 py-2 text-xs font-medium text-muted-foreground hover:bg-muted/45 hover:text-foreground"
+            onClick={() => {
+              void channelMembersQuery.refetch();
+              void relayMembersQuery.refetch();
+              void directoryQuery.refetch();
+            }}
+            type="button"
+          >
+            Couldn’t load all authors. Retry
+          </button>
+        ) : null}
+        {directoryQuery.hasNextPage ? (
+          <button
+            className="col-span-full rounded-md px-3 py-2 text-xs font-medium text-muted-foreground hover:bg-muted/45 hover:text-foreground"
+            disabled={disabled || directoryQuery.isFetchingNextPage}
+            onClick={() => void directoryQuery.fetchNextPage()}
+            type="button"
+          >
+            {directoryQuery.isFetchingNextPage
+              ? "Loading more…"
+              : "Load more authors"}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function AuthorOption({
+  active,
+  candidate,
+  disabled,
+  id,
+  onSelect,
+  optionRef,
+  selected,
+}: {
+  active: boolean;
+  candidate: WorkflowAuthorCandidate;
+  disabled?: boolean;
+  id: string;
+  onSelect: () => void;
+  optionRef: (node: HTMLButtonElement | null) => void;
+  selected: boolean;
+}) {
+  const label = resolveUserLabel({
+    fallbackName: candidate.displayName,
+    profiles: {
+      [candidate.pubkey]: {
+        displayName: candidate.displayName,
+        avatarUrl: candidate.avatarUrl,
+        nip05Handle: candidate.nip05Handle,
+        ownerPubkey: candidate.ownerPubkey,
+        isAgent: candidate.isAgent,
+      },
+    },
+    pubkey: candidate.pubkey,
+  });
+  return (
+    <button
+      aria-selected={selected}
+      className={cn(
+        "relative flex min-h-24 min-w-0 flex-col items-center justify-center gap-2 rounded-lg border bg-muted/20 p-3 text-center transition-colors",
+        selected
+          ? "border-primary bg-primary/10"
+          : "border-border hover:bg-accent",
+        active && "ring-2 ring-ring ring-offset-1",
+      )}
+      disabled={disabled}
+      id={id}
+      onClick={onSelect}
+      ref={optionRef}
+      role="option"
+      tabIndex={-1}
+      type="button"
+    >
+      <UserAvatar
+        avatarUrl={candidate.avatarUrl}
+        displayName={label}
+        size="md"
+      />
+      <span className="min-w-0 max-w-full">
+        <span className="block truncate text-sm font-medium">{label}</span>
+        <span className="block truncate text-xs text-muted-foreground">
+          {truncatePubkey(candidate.pubkey)}
+        </span>
+      </span>
+      <Check
+        className={cn(
+          "absolute right-2 top-2 h-4 w-4",
+          !selected && "opacity-0",
+        )}
+      />
+    </button>
+  );
+}

--- a/desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx
@@ -188,7 +188,10 @@ export function WorkflowAuthorPicker({
               visibleCandidates[activeIndex ?? 0]
             ) {
               event.preventDefault();
-              onChange(visibleCandidates[activeIndex ?? 0].pubkey);
+              const candidate = visibleCandidates[activeIndex ?? 0];
+              onChange(
+                candidate.pubkey === normalizedValue ? "" : candidate.pubkey,
+              );
             } else if (event.key === "Escape") {
               event.preventDefault();
               event.stopPropagation();
@@ -236,7 +239,9 @@ export function WorkflowAuthorPicker({
             key={candidate.pubkey}
             onSelect={() => {
               setActiveIndex(null);
-              onChange(candidate.pubkey);
+              onChange(
+                candidate.pubkey === normalizedValue ? "" : candidate.pubkey,
+              );
             }}
             optionRef={(node) => {
               if (node) optionRefs.current.set(candidate.pubkey, node);

--- a/desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx
@@ -17,6 +17,7 @@ import {
   enrichAuthorCandidates,
   filterAuthorCandidatePage,
   mergeAuthorCandidateSources,
+  nextWorkflowAuthorIndex,
   parseDirectAuthorInput,
   type WorkflowAuthorCandidate,
 } from "./workflowAuthorCandidates";
@@ -132,14 +133,9 @@ export function WorkflowAuthorPicker({
     directoryQuery.isError;
 
   function moveActive(delta: number) {
-    if (visibleCandidates.length === 0) return;
-    setActiveIndex((current) => {
-      const startingIndex = current ?? -1;
-      return (
-        (startingIndex + delta + visibleCandidates.length) %
-        visibleCandidates.length
-      );
-    });
+    setActiveIndex((current) =>
+      nextWorkflowAuthorIndex(current, delta, visibleCandidates.length),
+    );
   }
 
   return (

--- a/desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx
@@ -43,7 +43,8 @@ export function WorkflowAuthorPicker({
   const [query, setQuery] = React.useState("");
   const [activeIndex, setActiveIndex] = React.useState<number | null>(null);
   const [columnCount, setColumnCount] = React.useState(2);
-  const deferredQuery = React.useDeferredValue(query.trim());
+  const trimmedQuery = query.trim();
+  const deferredQuery = React.useDeferredValue(trimmedQuery);
   const normalizedValue = parseDirectAuthorInput(value);
   const channelMembersQuery = useChannelMembersQuery(channelId ?? null);
   const relayMembersQuery = useRelayMembersQuery(true);
@@ -170,6 +171,7 @@ export function WorkflowAuthorPicker({
             setActiveIndex(null);
           }}
           onKeyDown={(event) => {
+            const currentQuery = event.currentTarget.value.trim();
             const delta =
               event.key === "ArrowDown"
                 ? columnCount
@@ -185,6 +187,7 @@ export function WorkflowAuthorPicker({
               moveActive(delta);
             } else if (
               event.key === "Enter" &&
+              currentQuery === deferredQuery &&
               visibleCandidates[activeIndex ?? 0]
             ) {
               event.preventDefault();

--- a/desktop/src/features/workflows/ui/WorkflowCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowCard.tsx
@@ -28,12 +28,16 @@ import {
   getWorkflowTriggerType,
 } from "./workflowDefinition";
 import { StatusEmoji } from "@/features/user-status/ui/StatusEmoji";
-import { useWorkflowTriggerPresentation } from "./useWorkflowTriggerPresentation";
+import type { WorkflowCardAuthorPresentation } from "./useWorkflowListAuthorPresentations";
+import type { WorkflowMessagePresentation } from "./useWorkflowListMessagePresentations";
+import { workflowTriggerDescription } from "./workflowTriggerDescription";
 
 type WorkflowCardProps = {
   workflow: Workflow;
+  authorPresentation?: WorkflowCardAuthorPresentation;
   channelName?: string;
   isTogglingEnabled?: boolean;
+  messagePresentation?: WorkflowMessagePresentation;
   onView: (workflow: Workflow) => void;
   onTrigger: (workflowId: string) => void;
   onToggleEnabled: (workflow: Workflow) => void;
@@ -191,8 +195,10 @@ function ActionTileStack({
 
 export function WorkflowCard({
   workflow,
+  authorPresentation,
   channelName,
   isTogglingEnabled = false,
+  messagePresentation,
   onView,
   onTrigger,
   onToggleEnabled,
@@ -204,13 +210,14 @@ export function WorkflowCard({
     React.useState(0);
   const isEnabled = getWorkflowEnabled(workflow.definition);
   const configuredTrigger = getWorkflowTriggerConfig(workflow.definition);
-  const triggerPresentation = useWorkflowTriggerPresentation(
-    configuredTrigger ?? { on: "message_posted" },
-    workflow.channelId,
-  );
   const cardLabel = getWorkflowCardLabel(workflow.definition, {
     triggerDescription: configuredTrigger
-      ? triggerPresentation.description
+      ? workflowTriggerDescription(configuredTrigger, {
+          authorLabel: authorPresentation?.label ?? undefined,
+          authorLoading: authorPresentation?.loading,
+          messageLabel: messagePresentation?.messageLabel ?? undefined,
+          messageLoading: messagePresentation?.messageLoading,
+        })
       : undefined,
   });
   const triggerType = getWorkflowTriggerType(workflow.definition);

--- a/desktop/src/features/workflows/ui/WorkflowCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowCard.tsx
@@ -28,7 +28,7 @@ import {
   getWorkflowTriggerType,
 } from "./workflowDefinition";
 import { StatusEmoji } from "@/features/user-status/ui/StatusEmoji";
-import { useWorkflowAuthorPresentation } from "./useWorkflowAuthorPresentation";
+import { useWorkflowTriggerPresentation } from "./useWorkflowTriggerPresentation";
 
 type WorkflowCardProps = {
   workflow: Workflow;
@@ -204,12 +204,13 @@ export function WorkflowCard({
     React.useState(0);
   const isEnabled = getWorkflowEnabled(workflow.definition);
   const configuredTrigger = getWorkflowTriggerConfig(workflow.definition);
-  const authorPresentation = useWorkflowAuthorPresentation(
+  const triggerPresentation = useWorkflowTriggerPresentation(
     configuredTrigger ?? { on: "message_posted" },
+    workflow.channelId,
   );
   const cardLabel = getWorkflowCardLabel(workflow.definition, {
     triggerDescription: configuredTrigger
-      ? authorPresentation.description
+      ? triggerPresentation.description
       : undefined,
   });
   const triggerType = getWorkflowTriggerType(workflow.definition);

--- a/desktop/src/features/workflows/ui/WorkflowCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowCard.tsx
@@ -24,9 +24,11 @@ import {
   getWorkflowActionTiles,
   getWorkflowCardLabel,
   getWorkflowTriggerEmoji,
+  getWorkflowTriggerConfig,
   getWorkflowTriggerType,
 } from "./workflowDefinition";
 import { StatusEmoji } from "@/features/user-status/ui/StatusEmoji";
+import { useWorkflowAuthorPresentation } from "./useWorkflowAuthorPresentation";
 
 type WorkflowCardProps = {
   workflow: Workflow;
@@ -201,7 +203,15 @@ export function WorkflowCard({
   const [triggerAnimationSequence, setTriggerAnimationSequence] =
     React.useState(0);
   const isEnabled = getWorkflowEnabled(workflow.definition);
-  const cardLabel = getWorkflowCardLabel(workflow.definition);
+  const configuredTrigger = getWorkflowTriggerConfig(workflow.definition);
+  const authorPresentation = useWorkflowAuthorPresentation(
+    configuredTrigger ?? { on: "message_posted" },
+  );
+  const cardLabel = getWorkflowCardLabel(workflow.definition, {
+    triggerDescription: configuredTrigger
+      ? authorPresentation.description
+      : undefined,
+  });
   const triggerType = getWorkflowTriggerType(workflow.definition);
   const actionTiles = getWorkflowActionTiles(workflow.definition);
   const triggerEmoji = getWorkflowTriggerEmoji(workflow.definition);

--- a/desktop/src/features/workflows/ui/WorkflowDialog.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowDialog.tsx
@@ -557,6 +557,13 @@ export function WorkflowDialog({
         <DialogContent
           className="flex h-[88vh] max-h-[88vh] w-[calc(100vw-2rem)] max-w-6xl flex-col gap-0 overflow-hidden p-0"
           onEscapeKeyDown={(event) => {
+            if (
+              event.target instanceof HTMLElement &&
+              event.target.closest("[data-workflow-filter-picker-search]")
+            ) {
+              event.preventDefault();
+              return;
+            }
             if (formBuilderRef.current?.closeInspector()) {
               event.preventDefault();
               event.stopPropagation();

--- a/desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx
@@ -30,8 +30,9 @@ import { Switch } from "@/shared/ui/switch";
 import { Textarea } from "@/shared/ui/textarea";
 import { reactionConditionValue } from "./workflowReactionCondition";
 import { WorkflowTriggerConditions } from "./WorkflowTriggerConditions";
+import { WorkflowRichTriggerDescription } from "./WorkflowRichTriggerDescription";
+import { useWorkflowAuthorPresentation } from "./useWorkflowAuthorPresentation";
 import { workflowStepDescription } from "./workflowStepDescription";
-import { workflowTriggerDescription } from "./workflowTriggerDescription";
 import { WorkflowScheduleFields } from "./WorkflowScheduleFields";
 import { WorkflowStepCard } from "./WorkflowStepCard";
 import {
@@ -67,12 +68,14 @@ function TriggerConfigFields({
   trigger,
   onConditionDraftsChange,
   onUpdate,
+  workflowChannelId,
 }: {
   conditionDrafts: ParsedConditionExpression[] | null;
   disabled?: boolean;
   trigger: TriggerConfig;
   onConditionDraftsChange: (drafts: ParsedConditionExpression[] | null) => void;
   onUpdate: (trigger: TriggerConfig) => void;
+  workflowChannelId?: string | null;
 }) {
   switch (trigger.on) {
     case "message_posted":
@@ -94,6 +97,7 @@ function TriggerConfigFields({
           }
           triggerType={trigger.on}
           value={reactionConditionValue(trigger)}
+          workflowChannelId={workflowChannelId}
         />
       );
     case "webhook":
@@ -220,7 +224,7 @@ function WorkflowNode({
   terminal,
   title,
 }: {
-  description: string;
+  description: React.ReactNode;
   disabled?: boolean;
   icon?: React.ReactNode;
   label: string;
@@ -614,10 +618,18 @@ export const WorkflowFormBuilder = React.forwardRef<
       )
       ?.value.trim();
   }, [formState.trigger]);
-  const triggerDescription = workflowTriggerDescription(formState.trigger);
-  const visibleTriggerDescription = triggerEmoji
-    ? "Reaction added"
-    : triggerDescription;
+  const authorPresentation = useWorkflowAuthorPresentation(formState.trigger);
+  const triggerDescription = authorPresentation.description;
+  const visibleTriggerDescription = triggerEmoji ? (
+    "Reaction added"
+  ) : (
+    <WorkflowRichTriggerDescription
+      avatarUrl={authorPresentation.avatarUrl}
+      description={triggerDescription}
+      label={authorPresentation.label}
+      loading={authorPresentation.loading}
+    />
+  );
   const TriggerIcon = {
     diff_posted: GitPullRequest,
     message_posted: MessageSquare,
@@ -889,6 +901,7 @@ export const WorkflowFormBuilder = React.forwardRef<
                           >
                             <motion.div
                               animate="center"
+                              className="h-full min-h-0"
                               custom={selectionDirection}
                               exit="exit"
                               initial="enter"
@@ -905,7 +918,7 @@ export const WorkflowFormBuilder = React.forwardRef<
                               variants={inspectorContentVariants}
                             >
                               {selectedNode.type === "trigger" ? (
-                                <div>
+                                <div className="h-full min-h-0">
                                   <TriggerConfigFields
                                     conditionDrafts={triggerConditionDrafts}
                                     disabled={disabled}
@@ -916,6 +929,7 @@ export const WorkflowFormBuilder = React.forwardRef<
                                       updateFormState({ ...formState, trigger })
                                     }
                                     trigger={formState.trigger}
+                                    workflowChannelId={workflowChannelId}
                                   />
                                 </div>
                               ) : selectedStep ? (

--- a/desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx
@@ -31,7 +31,7 @@ import { Textarea } from "@/shared/ui/textarea";
 import { reactionConditionValue } from "./workflowReactionCondition";
 import { WorkflowTriggerConditions } from "./WorkflowTriggerConditions";
 import { WorkflowRichTriggerDescription } from "./WorkflowRichTriggerDescription";
-import { useWorkflowAuthorPresentation } from "./useWorkflowAuthorPresentation";
+import { useWorkflowTriggerPresentation } from "./useWorkflowTriggerPresentation";
 import { workflowStepDescription } from "./workflowStepDescription";
 import { WorkflowScheduleFields } from "./WorkflowScheduleFields";
 import { WorkflowStepCard } from "./WorkflowStepCard";
@@ -618,16 +618,19 @@ export const WorkflowFormBuilder = React.forwardRef<
       )
       ?.value.trim();
   }, [formState.trigger]);
-  const authorPresentation = useWorkflowAuthorPresentation(formState.trigger);
-  const triggerDescription = authorPresentation.description;
+  const triggerPresentation = useWorkflowTriggerPresentation(
+    formState.trigger,
+    workflowChannelId,
+  );
+  const triggerDescription = triggerPresentation.description;
   const visibleTriggerDescription = triggerEmoji ? (
     "Reaction added"
   ) : (
     <WorkflowRichTriggerDescription
-      avatarUrl={authorPresentation.avatarUrl}
+      avatarUrl={triggerPresentation.avatarUrl}
       description={triggerDescription}
-      label={authorPresentation.label}
-      loading={authorPresentation.loading}
+      label={triggerPresentation.label}
+      loading={triggerPresentation.loading}
     />
   );
   const TriggerIcon = {

--- a/desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx
@@ -32,6 +32,7 @@ import { reactionConditionValue } from "./workflowReactionCondition";
 import { WorkflowTriggerConditions } from "./WorkflowTriggerConditions";
 import { WorkflowRichTriggerDescription } from "./WorkflowRichTriggerDescription";
 import { useWorkflowTriggerPresentation } from "./useWorkflowTriggerPresentation";
+import { compactWorkflowTriggerDescription } from "./workflowTriggerDescription";
 import { workflowStepDescription } from "./workflowStepDescription";
 import { WorkflowScheduleFields } from "./WorkflowScheduleFields";
 import { WorkflowStepCard } from "./WorkflowStepCard";
@@ -623,12 +624,14 @@ export const WorkflowFormBuilder = React.forwardRef<
     workflowChannelId,
   );
   const triggerDescription = triggerPresentation.description;
-  const visibleTriggerDescription = triggerEmoji ? (
-    "Reaction added"
-  ) : (
+  const compactTriggerDescription = compactWorkflowTriggerDescription(
+    triggerDescription,
+    triggerEmoji,
+  );
+  const visibleTriggerDescription = (
     <WorkflowRichTriggerDescription
       avatarUrl={triggerPresentation.avatarUrl}
-      description={triggerDescription}
+      description={compactTriggerDescription}
       label={triggerPresentation.label}
       loading={triggerPresentation.loading}
     />

--- a/desktop/src/features/workflows/ui/WorkflowMessagePicker.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowMessagePicker.tsx
@@ -61,7 +61,8 @@ export function WorkflowMessagePicker({
   const optionRefs = React.useRef(new Map<string, HTMLButtonElement>());
   const [query, setQuery] = React.useState("");
   const [activeIndex, setActiveIndex] = React.useState<number | null>(null);
-  const deferredQuery = React.useDeferredValue(query.trim());
+  const trimmedQuery = query.trim();
+  const deferredQuery = React.useDeferredValue(trimmedQuery);
   const normalizedQuery = deferredQuery.toLowerCase();
   const selectedId = normalizeMessageEventId(value);
   const directId = normalizeMessageEventId(query);
@@ -248,6 +249,7 @@ export function WorkflowMessagePicker({
             setActiveIndex(null);
           }}
           onKeyDown={(event) => {
+            const currentQuery = event.currentTarget.value.trim();
             if (event.key === "ArrowDown" || event.key === "ArrowUp") {
               event.preventDefault();
               if (visibleCandidates.length > 0) {
@@ -261,13 +263,15 @@ export function WorkflowMessagePicker({
                   );
                 });
               }
-            } else if (
-              event.key === "Enter" &&
-              visibleCandidates[activeIndex ?? 0]
-            ) {
+            } else if (event.key === "Enter") {
+              const currentDirectId = normalizeMessageEventId(currentQuery);
+              if (currentQuery !== deferredQuery && !currentDirectId) return;
+              const candidate = currentDirectId
+                ? allCandidates.find(({ id }) => id === currentDirectId)
+                : visibleCandidates[activeIndex ?? 0];
+              if (!candidate) return;
               event.preventDefault();
               if (invalidDirectResult) return;
-              const candidate = visibleCandidates[activeIndex ?? 0];
               onChange(candidate.id === selectedId ? "" : candidate.id);
             } else if (event.key === "Escape") {
               event.preventDefault();

--- a/desktop/src/features/workflows/ui/WorkflowMessagePicker.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowMessagePicker.tsx
@@ -267,7 +267,8 @@ export function WorkflowMessagePicker({
             ) {
               event.preventDefault();
               if (invalidDirectResult) return;
-              onChange(visibleCandidates[activeIndex ?? 0].id);
+              const candidate = visibleCandidates[activeIndex ?? 0];
+              onChange(candidate.id === selectedId ? "" : candidate.id);
             } else if (event.key === "Escape") {
               event.preventDefault();
               event.stopPropagation();
@@ -330,7 +331,9 @@ export function WorkflowMessagePicker({
             key={candidate.id}
             onSelect={() => {
               setActiveIndex(null);
-              if (!invalidDirectResult) onChange(candidate.id);
+              if (!invalidDirectResult) {
+                onChange(candidate.id === selectedId ? "" : candidate.id);
+              }
             }}
             optionRef={(node) => {
               if (node) optionRefs.current.set(candidate.id, node);

--- a/desktop/src/features/workflows/ui/WorkflowMessagePicker.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowMessagePicker.tsx
@@ -1,0 +1,464 @@
+import { useInfiniteQuery, useQueries, useQuery } from "@tanstack/react-query";
+import { Check, LoaderCircle, Search } from "lucide-react";
+import * as React from "react";
+
+import { parseChannelWindowResponse } from "@/features/messages/lib/channelWindowResponse";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import {
+  resolveUserLabel,
+  type UserProfileLookup,
+} from "@/features/profile/lib/identity";
+import { useSearchMessagesQuery } from "@/features/search/hooks";
+import { getChannelWindowEvents } from "@/shared/api/channelWindow";
+import { getEventById } from "@/shared/api/tauri";
+import type { ChannelPageCursor } from "@/shared/api/types";
+import { cn } from "@/shared/lib/cn";
+import { Input } from "@/shared/ui/input";
+import { UserAvatar } from "@/shared/ui/UserAvatar";
+import {
+  mergeMessageCandidateSources,
+  normalizeMessageEventId,
+  type WorkflowMessageCandidate,
+  validatedWorkflowMessageCandidate,
+  validateWorkflowMessageSearchResults,
+} from "./workflowMessageCandidates";
+
+const PAGE_SIZE = 25;
+
+function truncateContent(content: string | null): string {
+  const normalized = content?.trim().replaceAll(/\s+/g, " ") ?? "";
+  if (!normalized) return "No message body";
+  return normalized.length > 120
+    ? `${normalized.slice(0, 117)}...`
+    : normalized;
+}
+
+function formatTimestamp(unixSeconds: number | null): string | null {
+  if (unixSeconds === null) return null;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(unixSeconds * 1_000));
+}
+
+export function WorkflowMessagePicker({
+  channelId,
+  disabled,
+  id,
+  onChange,
+  onEscape,
+  value,
+}: {
+  channelId?: string | null;
+  disabled?: boolean;
+  id: string;
+  onChange: (messageId: string) => void;
+  onEscape?: () => void;
+  value: string;
+}) {
+  const optionRefs = React.useRef(new Map<string, HTMLButtonElement>());
+  const [query, setQuery] = React.useState("");
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const deferredQuery = React.useDeferredValue(query.trim());
+  const normalizedQuery = deferredQuery.toLowerCase();
+  const selectedId = normalizeMessageEventId(value);
+  const directId = normalizeMessageEventId(query);
+  const lookupId = directId ?? selectedId;
+
+  const historyQuery = useInfiniteQuery({
+    enabled: Boolean(channelId),
+    initialPageParam: null as ChannelPageCursor | null,
+    queryKey: ["workflow-message-picker", channelId],
+    queryFn: async ({ pageParam }) => {
+      if (!channelId) throw new Error("Choose a channel first.");
+      return parseChannelWindowResponse(
+        await getChannelWindowEvents(channelId, pageParam, PAGE_SIZE),
+        channelId,
+        pageParam,
+      );
+    },
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    staleTime: 30_000,
+  });
+  const searchQuery = useSearchMessagesQuery(deferredQuery, {
+    channelId: channelId ?? undefined,
+    enabled: Boolean(channelId && normalizedQuery && !directId),
+    limit: 30,
+    minimumQueryLength: 1,
+  });
+  const exactQuery = useQuery({
+    enabled: Boolean(channelId && lookupId),
+    queryKey: ["workflow-message-picker-exact", channelId, lookupId],
+    queryFn: () => getEventById(lookupId ?? ""),
+    retry: false,
+    staleTime: 60_000,
+  });
+
+  const selectedFallback = selectedId
+    ? [{ id: selectedId, pubkey: null, content: null, createdAt: null }]
+    : [];
+  const directFallback = directId
+    ? [{ id: directId, pubkey: null, content: null, createdAt: null }]
+    : [];
+  const historyCandidates = React.useMemo(
+    () =>
+      (historyQuery.data?.pages ?? []).flatMap((page) =>
+        page.rows.flatMap(({ event }) => {
+          const candidate = channelId
+            ? validatedWorkflowMessageCandidate(event, { channelId })
+            : null;
+          return candidate ? [candidate] : [];
+        }),
+      ),
+    [channelId, historyQuery.data?.pages],
+  );
+  const searchHitIds = React.useMemo(
+    () => [
+      ...new Set(
+        (searchQuery.data?.hits ?? []).flatMap((hit) => {
+          const eventId = normalizeMessageEventId(hit.eventId);
+          return eventId ? [eventId] : [];
+        }),
+      ),
+    ],
+    [searchQuery.data?.hits],
+  );
+  const searchEventQueries = useQueries({
+    queries: searchHitIds.map((eventId) => ({
+      enabled: Boolean(channelId),
+      queryKey: ["workflow-message-picker-search-event", channelId, eventId],
+      queryFn: () => getEventById(eventId),
+      retry: false,
+      staleTime: 60_000,
+    })),
+  });
+  const searchCandidates = validateWorkflowMessageSearchResults(
+    searchHitIds.map((requestedId, index) => ({
+      requestedId,
+      event: searchEventQueries[index]?.data,
+    })),
+    channelId ?? "",
+  );
+  const exactCandidate = React.useMemo(() => {
+    if (!channelId || !lookupId) return null;
+    return validatedWorkflowMessageCandidate(exactQuery.data, {
+      channelId,
+      requestedId: lookupId,
+    });
+  }, [channelId, exactQuery.data, lookupId]);
+  const allCandidates = React.useMemo(() => {
+    const fetchedCandidates = [
+      ...(exactCandidate ? [exactCandidate] : []),
+      ...historyCandidates,
+      ...searchCandidates,
+    ];
+    const selectedCandidate = selectedId
+      ? fetchedCandidates.find(({ id }) => id === selectedId)
+      : null;
+    const directCandidate = directId
+      ? fetchedCandidates.find(({ id }) => id === directId)
+      : null;
+    return mergeMessageCandidateSources([
+      selectedCandidate ? [selectedCandidate] : selectedFallback,
+      directCandidate ? [directCandidate] : directFallback,
+      fetchedCandidates,
+    ]);
+  }, [
+    directFallback,
+    directId,
+    exactCandidate,
+    historyCandidates,
+    searchCandidates,
+    selectedFallback,
+    selectedId,
+  ]);
+  const visibleCandidates = React.useMemo(() => {
+    if (directId) return allCandidates.filter(({ id }) => id === directId);
+    if (!normalizedQuery) return allCandidates;
+    return allCandidates.filter(
+      (candidate) =>
+        candidate.id.includes(normalizedQuery) ||
+        candidate.content?.toLowerCase().includes(normalizedQuery),
+    );
+  }, [allCandidates, directId, normalizedQuery]);
+  const profilePubkeys = React.useMemo(
+    () => [
+      ...new Set(
+        visibleCandidates.flatMap(({ pubkey }) => (pubkey ? [pubkey] : [])),
+      ),
+    ],
+    [visibleCandidates],
+  );
+  const profilesQuery = useUsersBatchQuery(profilePubkeys);
+  const listId = `${id}-list`;
+
+  React.useEffect(() => {
+    if (activeIndex >= visibleCandidates.length) {
+      setActiveIndex(Math.max(visibleCandidates.length - 1, 0));
+    }
+  }, [activeIndex, visibleCandidates.length]);
+  React.useEffect(() => {
+    const candidate = visibleCandidates[activeIndex];
+    if (!candidate) return;
+    optionRefs.current
+      .get(candidate.id)
+      ?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [activeIndex, visibleCandidates]);
+
+  const searchEventsFetching = searchEventQueries.some(
+    ({ isFetching }) => isFetching,
+  );
+  const searchEventsFailed = searchEventQueries.some(({ isError }) => isError);
+  const loading =
+    (historyQuery.isLoading ||
+      searchQuery.isFetching ||
+      searchEventsFetching ||
+      exactQuery.isFetching) &&
+    visibleCandidates.length === 0;
+  const failed =
+    historyQuery.isError ||
+    searchQuery.isError ||
+    searchEventsFailed ||
+    exactQuery.isError;
+  const invalidDirectResult = Boolean(
+    directId && lookupId === directId && exactQuery.data && !exactCandidate,
+  );
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-border/70 bg-background/35"
+      data-testid="workflow-message-picker"
+    >
+      <div className="relative shrink-0 border-b border-border/70">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          aria-activedescendant={
+            visibleCandidates[activeIndex]
+              ? `${listId}-${visibleCandidates[activeIndex].id}`
+              : undefined
+          }
+          aria-controls={listId}
+          aria-label="Search messages or paste a message ID"
+          aria-expanded="true"
+          autoCapitalize="none"
+          autoComplete="off"
+          autoCorrect="off"
+          className="h-11 rounded-none border-0 bg-transparent pl-9 focus-visible:ring-0"
+          disabled={disabled || !channelId}
+          id={id}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setActiveIndex(0);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+              event.preventDefault();
+              if (visibleCandidates.length > 0) {
+                setActiveIndex(
+                  (current) =>
+                    (current +
+                      (event.key === "ArrowDown" ? 1 : -1) +
+                      visibleCandidates.length) %
+                    visibleCandidates.length,
+                );
+              }
+            } else if (
+              event.key === "Enter" &&
+              visibleCandidates[activeIndex]
+            ) {
+              event.preventDefault();
+              if (invalidDirectResult) return;
+              onChange(visibleCandidates[activeIndex].id);
+            } else if (event.key === "Escape") {
+              event.preventDefault();
+              event.stopPropagation();
+              if (query) {
+                setQuery("");
+                setActiveIndex(0);
+              } else {
+                onEscape?.();
+              }
+            }
+          }}
+          placeholder={
+            channelId
+              ? "Search messages or paste a message ID…"
+              : "Choose a channel first"
+          }
+          role="combobox"
+          spellCheck={false}
+          value={query}
+        />
+        {historyQuery.isFetching ||
+        searchQuery.isFetching ||
+        searchEventsFetching ||
+        exactQuery.isFetching ? (
+          <LoaderCircle
+            aria-label="Loading messages"
+            className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground"
+          />
+        ) : null}
+      </div>
+      {invalidDirectResult ? (
+        <p className="shrink-0 border-b border-border/70 px-3 py-2 text-xs text-destructive">
+          That message is not available in this channel.
+        </p>
+      ) : null}
+      <div
+        aria-label="Messages"
+        className="min-h-0 flex-1 space-y-1 overflow-y-auto overscroll-contain p-2"
+        data-testid="workflow-message-picker-results"
+        id={listId}
+        onScroll={(event) => {
+          const list = event.currentTarget;
+          if (
+            !normalizedQuery &&
+            list.scrollHeight - list.scrollTop - list.clientHeight < 64 &&
+            historyQuery.hasNextPage &&
+            !historyQuery.isFetchingNextPage
+          ) {
+            void historyQuery.fetchNextPage();
+          }
+        }}
+        role="listbox"
+      >
+        {visibleCandidates.map((candidate, index) => (
+          <MessageOption
+            active={index === activeIndex}
+            candidate={candidate}
+            disabled={disabled}
+            id={`${listId}-${candidate.id}`}
+            key={candidate.id}
+            onSelect={() => {
+              if (!invalidDirectResult) onChange(candidate.id);
+            }}
+            optionRef={(node) => {
+              if (node) optionRefs.current.set(candidate.id, node);
+              else optionRefs.current.delete(candidate.id);
+            }}
+            profiles={profilesQuery.data?.profiles}
+            selected={candidate.id === selectedId}
+          />
+        ))}
+        {loading ? (
+          <p
+            className="flex items-center justify-center gap-2 px-3 py-8 text-sm text-muted-foreground"
+            role="status"
+          >
+            <LoaderCircle className="h-4 w-4 animate-spin" /> Loading messages…
+          </p>
+        ) : visibleCandidates.length === 0 ? (
+          <p className="px-3 py-8 text-center text-sm text-muted-foreground">
+            {failed
+              ? "Couldn’t load messages."
+              : normalizedQuery
+                ? "No messages found."
+                : "No messages yet."}
+          </p>
+        ) : null}
+        {failed ? (
+          <button
+            className="w-full rounded-md px-3 py-2 text-xs font-medium text-muted-foreground hover:bg-muted/45 hover:text-foreground"
+            onClick={() => {
+              void historyQuery.refetch();
+              void searchQuery.refetch();
+              for (const searchEventQuery of searchEventQueries) {
+                void searchEventQuery.refetch();
+              }
+              void exactQuery.refetch();
+            }}
+            type="button"
+          >
+            Couldn’t load all messages. Retry
+          </button>
+        ) : null}
+        {!normalizedQuery && historyQuery.hasNextPage ? (
+          <button
+            className="w-full rounded-md px-3 py-2 text-xs font-medium text-muted-foreground hover:bg-muted/45 hover:text-foreground"
+            disabled={disabled || historyQuery.isFetchingNextPage}
+            onClick={() => void historyQuery.fetchNextPage()}
+            type="button"
+          >
+            {historyQuery.isFetchingNextPage
+              ? "Loading older messages…"
+              : "Load older messages"}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function MessageOption({
+  active,
+  candidate,
+  disabled,
+  id,
+  onSelect,
+  optionRef,
+  profiles,
+  selected,
+}: {
+  active: boolean;
+  candidate: WorkflowMessageCandidate;
+  disabled?: boolean;
+  id: string;
+  onSelect: () => void;
+  optionRef: (node: HTMLButtonElement | null) => void;
+  profiles?: UserProfileLookup;
+  selected: boolean;
+}) {
+  const author = candidate.pubkey
+    ? resolveUserLabel({ profiles, pubkey: candidate.pubkey })
+    : "Selected message";
+  const profile = candidate.pubkey
+    ? profiles?.[candidate.pubkey.toLowerCase()]
+    : undefined;
+  const timestamp = formatTimestamp(candidate.createdAt);
+  return (
+    <button
+      aria-selected={selected}
+      className={cn(
+        "relative flex w-full items-start gap-2.5 rounded-md border px-3 py-2.5 text-left transition-colors",
+        selected
+          ? "border-primary bg-primary/10"
+          : "border-transparent hover:border-border hover:bg-muted/45",
+        active && "ring-2 ring-ring ring-offset-1",
+      )}
+      disabled={disabled}
+      id={id}
+      onClick={onSelect}
+      ref={optionRef}
+      role="option"
+      tabIndex={-1}
+      type="button"
+    >
+      {candidate.pubkey ? (
+        <UserAvatar
+          avatarUrl={profile?.avatarUrl ?? null}
+          displayName={author}
+          size="sm"
+        />
+      ) : null}
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="truncate font-medium text-foreground">{author}</span>
+          {timestamp ? (
+            <span className="ml-auto shrink-0">{timestamp}</span>
+          ) : null}
+        </span>
+        <span className="mt-1 block text-sm leading-5 text-foreground">
+          {truncateContent(candidate.content)}
+        </span>
+        <span className="mt-1 block font-mono text-2xs text-muted-foreground">
+          {candidate.id.slice(0, 12)}…{candidate.id.slice(-8)}
+        </span>
+      </span>
+      <Check
+        className={cn("mt-1 h-4 w-4 shrink-0", !selected && "opacity-0")}
+      />
+    </button>
+  );
+}

--- a/desktop/src/features/workflows/ui/WorkflowMessagePicker.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowMessagePicker.tsx
@@ -60,7 +60,7 @@ export function WorkflowMessagePicker({
 }) {
   const optionRefs = React.useRef(new Map<string, HTMLButtonElement>());
   const [query, setQuery] = React.useState("");
-  const [activeIndex, setActiveIndex] = React.useState(0);
+  const [activeIndex, setActiveIndex] = React.useState<number | null>(null);
   const deferredQuery = React.useDeferredValue(query.trim());
   const normalizedQuery = deferredQuery.toLowerCase();
   const selectedId = normalizeMessageEventId(value);
@@ -149,30 +149,21 @@ export function WorkflowMessagePicker({
     });
   }, [channelId, exactQuery.data, lookupId]);
   const allCandidates = React.useMemo(() => {
-    const fetchedCandidates = [
-      ...(exactCandidate ? [exactCandidate] : []),
-      ...historyCandidates,
-      ...searchCandidates,
-    ];
-    const selectedCandidate = selectedId
-      ? fetchedCandidates.find(({ id }) => id === selectedId)
-      : null;
-    const directCandidate = directId
-      ? fetchedCandidates.find(({ id }) => id === directId)
-      : null;
+    // Preserve the relay-provided history/search order. Exact lookups and raw-ID
+    // fallbacks only fill gaps; selecting an existing row must not move it.
     return mergeMessageCandidateSources([
-      selectedCandidate ? [selectedCandidate] : selectedFallback,
-      directCandidate ? [directCandidate] : directFallback,
-      fetchedCandidates,
+      historyCandidates,
+      searchCandidates,
+      exactCandidate ? [exactCandidate] : [],
+      selectedFallback,
+      directFallback,
     ]);
   }, [
     directFallback,
-    directId,
     exactCandidate,
     historyCandidates,
     searchCandidates,
     selectedFallback,
-    selectedId,
   ]);
   const visibleCandidates = React.useMemo(() => {
     if (directId) return allCandidates.filter(({ id }) => id === directId);
@@ -195,11 +186,14 @@ export function WorkflowMessagePicker({
   const listId = `${id}-list`;
 
   React.useEffect(() => {
-    if (activeIndex >= visibleCandidates.length) {
-      setActiveIndex(Math.max(visibleCandidates.length - 1, 0));
+    if (activeIndex !== null && activeIndex >= visibleCandidates.length) {
+      setActiveIndex(
+        visibleCandidates.length > 0 ? visibleCandidates.length - 1 : null,
+      );
     }
   }, [activeIndex, visibleCandidates.length]);
   React.useEffect(() => {
+    if (activeIndex === null) return;
     const candidate = visibleCandidates[activeIndex];
     if (!candidate) return;
     optionRefs.current
@@ -235,7 +229,7 @@ export function WorkflowMessagePicker({
         <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           aria-activedescendant={
-            visibleCandidates[activeIndex]
+            activeIndex !== null && visibleCandidates[activeIndex]
               ? `${listId}-${visibleCandidates[activeIndex].id}`
               : undefined
           }
@@ -246,37 +240,40 @@ export function WorkflowMessagePicker({
           autoComplete="off"
           autoCorrect="off"
           className="h-11 rounded-none border-0 bg-transparent pl-9 focus-visible:ring-0"
+          data-workflow-filter-picker-search="true"
           disabled={disabled || !channelId}
           id={id}
           onChange={(event) => {
             setQuery(event.target.value);
-            setActiveIndex(0);
+            setActiveIndex(null);
           }}
           onKeyDown={(event) => {
             if (event.key === "ArrowDown" || event.key === "ArrowUp") {
               event.preventDefault();
               if (visibleCandidates.length > 0) {
-                setActiveIndex(
-                  (current) =>
-                    (current +
+                setActiveIndex((current) => {
+                  const startingIndex = current ?? -1;
+                  return (
+                    (startingIndex +
                       (event.key === "ArrowDown" ? 1 : -1) +
                       visibleCandidates.length) %
-                    visibleCandidates.length,
-                );
+                    visibleCandidates.length
+                  );
+                });
               }
             } else if (
               event.key === "Enter" &&
-              visibleCandidates[activeIndex]
+              visibleCandidates[activeIndex ?? 0]
             ) {
               event.preventDefault();
               if (invalidDirectResult) return;
-              onChange(visibleCandidates[activeIndex].id);
+              onChange(visibleCandidates[activeIndex ?? 0].id);
             } else if (event.key === "Escape") {
               event.preventDefault();
               event.stopPropagation();
               if (query) {
                 setQuery("");
-                setActiveIndex(0);
+                setActiveIndex(null);
               } else {
                 onEscape?.();
               }
@@ -326,12 +323,13 @@ export function WorkflowMessagePicker({
       >
         {visibleCandidates.map((candidate, index) => (
           <MessageOption
-            active={index === activeIndex}
+            active={activeIndex !== null && index === activeIndex}
             candidate={candidate}
             disabled={disabled}
             id={`${listId}-${candidate.id}`}
             key={candidate.id}
             onSelect={() => {
+              setActiveIndex(null);
               if (!invalidDirectResult) onChange(candidate.id);
             }}
             optionRef={(node) => {
@@ -421,11 +419,11 @@ function MessageOption({
     <button
       aria-selected={selected}
       className={cn(
-        "relative flex w-full items-start gap-2.5 rounded-md border px-3 py-2.5 text-left transition-colors",
+        "relative flex min-w-0 w-full items-start gap-2.5 overflow-hidden rounded-md border px-3 py-2.5 text-left transition-colors",
         selected
-          ? "border-primary bg-primary/10"
+          ? "border-foreground/40 bg-muted/70"
           : "border-transparent hover:border-border hover:bg-muted/45",
-        active && "ring-2 ring-ring ring-offset-1",
+        active && "ring-1 ring-ring",
       )}
       disabled={disabled}
       id={id}
@@ -449,7 +447,7 @@ function MessageOption({
             <span className="ml-auto shrink-0">{timestamp}</span>
           ) : null}
         </span>
-        <span className="mt-1 block text-sm leading-5 text-foreground">
+        <span className="mt-1 block min-w-0 break-words text-sm leading-5 text-foreground [overflow-wrap:anywhere]">
           {truncateContent(candidate.content)}
         </span>
         <span className="mt-1 block font-mono text-2xs text-muted-foreground">

--- a/desktop/src/features/workflows/ui/WorkflowRichTriggerDescription.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowRichTriggerDescription.tsx
@@ -1,6 +1,7 @@
 import { LoaderCircle } from "lucide-react";
 
 import { UserAvatar } from "@/shared/ui/UserAvatar";
+import { splitWorkflowAuthorDescription } from "./workflowTriggerDescription";
 
 export function WorkflowRichTriggerDescription({
   avatarUrl,
@@ -26,11 +27,12 @@ export function WorkflowRichTriggerDescription({
     );
   }
 
-  const labelIndex = label ? description.lastIndexOf(label) : -1;
-  if (!label || labelIndex < 0) return description;
+  const segments = label
+    ? splitWorkflowAuthorDescription(description, label)
+    : null;
+  if (!label || !segments) return description;
 
-  const prefix = description.slice(0, labelIndex).trimEnd();
-  const suffix = description.slice(labelIndex + label.length).trimStart();
+  const { prefix, suffix } = segments;
   return (
     <span className="flex min-w-0 items-center gap-1.5">
       {prefix ? <span className="shrink-0">{prefix}</span> : null}

--- a/desktop/src/features/workflows/ui/WorkflowRichTriggerDescription.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowRichTriggerDescription.tsx
@@ -1,0 +1,51 @@
+import { LoaderCircle } from "lucide-react";
+
+import { UserAvatar } from "@/shared/ui/UserAvatar";
+
+export function WorkflowRichTriggerDescription({
+  avatarUrl,
+  description,
+  label,
+  loading,
+}: {
+  avatarUrl?: string | null;
+  description: string;
+  label?: string | null;
+  loading?: boolean;
+}) {
+  if (loading) {
+    return (
+      <span className="flex min-w-0 items-center gap-1.5">
+        <span className="truncate">{description}</span>
+        <LoaderCircle
+          aria-label="Loading author"
+          className="h-3.5 w-3.5 shrink-0 animate-spin"
+          role="status"
+        />
+      </span>
+    );
+  }
+
+  const labelIndex = label ? description.lastIndexOf(label) : -1;
+  if (!label || labelIndex < 0) return description;
+
+  const prefix = description.slice(0, labelIndex).trimEnd();
+  const suffix = description.slice(labelIndex + label.length).trimStart();
+  return (
+    <span className="flex min-w-0 items-center gap-1.5">
+      {prefix ? <span className="shrink-0">{prefix}</span> : null}
+      <UserAvatar
+        avatarUrl={avatarUrl ?? null}
+        className="h-4 w-4"
+        displayName={label}
+        fallbackDelayMs={0}
+        size="xs"
+        testId="workflow-trigger-author-avatar"
+      />
+      <span className="min-w-0 truncate">
+        {label}
+        {suffix ? ` ${suffix}` : ""}
+      </span>
+    </span>
+  );
+}

--- a/desktop/src/features/workflows/ui/WorkflowTriggerConditions.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowTriggerConditions.tsx
@@ -154,6 +154,11 @@ export function WorkflowTriggerConditions({
   const [expandedField, setExpandedField] = React.useState<string | null>(
     () => conditionFieldsForTrigger(triggerType)[0]?.value ?? null,
   );
+  const disclosureButtons = React.useRef(new Map<string, HTMLButtonElement>());
+  const collapsePicker = React.useCallback((field: string) => {
+    setExpandedField(null);
+    disclosureButtons.current.get(field)?.focus();
+  }, []);
   const conditions = conditionDrafts ?? parsedValue ?? [];
   const localValue = React.useRef(value);
   const triggerPresentation = useWorkflowTriggerPresentation(
@@ -307,6 +312,11 @@ export function WorkflowTriggerConditions({
                   onClick={() =>
                     setExpandedField(expanded ? null : field.value)
                   }
+                  ref={(button) => {
+                    if (button)
+                      disclosureButtons.current.set(field.value, button);
+                    else disclosureButtons.current.delete(field.value);
+                  }}
                   type="button"
                 >
                   <span className="min-w-0 flex-1 truncate text-base font-medium">
@@ -412,7 +422,7 @@ export function WorkflowTriggerConditions({
                           channelId={workflowChannelId}
                           disabled={disabled}
                           id="wf-trigger-author-value"
-                          onEscape={() => setExpandedField(null)}
+                          onEscape={() => collapsePicker(field.value)}
                           onChange={(pubkey) =>
                             updateConditions(
                               pubkey
@@ -435,7 +445,7 @@ export function WorkflowTriggerConditions({
                           disabled={disabled}
                           id="wf-trigger-message-id-value"
                           key={workflowChannelId ?? "unscoped"}
-                          onEscape={() => setExpandedField(null)}
+                          onEscape={() => collapsePicker(field.value)}
                           onChange={(messageId) =>
                             updateConditions(
                               messageId

--- a/desktop/src/features/workflows/ui/WorkflowTriggerConditions.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowTriggerConditions.tsx
@@ -3,8 +3,11 @@ import * as React from "react";
 
 import { cn } from "@/shared/lib/cn";
 import { Input } from "@/shared/ui/input";
+import { UserAvatar } from "@/shared/ui/UserAvatar";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
+import { WorkflowAuthorPicker } from "./WorkflowAuthorPicker";
 import { WorkflowEmojiField } from "./WorkflowEmojiField";
+import { useWorkflowAuthorPresentation } from "./useWorkflowAuthorPresentation";
 import { FieldLabel } from "./workflowFormPrimitives";
 import {
   buildConditionExpressions,
@@ -45,6 +48,10 @@ function compact(value: string): string {
     : `${trimmed.slice(0, 11)}…${trimmed.slice(-6)}`;
 }
 
+function fieldUsesFullHeightPicker(field: string): boolean {
+  return field === "trigger_author" || field === "trigger_message_id";
+}
+
 function fieldPlaceholder(field: string): string {
   if (field === "trigger_author") return "64-character hex pubkey";
   if (field === "trigger_message_id") return "64-character hex event ID";
@@ -58,6 +65,7 @@ export function WorkflowTriggerConditions({
   onConditionDraftsChange,
   triggerType,
   value,
+  workflowChannelId,
 }: {
   conditionDrafts: ParsedConditionExpression[] | null;
   disabled?: boolean;
@@ -68,6 +76,7 @@ export function WorkflowTriggerConditions({
     "message_posted" | "diff_posted" | "reaction_added"
   >;
   value: string;
+  workflowChannelId?: string | null;
 }) {
   const parsedValue = React.useMemo(
     () => parseConditionExpressions(value, triggerType),
@@ -81,6 +90,15 @@ export function WorkflowTriggerConditions({
   );
   const conditions = conditionDrafts ?? parsedValue ?? [];
   const localValue = React.useRef(value);
+  const authorCondition = conditions.find(
+    ({ field }) => field === "trigger_author",
+  );
+  const authorPresentation = useWorkflowAuthorPresentation({
+    filter: authorCondition
+      ? buildConditionExpressions([authorCondition])
+      : undefined,
+    on: triggerType,
+  });
 
   React.useEffect(() => {
     if (value === localValue.current) return;
@@ -109,10 +127,16 @@ export function WorkflowTriggerConditions({
   };
 
   const fields = conditionFieldsForTrigger(triggerType);
+  const fullHeightPickerExpanded =
+    mode === "basic" && fieldUsesFullHeightPicker(expandedField ?? "");
 
   return (
     <Tabs
-      className="space-y-3"
+      className={cn(
+        "space-y-3",
+        fullHeightPickerExpanded &&
+          "flex h-full min-h-0 flex-col space-y-0 gap-3",
+      )}
       onValueChange={(next) => setMode(next as "basic" | "advanced")}
       value={mode}
     >
@@ -168,7 +192,12 @@ export function WorkflowTriggerConditions({
           </button>
         </div>
       ) : (
-        <div className="divide-y divide-border/50">
+        <div
+          className={cn(
+            "divide-y divide-border/50",
+            fullHeightPickerExpanded && "flex min-h-0 flex-1 flex-col",
+          )}
+        >
           {fields.map((field) => {
             const existing = conditions.find(
               (condition) => condition.field === field.value,
@@ -179,8 +208,23 @@ export function WorkflowTriggerConditions({
             const summary = existing
               ? `${OPERATOR_LABELS[condition.operator]}${condition.value ? ` ${compact(condition.value)}` : ""}`
               : "Any";
+            const authorSummary =
+              existing &&
+              field.value === "trigger_author" &&
+              authorPresentation.pubkey &&
+              authorPresentation.label
+                ? authorPresentation.label
+                : null;
             return (
-              <div className={cn(expanded && "pb-4")} key={field.value}>
+              <div
+                className={cn(
+                  expanded && "pb-4",
+                  expanded &&
+                    fieldUsesFullHeightPicker(field.value) &&
+                    "flex min-h-0 flex-1 flex-col",
+                )}
+                key={field.value}
+              >
                 <button
                   aria-expanded={expanded}
                   className="flex min-h-12 w-full items-center gap-3 py-3 text-left transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:opacity-50"
@@ -193,9 +237,22 @@ export function WorkflowTriggerConditions({
                   <span className="min-w-0 flex-1 truncate text-base font-medium">
                     {field.label}
                   </span>
-                  <span className="max-w-44 truncate font-mono text-xs text-muted-foreground">
-                    {summary}
-                  </span>
+                  {authorSummary ? (
+                    <span className="flex min-w-0 max-w-44 items-center gap-1.5 text-xs text-muted-foreground">
+                      <UserAvatar
+                        avatarUrl={authorPresentation.avatarUrl}
+                        className="h-4 w-4 shrink-0"
+                        displayName={authorSummary}
+                        fallbackDelayMs={0}
+                        size="xs"
+                      />
+                      <span className="truncate">{authorSummary}</span>
+                    </span>
+                  ) : (
+                    <span className="max-w-44 truncate font-mono text-xs text-muted-foreground">
+                      {summary}
+                    </span>
+                  )}
                   <ChevronRight
                     className={cn(
                       "h-4 w-4 shrink-0 text-muted-foreground/70 transition-transform duration-150 motion-reduce:transition-none",
@@ -204,7 +261,13 @@ export function WorkflowTriggerConditions({
                   />
                 </button>
                 {expanded ? (
-                  <div className="animate-in space-y-3 pt-1 fade-in slide-in-from-top-1 duration-150 motion-reduce:animate-none">
+                  <div
+                    className={cn(
+                      "animate-in space-y-3 pt-1 fade-in slide-in-from-top-1 duration-150 motion-reduce:animate-none",
+                      fieldUsesFullHeightPicker(field.value) &&
+                        "flex min-h-0 flex-1 flex-col space-y-0 gap-3",
+                    )}
+                  >
                     <fieldset>
                       <legend className="sr-only">Match</legend>
                       <div className="grid grid-cols-2 gap-2.5">
@@ -258,6 +321,27 @@ export function WorkflowTriggerConditions({
                           }
                           value={condition.value}
                         />
+                      ) : field.value === "trigger_author" ? (
+                        <div className="flex min-h-0 flex-1 flex-col gap-1.5">
+                          <FieldLabel htmlFor="wf-trigger-author-value">
+                            {field.label}
+                          </FieldLabel>
+                          <WorkflowAuthorPicker
+                            channelId={workflowChannelId}
+                            disabled={disabled}
+                            id="wf-trigger-author-value"
+                            onEscape={() => setExpandedField(null)}
+                            onChange={(pubkey) =>
+                              updateConditions([
+                                ...conditions.filter(
+                                  (item) => item.field !== field.value,
+                                ),
+                                { ...condition, value: pubkey },
+                              ])
+                            }
+                            value={condition.value}
+                          />
+                        </div>
                       ) : (
                         <div className="space-y-1.5">
                           <FieldLabel

--- a/desktop/src/features/workflows/ui/WorkflowTriggerConditions.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowTriggerConditions.tsx
@@ -59,6 +59,71 @@ function fieldPlaceholder(field: string): string {
   return "e.g. deploy";
 }
 
+function ExclusionStrike() {
+  return (
+    <span aria-hidden="true" className="pointer-events-none absolute inset-0">
+      <span className="absolute inset-0 [clip-path:circle(50%_at_50%_50%)]">
+        <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+          <span className="block h-1 w-9 translate-y-0.5 -rotate-45 rounded-full bg-background/90" />
+        </span>
+      </span>
+      <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+        <span className="block h-0.5 w-8 -rotate-45 rounded-full bg-muted-foreground" />
+      </span>
+    </span>
+  );
+}
+
+function AuthorConditionSummary({
+  avatarUrl,
+  excluded,
+  label,
+}: {
+  avatarUrl: string | null;
+  excluded: boolean;
+  label: string;
+}) {
+  return (
+    <span className="flex shrink-0 items-center">
+      <span className="relative shrink-0">
+        <UserAvatar
+          avatarUrl={avatarUrl}
+          className="h-6 w-6"
+          displayName={label}
+          fallbackDelayMs={0}
+          size="xs"
+        />
+        {excluded ? <ExclusionStrike /> : null}
+      </span>
+      <span className="sr-only">
+        {excluded ? "Excluded author: " : "Selected author: "}
+        {label}
+      </span>
+    </span>
+  );
+}
+
+function EmojiConditionSummary({
+  emoji,
+  excluded,
+}: {
+  emoji: string;
+  excluded: boolean;
+}) {
+  return (
+    <span className="relative flex h-6 w-6 shrink-0 items-center justify-center">
+      <span aria-hidden="true" className="text-2xl leading-none">
+        {emoji}
+      </span>
+      {excluded ? <ExclusionStrike /> : null}
+      <span className="sr-only">
+        {excluded ? "Excluded reaction emoji: " : "Selected reaction emoji: "}
+        {emoji}
+      </span>
+    </span>
+  );
+}
+
 export function WorkflowTriggerConditions({
   conditionDrafts,
   disabled,
@@ -228,7 +293,7 @@ export function WorkflowTriggerConditions({
             return (
               <div
                 className={cn(
-                  expanded && "pb-4",
+                  expanded && "pb-4 last:pb-0",
                   expanded &&
                     fieldUsesFullHeightPicker(field.value) &&
                     "flex min-h-0 flex-1 flex-col",
@@ -248,20 +313,27 @@ export function WorkflowTriggerConditions({
                     {field.label}
                   </span>
                   {authorSummary ? (
-                    <span className="flex min-w-0 max-w-44 items-center gap-1.5 text-xs text-muted-foreground">
-                      <UserAvatar
-                        avatarUrl={triggerPresentation.avatarUrl}
-                        className="h-4 w-4 shrink-0"
-                        displayName={authorSummary}
-                        fallbackDelayMs={0}
-                        size="xs"
-                      />
-                      <span className="truncate">{authorSummary}</span>
-                    </span>
+                    <AuthorConditionSummary
+                      avatarUrl={triggerPresentation.avatarUrl}
+                      excluded={condition.operator === "not_equals"}
+                      label={authorSummary}
+                    />
                   ) : messageSummary ? (
-                    <span className="max-w-44 truncate text-xs text-muted-foreground">
+                    <span
+                      className={cn(
+                        "max-w-44 truncate text-xs text-muted-foreground",
+                        condition.operator === "not_equals" && "line-through",
+                      )}
+                    >
                       “{messageSummary}”
                     </span>
+                  ) : existing &&
+                    field.value === "trigger_emoji" &&
+                    condition.value.trim() ? (
+                    <EmojiConditionSummary
+                      emoji={condition.value.trim()}
+                      excluded={condition.operator === "not_equals"}
+                    />
                   ) : (
                     <span className="max-w-44 truncate font-mono text-xs text-muted-foreground">
                       {summary}
@@ -336,48 +408,38 @@ export function WorkflowTriggerConditions({
                           value={condition.value}
                         />
                       ) : field.value === "trigger_author" ? (
-                        <div className="flex min-h-0 flex-1 flex-col gap-1.5">
-                          <FieldLabel htmlFor="wf-trigger-author-value">
-                            {field.label}
-                          </FieldLabel>
-                          <WorkflowAuthorPicker
-                            channelId={workflowChannelId}
-                            disabled={disabled}
-                            id="wf-trigger-author-value"
-                            onEscape={() => setExpandedField(null)}
-                            onChange={(pubkey) =>
-                              updateConditions([
-                                ...conditions.filter(
-                                  (item) => item.field !== field.value,
-                                ),
-                                { ...condition, value: pubkey },
-                              ])
-                            }
-                            value={condition.value}
-                          />
-                        </div>
+                        <WorkflowAuthorPicker
+                          channelId={workflowChannelId}
+                          disabled={disabled}
+                          id="wf-trigger-author-value"
+                          onEscape={() => setExpandedField(null)}
+                          onChange={(pubkey) =>
+                            updateConditions([
+                              ...conditions.filter(
+                                (item) => item.field !== field.value,
+                              ),
+                              { ...condition, value: pubkey },
+                            ])
+                          }
+                          value={condition.value}
+                        />
                       ) : field.value === "trigger_message_id" ? (
-                        <div className="flex min-h-0 flex-1 flex-col gap-1.5">
-                          <FieldLabel htmlFor="wf-trigger-message-id-value">
-                            {field.label}
-                          </FieldLabel>
-                          <WorkflowMessagePicker
-                            channelId={workflowChannelId}
-                            disabled={disabled}
-                            id="wf-trigger-message-id-value"
-                            key={workflowChannelId ?? "unscoped"}
-                            onEscape={() => setExpandedField(null)}
-                            onChange={(messageId) =>
-                              updateConditions([
-                                ...conditions.filter(
-                                  (item) => item.field !== field.value,
-                                ),
-                                { ...condition, value: messageId },
-                              ])
-                            }
-                            value={condition.value}
-                          />
-                        </div>
+                        <WorkflowMessagePicker
+                          channelId={workflowChannelId}
+                          disabled={disabled}
+                          id="wf-trigger-message-id-value"
+                          key={workflowChannelId ?? "unscoped"}
+                          onEscape={() => setExpandedField(null)}
+                          onChange={(messageId) =>
+                            updateConditions([
+                              ...conditions.filter(
+                                (item) => item.field !== field.value,
+                              ),
+                              { ...condition, value: messageId },
+                            ])
+                          }
+                          value={condition.value}
+                        />
                       ) : (
                         <div className="space-y-1.5">
                           <FieldLabel

--- a/desktop/src/features/workflows/ui/WorkflowTriggerConditions.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowTriggerConditions.tsx
@@ -7,7 +7,8 @@ import { UserAvatar } from "@/shared/ui/UserAvatar";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
 import { WorkflowAuthorPicker } from "./WorkflowAuthorPicker";
 import { WorkflowEmojiField } from "./WorkflowEmojiField";
-import { useWorkflowAuthorPresentation } from "./useWorkflowAuthorPresentation";
+import { WorkflowMessagePicker } from "./WorkflowMessagePicker";
+import { useWorkflowTriggerPresentation } from "./useWorkflowTriggerPresentation";
 import { FieldLabel } from "./workflowFormPrimitives";
 import {
   buildConditionExpressions,
@@ -90,15 +91,15 @@ export function WorkflowTriggerConditions({
   );
   const conditions = conditionDrafts ?? parsedValue ?? [];
   const localValue = React.useRef(value);
-  const authorCondition = conditions.find(
-    ({ field }) => field === "trigger_author",
+  const triggerPresentation = useWorkflowTriggerPresentation(
+    {
+      filter: conditions.length
+        ? buildConditionExpressions(conditions)
+        : undefined,
+      on: triggerType,
+    },
+    workflowChannelId,
   );
-  const authorPresentation = useWorkflowAuthorPresentation({
-    filter: authorCondition
-      ? buildConditionExpressions([authorCondition])
-      : undefined,
-    on: triggerType,
-  });
 
   React.useEffect(() => {
     if (value === localValue.current) return;
@@ -211,9 +212,18 @@ export function WorkflowTriggerConditions({
             const authorSummary =
               existing &&
               field.value === "trigger_author" &&
-              authorPresentation.pubkey &&
-              authorPresentation.label
-                ? authorPresentation.label
+              triggerPresentation.pubkey &&
+              triggerPresentation.label
+                ? triggerPresentation.label
+                : null;
+            const messageSummary =
+              existing &&
+              field.value === "trigger_message_id" &&
+              triggerPresentation.messageId &&
+              triggerPresentation.messageLabel
+                ? triggerPresentation.messageLabel
+                    .trim()
+                    .replaceAll(/\s+/g, " ")
                 : null;
             return (
               <div
@@ -240,13 +250,17 @@ export function WorkflowTriggerConditions({
                   {authorSummary ? (
                     <span className="flex min-w-0 max-w-44 items-center gap-1.5 text-xs text-muted-foreground">
                       <UserAvatar
-                        avatarUrl={authorPresentation.avatarUrl}
+                        avatarUrl={triggerPresentation.avatarUrl}
                         className="h-4 w-4 shrink-0"
                         displayName={authorSummary}
                         fallbackDelayMs={0}
                         size="xs"
                       />
                       <span className="truncate">{authorSummary}</span>
+                    </span>
+                  ) : messageSummary ? (
+                    <span className="max-w-44 truncate text-xs text-muted-foreground">
+                      “{messageSummary}”
                     </span>
                   ) : (
                     <span className="max-w-44 truncate font-mono text-xs text-muted-foreground">
@@ -337,6 +351,28 @@ export function WorkflowTriggerConditions({
                                   (item) => item.field !== field.value,
                                 ),
                                 { ...condition, value: pubkey },
+                              ])
+                            }
+                            value={condition.value}
+                          />
+                        </div>
+                      ) : field.value === "trigger_message_id" ? (
+                        <div className="flex min-h-0 flex-1 flex-col gap-1.5">
+                          <FieldLabel htmlFor="wf-trigger-message-id-value">
+                            {field.label}
+                          </FieldLabel>
+                          <WorkflowMessagePicker
+                            channelId={workflowChannelId}
+                            disabled={disabled}
+                            id="wf-trigger-message-id-value"
+                            key={workflowChannelId ?? "unscoped"}
+                            onEscape={() => setExpandedField(null)}
+                            onChange={(messageId) =>
+                              updateConditions([
+                                ...conditions.filter(
+                                  (item) => item.field !== field.value,
+                                ),
+                                { ...condition, value: messageId },
                               ])
                             }
                             value={condition.value}

--- a/desktop/src/features/workflows/ui/WorkflowTriggerConditions.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowTriggerConditions.tsx
@@ -414,12 +414,18 @@ export function WorkflowTriggerConditions({
                           id="wf-trigger-author-value"
                           onEscape={() => setExpandedField(null)}
                           onChange={(pubkey) =>
-                            updateConditions([
-                              ...conditions.filter(
-                                (item) => item.field !== field.value,
-                              ),
-                              { ...condition, value: pubkey },
-                            ])
+                            updateConditions(
+                              pubkey
+                                ? [
+                                    ...conditions.filter(
+                                      (item) => item.field !== field.value,
+                                    ),
+                                    { ...condition, value: pubkey },
+                                  ]
+                                : conditions.filter(
+                                    (item) => item.field !== field.value,
+                                  ),
+                            )
                           }
                           value={condition.value}
                         />
@@ -431,12 +437,18 @@ export function WorkflowTriggerConditions({
                           key={workflowChannelId ?? "unscoped"}
                           onEscape={() => setExpandedField(null)}
                           onChange={(messageId) =>
-                            updateConditions([
-                              ...conditions.filter(
-                                (item) => item.field !== field.value,
-                              ),
-                              { ...condition, value: messageId },
-                            ])
+                            updateConditions(
+                              messageId
+                                ? [
+                                    ...conditions.filter(
+                                      (item) => item.field !== field.value,
+                                    ),
+                                    { ...condition, value: messageId },
+                                  ]
+                                : conditions.filter(
+                                    (item) => item.field !== field.value,
+                                  ),
+                            )
                           }
                           value={condition.value}
                         />
@@ -481,7 +493,7 @@ export function WorkflowTriggerConditions({
                         </div>
                       )
                     ) : null}
-                    {existing ? (
+                    {existing && !fieldUsesFullHeightPicker(field.value) ? (
                       <button
                         className="text-xs font-medium text-muted-foreground hover:text-foreground"
                         disabled={disabled}

--- a/desktop/src/features/workflows/ui/WorkflowsView.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowsView.tsx
@@ -13,6 +13,8 @@ import { getWorkflowActivationWarning } from "@/features/workflows/ui/workflowAc
 import { WorkflowCard } from "@/features/workflows/ui/WorkflowCard";
 import { WorkflowDeleteDialog } from "@/features/workflows/ui/WorkflowDeleteDialog";
 import { WorkflowEditorHost } from "@/features/workflows/ui/WorkflowEditorHost";
+import { useWorkflowListAuthorPresentations } from "@/features/workflows/ui/useWorkflowListAuthorPresentations";
+import { useWorkflowListMessagePresentations } from "@/features/workflows/ui/useWorkflowListMessagePresentations";
 import type { WorkflowEditorRoute } from "@/features/workflows/ui/WorkflowsScreen";
 import type { WorkflowEditorPane } from "@/features/workflows/ui/workflowEditorPane";
 import {
@@ -146,6 +148,9 @@ export function WorkflowsView({
   });
 
   const allWorkflows = allWorkflowsQuery.data ?? [];
+  const workflows = allWorkflows.map(({ workflow }) => workflow);
+  const authorPresentations = useWorkflowListAuthorPresentations(workflows);
+  const messagePresentations = useWorkflowListMessagePresentations(workflows);
 
   const triggerMutation = useMutation({
     mutationFn: (workflowId: string) => triggerWorkflow(workflowId),
@@ -310,12 +315,14 @@ export function WorkflowsView({
               <CreateWorkflowCard onClick={onCreateWorkflow} />
               {allWorkflows.map(({ workflow, channelName }) => (
                 <WorkflowCard
+                  authorPresentation={authorPresentations.get(workflow.id)}
                   channelName={channelName}
                   isTogglingEnabled={
                     toggleEnabledMutation.isPending &&
                     toggleEnabledMutation.variables?.id === workflow.id
                   }
                   key={workflow.id}
+                  messagePresentation={messagePresentations.get(workflow.id)}
                   onDelete={handleDelete}
                   onDuplicate={handleDuplicate}
                   onEdit={handleEdit}

--- a/desktop/src/features/workflows/ui/useWorkflowAuthorPresentation.ts
+++ b/desktop/src/features/workflows/ui/useWorkflowAuthorPresentation.ts
@@ -1,0 +1,57 @@
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { resolveUserLabel } from "@/features/profile/lib/identity";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import { parseConditionExpressions } from "./workflowConditionExpression";
+import type { TriggerConfig } from "./workflowFormTypes";
+import { workflowTriggerDescription } from "./workflowTriggerDescription";
+
+const FULL_HEX_PUBKEY = /^[0-9a-f]{64}$/i;
+
+export type WorkflowAuthorPresentation = {
+  avatarUrl: string | null;
+  description: string;
+  label: string | null;
+  loading: boolean;
+  pubkey: string | null;
+};
+
+export function workflowTriggerAuthorPubkey(
+  trigger: TriggerConfig,
+): string | null {
+  const conditions = trigger.filter
+    ? parseConditionExpressions(trigger.filter, trigger.on)
+    : [];
+  const condition = conditions?.find(({ field }) => field === "trigger_author");
+  return condition && FULL_HEX_PUBKEY.test(condition.value)
+    ? condition.value.toLowerCase()
+    : null;
+}
+
+export function useWorkflowAuthorPresentation(
+  trigger: TriggerConfig,
+): WorkflowAuthorPresentation {
+  const identityQuery = useIdentityQuery();
+  const pubkey = workflowTriggerAuthorPubkey(trigger);
+  const profilesQuery = useUsersBatchQuery(pubkey ? [pubkey] : []);
+  const profile = pubkey ? profilesQuery.data?.profiles[pubkey] : undefined;
+  const loading = Boolean(pubkey && !profile && profilesQuery.isPending);
+  const label =
+    pubkey && !loading
+      ? resolveUserLabel({
+          currentPubkey: identityQuery.data?.pubkey,
+          profiles: profilesQuery.data?.profiles,
+          pubkey,
+        })
+      : null;
+
+  return {
+    avatarUrl: profile?.avatarUrl ?? null,
+    description: workflowTriggerDescription(trigger, {
+      authorLabel: label ?? undefined,
+      authorLoading: loading,
+    }),
+    label,
+    loading,
+    pubkey,
+  };
+}

--- a/desktop/src/features/workflows/ui/useWorkflowListAuthorPresentations.test.mjs
+++ b/desktop/src/features/workflows/ui/useWorkflowListAuthorPresentations.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { workflowAuthorLookups } from "./useWorkflowListAuthorPresentations.ts";
+
+function workflow(index, pubkey) {
+  return {
+    id: `workflow-${index}`,
+    definition: {
+      trigger: {
+        on: "message_posted",
+        filter: `trigger_author == "${pubkey}"`,
+      },
+      steps: [],
+    },
+  };
+}
+
+test("collects configured authors for one list-level batch", () => {
+  const authors = ["a".repeat(64), "b".repeat(64), "a".repeat(64)];
+  const lookups = authors.flatMap((pubkey, index) =>
+    workflowAuthorLookups([workflow(index, pubkey)]),
+  );
+
+  assert.equal(lookups.length, 3);
+  assert.deepEqual(
+    [...new Set(lookups.map(({ pubkey }) => pubkey))],
+    authors.slice(0, 2),
+  );
+});

--- a/desktop/src/features/workflows/ui/useWorkflowListAuthorPresentations.ts
+++ b/desktop/src/features/workflows/ui/useWorkflowListAuthorPresentations.ts
@@ -1,0 +1,60 @@
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { resolveUserLabel } from "@/features/profile/lib/identity";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import type { Workflow } from "@/shared/api/types";
+import { getWorkflowTriggerConfig } from "./workflowDefinition";
+import {
+  type WorkflowAuthorPresentation,
+  workflowTriggerAuthorPubkey,
+} from "./useWorkflowAuthorPresentation";
+
+export type WorkflowCardAuthorPresentation = Omit<
+  WorkflowAuthorPresentation,
+  "description"
+>;
+
+type WorkflowAuthorLookup = {
+  pubkey: string;
+  workflowId: string;
+};
+
+export function workflowAuthorLookups(
+  workflows: readonly Workflow[],
+): WorkflowAuthorLookup[] {
+  return workflows.flatMap((workflow) => {
+    const trigger = getWorkflowTriggerConfig(workflow.definition);
+    const pubkey = trigger ? workflowTriggerAuthorPubkey(trigger) : null;
+    return pubkey ? [{ pubkey, workflowId: workflow.id }] : [];
+  });
+}
+
+export function useWorkflowListAuthorPresentations(
+  workflows: readonly Workflow[],
+): Map<string, WorkflowCardAuthorPresentation> {
+  const identityQuery = useIdentityQuery();
+  const lookups = workflowAuthorLookups(workflows);
+  const pubkeys = [...new Set(lookups.map(({ pubkey }) => pubkey))];
+  const profilesQuery = useUsersBatchQuery(pubkeys);
+
+  return new Map(
+    lookups.map(({ pubkey, workflowId }) => {
+      const profile = profilesQuery.data?.profiles[pubkey];
+      const loading = !profile && profilesQuery.isPending;
+      return [
+        workflowId,
+        {
+          avatarUrl: profile?.avatarUrl ?? null,
+          label: loading
+            ? null
+            : resolveUserLabel({
+                currentPubkey: identityQuery.data?.pubkey,
+                profiles: profilesQuery.data?.profiles,
+                pubkey,
+              }),
+          loading,
+          pubkey,
+        },
+      ];
+    }),
+  );
+}

--- a/desktop/src/features/workflows/ui/useWorkflowListMessagePresentations.test.mjs
+++ b/desktop/src/features/workflows/ui/useWorkflowListMessagePresentations.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  loadWorkflowMessagePresentations,
+  workflowMessageLookups,
+} from "./useWorkflowListMessagePresentations.ts";
+
+const CHANNEL_ID = "94a444a4-c0a3-5966-ab05-530c6ddc2301";
+
+function workflow(index) {
+  const messageId = index.toString(16).padStart(64, "0");
+  return {
+    id: `workflow-${index}`,
+    channelId: CHANNEL_ID,
+    definition: {
+      trigger: {
+        on: "reaction_added",
+        filter: `trigger_message_id == "${messageId}"`,
+      },
+      steps: [],
+    },
+  };
+}
+
+test("loads presentation for many workflow cards with one batched fetch", async () => {
+  const workflows = Array.from({ length: 40 }, (_, index) =>
+    workflow(index + 1),
+  );
+  const lookups = workflowMessageLookups(workflows);
+  const calls = [];
+
+  const presentations = await loadWorkflowMessagePresentations(
+    lookups,
+    async (eventIds) => {
+      calls.push(eventIds);
+      return eventIds.map((id, index) => ({
+        id,
+        pubkey: "a".repeat(64),
+        created_at: index,
+        kind: 9,
+        tags: [["h", CHANNEL_ID]],
+        content: `Message ${index + 1}`,
+        sig: "b".repeat(128),
+      }));
+    },
+  );
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].length, workflows.length);
+  assert.equal(presentations.size, workflows.length);
+  assert.equal(presentations.get("workflow-40")?.messageLabel, "Message 40");
+});
+
+test("deduplicates shared message IDs inside the single batch", async () => {
+  const duplicate = workflow(1);
+  duplicate.id = "workflow-duplicate";
+  const lookups = workflowMessageLookups([workflow(1), duplicate]);
+  let requestedIds = [];
+
+  await loadWorkflowMessagePresentations(lookups, async (eventIds) => {
+    requestedIds = eventIds;
+    return [];
+  });
+
+  assert.deepEqual(requestedIds, [`${"0".repeat(63)}1`]);
+});

--- a/desktop/src/features/workflows/ui/useWorkflowListMessagePresentations.ts
+++ b/desktop/src/features/workflows/ui/useWorkflowListMessagePresentations.ts
@@ -1,0 +1,92 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getEventsByIds } from "@/shared/api/tauri";
+import type { RelayEvent, Workflow } from "@/shared/api/types";
+import { getWorkflowTriggerConfig } from "./workflowDefinition";
+import {
+  type WorkflowTriggerPresentation,
+  workflowTriggerMessageId,
+} from "./useWorkflowTriggerPresentation";
+import { validatedWorkflowMessageCandidate } from "./workflowMessageCandidates";
+
+export type WorkflowMessagePresentation = Pick<
+  WorkflowTriggerPresentation,
+  "messageId" | "messageLabel" | "messageLoading"
+>;
+
+type WorkflowMessageLookup = {
+  channelId: string;
+  messageId: string;
+  workflowId: string;
+};
+
+export function workflowMessageLookups(
+  workflows: readonly Workflow[],
+): WorkflowMessageLookup[] {
+  return workflows.flatMap((workflow) => {
+    const trigger = getWorkflowTriggerConfig(workflow.definition);
+    const messageId = trigger ? workflowTriggerMessageId(trigger) : null;
+    return workflow.channelId && messageId
+      ? [{ channelId: workflow.channelId, messageId, workflowId: workflow.id }]
+      : [];
+  });
+}
+
+export async function loadWorkflowMessagePresentations(
+  lookups: readonly WorkflowMessageLookup[],
+  fetchEvents: (eventIds: string[]) => Promise<RelayEvent[]> = getEventsByIds,
+): Promise<Map<string, WorkflowMessagePresentation>> {
+  const eventIds = [...new Set(lookups.map(({ messageId }) => messageId))];
+  if (eventIds.length === 0) return new Map();
+
+  const events = await fetchEvents(eventIds);
+  const eventById = new Map(
+    events.map((event) => [event.id.toLowerCase(), event]),
+  );
+  return new Map(
+    lookups.map(({ channelId, messageId, workflowId }) => {
+      const message = validatedWorkflowMessageCandidate(
+        eventById.get(messageId),
+        {
+          channelId,
+          requestedId: messageId,
+        },
+      );
+      return [
+        workflowId,
+        {
+          messageId,
+          messageLabel: message?.content?.trim() || null,
+          messageLoading: false,
+        },
+      ];
+    }),
+  );
+}
+
+export function useWorkflowListMessagePresentations(
+  workflows: readonly Workflow[],
+): Map<string, WorkflowMessagePresentation> {
+  const lookups = workflowMessageLookups(workflows);
+  const lookupKey = lookups
+    .map(({ channelId, messageId, workflowId }) =>
+      [workflowId, channelId, messageId].join(":"),
+    )
+    .sort()
+    .join(",");
+  const query = useQuery({
+    queryKey: ["workflow-list-message-presentations", lookupKey],
+    queryFn: () => loadWorkflowMessagePresentations(lookups),
+    enabled: lookups.length > 0,
+    retry: false,
+    staleTime: 60_000,
+  });
+
+  if (!query.isPending) return query.data ?? new Map();
+  return new Map(
+    lookups.map(({ messageId, workflowId }) => [
+      workflowId,
+      { messageId, messageLabel: null, messageLoading: true },
+    ]),
+  );
+}

--- a/desktop/src/features/workflows/ui/useWorkflowTriggerPresentation.ts
+++ b/desktop/src/features/workflows/ui/useWorkflowTriggerPresentation.ts
@@ -1,0 +1,70 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getEventById } from "@/shared/api/tauri";
+import { useWorkflowAuthorPresentation } from "./useWorkflowAuthorPresentation";
+import { parseConditionExpressions } from "./workflowConditionExpression";
+import type { TriggerConfig } from "./workflowFormTypes";
+import {
+  normalizeMessageEventId,
+  validatedWorkflowMessageCandidate,
+} from "./workflowMessageCandidates";
+import { workflowTriggerDescription } from "./workflowTriggerDescription";
+
+export type WorkflowTriggerPresentation = ReturnType<
+  typeof useWorkflowAuthorPresentation
+> & {
+  messageId: string | null;
+  messageLabel: string | null;
+  messageLoading: boolean;
+};
+
+export function workflowTriggerMessageId(
+  trigger: TriggerConfig,
+): string | null {
+  const conditions = trigger.filter
+    ? parseConditionExpressions(trigger.filter, trigger.on)
+    : [];
+  const condition = conditions?.find(
+    ({ field }) => field === "trigger_message_id",
+  );
+  return condition ? normalizeMessageEventId(condition.value) : null;
+}
+
+export function useWorkflowTriggerPresentation(
+  trigger: TriggerConfig,
+  workflowChannelId?: string | null,
+): WorkflowTriggerPresentation {
+  const author = useWorkflowAuthorPresentation(trigger);
+  const messageId = workflowTriggerMessageId(trigger);
+  const messageQuery = useQuery({
+    enabled: Boolean(messageId && workflowChannelId),
+    queryKey: ["workflow-trigger-message", workflowChannelId, messageId],
+    queryFn: () => getEventById(messageId ?? ""),
+    retry: false,
+    staleTime: 60_000,
+  });
+  const message =
+    workflowChannelId && messageId
+      ? validatedWorkflowMessageCandidate(messageQuery.data, {
+          channelId: workflowChannelId,
+          requestedId: messageId,
+        })
+      : null;
+  const messageLoading = Boolean(
+    messageId && workflowChannelId && messageQuery.isPending,
+  );
+  const messageLabel = message?.content?.trim() || null;
+
+  return {
+    ...author,
+    description: workflowTriggerDescription(trigger, {
+      authorLabel: author.label ?? undefined,
+      authorLoading: author.loading,
+      messageLabel: messageLabel ?? undefined,
+      messageLoading,
+    }),
+    messageId,
+    messageLabel,
+    messageLoading,
+  };
+}

--- a/desktop/src/features/workflows/ui/workflowAuthorCandidates.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowAuthorCandidates.test.mjs
@@ -4,6 +4,7 @@ import { npubEncode } from "nostr-tools/nip19";
 
 import {
   enrichAuthorCandidates,
+  filterAuthorCandidatePage,
   mergeAuthorCandidateSources,
   normalizeAuthorPubkey,
   parseDirectAuthorInput,
@@ -49,6 +50,41 @@ test("merges valid candidates with stable first-wins source priority", () => {
     ],
   );
   assert.equal(merged[1].isAgent, true);
+});
+
+test("bounds filtered candidates while pinning direct input", () => {
+  const candidates = mergeAuthorCandidateSources([
+    Array.from({ length: 1_500 }, (_, index) => ({
+      pubkey: index.toString(16).padStart(64, "0"),
+      displayName: `Member ${index}`,
+    })),
+  ]);
+
+  const initialPage = filterAuthorCandidatePage(candidates, "", null, 50);
+  assert.equal(initialPage.length, 50);
+  assert.deepEqual(
+    initialPage.map(({ displayName }) => displayName),
+    Array.from({ length: 50 }, (_, index) => `Member ${index}`),
+  );
+
+  const filteredPage = filterAuthorCandidatePage(
+    candidates,
+    "Member 12",
+    null,
+    50,
+  );
+  assert.equal(filteredPage.length, 50);
+  assert.ok(
+    filteredPage.every(({ displayName }) => displayName.includes("Member 12")),
+  );
+
+  const direct = candidates[1_234].pubkey;
+  assert.deepEqual(
+    filterAuthorCandidatePage(candidates, direct, direct, 50).map(
+      ({ pubkey }) => pubkey,
+    ),
+    [direct],
+  );
 });
 
 test("profile enrichment updates matching presentation without reordering", () => {

--- a/desktop/src/features/workflows/ui/workflowAuthorCandidates.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowAuthorCandidates.test.mjs
@@ -6,6 +6,7 @@ import {
   enrichAuthorCandidates,
   filterAuthorCandidatePage,
   mergeAuthorCandidateSources,
+  nextWorkflowAuthorIndex,
   normalizeAuthorPubkey,
   parseDirectAuthorInput,
 } from "./workflowAuthorCandidates.ts";
@@ -50,6 +51,14 @@ test("merges valid candidates with stable first-wins source priority", () => {
     ],
   );
   assert.equal(merged[1].isAgent, true);
+});
+
+test("wraps author grid movement without producing negative indices", () => {
+  assert.equal(nextWorkflowAuthorIndex(null, -2, 2), 1);
+  assert.equal(nextWorkflowAuthorIndex(null, -3, 3), 2);
+  assert.equal(nextWorkflowAuthorIndex(1, -2, 2), 1);
+  assert.equal(nextWorkflowAuthorIndex(null, 2, 2), 1);
+  assert.equal(nextWorkflowAuthorIndex(null, 1, 0), null);
 });
 
 test("bounds filtered candidates while pinning direct input", () => {

--- a/desktop/src/features/workflows/ui/workflowAuthorCandidates.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowAuthorCandidates.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { npubEncode } from "nostr-tools/nip19";
+
+import {
+  enrichAuthorCandidates,
+  mergeAuthorCandidateSources,
+  normalizeAuthorPubkey,
+  parseDirectAuthorInput,
+} from "./workflowAuthorCandidates.ts";
+
+const A = "a".repeat(64);
+const B = "b".repeat(64);
+const C = "c".repeat(64);
+
+test("normalizes only valid 64-character hex candidate identities", () => {
+  assert.equal(normalizeAuthorPubkey(`  ${A.toUpperCase()}  `), A);
+  assert.equal(normalizeAuthorPubkey(A.slice(1)), null);
+  assert.equal(normalizeAuthorPubkey("z".repeat(64)), null);
+  assert.equal(normalizeAuthorPubkey(npubEncode(A)), null);
+});
+
+test("parses direct hex and npub input to normalized hex", () => {
+  assert.equal(parseDirectAuthorInput(A.toUpperCase()), A);
+  assert.equal(parseDirectAuthorInput(`  ${npubEncode(A)}  `), A);
+  assert.equal(parseDirectAuthorInput("not-a-pubkey"), null);
+});
+
+test("merges valid candidates with stable first-wins source priority", () => {
+  const merged = mergeAuthorCandidateSources([
+    [
+      { pubkey: B.toUpperCase(), displayName: "Channel B" },
+      { pubkey: "invalid", displayName: "Invalid" },
+      { pubkey: A, displayName: "Channel A", isAgent: true },
+    ],
+    [
+      { pubkey: A.toUpperCase(), displayName: "Directory A" },
+      { pubkey: C, displayName: "Directory C" },
+      { pubkey: B, displayName: "Directory B" },
+    ],
+  ]);
+
+  assert.deepEqual(
+    merged.map(({ pubkey, displayName }) => ({ pubkey, displayName })),
+    [
+      { pubkey: B, displayName: "Channel B" },
+      { pubkey: A, displayName: "Channel A" },
+      { pubkey: C, displayName: "Directory C" },
+    ],
+  );
+  assert.equal(merged[1].isAgent, true);
+});
+
+test("profile enrichment updates matching presentation without reordering", () => {
+  const candidates = mergeAuthorCandidateSources([
+    [
+      {
+        pubkey: B,
+        displayName: "Roster B",
+        nip05Handle: "b@old.example",
+      },
+      { pubkey: A, displayName: "Roster A" },
+      { pubkey: C, displayName: "Roster C" },
+    ],
+  ]);
+
+  const enriched = enrichAuthorCandidates(candidates, {
+    [A.toUpperCase()]: {
+      displayName: "Profile A",
+      avatarUrl: "https://example.test/a.png",
+      nip05Handle: null,
+      ownerPubkey: B.toUpperCase(),
+      isAgent: true,
+    },
+    [B]: {
+      displayName: null,
+      name: "Profile B name",
+      avatarUrl: null,
+      nip05Handle: null,
+      ownerPubkey: null,
+    },
+    ["d".repeat(64)]: {
+      displayName: "Not a candidate",
+      avatarUrl: null,
+      nip05Handle: null,
+      ownerPubkey: null,
+    },
+  });
+
+  assert.deepEqual(
+    enriched.map(({ pubkey }) => pubkey),
+    [B, A, C],
+  );
+  assert.equal(enriched[0].displayName, "Profile B name");
+  assert.equal(enriched[0].nip05Handle, "b@old.example");
+  assert.equal(enriched[1].displayName, "Profile A");
+  assert.equal(enriched[1].avatarUrl, "https://example.test/a.png");
+  assert.equal(enriched[1].ownerPubkey, B);
+  assert.equal(enriched[1].isAgent, true);
+  assert.strictEqual(enriched[2], candidates[2]);
+});

--- a/desktop/src/features/workflows/ui/workflowAuthorCandidates.ts
+++ b/desktop/src/features/workflows/ui/workflowAuthorCandidates.ts
@@ -61,6 +61,16 @@ export function mergeAuthorCandidateSources(
   return merged;
 }
 
+export function nextWorkflowAuthorIndex(
+  current: number | null,
+  delta: number,
+  length: number,
+): number | null {
+  if (length === 0) return null;
+  const startingIndex = current ?? -1;
+  return (((startingIndex + delta) % length) + length) % length;
+}
+
 export function filterAuthorCandidatePage(
   candidates: readonly WorkflowAuthorCandidate[],
   query: string,

--- a/desktop/src/features/workflows/ui/workflowAuthorCandidates.ts
+++ b/desktop/src/features/workflows/ui/workflowAuthorCandidates.ts
@@ -61,6 +61,29 @@ export function mergeAuthorCandidateSources(
   return merged;
 }
 
+export function filterAuthorCandidatePage(
+  candidates: readonly WorkflowAuthorCandidate[],
+  query: string,
+  directPubkey: string | null,
+  limit: number,
+): WorkflowAuthorCandidate[] {
+  if (directPubkey) {
+    return candidates
+      .filter(({ pubkey }) => pubkey === directPubkey)
+      .slice(0, 1);
+  }
+  const needle = query.toLowerCase();
+  return candidates
+    .filter(
+      (candidate) =>
+        !needle ||
+        [candidate.displayName, candidate.nip05Handle, candidate.pubkey].some(
+          (field) => field?.toLowerCase().includes(needle),
+        ),
+    )
+    .slice(0, limit);
+}
+
 /**
  * Add fetched profile presentation to existing identities without changing
  * candidate membership or order. Missing profile fields preserve useful data

--- a/desktop/src/features/workflows/ui/workflowAuthorCandidates.ts
+++ b/desktop/src/features/workflows/ui/workflowAuthorCandidates.ts
@@ -1,0 +1,97 @@
+import type { UserProfileSummary } from "@/shared/api/types";
+import { parsePubkeyInput } from "@/shared/lib/nostrUtils";
+
+const HEX_PUBKEY = /^[0-9a-f]{64}$/;
+
+export type WorkflowAuthorCandidate = {
+  pubkey: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  nip05Handle: string | null;
+  ownerPubkey: string | null;
+  isAgent: boolean;
+};
+
+export type WorkflowAuthorCandidateInput = {
+  pubkey: string;
+  displayName?: string | null;
+  avatarUrl?: string | null;
+  nip05Handle?: string | null;
+  ownerPubkey?: string | null;
+  isAgent?: boolean;
+};
+
+/** Normalize a candidate identity without accepting alternate encodings. */
+export function normalizeAuthorPubkey(pubkey: string): string | null {
+  const normalized = pubkey.trim().toLowerCase();
+  return HEX_PUBKEY.test(normalized) ? normalized : null;
+}
+
+/** Parse direct user input (hex or npub) into the canonical stored hex form. */
+export function parseDirectAuthorInput(input: string): string | null {
+  return parsePubkeyInput(input);
+}
+
+/**
+ * Merge candidate sources in priority order. The first occurrence of an
+ * identity owns both its position and source-provided presentation fields.
+ */
+export function mergeAuthorCandidateSources(
+  sources: readonly (readonly WorkflowAuthorCandidateInput[])[],
+): WorkflowAuthorCandidate[] {
+  const merged: WorkflowAuthorCandidate[] = [];
+  const seen = new Set<string>();
+
+  for (const source of sources) {
+    for (const candidate of source) {
+      const pubkey = normalizeAuthorPubkey(candidate.pubkey);
+      if (!pubkey || seen.has(pubkey)) continue;
+      seen.add(pubkey);
+      merged.push({
+        pubkey,
+        displayName: candidate.displayName ?? null,
+        avatarUrl: candidate.avatarUrl ?? null,
+        nip05Handle: candidate.nip05Handle ?? null,
+        ownerPubkey: normalizeAuthorPubkey(candidate.ownerPubkey ?? ""),
+        isAgent: candidate.isAgent ?? false,
+      });
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Add fetched profile presentation to existing identities without changing
+ * candidate membership or order. Missing profile fields preserve useful data
+ * already supplied by the higher-priority discovery source.
+ */
+export function enrichAuthorCandidates(
+  candidates: readonly WorkflowAuthorCandidate[],
+  profiles: Readonly<Record<string, UserProfileSummary | undefined>>,
+): WorkflowAuthorCandidate[] {
+  const normalizedProfiles = new Map(
+    Object.entries(profiles).flatMap(([pubkey, profile]) => {
+      const normalized = normalizeAuthorPubkey(pubkey);
+      return normalized && profile ? [[normalized, profile] as const] : [];
+    }),
+  );
+
+  return candidates.map((candidate) => {
+    const profile = normalizedProfiles.get(candidate.pubkey);
+    if (!profile) return candidate;
+    return {
+      ...candidate,
+      displayName:
+        profile.displayName?.trim() ||
+        profile.name?.trim() ||
+        candidate.displayName,
+      avatarUrl: profile.avatarUrl ?? candidate.avatarUrl,
+      nip05Handle: profile.nip05Handle ?? candidate.nip05Handle,
+      ownerPubkey:
+        normalizeAuthorPubkey(profile.ownerPubkey ?? "") ??
+        candidate.ownerPubkey,
+      isAgent: profile.isAgent ?? candidate.isAgent,
+    };
+  });
+}

--- a/desktop/src/features/workflows/ui/workflowConditionExpression.ts
+++ b/desktop/src/features/workflows/ui/workflowConditionExpression.ts
@@ -27,7 +27,7 @@ export type ParsedConditionExpression = {
 };
 
 const AUTHOR_FIELD: ConditionField = {
-  label: "Author pubkey",
+  label: "Author",
   value: "trigger_author",
 };
 const FIELDS_BY_TRIGGER: Record<TriggerType, ConditionField[]> = {
@@ -39,7 +39,7 @@ const FIELDS_BY_TRIGGER: Record<TriggerType, ConditionField[]> = {
   reaction_added: [
     { label: "Reaction emoji", value: "trigger_emoji" },
     AUTHOR_FIELD,
-    { label: "Message event ID", value: "trigger_message_id" },
+    { label: "Message", value: "trigger_message_id" },
   ],
   webhook: [],
   schedule: [],

--- a/desktop/src/features/workflows/ui/workflowDefinition.ts
+++ b/desktop/src/features/workflows/ui/workflowDefinition.ts
@@ -89,7 +89,7 @@ export function getWorkflowTriggerEmoji(
   return nonEmptyString(emojiCondition?.value);
 }
 
-function getWorkflowTriggerConfig(
+export function getWorkflowTriggerConfig(
   definition: Record<string, unknown>,
 ): TriggerConfig | null {
   const trigger = asRecord(definition.trigger);

--- a/desktop/src/features/workflows/ui/workflowMessageCandidates.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowMessageCandidates.test.mjs
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  enrichMessageCandidateFromExactLookup,
+  isPickableWorkflowMessageEvent,
+  mergeMessageCandidateSources,
+  normalizeMessageEventId,
+  validateWorkflowMessageSearchResults,
+  validatedWorkflowMessageCandidate,
+} from "./workflowMessageCandidates.ts";
+
+const A = "a".repeat(64);
+const B = "b".repeat(64);
+const C = "c".repeat(64);
+const CHANNEL = "workflow-channel";
+
+function relayEvent({
+  id = A,
+  kind = 9,
+  channelId = CHANNEL,
+  content = "Fetched preview",
+} = {}) {
+  return {
+    id,
+    pubkey: C,
+    created_at: 1_725_000_000,
+    kind,
+    tags: channelId === null ? [] : [["h", channelId]],
+    content,
+    sig: "",
+  };
+}
+
+function fallback(id = A) {
+  return { id, pubkey: null, content: null, createdAt: null };
+}
+
+test("normalizes only valid 64-character hex event IDs", () => {
+  assert.equal(normalizeMessageEventId(`  ${A.toUpperCase()}  `), A);
+  assert.equal(normalizeMessageEventId(A.slice(1)), null);
+  assert.equal(normalizeMessageEventId("z".repeat(64)), null);
+});
+
+test("merges valid candidates with stable first-wins source priority", () => {
+  const merged = mergeMessageCandidateSources([
+    [
+      { id: B.toUpperCase(), content: "Recent B" },
+      { id: "invalid", content: "Invalid" },
+      { id: A, content: "Recent A", pubkey: C },
+    ],
+    [
+      { id: A.toUpperCase(), content: "Search A" },
+      { id: C, content: "Search C" },
+      { id: B, content: "Search B" },
+    ],
+  ]);
+
+  assert.deepEqual(
+    merged.map(({ id, content }) => ({ id, content })),
+    [
+      { id: B, content: "Recent B" },
+      { id: A, content: "Recent A" },
+      { id: C, content: "Search C" },
+    ],
+  );
+  assert.equal(merged[1].pubkey, C);
+});
+
+test("accepts only the existing narrow message kinds in the exact channel", () => {
+  for (const kind of [9, 40_002, 45_001, 45_003, 40_008]) {
+    assert.equal(
+      isPickableWorkflowMessageEvent(relayEvent({ kind }), CHANNEL),
+      true,
+    );
+  }
+
+  assert.equal(
+    isPickableWorkflowMessageEvent(relayEvent({ kind: 40_099 }), CHANNEL),
+    false,
+  );
+  assert.equal(
+    isPickableWorkflowMessageEvent(
+      relayEvent({ channelId: "another-channel" }),
+      CHANNEL,
+    ),
+    false,
+  );
+  assert.equal(
+    isPickableWorkflowMessageEvent(
+      {
+        ...relayEvent(),
+        tags: [
+          ["h", CHANNEL],
+          ["h", "another-channel"],
+        ],
+      },
+      CHANNEL,
+    ),
+    false,
+  );
+  assert.equal(
+    isPickableWorkflowMessageEvent(relayEvent({ channelId: null }), CHANNEL),
+    false,
+  );
+});
+
+test("single validator rejects wrong IDs, channels, and kinds", () => {
+  assert.deepEqual(
+    validatedWorkflowMessageCandidate(relayEvent(), {
+      channelId: CHANNEL,
+      requestedId: A.toUpperCase(),
+    }),
+    {
+      id: A,
+      pubkey: C,
+      content: "Fetched preview",
+      createdAt: 1_725_000_000,
+    },
+  );
+  assert.equal(
+    validatedWorkflowMessageCandidate(relayEvent({ id: B }), {
+      channelId: CHANNEL,
+      requestedId: A,
+    }),
+    null,
+  );
+  assert.equal(
+    validatedWorkflowMessageCandidate(
+      relayEvent({ channelId: "another-channel" }),
+      { channelId: CHANNEL },
+    ),
+    null,
+  );
+  assert.equal(
+    validatedWorkflowMessageCandidate(relayEvent({ kind: 40_099 }), {
+      channelId: CHANNEL,
+    }),
+    null,
+  );
+});
+
+test("exact lookup enriches only the normalized requested event ID", () => {
+  const enriched = enrichMessageCandidateFromExactLookup(
+    fallback(A.toUpperCase()),
+    relayEvent({ id: A.toUpperCase() }),
+    CHANNEL,
+  );
+
+  assert.deepEqual(enriched, {
+    id: A,
+    pubkey: C,
+    content: "Fetched preview",
+    createdAt: 1_725_000_000,
+  });
+
+  const wrongEvent = relayEvent({ id: B, content: "Wrong preview" });
+  const original = fallback(A);
+  assert.strictEqual(
+    enrichMessageCandidateFromExactLookup(original, wrongEvent, CHANNEL),
+    original,
+  );
+});
+
+test("search discovery exposes only exact events that pass the real event boundary", () => {
+  const candidates = validateWorkflowMessageSearchResults(
+    [
+      {
+        requestedId: A,
+        event: relayEvent({ id: A, content: "Validated search preview" }),
+      },
+      {
+        requestedId: B,
+        event: {
+          ...relayEvent({ id: B, content: "Projection-laundered preview" }),
+          tags: [
+            ["h", CHANNEL],
+            ["h", "another-channel"],
+          ],
+        },
+      },
+      {
+        requestedId: C,
+        event: relayEvent({ id: B, content: "Wrong exact event" }),
+      },
+    ],
+    CHANNEL,
+  );
+
+  assert.deepEqual(candidates, [
+    {
+      id: A,
+      pubkey: C,
+      content: "Validated search preview",
+      createdAt: 1_725_000_000,
+    },
+  ]);
+});
+
+test("invalid lookup results preserve the deterministic fallback without preview", () => {
+  const original = fallback(A);
+  const invalidEvents = [
+    undefined,
+    relayEvent({ channelId: "another-channel", content: "Cross-channel" }),
+    relayEvent({ kind: 40_099, content: "System message" }),
+    relayEvent({ channelId: null, content: "Unscoped" }),
+  ];
+
+  for (const event of invalidEvents) {
+    const result = enrichMessageCandidateFromExactLookup(
+      original,
+      event,
+      CHANNEL,
+    );
+    assert.strictEqual(result, original);
+    assert.equal(result.content, null);
+  }
+});

--- a/desktop/src/features/workflows/ui/workflowMessageCandidates.ts
+++ b/desktop/src/features/workflows/ui/workflowMessageCandidates.ts
@@ -1,0 +1,139 @@
+import type { RelayEvent } from "@/shared/api/types";
+import {
+  CHANNEL_MESSAGE_EVENT_KINDS,
+  KIND_STREAM_MESSAGE_DIFF,
+} from "@/shared/constants/kinds";
+
+const HEX_EVENT_ID = /^[0-9a-f]{64}$/;
+const PICKABLE_MESSAGE_KINDS = new Set<number>([
+  ...CHANNEL_MESSAGE_EVENT_KINDS,
+  KIND_STREAM_MESSAGE_DIFF,
+]);
+
+export type WorkflowMessageCandidate = {
+  id: string;
+  pubkey: string | null;
+  content: string | null;
+  createdAt: number | null;
+};
+
+export type WorkflowMessageCandidateInput = {
+  id: string;
+  pubkey?: string | null;
+  content?: string | null;
+  createdAt?: number | null;
+};
+
+export type WorkflowMessageEventValidation = {
+  channelId: string;
+  requestedId?: string | null;
+};
+
+/** Normalize an event ID without accepting alternate encodings. */
+export function normalizeMessageEventId(eventId: string): string | null {
+  const normalized = eventId.trim().toLowerCase();
+  return HEX_EVENT_ID.test(normalized) ? normalized : null;
+}
+
+/**
+ * Merge candidate sources in priority order. The first occurrence of an event
+ * owns both its position and its presentation fields.
+ */
+export function mergeMessageCandidateSources(
+  sources: readonly (readonly WorkflowMessageCandidateInput[])[],
+): WorkflowMessageCandidate[] {
+  const merged: WorkflowMessageCandidate[] = [];
+  const seen = new Set<string>();
+
+  for (const source of sources) {
+    for (const candidate of source) {
+      const id = normalizeMessageEventId(candidate.id);
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      merged.push({
+        id,
+        pubkey: candidate.pubkey ?? null,
+        content: candidate.content ?? null,
+        createdAt: candidate.createdAt ?? null,
+      });
+    }
+  }
+
+  return merged;
+}
+
+/** Whether an event is a user-pickable message in exactly the given channel. */
+export function isPickableWorkflowMessageEvent(
+  event: RelayEvent,
+  channelId: string,
+): boolean {
+  return (
+    PICKABLE_MESSAGE_KINDS.has(event.kind) &&
+    event.tags.filter((tag) => tag[0] === "h").length === 1 &&
+    event.tags.find((tag) => tag[0] === "h")?.[1] === channelId
+  );
+}
+
+/**
+ * Validate any fetched event before it can enrich a deterministic message ID.
+ * Transport scoping is not trusted: the event must carry exactly one matching
+ * channel tag, use a pickable kind, and match a requested ID when provided.
+ */
+export function validatedWorkflowMessageCandidate(
+  event: RelayEvent | null | undefined,
+  { channelId, requestedId }: WorkflowMessageEventValidation,
+): WorkflowMessageCandidate | null {
+  if (!event || !isPickableWorkflowMessageEvent(event, channelId)) return null;
+  const eventId = normalizeMessageEventId(event.id);
+  if (!eventId) return null;
+  if (requestedId !== undefined && requestedId !== null) {
+    const normalizedRequestedId = normalizeMessageEventId(requestedId);
+    if (!normalizedRequestedId || eventId !== normalizedRequestedId)
+      return null;
+  }
+  return {
+    id: eventId,
+    pubkey: event.pubkey,
+    content: event.content,
+    createdAt: event.created_at,
+  };
+}
+
+export type WorkflowMessageSearchResult = {
+  requestedId: string;
+  event: RelayEvent | null | undefined;
+};
+
+/**
+ * Validate exact events resolved from search-hit IDs. Search projections are
+ * discovery hints only and never supply presentation or selection fields.
+ */
+export function validateWorkflowMessageSearchResults(
+  results: readonly WorkflowMessageSearchResult[],
+  channelId: string,
+): WorkflowMessageCandidate[] {
+  return results.flatMap(({ requestedId, event }) => {
+    const candidate = validatedWorkflowMessageCandidate(event, {
+      channelId,
+      requestedId,
+    });
+    return candidate ? [candidate] : [];
+  });
+}
+
+/**
+ * Enrich a deterministic event-ID fallback only when an exact lookup returned
+ * that same event in the expected channel and with a pickable message kind.
+ * Invalid or unrelated fetches leave the fallback untouched.
+ */
+export function enrichMessageCandidateFromExactLookup(
+  fallback: WorkflowMessageCandidate,
+  event: RelayEvent | null | undefined,
+  channelId: string,
+): WorkflowMessageCandidate {
+  const candidate = validatedWorkflowMessageCandidate(event, {
+    channelId,
+    requestedId: fallback.id,
+  });
+  return candidate ?? fallback;
+}

--- a/desktop/src/features/workflows/ui/workflowTriggerDescription.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowTriggerDescription.test.mjs
@@ -3,8 +3,34 @@ import test from "node:test";
 
 import {
   compactWorkflowTriggerDescription,
+  splitWorkflowAuthorDescription,
   workflowTriggerDescription,
 } from "./workflowTriggerDescription.ts";
+
+test("splits generated author attribution instead of matching quoted user copy", () => {
+  assert.deepEqual(
+    splitWorkflowAuthorDescription(
+      "Reaction added by Carl to “thanks Carl”",
+      "Carl",
+    ),
+    { prefix: "Reaction added by", suffix: "to “thanks Carl”" },
+  );
+  assert.deepEqual(
+    splitWorkflowAuthorDescription("Message by Carl contains “Carl”", "Carl"),
+    { prefix: "Message by", suffix: "contains “Carl”" },
+  );
+  assert.deepEqual(
+    splitWorkflowAuthorDescription(
+      "Message by anyone except Carl contains “Carl”",
+      "Carl",
+    ),
+    { prefix: "Message by anyone except", suffix: "contains “Carl”" },
+  );
+  assert.equal(
+    splitWorkflowAuthorDescription("Message contains “Carl”", "Carl"),
+    null,
+  );
+});
 
 test("describes selected trigger conditions on the workflow canvas", () => {
   assert.equal(

--- a/desktop/src/features/workflows/ui/workflowTriggerDescription.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowTriggerDescription.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { workflowTriggerDescription } from "./workflowTriggerDescription.ts";
+import {
+  compactWorkflowTriggerDescription,
+  workflowTriggerDescription,
+} from "./workflowTriggerDescription.ts";
 
 test("describes selected trigger conditions on the workflow canvas", () => {
   assert.equal(
@@ -140,6 +143,38 @@ test("describes selected trigger conditions on the workflow canvas", () => {
       { authorLabel: "Carl", messageLabel: "hey yourself" },
     ),
     "👾 reaction added by Carl to “hey yourself”",
+  );
+});
+
+test("compacts only an included emoji already rendered as the node icon", () => {
+  assert.equal(
+    compactWorkflowTriggerDescription("😍 reaction added", "😍"),
+    "Reaction added",
+  );
+  assert.equal(
+    compactWorkflowTriggerDescription("😍 reaction added by Carl", "😍"),
+    "Reaction added by Carl",
+  );
+  assert.equal(
+    compactWorkflowTriggerDescription(
+      "😍 reaction added by Carl to “release 😍 notes”",
+      "😍",
+    ),
+    "Reaction added by Carl to “release 😍 notes”",
+  );
+  assert.equal(
+    compactWorkflowTriggerDescription(
+      "Any reaction except 😍 added",
+      undefined,
+    ),
+    "Any reaction except 😍 added",
+  );
+  assert.equal(
+    compactWorkflowTriggerDescription(
+      "Reaction added to “😍 reaction added”",
+      "😍",
+    ),
+    "Reaction added to “😍 reaction added”",
   );
 });
 

--- a/desktop/src/features/workflows/ui/workflowTriggerDescription.ts
+++ b/desktop/src/features/workflows/ui/workflowTriggerDescription.ts
@@ -66,6 +66,18 @@ function textConditionDescription(
   }
 }
 
+/** Remove a reaction value from compact copy when the node icon already shows it. */
+export function compactWorkflowTriggerDescription(
+  description: string,
+  triggerEmoji?: string,
+): string {
+  if (!triggerEmoji) return description;
+  const emojiPrefix = `${triggerEmoji} reaction added`;
+  return description.startsWith(emojiPrefix)
+    ? `Reaction added${description.slice(emojiPrefix.length)}`
+    : description;
+}
+
 /** Build the concise trigger summary rendered on the workflow canvas. */
 export function workflowTriggerDescription(
   trigger: TriggerConfig,

--- a/desktop/src/features/workflows/ui/workflowTriggerDescription.ts
+++ b/desktop/src/features/workflows/ui/workflowTriggerDescription.ts
@@ -66,6 +66,41 @@ function textConditionDescription(
   }
 }
 
+export type WorkflowAuthorDescriptionSegments = {
+  prefix: string;
+  suffix: string;
+};
+
+/** Locate the generated author attribution without matching quoted user copy. */
+export function splitWorkflowAuthorDescription(
+  description: string,
+  label: string,
+): WorkflowAuthorDescriptionSegments | null {
+  const markers = [` by anyone except ${label}`, ` by ${label}`];
+
+  for (const marker of markers) {
+    let insideQuote = false;
+    for (
+      let index = 0;
+      index <= description.length - marker.length;
+      index += 1
+    ) {
+      const character = description[index];
+      if (character === "“") insideQuote = true;
+      if (character === "”") insideQuote = false;
+      if (!insideQuote && description.startsWith(marker, index)) {
+        const labelIndex = index + marker.length - label.length;
+        return {
+          prefix: description.slice(0, labelIndex).trimEnd(),
+          suffix: description.slice(labelIndex + label.length).trimStart(),
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
 /** Remove a reaction value from compact copy when the node icon already shows it. */
 export function compactWorkflowTriggerDescription(
   description: string,

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -43,6 +43,7 @@ import type {
 
 export * from "@/shared/api/tauriChannels";
 export { sendChannelMessage } from "@/shared/api/tauriMessages";
+export { getEventById, getEventsByIds } from "@/shared/api/tauriEvents";
 
 type RawPresenceLookup = Record<string, PresenceStatus>;
 
@@ -463,18 +464,6 @@ export async function searchMessages(
     hits: response.hits.map(fromRawSearchHit),
     found: response.found,
   };
-}
-
-export async function getEventById(eventId: string): Promise<RelayEvent> {
-  const eventJson = await invokeTauri<string>("get_event", { eventId });
-  return JSON.parse(eventJson) as RelayEvent;
-}
-
-export async function getEventsByIds(
-  eventIds: string[],
-): Promise<RelayEvent[]> {
-  if (eventIds.length === 0) return [];
-  return invokeTauri<RelayEvent[]>("get_events", { eventIds });
 }
 
 type RawThreadCursor = {

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -470,6 +470,13 @@ export async function getEventById(eventId: string): Promise<RelayEvent> {
   return JSON.parse(eventJson) as RelayEvent;
 }
 
+export async function getEventsByIds(
+  eventIds: string[],
+): Promise<RelayEvent[]> {
+  if (eventIds.length === 0) return [];
+  return invokeTauri<RelayEvent[]>("get_events", { eventIds });
+}
+
 type RawThreadCursor = {
   created_at: number;
   event_id: string;

--- a/desktop/src/shared/api/tauriEvents.ts
+++ b/desktop/src/shared/api/tauriEvents.ts
@@ -1,0 +1,14 @@
+import { invokeTauri } from "@/shared/api/tauri";
+import type { RelayEvent } from "@/shared/api/types";
+
+export async function getEventById(eventId: string): Promise<RelayEvent> {
+  const eventJson = await invokeTauri<string>("get_event", { eventId });
+  return JSON.parse(eventJson) as RelayEvent;
+}
+
+export async function getEventsByIds(
+  eventIds: string[],
+): Promise<RelayEvent[]> {
+  if (eventIds.length === 0) return [];
+  return invokeTauri<RelayEvent[]>("get_events", { eventIds });
+}

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -13585,6 +13585,15 @@ export function maybeInstallE2eTauriMocks() {
           payload as Parameters<typeof handleGetEvent>[0],
           activeConfig,
         );
+      case "get_events":
+        return Promise.all(
+          (payload as { eventIds: string[] }).eventIds.map(
+            async (eventId) =>
+              JSON.parse(
+                await handleGetEvent({ eventId }, activeConfig),
+              ) as RelayEvent,
+          ),
+        );
       case "sign_event":
         window.__BUZZ_E2E_SIGNED_EVENTS__?.push({
           content: (payload as { content: string }).content,

--- a/desktop/tests/e2e/workflow-local-controls.spec.ts
+++ b/desktop/tests/e2e/workflow-local-controls.spec.ts
@@ -432,25 +432,42 @@ test("round-trips manual author and reaction message IDs through save and reopen
   await openTriggerInspector(dialog);
 
   await dialog.getByRole("button", { name: "Author pubkey" }).click();
-  await dialog.getByLabel("Author pubkey").fill("not-hex");
-  await expect(
-    dialog.getByText("Enter a 64-character hex pubkey."),
-  ).toBeVisible();
-  await expect(dialog.getByRole("button", { name: "Create" })).toBeDisabled();
+  const authorResults = dialog.getByTestId("workflow-author-picker-results");
   await expect
     .poll(() =>
-      page.evaluate(
-        () =>
-          (window.__BUZZ_E2E_COMMAND_PAYLOADS__ ?? []).filter(
-            (call) => call.command === "create_workflow",
-          ).length,
-      ),
+      authorResults.evaluate((results) => {
+        const template = results.querySelector<HTMLElement>("[role=option]");
+        if (!template) return false;
+        for (let index = 0; index < 20; index += 1) {
+          const clone = template.cloneNode(true) as HTMLElement;
+          clone.dataset.scrollFixture = "true";
+          clone.removeAttribute("id");
+          results.append(clone);
+        }
+        return results.scrollHeight > results.clientHeight;
+      }),
     )
-    .toBe(0);
-  await dialog.getByLabel("Author pubkey").fill(author);
+    .toBe(true);
+  await authorResults.hover();
+  await page.mouse.wheel(0, 240);
+  await expect
+    .poll(() => authorResults.evaluate((node) => node.scrollTop))
+    .toBeGreaterThan(0);
+  await authorResults.evaluate((results) => {
+    for (const fixture of results.querySelectorAll("[data-scroll-fixture]")) {
+      fixture.remove();
+    }
+    results.scrollTop = 0;
+  });
+  const authorSearch = dialog.getByRole("combobox", {
+    name: "Search authors or paste a public key",
+  });
+  await authorSearch.fill(author);
+  await authorSearch.press("Enter");
+  await expect(
+    dialog.getByRole("option", { name: new RegExp(author.slice(0, 8)) }),
+  ).toHaveAttribute("aria-selected", "true");
   await expect(dialog.getByRole("button", { name: "Create" })).toBeEnabled();
-  await dialog.getByLabel("Author pubkey").fill("still-not-hex");
-  await expect(dialog.getByRole("button", { name: "Create" })).toBeDisabled();
   await dialog.getByRole("tab", { name: "YAML" }).click();
   const correctionEditor = dialog.getByRole("textbox", {
     name: "Workflow YAML",
@@ -462,8 +479,12 @@ test("round-trips manual author and reaction message IDs through save and reopen
   await dialog.getByRole("tab", { name: "Form" }).click();
   await openTriggerInspector(dialog);
   await dialog.getByRole("button", { name: "Author pubkey" }).click();
-  await expect(dialog.getByLabel("Author pubkey")).toHaveValue("");
-  await dialog.getByLabel("Author pubkey").fill(author);
+  await dialog
+    .getByRole("combobox", { name: "Search authors or paste a public key" })
+    .fill(author);
+  await dialog
+    .getByRole("combobox", { name: "Search authors or paste a public key" })
+    .press("Enter");
   await dialog
     .getByRole("group", { name: "Match" })
     .getByRole("button", { name: "is not", exact: true })
@@ -487,7 +508,9 @@ test("round-trips manual author and reaction message IDs through save and reopen
   const reopened = await reopenWorkflow(page, name);
   await openTriggerInspector(reopened);
   await reopened.getByRole("button", { name: "Author pubkey" }).click();
-  await expect(reopened.getByLabel("Author pubkey")).toHaveValue(author);
+  await expect(
+    reopened.getByRole("option", { name: new RegExp(author.slice(0, 8)) }),
+  ).toHaveAttribute("aria-selected", "true");
   await reopened.getByRole("button", { name: "Message event ID" }).click();
   await expect(reopened.getByLabel("Message event ID")).toHaveValue(messageId);
   await reopened.getByRole("tab", { name: "YAML" }).click();

--- a/desktop/tests/e2e/workflow-local-controls.spec.ts
+++ b/desktop/tests/e2e/workflow-local-controls.spec.ts
@@ -563,6 +563,91 @@ test("round-trips manual author and reaction message IDs through save and reopen
   expect(definition.trigger.filter).toContain(messageId);
 });
 
+test("toggles selected author and message filters while preserving sibling conditions", async ({
+  page,
+}) => {
+  const author = "a".repeat(64);
+  const replacementAuthor = "c".repeat(64);
+  const messageId = "b".repeat(64);
+  const dialog = await openCreateWorkflow(
+    page,
+    `toggle_trigger_ids_${Date.now()}`,
+  );
+  await selectTrigger(page, dialog, "Reaction Added");
+  await dialog.getByRole("tab", { name: "YAML" }).click();
+  const yamlEditor = dialog.getByRole("textbox", { name: "Workflow YAML" });
+  const definition = parseYaml(await yamlEditor.inputValue());
+  definition.trigger.filter =
+    `trigger_emoji == "👍" && trigger_author == "${author.toUpperCase()}" && ` +
+    `trigger_message_id == "${messageId.toUpperCase()}"`;
+  await yamlEditor.fill(stringifyYaml(definition));
+  await dialog.getByRole("tab", { name: "Form" }).click();
+  await openTriggerInspector(dialog);
+  const authorField = dialog
+    .getByRole("button", { name: "Author pubkey" })
+    .locator("..");
+  await authorField.getByRole("button", { name: "Author pubkey" }).click();
+  const authorOption = dialog.getByRole("option", {
+    name: new RegExp(author.slice(0, 8)),
+  });
+  await expect(authorOption).toHaveAttribute("aria-selected", "true");
+  await expect(
+    authorField.getByRole("button", { name: "Clear filter" }),
+  ).toHaveCount(0);
+  await authorOption.click();
+
+  const authorSearch = dialog.getByRole("combobox", {
+    name: "Search authors or paste a public key",
+  });
+  await authorSearch.fill(replacementAuthor);
+  const replacementAuthorOption = dialog.getByRole("option", {
+    name: new RegExp(replacementAuthor.slice(0, 8)),
+  });
+  await expect(replacementAuthorOption).toBeVisible();
+  await authorSearch.press("Enter");
+  await expect(replacementAuthorOption).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await expect(authorSearch).toHaveValue(replacementAuthor);
+  await authorSearch.press("Enter");
+  await expect(authorSearch).toHaveValue(replacementAuthor);
+
+  const messageField = dialog
+    .getByRole("button", { name: "Message event ID" })
+    .locator("..");
+  await messageField.getByRole("button", { name: "Message event ID" }).click();
+  const messageSearch = dialog.getByRole("combobox", {
+    name: "Search messages or paste a message ID",
+  });
+  await expect(
+    dialog.getByRole("option", { name: new RegExp(messageId.slice(0, 12)) }),
+  ).toHaveAttribute("aria-selected", "true");
+  await expect(
+    messageField.getByRole("button", { name: "Clear filter" }),
+  ).toHaveCount(0);
+  await messageSearch.fill(messageId);
+  await messageSearch.press("Enter");
+  await expect(messageSearch).toHaveValue(messageId);
+  await messageSearch.press("Enter");
+  const selectedMessage = dialog.getByRole("option", {
+    name: new RegExp(messageId.slice(0, 12)),
+  });
+  await expect(selectedMessage).toHaveAttribute("aria-selected", "true");
+  await selectedMessage.click();
+  await expect(messageSearch).toHaveValue(messageId);
+
+  await dialog.getByRole("button", { name: "Reaction emoji" }).click();
+  await expect(
+    dialog.getByRole("button", { name: "Clear filter" }),
+  ).toBeVisible();
+
+  await dialog.getByRole("tab", { name: "YAML" }).click();
+  expect(parseYaml(await yamlEditor.inputValue()).trigger.filter).toBe(
+    'trigger_emoji == "👍"',
+  );
+});
+
 test("hides and clears message-text step conditions for schedule triggers", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/workflow-local-controls.spec.ts
+++ b/desktop/tests/e2e/workflow-local-controls.spec.ts
@@ -4,6 +4,15 @@ import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { waitForAnimations } from "../helpers/animations";
 import { installMockBridge } from "../helpers/bridge";
 
+declare global {
+  interface Window {
+    __BUZZ_WORKFLOW_BATCH_CALLS__?: {
+      eventBatches: number[];
+      userBatches: number[];
+    };
+  }
+}
+
 test.beforeEach(async ({ page }) => {
   await installMockBridge(page);
 });
@@ -419,7 +428,9 @@ test("renders deterministic trigger, step, and workflow-card summaries", async (
   ).toBeLessThan(0.5);
 });
 
-test("Escape closes a filter picker before its inspector", async ({ page }) => {
+test("Escape closes a filter picker, restores disclosure focus, then closes its inspector", async ({
+  page,
+}) => {
   for (const width of [760, 1280]) {
     await page.setViewportSize({ width, height: 820 });
     await page.goto(
@@ -428,22 +439,99 @@ test("Escape closes a filter picker before its inspector", async ({ page }) => {
 
     const dialog = page.getByRole("dialog", { name: "Create workflow" });
     const inspector = dialog.getByTestId("workflow-node-inspector");
-    await dialog.getByText("Author", { exact: true }).locator("..").click();
+    await selectTrigger(page, dialog, "Reaction Added");
+    for (const field of [
+      {
+        label: "Author",
+        picker: "workflow-author-picker",
+        search: "Search authors or paste a public key",
+      },
+      {
+        label: "Message",
+        picker: "workflow-message-picker",
+        search: "Search messages or paste a message ID",
+      },
+    ]) {
+      const disclosure = dialog
+        .getByText(field.label, { exact: true })
+        .locator("..");
+      await disclosure.click();
+      const picker = dialog.getByTestId(field.picker);
+      const search = dialog.getByRole("combobox", { name: field.search });
+      await expect(picker).toBeVisible();
 
-    const picker = dialog.getByTestId("workflow-author-picker");
-    const search = dialog.getByRole("combobox", {
-      name: "Search authors or paste a public key",
-    });
-    await expect(picker).toBeVisible();
-
-    await search.press("Escape");
-    await expect(picker).toBeHidden();
-    await expect(inspector).toBeVisible();
+      await search.press("Escape");
+      await expect(picker).toBeHidden();
+      await expect(disclosure).toBeFocused();
+      await expect(inspector).toBeVisible();
+    }
 
     await page.keyboard.press("Escape");
     await expect(inspector).toBeHidden();
     await expect(dialog).toBeVisible();
   }
+});
+
+test("workflow grid batches card author and message presentation reads", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.waitForFunction(
+    () => typeof window.__TAURI_INTERNALS__?.invoke === "function",
+  );
+  await page.evaluate(async () => {
+    const invoke = window.__TAURI_INTERNALS__?.invoke;
+    if (!invoke) throw new Error("mock invoke bridge unavailable");
+    for (let index = 0; index < 40; index += 1) {
+      const messageId = (index + 1).toString(16).padStart(64, "0");
+      const author = (index + 101).toString(16).padStart(64, "0");
+      await invoke("create_workflow", {
+        channelId: "94a444a4-c0a3-5966-ab05-530c6ddc2301",
+        yamlDefinition: JSON.stringify({
+          name: `batched_card_${index}`,
+          trigger: {
+            on: "reaction_added",
+            filter: `trigger_author == "${author}" && trigger_message_id == "${messageId}"`,
+          },
+          steps: [],
+        }),
+      });
+    }
+
+    const calls = { eventBatches: [], userBatches: [] };
+    window.__BUZZ_WORKFLOW_BATCH_CALLS__ = calls;
+    window.__TAURI_INTERNALS__.invoke = async (command, args) => {
+      if (command === "get_events") {
+        calls.eventBatches.push(
+          (args?.eventIds as unknown[] | undefined)?.length ?? 0,
+        );
+      }
+      if (command === "get_users_batch") {
+        calls.userBatches.push(
+          (args?.pubkeys as unknown[] | undefined)?.length ?? 0,
+        );
+      }
+      return invoke(command, args);
+    };
+  });
+
+  await page.getByTestId("open-workflows-view").click();
+  await expect(
+    page.locator('[data-testid^="workflow-card-mock-wf-"]'),
+  ).toHaveCount(40);
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const calls = window.__BUZZ_WORKFLOW_BATCH_CALLS__;
+        return {
+          eventBatchCount: calls?.eventBatches.filter((size) => size === 40)
+            .length,
+          userBatchCount: calls?.userBatches.filter((size) => size === 40)
+            .length,
+        };
+      }),
+    )
+    .toEqual({ eventBatchCount: 1, userBatchCount: 1 });
 });
 
 test("does not select stale picker results when Enter outruns deferred filtering", async ({

--- a/desktop/tests/e2e/workflow-local-controls.spec.ts
+++ b/desktop/tests/e2e/workflow-local-controls.spec.ts
@@ -446,6 +446,67 @@ test("Escape closes a filter picker before its inspector", async ({ page }) => {
   }
 });
 
+test("does not select stale picker results when Enter outruns deferred filtering", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function",
+  );
+  await page.evaluate(() => {
+    window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "agents",
+      content: "Deferred message candidate",
+      id: "d".repeat(64),
+    });
+  });
+  await page.getByTestId("open-workflows-view").click();
+  await page.getByRole("button", { name: "Create Workflow" }).click();
+  const dialog = page.getByRole("dialog", { name: "Create workflow" });
+  const channelList = page.getByTestId("channel-combobox-list");
+  if (!(await channelList.isVisible())) {
+    await dialog.getByRole("combobox", { name: "Channel" }).click();
+  }
+  await channelList
+    .getByRole("option", { name: "agents", exact: true })
+    .click();
+  await selectTrigger(page, dialog, "Reaction Added");
+
+  await dialog.getByText("Author", { exact: true }).locator("..").click();
+  const authorSearch = dialog.getByRole("combobox", {
+    name: "Search authors or paste a public key",
+  });
+  await expect(dialog.getByRole("option").first()).toBeVisible();
+  await authorSearch.evaluate((input: HTMLInputElement) => {
+    input.value = "no-such-author";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }),
+    );
+  });
+
+  await dialog.getByText("Message", { exact: true }).locator("..").click();
+  const messageSearch = dialog.getByRole("combobox", {
+    name: "Search messages or paste a message ID",
+  });
+  await expect(
+    dialog.getByRole("option", { name: /Deferred message/ }),
+  ).toBeVisible();
+  await messageSearch.evaluate((input: HTMLInputElement) => {
+    input.value = "no-such-message";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }),
+    );
+  });
+
+  await dialog.getByRole("tab", { name: "YAML" }).click();
+  const definition = parseYaml(
+    await dialog.getByRole("textbox", { name: "Workflow YAML" }).inputValue(),
+  );
+  expect(definition.trigger.filter).toBeUndefined();
+});
+
 test("round-trips manual author and reaction message IDs through save and reopen", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/workflow-local-controls.spec.ts
+++ b/desktop/tests/e2e/workflow-local-controls.spec.ts
@@ -463,6 +463,9 @@ test("round-trips manual author and reaction message IDs through save and reopen
     name: "Search authors or paste a public key",
   });
   await authorSearch.fill(author);
+  await expect(
+    dialog.getByRole("option", { name: new RegExp(author.slice(0, 8)) }),
+  ).toBeVisible();
   await authorSearch.press("Enter");
   await expect(
     dialog.getByRole("option", { name: new RegExp(author.slice(0, 8)) }),
@@ -479,19 +482,28 @@ test("round-trips manual author and reaction message IDs through save and reopen
   await dialog.getByRole("tab", { name: "Form" }).click();
   await openTriggerInspector(dialog);
   await dialog.getByRole("button", { name: "Author pubkey" }).click();
-  await dialog
-    .getByRole("combobox", { name: "Search authors or paste a public key" })
-    .fill(author);
-  await dialog
-    .getByRole("combobox", { name: "Search authors or paste a public key" })
-    .press("Enter");
+  const correctedAuthorSearch = dialog.getByRole("combobox", {
+    name: "Search authors or paste a public key",
+  });
+  await correctedAuthorSearch.fill(author);
+  await expect(
+    dialog.getByRole("option", { name: new RegExp(author.slice(0, 8)) }),
+  ).toBeVisible();
+  await correctedAuthorSearch.press("Enter");
   await dialog
     .getByRole("group", { name: "Match" })
     .getByRole("button", { name: "is not", exact: true })
     .click();
 
   await dialog.getByRole("button", { name: "Message event ID" }).click();
-  await dialog.getByLabel("Message event ID").fill(messageId);
+  const messageSearch = dialog.getByRole("combobox", {
+    name: "Search messages or paste a message ID",
+  });
+  await messageSearch.fill(messageId);
+  await messageSearch.press("Enter");
+  await expect(
+    dialog.getByRole("option", { name: new RegExp(messageId.slice(0, 12)) }),
+  ).toHaveAttribute("aria-selected", "true");
 
   await dialog.getByRole("tab", { name: "YAML" }).click();
   const yamlEditor = dialog.getByRole("textbox", { name: "Workflow YAML" });
@@ -512,7 +524,11 @@ test("round-trips manual author and reaction message IDs through save and reopen
     reopened.getByRole("option", { name: new RegExp(author.slice(0, 8)) }),
   ).toHaveAttribute("aria-selected", "true");
   await reopened.getByRole("button", { name: "Message event ID" }).click();
-  await expect(reopened.getByLabel("Message event ID")).toHaveValue(messageId);
+  await expect(
+    reopened.getByRole("option", {
+      name: new RegExp(messageId.slice(0, 12)),
+    }),
+  ).toHaveAttribute("aria-selected", "true");
   await reopened.getByRole("tab", { name: "YAML" }).click();
   definition = parseYaml(
     await reopened.getByRole("textbox", { name: "Workflow YAML" }).inputValue(),

--- a/desktop/tests/e2e/workflow-local-controls.spec.ts
+++ b/desktop/tests/e2e/workflow-local-controls.spec.ts
@@ -428,7 +428,7 @@ test("Escape closes a filter picker before its inspector", async ({ page }) => {
 
     const dialog = page.getByRole("dialog", { name: "Create workflow" });
     const inspector = dialog.getByTestId("workflow-node-inspector");
-    await dialog.getByRole("button", { name: "Author pubkey" }).click();
+    await dialog.getByText("Author", { exact: true }).locator("..").click();
 
     const picker = dialog.getByTestId("workflow-author-picker");
     const search = dialog.getByRole("combobox", {
@@ -458,7 +458,7 @@ test("round-trips manual author and reaction message IDs through save and reopen
   await dialog.getByRole("button", { name: /^Trigger:/ }).click();
   await openTriggerInspector(dialog);
 
-  await dialog.getByRole("button", { name: "Author pubkey" }).click();
+  await dialog.getByText("Author", { exact: true }).locator("..").click();
   const authorResults = dialog.getByTestId("workflow-author-picker-results");
   await expect
     .poll(() =>
@@ -508,7 +508,7 @@ test("round-trips manual author and reaction message IDs through save and reopen
   await expect(dialog.getByRole("button", { name: "Create" })).toBeEnabled();
   await dialog.getByRole("tab", { name: "Form" }).click();
   await openTriggerInspector(dialog);
-  await dialog.getByRole("button", { name: "Author pubkey" }).click();
+  await dialog.getByText("Author", { exact: true }).locator("..").click();
   const correctedAuthorSearch = dialog.getByRole("combobox", {
     name: "Search authors or paste a public key",
   });
@@ -522,7 +522,7 @@ test("round-trips manual author and reaction message IDs through save and reopen
     .getByRole("button", { name: "is not", exact: true })
     .click();
 
-  await dialog.getByRole("button", { name: "Message event ID" }).click();
+  await dialog.getByText("Message", { exact: true }).locator("..").click();
   const messageSearch = dialog.getByRole("combobox", {
     name: "Search messages or paste a message ID",
   });
@@ -546,11 +546,11 @@ test("round-trips manual author and reaction message IDs through save and reopen
 
   const reopened = await reopenWorkflow(page, name);
   await openTriggerInspector(reopened);
-  await reopened.getByRole("button", { name: "Author pubkey" }).click();
+  await reopened.getByText("Author", { exact: true }).locator("..").click();
   await expect(
     reopened.getByRole("option", { name: new RegExp(author.slice(0, 8)) }),
   ).toHaveAttribute("aria-selected", "true");
-  await reopened.getByRole("button", { name: "Message event ID" }).click();
+  await reopened.getByText("Message", { exact: true }).locator("..").click();
   await expect(
     reopened.getByRole("option", {
       name: new RegExp(messageId.slice(0, 12)),
@@ -584,9 +584,10 @@ test("toggles selected author and message filters while preserving sibling condi
   await dialog.getByRole("tab", { name: "Form" }).click();
   await openTriggerInspector(dialog);
   const authorField = dialog
-    .getByRole("button", { name: "Author pubkey" })
+    .getByText("Author", { exact: true })
+    .locator("..")
     .locator("..");
-  await authorField.getByRole("button", { name: "Author pubkey" }).click();
+  await authorField.getByText("Author", { exact: true }).locator("..").click();
   const authorOption = dialog.getByRole("option", {
     name: new RegExp(author.slice(0, 8)),
   });
@@ -614,9 +615,13 @@ test("toggles selected author and message filters while preserving sibling condi
   await expect(authorSearch).toHaveValue(replacementAuthor);
 
   const messageField = dialog
-    .getByRole("button", { name: "Message event ID" })
+    .getByText("Message", { exact: true })
+    .locator("..")
     .locator("..");
-  await messageField.getByRole("button", { name: "Message event ID" }).click();
+  await messageField
+    .getByText("Message", { exact: true })
+    .locator("..")
+    .click();
   const messageSearch = dialog.getByRole("combobox", {
     name: "Search messages or paste a message ID",
   });

--- a/desktop/tests/e2e/workflow-local-controls.spec.ts
+++ b/desktop/tests/e2e/workflow-local-controls.spec.ts
@@ -419,6 +419,33 @@ test("renders deterministic trigger, step, and workflow-card summaries", async (
   ).toBeLessThan(0.5);
 });
 
+test("Escape closes a filter picker before its inspector", async ({ page }) => {
+  for (const width of [760, 1280]) {
+    await page.setViewportSize({ width, height: 820 });
+    await page.goto(
+      "/#/workflows?view=create&channel=94a444a4-c0a3-5966-ab05-530c6ddc2301&pane=trigger",
+    );
+
+    const dialog = page.getByRole("dialog", { name: "Create workflow" });
+    const inspector = dialog.getByTestId("workflow-node-inspector");
+    await dialog.getByRole("button", { name: "Author pubkey" }).click();
+
+    const picker = dialog.getByTestId("workflow-author-picker");
+    const search = dialog.getByRole("combobox", {
+      name: "Search authors or paste a public key",
+    });
+    await expect(picker).toBeVisible();
+
+    await search.press("Escape");
+    await expect(picker).toBeHidden();
+    await expect(inspector).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(inspector).toBeHidden();
+    await expect(dialog).toBeVisible();
+  }
+});
+
 test("round-trips manual author and reaction message IDs through save and reopen", async ({
   page,
 }) => {


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Workflow authors can discover people and messages while configuring trigger filters, then see readable enriched labels instead of raw identifiers.

**Problem:** Author and message filters required users to know and paste raw public keys or event IDs, and configured workflows surfaced those opaque values afterward. **Solution:** Add network-backed pickers and presentation enrichment while keeping deterministic local public-key and event-ID fallbacks authoritative whenever discovery is unavailable or untrusted.

Related issue: none found.

<details>
<summary>File changes</summary>

**desktop/src/features/workflows/ui/WorkflowAuthorPicker.tsx**
Adds channel-aware author discovery, profile search, keyboard navigation, loading states, and deterministic public-key fallback selection.

**desktop/src/features/workflows/ui/WorkflowCard.tsx**
Uses enriched trigger presentation when building the workflow card’s readable summary.

**desktop/src/features/workflows/ui/WorkflowDialog.tsx**
Keeps Escape scoped to an active filter picker before allowing the inspector or dialog to close.

**desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx**
Threads channel context into trigger filters and renders enriched author/message summaries in the workflow sequence.

**desktop/src/features/workflows/ui/WorkflowMessagePicker.tsx**
Adds paged channel-history discovery, message search, exact event lookup, profile labels, keyboard navigation, and bounded results.

**desktop/src/features/workflows/ui/WorkflowRichTriggerDescription.tsx**
Renders compact author identity details and loading presentation inside trigger summaries.

**desktop/src/features/workflows/ui/WorkflowTriggerConditions.tsx**
Connects author and message filter accordions to their pickers while preserving selected and excluded condition semantics.

**desktop/src/features/workflows/ui/useWorkflowAuthorPresentation.ts**
Resolves configured author keys to trusted display labels with deterministic fallbacks.

**desktop/src/features/workflows/ui/useWorkflowTriggerPresentation.ts**
Enriches configured message IDs only after validating the fetched event and channel.

**desktop/src/features/workflows/ui/workflowAuthorCandidates.test.mjs**
Covers author candidate normalization, ordering, deduplication, and fallback behavior.

**desktop/src/features/workflows/ui/workflowAuthorCandidates.ts**
Builds stable author candidates from channel members, profiles, and raw public keys.

**desktop/src/features/workflows/ui/workflowConditionExpression.ts**
Allows message IDs to participate in basic trigger-filter parsing.

**desktop/src/features/workflows/ui/workflowDefinition.ts**
Accepts enriched trigger text when generating workflow card labels.

**desktop/src/features/workflows/ui/workflowMessageCandidates.test.mjs**
Covers event validation, source merging, deterministic ordering, and exact-lookup enrichment boundaries.

**desktop/src/features/workflows/ui/workflowMessageCandidates.ts**
Validates message candidates by event kind, channel, and exact event ID before permitting enrichment.

**desktop/src/features/workflows/ui/workflowTriggerDescription.test.mjs**
Covers readable selected/excluded author and message descriptions plus loading fallbacks.

**desktop/src/features/workflows/ui/workflowTriggerDescription.ts**
Builds concise enriched trigger descriptions while retaining stable raw-ID fallbacks.

**desktop/tests/e2e/workflow-local-controls.spec.ts**
Exercises picker discovery, selection toggles, Escape ownership, bounded scrolling, and enriched workflow summaries.

</details>

## Reproduction steps

1. Open Workflows and create a workflow for a channel with members and message history.
2. Choose **Reaction Added** as the trigger and expand **Author**.
3. Confirm channel members and fetched profile results are discoverable, searchable, and keyboard accessible; choose one.
4. Expand **Message**, confirm recent channel messages appear in a bounded list, and choose one.
5. Toggle either selected filter between **is** and **is not**, then collapse the inspector and confirm the sequence summary stays readable.
6. Add a send-message step and create the workflow; confirm its card uses the resolved author and message labels.
7. Repeat while discovery is unavailable and confirm raw public keys/event IDs remain selectable and authoritative.

## Screenshots

### Author discovery

![Author picker showing discoverable channel members and profile labels](https://raw.githubusercontent.com/block/buzz/df47bdab841e0f52eb1f4ea9ac4e70aa16d240e0/pr-6712--01-author-discovery.png)

### Message discovery

![Message picker showing bounded channel history discovery](https://raw.githubusercontent.com/block/buzz/df47bdab841e0f52eb1f4ea9ac4e70aa16d240e0/pr-6712--02-message-discovery.png)

### Selected filter summaries

![Workflow builder showing readable selected author and message filters](https://raw.githubusercontent.com/block/buzz/df47bdab841e0f52eb1f4ea9ac4e70aa16d240e0/pr-6712--03-selected-filter-summaries.png)

### Enriched workflow card

![Workflow card showing enriched author and message labels](https://raw.githubusercontent.com/block/buzz/df47bdab841e0f52eb1f4ea9ac4e70aa16d240e0/pr-6712--04-enriched-workflow-card.png)
