### PR TITLE
fix(desktop): render diff replies (kind 40008) in forum threads

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
         "**/identity-key-help.spec.ts",
         "**/key-import-reveal.spec.ts",
         "**/navigation.spec.ts",
+        "**/forum-diff.spec.ts",
         "**/channels.spec.ts",
         "**/channel-shared-header-backdrop.spec.ts",
         "**/channel-composer-overflow.spec.ts",

--- a/desktop/src-tauri/src/commands/messages/forum.rs
+++ b/desktop/src-tauri/src/commands/messages/forum.rs
@@ -1,3 +1,4 @@
+use buzz_core_pkg::kind::KIND_STREAM_MESSAGE_DIFF;
 use tauri::State;
 
 use crate::{
@@ -212,14 +213,15 @@ pub async fn get_forum_thread(
     state: State<'_, AppState>,
 ) -> Result<ForumThreadResponse, String> {
     let _ = (limit, cursor);
-    // Two filters: the root event itself, plus any reply (kinds 9/45003)
-    // that references it via #e.
+    // Two filters: the root event itself, plus any reply (kinds 9/40008/45003)
+    // that references it via #e. Diff replies (40008) render as their own card
+    // in the thread, the same way they do in a stream timeline.
     let events = query_relay(
         &state,
         &[
             serde_json::json!({ "ids": [event_id.clone()], "kinds": [9, 40002, 45001, 45003] }),
             serde_json::json!({
-                "kinds": [9, 45003],
+                "kinds": [9, KIND_STREAM_MESSAGE_DIFF, 45003],
                 "#e": [event_id.clone()],
                 "#h": [channel_id.clone()],
             }),

--- a/desktop/src/features/forum/ui/ForumThreadPanel.tsx
+++ b/desktop/src/features/forum/ui/ForumThreadPanel.tsx
@@ -16,11 +16,19 @@ import { Button } from "@/shared/ui/button";
 import { parseImetaTags } from "@/shared/ui/markdown/parseImeta";
 import { Markdown } from "@/shared/ui/markdown";
 import { hasLinkPreviewSuppression } from "@/features/messages/lib/formatTimelineMessages";
+import { KIND_STREAM_MESSAGE_DIFF } from "@/shared/constants/kinds";
 import { Skeleton } from "@/shared/ui/skeleton";
 
 import { formatRelativeTime } from "../lib/time";
 import { DeleteActionMenu } from "./DeleteActionMenu";
 import { ForumComposer } from "./ForumComposer";
+
+const DiffMessage = React.lazy(
+  () => import("@/features/messages/ui/DiffMessage"),
+);
+const DiffMessageExpanded = React.lazy(
+  () => import("@/features/messages/ui/DiffMessageExpanded"),
+);
 
 type ForumThreadPanelProps = {
   thread: ForumThreadResponse | undefined;
@@ -77,6 +85,10 @@ function ReplyRow({
     mentionNames: replyMentionNames,
     mentionPubkeysByName: replyMentionPubkeysByName,
   } = resolveMentionProps(reply.tags, profiles);
+  const [diffExpanded, setDiffExpanded] = React.useState(false);
+  const isDiff = reply.kind === KIND_STREAM_MESSAGE_DIFF;
+  const getTag = (name: string) =>
+    reply.tags.find((tag) => tag[0] === name)?.[1];
 
   return (
     <div
@@ -112,18 +124,57 @@ function ReplyRow({
         ) : null}
       </div>
       <div className="mt-1.5 pl-8">
-        <Markdown
-          channelNames={channelNames}
-          className="text-sm"
-          content={reply.content}
-          messageId={reply.eventId}
-          linkPreviewsSuppressed={hasLinkPreviewSuppression(reply.tags)}
-          linkPreviewTags={reply.tags}
-          imetaByUrl={parseImetaTags(reply.tags)}
-          mentionNames={replyMentionNames}
-          mentionPubkeysByName={replyMentionPubkeysByName}
-        />
+        {isDiff ? (
+          <React.Suspense
+            fallback={
+              <div className="p-3 text-sm text-muted-foreground">
+                Loading diff…
+              </div>
+            }
+          >
+            <DiffMessage
+              commitSha={getTag("commit")}
+              content={reply.content}
+              description={getTag("description")}
+              filePath={getTag("file")}
+              onExpand={() => {
+                setDiffExpanded(true);
+              }}
+              repoUrl={getTag("repo")}
+              truncated={getTag("truncated") === "true"}
+            />
+          </React.Suspense>
+        ) : (
+          <Markdown
+            channelNames={channelNames}
+            className="text-sm"
+            content={reply.content}
+            messageId={reply.eventId}
+            linkPreviewsSuppressed={hasLinkPreviewSuppression(reply.tags)}
+            linkPreviewTags={reply.tags}
+            imetaByUrl={parseImetaTags(reply.tags)}
+            mentionNames={replyMentionNames}
+            mentionPubkeysByName={replyMentionPubkeysByName}
+          />
+        )}
       </div>
+      {isDiff && diffExpanded ? (
+        <React.Suspense
+          fallback={
+            <div className="p-3 text-sm text-muted-foreground">
+              Loading diff viewer…
+            </div>
+          }
+        >
+          <DiffMessageExpanded
+            content={reply.content}
+            filePath={getTag("file")}
+            onClose={() => {
+              setDiffExpanded(false);
+            }}
+          />
+        </React.Suspense>
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -52,6 +52,7 @@ import {
   KIND_PROJECT_ANNOUNCEMENT,
   KIND_REPO_ANNOUNCEMENT,
   KIND_REPO_STATE,
+  KIND_STREAM_MESSAGE_DIFF,
   KIND_STREAM_MESSAGE_EDIT,
   KIND_SYSTEM_MESSAGE,
   KIND_TEXT_NOTE,
@@ -4992,8 +4993,15 @@ async function handleGetForumThread(args: {
     throw new Error(`Mock forum thread not found: ${args.eventId}`);
   }
 
+  // Mirrors the real `get_forum_thread` reply filter (kinds 9/40008/45003) in
+  // desktop/src-tauri/src/commands/messages/forum.rs — keep the two in sync.
   const replies = events
-    .filter((event) => event.kind === 45003)
+    .filter(
+      (event) =>
+        event.kind === 45003 ||
+        event.kind === 9 ||
+        event.kind === KIND_STREAM_MESSAGE_DIFF,
+    )
     .filter((event) => {
       const thread = getThreadReferenceFromTags(event.tags);
       return (thread.rootEventId ?? thread.parentEventId) === root.id;

--- a/desktop/tests/e2e/forum-diff.spec.ts
+++ b/desktop/tests/e2e/forum-diff.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+const WATERCOOLER_CHANNEL_ID = "a27e1ee9-76a6-5bdf-a5d5-1d85610dad11";
+const FORUM_POST_ID = "mock-forum-release-thread";
+
+const DIFF_CONTENT = `diff --git a/src/hive.ts b/src/hive.ts
+index 1111111..2222222 100644
+--- a/src/hive.ts
++++ b/src/hive.ts
+@@ -1,3 +1,3 @@
+ export function hive() {
+-  return "old";
++  return "new";
+ }
+`;
+
+test.beforeEach(async ({ page }) => {
+  await installMockBridge(page);
+});
+
+/**
+ * Seeds a kind-40008 diff reply on the seeded forum thread and opens the
+ * thread scrolled to it. The thread carries 25 seeded replies and rows use
+ * `content-visibility: auto`, so the reply must be deep-linked by id rather
+ * than searched for at the bottom of the list.
+ */
+async function openThreadAtDiffReply(
+  page: import("@playwright/test").Page,
+  extraTags: string[][],
+) {
+  await page.goto("/");
+
+  // The bridge installs its emit hook after navigation settles; without this
+  // wait the evaluate below can run against a window that has no hook yet.
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function",
+  );
+
+  const replyId = await page.evaluate(
+    ({ parentEventId, content, tags }) => {
+      const event = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "watercooler",
+        content,
+        kind: 40008,
+        parentEventId,
+        extraTags: tags,
+      });
+      return event?.id ?? null;
+    },
+    { parentEventId: FORUM_POST_ID, content: DIFF_CONTENT, tags: extraTags },
+  );
+
+  expect(replyId).toBeTruthy();
+
+  await page.goto(
+    `/#/channels/${WATERCOOLER_CHANNEL_ID}/posts/${FORUM_POST_ID}?replyId=${replyId}`,
+  );
+
+  await expect(page.getByTestId("chat-title")).toHaveText("watercooler");
+}
+
+// Diffs (kind 40008) used to be fetched only by the stream timeline, so a diff
+// posted into a forum thread was stored but invisible. The thread reply filter
+// now includes 40008 and ReplyRow renders it through DiffMessage.
+test("forum threads render a diff reply as a diff card", async ({ page }) => {
+  await openThreadAtDiffReply(page, [
+    ["repo", "https://github.com/block/buzz"],
+    ["commit", "abcdef1234567890abcdef1234567890abcdef12"],
+    ["file", "src/hive.ts"],
+    ["description", "Return the new value"],
+  ]);
+
+  // The diff card chrome — file path, short SHA, description, expand control —
+  // only exists on the DiffMessage path. Markdown rendering would show the raw
+  // `diff --git` text instead.
+  await expect(page.getByText("src/hive.ts").first()).toBeVisible();
+  await expect(page.getByText("abcdef1").first()).toBeVisible();
+  await expect(page.getByText("Return the new value")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Expand diff" })).toBeVisible();
+});
+
+test("expanding a forum diff reply opens the full diff viewer", async ({
+  page,
+}) => {
+  await openThreadAtDiffReply(page, [["file", "src/hive.ts"]]);
+
+  await page.getByRole("button", { name: "Expand diff" }).click();
+
+  await expect(page.getByRole("dialog")).toBeVisible();
+});


### PR DESCRIPTION
## Summary

A code diff posted as a reply in a forum thread was signed, accepted by the relay, and threaded correctly — but never rendered. The forum surface dropped it on the floor.

`get_forum_thread` fetched replies with `kinds: [9, 45003]`, so kind 40008 (`KIND_STREAM_MESSAGE_DIFF`) was never returned for a forum thread. 40008 appears only in `CHANNEL_TIMELINE_CONTENT_KINDS`, which the stream timeline uses. That contradicts "one event log, one search index, three lenses" (`VISION.md`), and `VISION_PROJECTS.md` opens on a co-maintainer reviewing a diff inline.

This adds 40008 to the forum thread reply filter and gives `ReplyRow` the same kind dispatch `MessageRow` already has, so a diff reply renders as the same collapsed-by-default `DiffMessage` card, expanding to the full `DiffViewer` with per-file syntax highlighting.

| File | Change |
|---|---|
| `desktop/src-tauri/src/commands/messages/forum.rs` | `get_forum_thread` reply filter becomes `[9, KIND_STREAM_MESSAGE_DIFF, 45003]` |
| `desktop/src/features/forum/ui/ForumThreadPanel.tsx` | `ReplyRow` renders 40008 via the lazily-loaded `DiffMessage`, with local expand state driving `DiffMessageExpanded`; all other kinds keep the existing `Markdown` path |
| `desktop/src/testing/e2eBridge.ts` | The mock `get_forum_thread` hardcoded the old `kind === 45003` filter and would have silently diverged from the backend — updated in lockstep |
| `desktop/tests/e2e/forum-diff.spec.ts` | New spec, registered in the smoke project in `playwright.config.ts` |

Relay behavior was probed directly rather than inferred from the client: a throwaway private forum channel with a 45001 root and a `buzz messages send-diff` reply came back as

```
45001 4a2d84db99  e-tags: []
40008 55f42f6db6  e-tags: [["e","4a2d84db99…","","reply"]]
```

So the relay already accepts and threads 40008 under a 45001 root. This was purely a client fetch-and-render gap.

### Related issue

None found. Searched open issues and PRs for `forum diff` and `40008` — the nearby forum PRs (#5936, #5287, #5945, #5925) are all ACP mention-dispatch or CLI kind-selection, not forum rendering. Closest is #5388 (agent messages not appearing in channel feeds), which is a different surface.

### Testing

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `biome lint` | 2 warnings, both pre-existing in files not touched here |
| desktop unit tests | 5393 passed, 0 failed |
| `forum-diff.spec.ts`, `--repeat-each=2` | 4 passed |
| navigation + channels + virtualization e2e | 117 passed, 1 skipped (pre-existing `test.fixme`) |
| `just desktop-tauri-fmt-check` | passed |

The adjacent e2e specs were run because the mock-bridge change alters forum thread reply counts, which those specs assert on.

No screenshot: the rendered card is the existing `DiffMessage` component unchanged — this PR only changes which surface reaches it. The new e2e spec asserts the card chrome (file path, short SHA, description, expand control) and that the expand control opens the full viewer.

Out of scope: forum topic-card reply counts. `forum_message_from_event` hardcodes `reply_count: 0`; where that number should come from is a separate question.
