### PR TITLE
fix(acp): resume event replay across restarts via a persisted watermark

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -424,6 +424,14 @@ pub struct CliArgs {
     )]
     pub base_prompt_file: Option<PathBuf>,
 
+    /// Path where the harness persists the newest event timestamp it has
+    /// received. On startup, event replay resumes just after this timestamp,
+    /// so mentions posted while the process was down or hung are delivered
+    /// instead of silently lost. Unset = no persistence (live-only delivery,
+    /// the prior behavior).
+    #[arg(long, env = "BUZZ_ACP_SEEN_STATE_FILE")]
+    pub seen_state_file: Option<PathBuf>,
+
     /// Desired LLM model ID. Applied to every new ACP session after creation.
     /// Use `buzz-acp models` to discover available model IDs.
     #[arg(long, env = "BUZZ_ACP_MODEL")]
@@ -541,6 +549,8 @@ pub struct Config {
     pub kinds_override: Option<Vec<u32>>,
     pub channels_override: Option<Vec<String>>,
     pub no_mention_filter: bool,
+    /// See `Args::seen_state_file`. `None` disables watermark persistence.
+    pub seen_state_file: Option<PathBuf>,
     pub config_path: PathBuf,
     pub context_message_limit: u32,
     /// Maximum turns per session before proactive rotation. 0 = disabled.
@@ -1118,6 +1128,7 @@ impl Config {
             kinds_override: args.kinds,
             channels_override: args.channels,
             no_mention_filter: args.no_mention_filter,
+            seen_state_file: args.seen_state_file,
             config_path: args.config,
             context_message_limit: args.context_message_limit,
             max_turns_per_session: args.max_turns_per_session,
@@ -1494,6 +1505,7 @@ mod tests {
             kinds_override: None,
             channels_override: None,
             no_mention_filter: false,
+            seen_state_file: None,
             config_path: PathBuf::from("./buzz-acp.toml"),
             context_message_limit: 12,
             max_turns_per_session: 0,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1892,6 +1892,26 @@ mod idle_pool_sleep_tests {
     }
 }
 
+/// Read the persisted newest-event timestamp. An absent file, an unreadable
+/// file, or non-numeric content all mean "no watermark": the harness starts
+/// live-only, exactly as it did before persistence existed.
+fn read_seen_state(path: Option<&std::path::Path>) -> Option<u64> {
+    let text = std::fs::read_to_string(path?).ok()?;
+    text.trim().parse::<u64>().ok()
+}
+
+/// Persist the newest received event timestamp, atomically (tmp + rename), so
+/// a crash mid-write can never leave a corrupt watermark behind.
+fn write_seen_state(path: &std::path::Path, ts: u64) {
+    let tmp = path.with_extension("tmp");
+    if std::fs::write(&tmp, ts.to_string())
+        .and_then(|_| std::fs::rename(&tmp, path))
+        .is_err()
+    {
+        tracing::warn!(path = %path.display(), "failed to persist seen-state watermark");
+    }
+}
+
 pub fn run() -> Result<()> {
     config::propagate_legacy_env_vars();
     tokio_main()
@@ -1989,10 +2009,24 @@ async fn tokio_main() -> Result<()> {
     // the initial subscribe_since for channels discovered at startup. The Subscribe
     // handler falls back to subscribe_since when last_seen is None, closing the
     // blind spot between "agents ready" and "first REQ sent".
-    let startup_watermark: u64 = std::time::SystemTime::now()
+    let now_secs: u64 = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
+    // When a seen-state file holds the newest timestamp a previous process
+    // received, resume replay just after it instead of from now: mentions
+    // posted while the process was down or hung are re-delivered by the
+    // relay's `since` replay instead of being lost forever. `+1` skips the
+    // boundary event the previous process already handled; `min(now)` guards
+    // against a future timestamp from a skewed clock or corrupt file.
+    let startup_watermark: u64 = match read_seen_state(config.seen_state_file.as_deref()) {
+        Some(saved) => {
+            tracing::info!(saved, "resuming event replay after persisted watermark");
+            (saved + 1).min(now_secs)
+        }
+        None => now_secs,
+    };
+    let mut newest_seen: u64 = 0;
 
     let pubkey_hex = config.keys.public_key().to_hex();
 
@@ -2628,6 +2662,16 @@ async fn tokio_main() -> Result<()> {
                     let _ = result_rx; // end split borrow before relay handling
                     match buzz_event {
                         Some(buzz_event) => {
+                            // Persist the newest event timestamp so a future
+                            // process resumes replay from here instead of
+                            // losing whatever arrives while it is down.
+                            if let Some(path) = config.seen_state_file.as_deref() {
+                                let ts = buzz_event.event.created_at.as_secs();
+                                if ts > newest_seen {
+                                    newest_seen = ts;
+                                    write_seen_state(path, ts);
+                                }
+                            }
                             let kind_u32 = buzz_event.event.kind.as_u16() as u32;
 
                             if kind_u32 == KIND_MEMBER_ADDED_NOTIFICATION
@@ -6776,6 +6820,7 @@ mod build_mcp_servers_tests {
             kinds_override: None,
             channels_override: None,
             no_mention_filter: false,
+            seen_state_file: None,
             config_path: std::path::PathBuf::from("./buzz-acp.toml"),
             context_message_limit: 12,
             max_turns_per_session: 0,
@@ -7000,6 +7045,7 @@ mod error_outcome_emission_tests {
             kinds_override: None,
             channels_override: None,
             no_mention_filter: false,
+            seen_state_file: None,
             config_path: std::path::PathBuf::from("./buzz-acp.toml"),
             context_message_limit: 12,
             max_turns_per_session: 0,
@@ -8709,5 +8755,27 @@ mod observer_payload_trim_tests {
         assert!(leaf.starts_with('…'));
         assert!(leaf.ends_with('…'));
         assert!(leaf.contains("[elided"));
+    }
+
+    #[test]
+    fn seen_state_round_trips_and_survives_rewrite() {
+        let path =
+            std::env::temp_dir().join(format!("acp-seen-roundtrip-{}", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(read_seen_state(Some(&path)), None, "absent file = no watermark");
+        write_seen_state(&path, 1_787_415_033);
+        assert_eq!(read_seen_state(Some(&path)), Some(1_787_415_033));
+        write_seen_state(&path, 1_787_415_100);
+        assert_eq!(read_seen_state(Some(&path)), Some(1_787_415_100));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn seen_state_ignores_garbage_and_unset_path() {
+        let path = std::env::temp_dir().join(format!("acp-seen-garbage-{}", std::process::id()));
+        std::fs::write(&path, "not a number\n").unwrap();
+        assert_eq!(read_seen_state(Some(&path)), None, "corrupt file = no watermark");
+        assert_eq!(read_seen_state(None), None, "unconfigured = no watermark");
+        let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
## The defect

A mention delivered while buzz-acp is down, hung, or restarting is lost permanently. The reconnect `since`-replay protects only a live process: `last_seen` exists in memory, so a fresh process subscribes from "now" and never learns what it missed — even though the relay holds the full history it could have asked for. An agent that looks online (presence set, container running) can therefore silently lose work addressed to it, and nothing anywhere records that delivery was owed.

We hit this in production: an agent's process wedged, its container was restarted, and a job posted in the gap vanished without a trace. The sender believed it delivered; the receiver never knew it existed.

## The fix

One opt-in flag, `--seen-state-file` / `BUZZ_ACP_SEEN_STATE_FILE`. When set, the harness persists the newest received event timestamp (atomic tmp+rename, corruption-safe), and on startup feeds `saved+1` into the existing startup-watermark plumbing, so the relay's own replay delivers everything missed while the process was away. `+1` skips the already-handled boundary event; `min(now)` guards a skewed clock or corrupt file. Unset, behavior is byte-for-byte unchanged.

## Evidence

- Two unit tests cover the round-trip and the corrupt/absent/unset cases.
- Full `buzz-acp` suite against current main: baseline 746 passed / 55 failed in our environment; with this patch 748 / 55 — it adds exactly its own two passing tests and changes nothing else (the 55 fail identically on unpatched main here).
- Verified end to end on our production relay: stop the listener, post a mention into the outage, start it — the log shows `resuming event replay after persisted watermark`, the mention arrives, and the agent replies once, with no duplicate of the boundary event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M1gKTDVhVWhED8NbW1CBVZ
