### PR TITLE
ci: check PR bodies for relay image URLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
         run: scripts/test-release-ref-contract.sh
       - name: Relay image eligibility contract
         run: scripts/test-relay-image-eligibility-workflow.sh
+      - name: PR image URL event contract
+        run: scripts/test-pr-image-url-event.sh
       - name: Desktop release candidate contract
         run: scripts/test-desktop-release-candidate.sh
       - name: OSS desktop promotion contract

--- a/.github/workflows/pr-image-urls.yml
+++ b/.github/workflows/pr-image-urls.yml
@@ -2,7 +2,7 @@ name: PR Image URLs
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-image-urls.yml
+++ b/.github/workflows/pr-image-urls.yml
@@ -1,0 +1,23 @@
+name: PR Image URLs
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check PR image URLs
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      # pull_request_target has a privileged context. Check out only the trusted
+      # base commit and never execute code from the pull request branch.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+      - name: Check pull request body
+        run: scripts/check-pr-image-urls-event.sh

--- a/scripts/check-pr-image-urls-event.sh
+++ b/scripts/check-pr-image-urls-event.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${GITHUB_EVENT_PATH:-}" ]]; then
+  echo "error: GITHUB_EVENT_PATH is required" >&2
+  exit 1
+fi
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+markdown_file=$(mktemp)
+trap 'rm -f "$markdown_file"' EXIT
+
+jq -er '
+  if (.pull_request | type) != "object" then
+    error("event does not contain a pull_request object")
+  elif .pull_request.body == null then
+    ""
+  elif (.pull_request.body | type) == "string" then
+    .pull_request.body
+  else
+    error("pull_request.body must be a string or null")
+  end
+' "$GITHUB_EVENT_PATH" >"$markdown_file"
+
+"$script_dir/check-pr-image-urls.sh" "$markdown_file"

--- a/scripts/check-pr-image-urls-event.sh
+++ b/scripts/check-pr-image-urls-event.sh
@@ -10,10 +10,14 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 markdown_file=$(mktemp)
 trap 'rm -f "$markdown_file"' EXIT
 
+if ! jq -e '(.pull_request | type) == "object"' "$GITHUB_EVENT_PATH" \
+  >/dev/null 2>&1; then
+  echo "error: event does not contain a pull_request object" >&2
+  exit 1
+fi
+
 jq -er '
-  if (.pull_request | type) != "object" then
-    error("event does not contain a pull_request object")
-  elif .pull_request.body == null then
+  if .pull_request.body == null then
     ""
   elif (.pull_request.body | type) == "string" then
     .pull_request.body

--- a/scripts/test-pr-image-url-event.sh
+++ b/scripts/test-pr-image-url-event.sh
@@ -27,4 +27,16 @@ GITHUB_EVENT_PATH="$test_tmp/good-event.json" "$checker"
 jq -n '{pull_request: {body: null}}' >"$test_tmp/empty-event.json"
 GITHUB_EVENT_PATH="$test_tmp/empty-event.json" "$checker"
 
+jq -n '{workflow_dispatch: {}}' >"$test_tmp/non-pr-event.json"
+if GITHUB_EVENT_PATH="$test_tmp/non-pr-event.json" "$checker" \
+  >"$test_tmp/non-pr-output" 2>&1; then
+  echo "PR event checker accepted an event without a pull_request object" >&2
+  exit 1
+fi
+expected_non_pr_error="error: event does not contain a pull_request object"
+if [[ "$(<"$test_tmp/non-pr-output")" != "$expected_non_pr_error" ]]; then
+  echo "PR event checker did not emit the expected non-PR event error" >&2
+  exit 1
+fi
+
 echo "PR image URL event test passed"

--- a/scripts/test-pr-image-url-event.sh
+++ b/scripts/test-pr-image-url-event.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+checker="$repo_root/scripts/check-pr-image-urls-event.sh"
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+bad_url="https://buzz.example.com/media/$(printf 'a%.0s' {1..64}).png"
+bad_body="Screenshot: ![broken]($bad_url)"$'\n'"\$(touch \"$test_tmp/injected\")"
+jq -n --arg body "$bad_body" \
+  '{pull_request: {body: $body}}' >"$test_tmp/bad-event.json"
+
+if GITHUB_EVENT_PATH="$test_tmp/bad-event.json" "$checker" \
+  >"$test_tmp/bad-output" 2>&1; then
+  echo "PR event checker accepted a relay media URL" >&2
+  exit 1
+fi
+grep -Fq "$bad_url" "$test_tmp/bad-output"
+grep -Fq "scripts/post-screenshots.sh" "$test_tmp/bad-output"
+[[ ! -e "$test_tmp/injected" ]]
+
+jq -n --arg body 'Screenshot: ![safe](https://github.com/user-attachments/assets/example)' \
+  '{pull_request: {body: $body}}' >"$test_tmp/good-event.json"
+GITHUB_EVENT_PATH="$test_tmp/good-event.json" "$checker"
+
+jq -n '{pull_request: {body: null}}' >"$test_tmp/empty-event.json"
+GITHUB_EVENT_PATH="$test_tmp/empty-event.json" "$checker"
+
+echo "PR image URL event test passed"


### PR DESCRIPTION
## Summary

- Enforce the existing PR image URL guard whenever a pull request body can change.
- Read the body from GitHub's event JSON and pass it to the existing checker as data, without evaluating contributor-controlled text.
- Run only trusted base-branch code in the `pull_request_target` workflow, with read-only contents permission, a SHA-pinned checkout, and persisted credentials disabled.
- Add regression coverage for rejected relay media URLs, accepted GitHub attachments, empty bodies, non-PR events, and shell-shaped input.

### Related issue

Fixes #6726.

### Required-check status

The repository's active default-branch ruleset does not currently list `Check PR image URLs` as a required status check, so the new workflow is advisory until that repository setting is updated. Maintainer follow-up after merge: add `Check PR image URLs` to the required checks for the default branch.

The contract test remains part of `ci.yml`, but that verifies the checker integration rather than enforcing each PR body's current content.

### Untrusted-input coverage

The shell-injection fixture places a literal `$(touch "...")` expression in the PR body and asserts that the target file is never created. The body itself is extracted by `jq` into a temporary Markdown file; only that generated file path is passed to the checker, so PR text is not evaluated or supplied as command-line arguments.

### Testing

- `just ci`
- `./scripts/test-pr-image-url-event.sh`
- `actionlint .github/workflows/pr-image-urls.yml`
- `shellcheck scripts/check-pr-image-urls-event.sh scripts/test-pr-image-url-event.sh scripts/check-pr-image-urls.sh`

No screenshots: this is a CI-only change.
