### PR TITLE
fix(desktop): allow clearing the community repos directory override

### DIFF
--- a/desktop/src/features/communities/communityStorage.test.mjs
+++ b/desktop/src/features/communities/communityStorage.test.mjs
@@ -8,6 +8,7 @@ import {
   loadCommunityDiscoveryAfterLeave,
   markCommunityDiscoveryAfterLeave,
   migrateLegacyCommunityStorage,
+  resolveReposDirUpdate,
   saveCommunities,
   shouldAutoConnectDefaultRelay,
 } from "./communityStorage.ts";
@@ -115,6 +116,66 @@ test("completed final leave persists discovery until a community is saved", () =
 
   assert.equal(saveCommunities([{ id: "joined" }]), true);
   assert.equal(loadCommunityDiscoveryAfterLeave(storage), false);
+});
+
+test("clearing the repos dir skips validation and emits the clear", async () => {
+  const validated = [];
+  const validate = async (dir) => {
+    validated.push(dir);
+    throw new Error("repos dir must be an absolute path (got ``)");
+  };
+
+  // Regression for #6755: the cleared field used to be run through
+  // validate_repos_dir, which always rejects "", so the override could
+  // never be removed once set.
+  const result = await resolveReposDirUpdate("", "/Users/me/dev", validate);
+
+  assert.deepEqual(result, { kind: "changed", value: undefined });
+  assert.deepEqual(validated, []);
+});
+
+test("a repos dir left blank with no override set is unchanged", async () => {
+  const result = await resolveReposDirUpdate("", undefined, async () => {
+    throw new Error("should not be called");
+  });
+
+  assert.deepEqual(result, { kind: "unchanged" });
+});
+
+test("an untouched repos dir does not re-validate or emit", async () => {
+  const result = await resolveReposDirUpdate(
+    "/Users/me/dev",
+    "/Users/me/dev",
+    async () => {
+      throw new Error("should not be called");
+    },
+  );
+
+  assert.deepEqual(result, { kind: "unchanged" });
+});
+
+test("a new repos dir is validated and rejections surface as errors", async () => {
+  const validated = [];
+  const validate = async (dir) => {
+    validated.push(dir);
+    if (dir === "relative/path") {
+      throw new Error("repos dir must be an absolute path");
+    }
+  };
+
+  assert.deepEqual(
+    await resolveReposDirUpdate("relative/path", undefined, validate),
+    { kind: "invalid", error: "Error: repos dir must be an absolute path" },
+  );
+  assert.deepEqual(
+    await resolveReposDirUpdate(
+      "/Users/me/checkouts",
+      "/Users/me/dev",
+      validate,
+    ),
+    { kind: "changed", value: "/Users/me/checkouts" },
+  );
+  assert.deepEqual(validated, ["relative/path", "/Users/me/checkouts"]);
 });
 
 test("clearCommunityStorage preserves completed final-leave discovery", () => {

--- a/desktop/src/features/communities/communityStorage.ts
+++ b/desktop/src/features/communities/communityStorage.ts
@@ -32,6 +32,40 @@ export async function expandTilde(input: string): Promise<string | undefined> {
   return trimmed;
 }
 
+/**
+ * Resolve the Repos Directory field of the edit dialog into a community
+ * update. Expands `~`, then validates the expanded path with the
+ * caller-supplied validator (the backend's `validate_repos_dir`). A cleared
+ * field skips validation entirely: empty input means "remove the override",
+ * and the backend's absolute-path check would always reject `""`, which made
+ * the override impossible to clear from the dialog.
+ *
+ * Pure apart from the injected validator — extracted so it can be unit-tested
+ * without a DOM or Tauri.
+ */
+export async function resolveReposDirUpdate(
+  input: string,
+  current: string | undefined,
+  validate: (dir: string) => Promise<unknown>,
+): Promise<
+  | { kind: "unchanged" }
+  | { kind: "invalid"; error: string }
+  | { kind: "changed"; value: string | undefined }
+> {
+  const expanded = await expandTilde(input);
+  if (expanded === current) {
+    return { kind: "unchanged" };
+  }
+  if (expanded !== undefined) {
+    try {
+      await validate(expanded);
+    } catch (error) {
+      return { kind: "invalid", error: String(error) };
+    }
+  }
+  return { kind: "changed", value: expanded };
+}
+
 export function migrateLegacyCommunityStorage(
   storage: Storage = localStorage,
 ): void {

--- a/desktop/src/features/communities/ui/EditCommunityDialog.tsx
+++ b/desktop/src/features/communities/ui/EditCommunityDialog.tsx
@@ -4,8 +4,8 @@ import { CommunityIconSettingsCard } from "@/features/communities/ui/CommunityIc
 import { useMyRelayMembershipLookupQuery } from "@/features/community-members/hooks";
 import type { Community } from "@/features/communities/types";
 import {
-  expandTilde,
   normalizeRelayUrl,
+  resolveReposDirUpdate,
 } from "@/features/communities/communityStorage";
 import { validateReposDir } from "@/shared/api/tauri";
 import { Button } from "@/shared/ui/button";
@@ -94,19 +94,22 @@ export function EditCommunityDialog({
 
       // Expand `~` to an absolute path before save — the backend rejects
       // tilde paths. An empty field clears the override (REPOS reverts to a
-      // real dir). Validate the expanded value (the bytes the backend
-      // canonicalizes) before save so a bad path is caught here instead of
-      // bricking a later boot. Only emit when the resolved value actually
-      // changed so a no-op edit doesn't trigger a backend re-apply.
-      const expandedReposDir = await expandTilde(reposDir);
-      if (expandedReposDir !== community.reposDir) {
-        try {
-          await validateReposDir(expandedReposDir ?? "");
-        } catch (error) {
-          setReposDirError(String(error));
-          return;
-        }
-        updates.reposDir = expandedReposDir;
+      // real dir) and is not validated, since the backend's absolute-path
+      // check would reject `""`. A real path is validated (the bytes the
+      // backend canonicalizes) before save so a bad path is caught here
+      // instead of bricking a later boot. Only emit when the resolved value
+      // actually changed so a no-op edit doesn't trigger a backend re-apply.
+      const reposDirUpdate = await resolveReposDirUpdate(
+        reposDir,
+        community.reposDir,
+        validateReposDir,
+      );
+      if (reposDirUpdate.kind === "invalid") {
+        setReposDirError(reposDirUpdate.error);
+        return;
+      }
+      if (reposDirUpdate.kind === "changed") {
+        updates.reposDir = reposDirUpdate.value;
       }
 
       if (Object.keys(updates).length > 0) {


### PR DESCRIPTION
The Repos Directory half of #6755: once a repos dir is set on a community, clearing the field in Edit Community never saves. `expandTilde("")` resolves the empty field to `undefined`, the dialog then calls `validateReposDir(expandedReposDir ?? "")`, and `validate_repos_dir` rejects `""` as a non-absolute path, so submit bails with an inline error. The comment right above that block already says an empty field is supposed to clear the override.

This change skips path validation when the field resolves to a clear and passes the cleared value through. I moved the expand/compare/validate step out of the dialog into `resolveReposDirUpdate` in `communityStorage.ts` (validator injected) so it could get unit tests next to `expandTilde`. Behavior for a non-empty path is unchanged, including the error rendered under the field.

Closest existing PR is #6379, which is also needed for the clear to actually persist: `resolveCommunityUpdateResult` currently classifies a clear-only update as unchanged and drops it. This PR unblocks the dialog layer above that, and the two are independent diffs.

Ran the communities unit tests through the repo test loader (4 new cases, including the regression where the validator must not run on a clear), plus `tsc --noEmit` and biome on the touched files. I don't have the relay stack on this machine, so I did not exercise the full save round-trip.

The workflows-delete half of #6755 is relay-side and untouched here.