### PR TITLE
docs(security): route reports through private advisories

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -4,6 +4,10 @@ about: Report a reproducible bug in Buzz
 labels: bug
 ---
 
+> [!IMPORTANT]
+> Do not include security vulnerabilities in a public issue. [Report them
+> privately through a GitHub security advisory](https://github.com/block/buzz/security/advisories/new).
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/block/buzz/security/advisories/new
+    about: Report security vulnerabilities privately to the Buzz maintainers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,10 @@ get from zero to a merged pull request.
 
 If you have questions that aren't answered here, [open an issue](https://github.com/block/buzz/issues/new).
 
+If you believe you found a security vulnerability, do not open a public issue.
+Follow our [security policy](SECURITY.md) to submit a private vulnerability
+report instead.
+
 ---
 
 ## Table of Contents

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,24 @@
 
 ## Reporting a Vulnerability
 
-**Please do not report security vulnerabilities through public GitHub issues.**
+**Do not report security vulnerabilities through a public GitHub issue, pull
+request, discussion, or other public channel.**
 
-If you discover a security vulnerability in Buzz, please report it by emailing
-**buzz@block.xyz**. Include as much detail as possible:
+Use GitHub's private vulnerability reporting form instead:
+
+**[Report a vulnerability privately](https://github.com/block/buzz/security/advisories/new)**
+
+Submitting the form starts a private security advisory with the Buzz
+maintainers. Use that advisory for vulnerability details, follow-up questions,
+and coordinated remediation. Include as much detail as possible:
 
 - A description of the vulnerability and its potential impact
 - Steps to reproduce or a proof-of-concept (if available)
 - The affected version(s) or commit range
 - Any suggested mitigations you've identified
+
+If GitHub's private reporting form is unavailable to you, email
+**buzz@block.xyz** and do not include vulnerability details in a public issue.
 
 You will receive an acknowledgment within **48 hours**. We aim to provide a
 full response — including a timeline for a fix — within **7 days** of initial
@@ -121,4 +130,6 @@ We use `cargo audit` in CI to scan for known vulnerabilities in dependencies.
 ## Disclosure Policy
 
 We follow [coordinated disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure).
-Reporters will be credited unless they request anonymity.
+We use the private advisory to coordinate validation, remediation, and
+disclosure with the reporter. Reporters will be credited unless they request
+anonymity.


### PR DESCRIPTION
Routes security researchers to GitHub's private vulnerability reporting workflow instead of a public issue or email-first disclosure.

- Makes the private advisory form the primary path in `SECURITY.md`, with email retained as a fallback.
- Adds private-reporting links to the contributor guide, issue chooser, and bug template.

Checked with `git diff --check`, Ruby YAML parsing, and confirmation that private vulnerability reporting is enabled for `block/buzz`.
