### PR TITLE
fix(mobile): skip thread tail jumps that retrigger iOS bounce

### DIFF
--- a/mobile/lib/features/channels/thread_detail_helpers.dart
+++ b/mobile/lib/features/channels/thread_detail_helpers.dart
@@ -9,9 +9,23 @@ part of 'thread_detail_page.dart';
 bool threadTailCorrectionReachedEnd({
   required bool tailIsVisible,
   required double? extentAfter,
-}) =>
-    tailIsVisible ||
-    (extentAfter != null && extentAfter <= _threadTailScrollTolerance);
+}) => tailIsVisible || threadScrollPositionIsAtTail(extentAfter);
+
+/// Whether the thread scroll position is already at its max extent.
+///
+/// On iOS bouncing physics, `jumpTo(maxScrollExtent)` / `animateTo` at that
+/// offset restarts rubber-banding even when pixels do not change. Short
+/// threads on iPhone show that as a continuous header jank.
+@visibleForTesting
+bool threadScrollPositionIsAtTail(double? extentAfter) =>
+    extentAfter != null && extentAfter <= _threadTailScrollTolerance;
+
+bool _jumpThreadScrollPositionToTail(ScrollPosition position) {
+  if (!position.hasContentDimensions) return false;
+  if (threadScrollPositionIsAtTail(position.extentAfter)) return true;
+  position.jumpTo(position.maxScrollExtent);
+  return true;
+}
 
 int _threadTailIndex(int replyCount) => replyCount;
 

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -341,20 +341,18 @@ class ThreadDetailPage extends HookConsumerWidget {
 
     bool jumpActiveScrollPositionToTail() {
       final position = activeThreadScrollPosition.value;
-      if (position == null || !position.hasContentDimensions) return false;
-      // Move the one active viewport to its exact end. Unlike indexed
-      // jumpTo/scrollTo, this does not reset or cross-fade through a second
-      // list, so iOS never exposes the intermediate top-of-thread frame.
-      position.jumpTo(position.maxScrollExtent);
-      return true;
+      if (position == null) return false;
+      // Indexed jumpTo/scrollTo can cross-fade a second list and flash the
+      // thread head. Directly moving this position does not.
+      return _jumpThreadScrollPositionToTail(position);
     }
 
     Future<bool> animateActiveScrollPositionToTail() async {
       final position = activeThreadScrollPosition.value;
       if (position == null || !position.hasContentDimensions) return false;
-      if (MediaQuery.disableAnimationsOf(context)) {
-        position.jumpTo(position.maxScrollExtent);
-        return true;
+      if (threadScrollPositionIsAtTail(position.extentAfter) ||
+          MediaQuery.disableAnimationsOf(context)) {
+        return _jumpThreadScrollPositionToTail(position);
       }
       // Match the channel's visible Latest glide while moving only the active
       // thread viewport. The indexed-list animation path can create a temporary
@@ -384,7 +382,13 @@ class ThreadDetailPage extends HookConsumerWidget {
         isAtThreadTail.value = threadTailIsVisible();
         return;
       }
-      final reachedTail = threadTailIsVisible();
+      final position = activeThreadScrollPosition.value;
+      final reachedTail = threadTailCorrectionReachedEnd(
+        tailIsVisible: threadTailIsVisible(),
+        extentAfter: position != null && position.hasContentDimensions
+            ? position.extentAfter
+            : null,
+      );
       // Lazy children can revise maxScrollExtent for several frames. Keep
       // moving the same active position until the measured tail is visible;
       // the cap only guards pathological layouts that never stabilize.
@@ -403,17 +407,7 @@ class ThreadDetailPage extends HookConsumerWidget {
       tailCorrectionInProgress.value = false;
       isNavigatingToThreadTail.value = false;
       if (revealViewport) initialViewportReady.value = true;
-      // Item positions can trail the ScrollPosition by a frame after an
-      // animated jump. Once the bounded lazy-layout correction is exhausted,
-      // trust an exact end-of-scroll position too: there is nowhere further
-      // for Latest to navigate, so leaving the control visible is misleading.
-      final position = activeThreadScrollPosition.value;
-      isAtThreadTail.value = threadTailCorrectionReachedEnd(
-        tailIsVisible: reachedTail,
-        extentAfter: position != null && position.hasContentDimensions
-            ? position.extentAfter
-            : null,
-      );
+      isAtThreadTail.value = reachedTail;
     }
 
     void correctThreadTailInstantly() {
@@ -752,6 +746,12 @@ class ThreadDetailPage extends HookConsumerWidget {
                       0.005 ||
                   (headIsVisible &&
                       anchorPosition.itemLeadingEdge < targetAlignment))) {
+            return;
+          }
+          final scrollPosition = activeThreadScrollPosition.value;
+          if (scrollPosition != null &&
+              scrollPosition.hasContentDimensions &&
+              threadScrollPositionIsAtTail(scrollPosition.extentAfter)) {
             return;
           }
           // This runs once after Android's frame-by-frame IME metrics settle.

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -9376,6 +9376,93 @@ void main() {
       );
     });
 
+    testWidgets(
+      'short thread does not rubber-band after idle layout and viewport jitter',
+      (tester) async {
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+
+        final rootEvent = _textMsg(
+          id: 'thread-root',
+          pubkey: 'alice',
+          content: 'A short thread',
+          createdAt: 1000,
+        );
+        final replyEvent = _textMsg(
+          id: 'reply-0',
+          pubkey: 'bob',
+          content: 'Short reply',
+          createdAt: 1100,
+          extraTags: const [
+            ['e', 'thread-root', '', 'reply'],
+          ],
+        );
+
+        await tester.pumpWidget(
+          _buildTestable(
+            messages: [rootEvent, replyEvent],
+            threadReplies: {
+              'thread-root': [replyEvent],
+            },
+            users: const {
+              'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+              'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final threadHead = formatTimeline([rootEvent]).single;
+        Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
+          MaterialPageRoute<void>(
+            builder: (_) => ThreadDetailPage(
+              threadHead: threadHead,
+              allMessages: formatTimeline([rootEvent, replyEvent]),
+              channelId: _channelId,
+              currentPubkey: 'self',
+              isMember: true,
+              isArchived: false,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final head = find.byKey(
+          const ValueKey('thread-message-group-thread-root'),
+        );
+        final list = find.descendant(
+          of: find.byKey(const ValueKey('thread-message-list')),
+          matching: find.byType(Scrollable),
+        );
+        final initialHeadY = tester.getTopLeft(head).dy;
+        final scrollable = tester.state<ScrollableState>(list.first);
+        final initialPixels = scrollable.position.pixels;
+        expect(scrollable.position.extentAfter, lessThanOrEqualTo(0.5));
+
+        tester.view.viewInsets = const FakeViewPadding(bottom: 1);
+        await tester.pump();
+        tester.view.viewInsets = FakeViewPadding.zero;
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 250));
+        await tester.pump(const Duration(milliseconds: 250));
+
+        expect(
+          tester.getTopLeft(head).dy,
+          closeTo(initialHeadY, 1),
+          reason:
+              'Idle layout and inset jitter must not restart rubber-banding '
+              'on a short thread already at its tail.',
+        );
+        expect(
+          scrollable.position.pixels,
+          closeTo(initialPixels, 0.5),
+          reason: 'Already-at-tail jumpTo must be a no-op.',
+        );
+        expect(scrollable.position.isScrollingNotifier.value, isFalse);
+      },
+    );
+
     for (final replyCount in [0, 1]) {
       testWidgets(
         'cached writable $replyCount-reply thread defers dock correction until measured',
@@ -11547,6 +11634,10 @@ void main() {
           threadTailCorrectionReachedEnd(tailIsVisible: false, extentAfter: 1),
           isFalse,
         );
+        expect(threadScrollPositionIsAtTail(0), isTrue);
+        expect(threadScrollPositionIsAtTail(0.5), isTrue);
+        expect(threadScrollPositionIsAtTail(0.51), isFalse);
+        expect(threadScrollPositionIsAtTail(null), isFalse);
       },
     );
 


### PR DESCRIPTION
## Summary

- Stop thread follow-tail from calling `jumpTo(maxScrollExtent)` / `animateTo` when `extentAfter` is already ~0.
- Treat that exhausted extent as “at the tail” in the correction loop, even if item positions still lag.
- Skip metrics realign when the thread is already at its end.

Short threads on iPhone rubber-band under the Thread header when follow-tail keeps poking iOS bouncing physics at an offset that is already the end. Screen recording from an iPhone 16 Pro showed ~60px, ~3Hz oscillation with no finger on the glass.

## Why this is not already on a store build

- #4862 merged (channel timeline bounce) — different list.
- #5911 is still open and stale against current `main` (format + 1000-line cap). It skipped *animated* tail follow when the tail item was already visible; it does not land this `extentAfter` no-op.
- #6399 is on `main` and in `mobile-v0.14.0-rc.*` — hides Latest / liquid-glass Back. It does not stop the jump loop.

## Validation

Exact pushed head: `e9fa5ad47494a586bba74c1407351c731dfa452c`

- `just mobile-check` (dart format + `flutter analyze`: no issues)
- `just mobile-test` — 1808/1808 passed
- `just file-size-check`
- `git diff --check`

Not verified on a physical iPhone 16 Pro (no device here). The new widget test covers a 1-reply thread after idle layout + inset jitter.