### PR TITLE
fix(desktop): space add-agent teams section

### DIFF
--- a/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
@@ -231,7 +231,7 @@ export function AddChannelBotDialog({
         footerClassName="justify-end gap-2"
         footerTestId="add-channel-bot-dialog-footer"
         headerTestId="add-channel-bot-dialog-header"
-        scrollAreaClassName="space-y-5"
+        contentClassName="space-y-5"
         scrollAreaTestId="add-channel-bot-dialog-scroll-area"
         title="Add agents"
       >

--- a/desktop/tests/e2e/welcome-agent-modal-screenshots.spec.ts
+++ b/desktop/tests/e2e/welcome-agent-modal-screenshots.spec.ts
@@ -257,36 +257,6 @@ test.describe("welcome and channel agent entry points", () => {
     await dialog.screenshot({ path: `${SHOTS}/03-agents-available.png` });
   });
 
-  test("teams are visually separated from the agent controls", async ({
-    page,
-  }) => {
-    await page.setViewportSize({ width: 1212, height: 512 });
-    await installMockBridge(page, {
-      personas: [scoutPersona, editorPersona],
-      teams: [
-        {
-          id: "research-team",
-          name: "Research team",
-          personaIds: [scoutPersona.id, editorPersona.id],
-        },
-      ],
-    });
-    const dialog = await openAgentPicker(page);
-    const createAgent = dialog.getByTestId("add-channel-create-agent");
-    const teamsHeading = dialog.getByText("Teams", { exact: true });
-
-    const createAgentBox = await createAgent.boundingBox();
-    const teamsHeadingBox = await teamsHeading.boundingBox();
-    expect(createAgentBox).not.toBeNull();
-    expect(teamsHeadingBox).not.toBeNull();
-    expect(
-      (teamsHeadingBox?.y ?? 0) -
-        ((createAgentBox?.y ?? 0) + (createAgentBox?.height ?? 0)),
-    ).toBeGreaterThanOrEqual(20);
-
-    await dialog.screenshot({ path: `${SHOTS}/04-teams-spacing.png` });
-  });
-
   test("all personal agents are already in the channel", async ({ page }) => {
     await installMockBridge(page, {
       activePersonaIds: ["builtin:fizz"],

--- a/desktop/tests/e2e/welcome-agent-modal-screenshots.spec.ts
+++ b/desktop/tests/e2e/welcome-agent-modal-screenshots.spec.ts
@@ -257,6 +257,36 @@ test.describe("welcome and channel agent entry points", () => {
     await dialog.screenshot({ path: `${SHOTS}/03-agents-available.png` });
   });
 
+  test("teams are visually separated from the agent controls", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1212, height: 512 });
+    await installMockBridge(page, {
+      personas: [scoutPersona, editorPersona],
+      teams: [
+        {
+          id: "research-team",
+          name: "Research team",
+          personaIds: [scoutPersona.id, editorPersona.id],
+        },
+      ],
+    });
+    const dialog = await openAgentPicker(page);
+    const createAgent = dialog.getByTestId("add-channel-create-agent");
+    const teamsHeading = dialog.getByText("Teams", { exact: true });
+
+    const createAgentBox = await createAgent.boundingBox();
+    const teamsHeadingBox = await teamsHeading.boundingBox();
+    expect(createAgentBox).not.toBeNull();
+    expect(teamsHeadingBox).not.toBeNull();
+    expect(
+      (teamsHeadingBox?.y ?? 0) -
+        ((createAgentBox?.y ?? 0) + (createAgentBox?.height ?? 0)),
+    ).toBeGreaterThanOrEqual(20);
+
+    await dialog.screenshot({ path: `${SHOTS}/04-teams-spacing.png` });
+  });
+
   test("all personal agents are already in the channel", async ({ page }) => {
     await installMockBridge(page, {
       activePersonaIds: ["builtin:fizz"],


### PR DESCRIPTION
## Summary

- apply the add-agent dialog's intended section spacing to the inner content wrapper
- preserve a 20px gap above the Teams heading with a viewport-specific Playwright regression check


Before
![BEFORE-prefix-0px](https://raw.githubusercontent.com/block/buzz/de9a73fa36e2eaa8a99bc393e58b3166ee87d267/pr-6743--BEFORE-prefix-0px.png)

After
![AFTER-scrolled-20px](https://raw.githubusercontent.com/block/buzz/de9a73fa36e2eaa8a99bc393e58b3166ee87d267/pr-6743--AFTER-scrolled-20px.png)



### Related issue

None found.

Originating Buzz thread: `buzz://message?channel=dc957be2-2e2a-4f91-a64d-33920591bc8e&id=f79882f1eece0dadc9894834ad6693dd93b1cb8f15758168098263b2e1b8c2f8`

### Testing

- `pnpm --dir desktop run build:e2e`
- `pnpm --dir desktop test` (5,452 passed)
- `playwright test tests/e2e/welcome-agent-modal-screenshots.spec.ts --project=smoke` (7 passed)
- independently verified by PI Montgomery at 1212x512: 0px before, 20px after
