### PR TITLE
feat(relay): allowlist NIP-89 handler-info (kind 31990)

### DIFF
--- a/crates/buzz-core/src/kind.rs
+++ b/crates/buzz-core/src/kind.rs
@@ -631,6 +631,15 @@ pub const KIND_GIT_STATUS_DRAFT: u32 = 1633;
 /// announcement, never a project. See `docs/nips/NIP-MP.md`.
 pub const KIND_PROJECT: u32 = 30621;
 
+/// NIP-89: Recommended Application Handlers — "handler information". An
+/// application or agent's own declaration of which event kinds it handles,
+/// separate from (and addressable alongside) its `kind:0` profile. User-owned
+/// global state, keyed by `(pubkey, kind, d_tag)` in the NIP-33 parameterized
+/// replaceable range. Content is free-form JSON (commonly overlaps profile
+/// fields); `k` tags name each handled kind. See NIP-89 upstream — Buzz has no
+/// local doc for it since the relay defers entirely to the standard.
+pub const KIND_HANDLER_INFO: u32 = 31990;
+
 /// All registered kind constants — used for duplicate detection and iteration.
 pub const ALL_KINDS: &[u32] = &[
     KIND_PROFILE,
@@ -763,6 +772,7 @@ pub const ALL_KINDS: &[u32] = &[
     KIND_GIT_STATUS_CLOSED,
     KIND_GIT_STATUS_DRAFT,
     KIND_PROJECT,
+    KIND_HANDLER_INFO,
 ];
 
 /// Returns `true` if `kind` is in the ephemeral range (20000–29999).
@@ -861,6 +871,7 @@ const _: () = assert!(is_parameterized_replaceable(KIND_PRIVATE_MANAGED_AGENT));
 const _: () = assert!(is_parameterized_replaceable(KIND_WORKFLOW_DEF)); // 30620 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_EVENT_REMINDER)); // 30300 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_DM_VISIBILITY)); // 30622 ∈ 30000–39999
+const _: () = assert!(is_parameterized_replaceable(KIND_HANDLER_INFO)); // 31990 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_PROJECT)); // 30621 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_THREAD_SUMMARY)); // 39005 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_WINDOW_BOUNDS)); // 39006 ∈ 30000–39999

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -19,7 +19,7 @@ use buzz_core::kind::{
     KIND_FORUM_POST, KIND_FORUM_VOTE, KIND_GIFT_WRAP, KIND_GIT_ISSUE, KIND_GIT_PATCH,
     KIND_GIT_PR_UPDATE, KIND_GIT_PULL_REQUEST, KIND_GIT_REPO_ANNOUNCEMENT, KIND_GIT_REPO_STATE,
     KIND_GIT_STATUS_CLOSED, KIND_GIT_STATUS_DRAFT, KIND_GIT_STATUS_MERGED, KIND_GIT_STATUS_OPEN,
-    KIND_HUDDLE_ENDED, KIND_HUDDLE_GUIDELINES, KIND_HUDDLE_PARTICIPANT_JOINED,
+    KIND_HANDLER_INFO, KIND_HUDDLE_ENDED, KIND_HUDDLE_GUIDELINES, KIND_HUDDLE_PARTICIPANT_JOINED,
     KIND_HUDDLE_PARTICIPANT_LEFT, KIND_HUDDLE_STARTED, KIND_IA_ARCHIVE_REQUEST,
     KIND_IA_UNARCHIVE_REQUEST, KIND_LONG_FORM, KIND_MANAGED_AGENT, KIND_MEMBER_ADDED_NOTIFICATION,
     KIND_MEMBER_REMOVED_NOTIFICATION, KIND_MODERATION_BAN, KIND_MODERATION_RESOLVE_REPORT,
@@ -466,7 +466,10 @@ fn required_scope_for_kind(kind: u32, event: &Event) -> Result<Scope, &'static s
         // palette is the client-side union of every member's own set.
         | KIND_EMOJI_SET
         | KIND_EMOJI_LIST
-        | KIND_AGENT_PROFILE => Ok(Scope::UsersWrite),
+        | KIND_AGENT_PROFILE
+        // NIP-89: handler-info is a self-declaration, same ownership shape as
+        // kind:0 and the NIP-65 relay list above.
+        | KIND_HANDLER_INFO => Ok(Scope::UsersWrite),
         KIND_DELETION
         | KIND_REACTION
         | KIND_GIFT_WRAP
@@ -646,6 +649,9 @@ pub(crate) fn is_global_only_kind(kind: u32) -> bool {
             | KIND_EVENT_REMINDER
             // Agent profile (10100): user-owned replaceable, keyed by pubkey.
             | KIND_AGENT_PROFILE
+            // NIP-89 handler-info (31990): self-declared, keyed by (pubkey, kind, d_tag).
+            // A stray `h` tag must not channel-scope it.
+            | KIND_HANDLER_INFO
             // NIP-AP: persona definitions (30175): owner-authored, keyed by (pubkey, kind, d_tag).
             | KIND_PERSONA
             // NIP-AP: team (30176) + managed-agent (30177) definitions and the

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -3952,6 +3952,24 @@ mod tests {
     }
 
     #[test]
+    fn handler_info_is_global_only_and_in_scope_allowlist() {
+        let dummy = make_dummy_event();
+        assert!(
+            is_global_only_kind(KIND_HANDLER_INFO),
+            "kind:31990 (NIP-89 handler-info) must be global-only (no h tag)"
+        );
+        assert!(
+            !requires_h_channel_scope(KIND_HANDLER_INFO),
+            "kind:31990 must not require an h-tag"
+        );
+        assert_eq!(
+            required_scope_for_kind(KIND_HANDLER_INFO, &dummy).unwrap(),
+            Scope::UsersWrite,
+            "kind:31990 requires UsersWrite scope, same as kind:0 and the NIP-65 relay list"
+        );
+    }
+
+    #[test]
     fn nip51_and_nip65_lists_are_global_only() {
         for kind in [
             KIND_MUTE_LIST,


### PR DESCRIPTION
## Summary
Adds KIND_HANDLER_INFO = 31990 (NIP-89 "Recommended Application Handlers" / handler-info) to the kind registry, and allowlists it in required_scope_for_kind (Scope::UsersWrite, the same bucket as kind:0 and the NIP-65 relay list: a self-declared, user-owned addressable event) and is_global_only_kind (never channel-scoped, alongside KIND_AGENT_PROFILE). Storage semantics for the 30000–39999 parameterized-replaceable range are already generic, so no storage-layer change is needed.

Motivation: an external client (Workline) publishes a kind-0 declaration plus, additively, a standard NIP-89 handler-info event declaring which event kinds it handles. That's the standard addressable primitive for "which event kinds does this identity handle," queryable by any Nostr client rather than only a reader that knows this app's own bespoke vocabulary. Without this patch the write is rejected with `restricted: unknown event kind`.

### Related issue
Searched open issues/PRs for kind 31990 / NIP-89 handler-info — none found.

### Testing
- `cargo test -p buzz-core -p buzz-relay --lib` — added `handler_info_is_global_only_and_in_scope_allowlist`, mirroring the existing per-kind pattern (e.g. `agent_turn_metric_is_global_only_and_in_scope_allowlist`). Passes clean, no live Postgres/Redis needed.
- No UI change; no screenshots applicable.