### PR TITLE
fix(acp): surface imeta attachments as a labeled prompt line

### DIFF
--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1140,6 +1140,36 @@ pub(crate) fn format_event_block(
         block.push_str(&format!("\nTags: {tags_str}"));
     }
 
+    // Attachments surface as their own labeled line: an image a person attached is
+    // evidence addressed to the reader, and buried in the tags JSON above it was
+    // ignored by every agent that ever received one.
+    let attachment_urls: Vec<String> = be
+        .event
+        .tags
+        .iter()
+        .filter_map(|t| {
+            let s = t.as_slice();
+            if s.first().map(|k| k == "imeta").unwrap_or(false) {
+                Some(
+                    s[1..]
+                        .iter()
+                        .filter_map(|f| f.strip_prefix("url ").map(str::to_string))
+                        .collect::<Vec<_>>(),
+                )
+            } else {
+                None
+            }
+        })
+        .flatten()
+        .collect();
+    if !attachment_urls.is_empty() {
+        block.push_str(&format!(
+            "\nAttachments ({}): {}",
+            attachment_urls.len(),
+            attachment_urls.join(" ")
+        ));
+    }
+
     // Parsed structural fields.
     let thread = parse_thread_tags(&be.event);
     let mut parsed_parts = Vec::new();
@@ -3846,6 +3876,34 @@ mod tests {
         assert!(
             !prompt.contains("buzz messages thread"),
             "DM non-reply should NOT mention `buzz messages thread`"
+        );
+    }
+
+    #[test]
+    fn test_format_event_block_lists_imeta_attachments() {
+        let ch = Uuid::new_v4();
+        let event = make_event_with_tags(
+            "look at my screenshot",
+            vec![vec![
+                "imeta".into(),
+                "url https://relay.example/media/shot.png".into(),
+                "m image/png".into(),
+            ]],
+        );
+        let batch = FlushBatch {
+            channel_id: ch,
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "test".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
+        assert!(
+            prompt.contains("Attachments (1): https://relay.example/media/shot.png"),
+            "an imeta url must surface as a first-class Attachments line, not stay buried in the tags JSON"
         );
     }
 


### PR DESCRIPTION
## The defect

An image attached to a channel message never reaches an agent as anything it can recognize. The `imeta` tag is serialized into the raw `Tags:` JSON of the prompt's event block — present in principle, invisible in practice, because nothing marks it as content. Human members see the attachment rendered in the apps; agent members do not know it exists.

In practice: a business user attached screenshots to visual bug reports for days, and the agent answered the surrounding text every time while never seeing the evidence — five escalating rounds of "look at my screenshot" with the agent unable to know a screenshot was there. For a product whose premise is agents as first-class members, attachments are effectively human-only.

## The fix

`format_event_block` extracts every `imeta` `url` field and appends an `Attachments (N): <urls>` line beside `Content`, making the attachment first-class information the agent can fetch and view — `claude-agent-acp` already advertises image support, and agent runtimes can read image files. No configuration, and no change for events without attachments.

## Evidence

- Unit test: an event carrying an `imeta` tag must surface its URL as an `Attachments (1): …` line in the formatted prompt.
- Full `buzz-acp` suite against current main: baseline 746 passed / 55 failed in our environment; with this patch 747 / 55 — it adds exactly its own passing test (the 55 fail identically on unpatched main here).
- Running in our production deployment: agents now download and view attached screenshots before answering, ending the blind-spec loop that surfaced this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M1gKTDVhVWhED8NbW1CBVZ
