### PR TITLE
fix(desktop): resolve the huddle channel before relay membership propagates

### DIFF
--- a/desktop/src-tauri/src/app_state_pending_channels.rs
+++ b/desktop/src-tauri/src/app_state_pending_channels.rs
@@ -52,4 +52,17 @@ impl AppState {
             set.remove(&(my_pubkey.to_string(), channel_id.to_string()));
         }
     }
+
+    /// Drop every identity's pending-owner entry for `channel_id`. For when
+    /// the channel itself is destroyed (a huddle's ephemeral channel is
+    /// archived on end/rollback): the mark must not outlive the channel, and
+    /// keying the clear off the *current* signing identity would leak the
+    /// creator's entry after an in-process identity swap or in recovery
+    /// mode. Only the creating identity ever holds an entry for a given
+    /// channel id, so this removes exactly the creator's mark.
+    pub fn clear_pending_owned_channel_all_identities(&self, channel_id: &str) {
+        if let Ok(mut set) = self.pending_owned_channels.lock() {
+            set.retain(|(_, id)| id != channel_id);
+        }
+    }
 }

--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -258,6 +258,16 @@ pub async fn start_huddle(
         submit_event(create_builder, &state).await?;
         channel_was_created = true;
 
+        // The huddle window resolves this channel through the member-only
+        // channel poll, but the relay-signed kind:39002 owner membership can
+        // lag the create. Mark the channel pending-owned (same overlay as
+        // `create_channel`, #1761) so the window never races propagation and
+        // falls into the "Select a channel" empty state. Cleared automatically
+        // once real membership is observed, and explicitly on end/rollback.
+        if let Ok(keys) = state.signing_keys() {
+            state.mark_pending_owned_channel(&keys.public_key().to_hex(), &ephemeral_channel_id);
+        }
+
         // 2. Post voice-mode guidelines as kind:48106 BEFORE adding agents.
         //    Agents auto-subscribe on membership notification (kind:9000) and may
         //    complete EOSE before guidelines are stored if we post them after.
@@ -367,6 +377,7 @@ pub async fn start_huddle(
         Err(e) => {
             // Rollback: archive the orphaned ephemeral channel if it was created.
             if channel_was_created {
+                clear_pending_owned_huddle_channel(&state, &ephemeral_channel_id);
                 if let Ok(archive_builder) = events::build_archive(ephemeral_uuid) {
                     if let Err(ae) = submit_event(archive_builder, &state).await {
                         eprintln!(
@@ -523,6 +534,15 @@ fn teardown_huddle(state: &AppState) -> Result<(), String> {
     Ok(())
 }
 
+/// Drop the huddle channel's pending-owned overlay entry (see the mark in
+/// `start_huddle`). Archived huddle channels must not linger classified as
+/// owned-and-visible if the relay's kind:39002 update never arrived.
+fn clear_pending_owned_huddle_channel(state: &AppState, ephemeral_channel_id: &str) {
+    if let Ok(keys) = state.signing_keys() {
+        state.clear_pending_owned_channel(&keys.public_key().to_hex(), ephemeral_channel_id);
+    }
+}
+
 /// Emit HUDDLE_ENDED to the parent channel and archive the ephemeral channel.
 ///
 /// Both steps are best-effort — failures are logged but do not propagate.
@@ -532,6 +552,7 @@ async fn emit_end_and_archive(
     ephemeral_channel_id: &str,
     state: &AppState,
 ) {
+    clear_pending_owned_huddle_channel(state, ephemeral_channel_id);
     if !parent_channel_id.is_empty() && !ephemeral_channel_id.is_empty() {
         if let Ok(ended_builder) =
             events::build_huddle_ended(parent_channel_id, ephemeral_channel_id)
@@ -930,3 +951,7 @@ pub async fn speak_agent_message(
         eprintln!("buzz-desktop: tts stage=queue status=failed reason=closed route_id={route_id}")
     })
 }
+
+#[cfg(test)]
+#[path = "pending_owned_tests.rs"]
+mod pending_owned_tests;

--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -90,7 +90,11 @@ use std::sync::{atomic::Ordering, Arc};
 use tauri::State;
 use uuid::Uuid;
 
-use crate::{app_state::AppState, events, relay::submit_event};
+use crate::{
+    app_state::AppState,
+    events,
+    relay::{submit_event, submit_event_with_keys},
+};
 
 use agent_tts_routing::{
     classify_agent_tts_runtime, enqueue_agent_tts_text, normalize_agent_tts_text,
@@ -255,18 +259,23 @@ pub async fn start_huddle(
             None,
             Some(3600),
         )?;
-        submit_event(create_builder, &state).await?;
+        // Capture the signing identity before submission and sign with exactly
+        // those keys, mirroring `create_channel` (`commands/channels.rs`): an
+        // in-process identity swap during the network await must not be able
+        // to retarget the pending-owned mark below onto a non-creator.
+        let creator_keys = state.signing_keys()?;
+        let creator_pubkey = creator_keys.public_key().to_hex();
+        submit_event_with_keys(create_builder, &state, &creator_keys, None).await?;
         channel_was_created = true;
 
         // The huddle window resolves this channel through the member-only
         // channel poll, but the relay-signed kind:39002 owner membership can
         // lag the create. Mark the channel pending-owned (same overlay as
         // `create_channel`, #1761) so the window never races propagation and
-        // falls into the "Select a channel" empty state. Cleared automatically
-        // once real membership is observed, and explicitly on end/rollback.
-        if let Ok(keys) = state.signing_keys() {
-            state.mark_pending_owned_channel(&keys.public_key().to_hex(), &ephemeral_channel_id);
-        }
+        // falls into the "Select a channel" empty state. Bound to the identity
+        // that signed the create above. Cleared automatically once real
+        // membership is observed, and explicitly on end/rollback.
+        state.mark_pending_owned_channel(&creator_pubkey, &ephemeral_channel_id);
 
         // 2. Post voice-mode guidelines as kind:48106 BEFORE adding agents.
         //    Agents auto-subscribe on membership notification (kind:9000) and may
@@ -536,11 +545,13 @@ fn teardown_huddle(state: &AppState) -> Result<(), String> {
 
 /// Drop the huddle channel's pending-owned overlay entry (see the mark in
 /// `start_huddle`). Archived huddle channels must not linger classified as
-/// owned-and-visible if the relay's kind:39002 update never arrived.
+/// owned-and-visible if the relay's kind:39002 update never arrived. Clears
+/// the channel id for every identity rather than re-reading the current
+/// signing keys: by end/rollback time an in-process identity swap may have
+/// replaced the creator's keys (and recovery mode has none at all), and the
+/// creator's mark must die with the channel regardless.
 fn clear_pending_owned_huddle_channel(state: &AppState, ephemeral_channel_id: &str) {
-    if let Ok(keys) = state.signing_keys() {
-        state.clear_pending_owned_channel(&keys.public_key().to_hex(), ephemeral_channel_id);
-    }
+    state.clear_pending_owned_channel_all_identities(ephemeral_channel_id);
 }
 
 /// Emit HUDDLE_ENDED to the parent channel and archive the ephemeral channel.

--- a/desktop/src-tauri/src/huddle/pending_owned_tests.rs
+++ b/desktop/src-tauri/src/huddle/pending_owned_tests.rs
@@ -1,0 +1,47 @@
+//! Tests for the huddle channel pending-owned overlay lifecycle
+//! (`start_huddle` mark → `clear_pending_owned_huddle_channel`).
+
+use super::clear_pending_owned_huddle_channel;
+
+/// `start_huddle` marks the ephemeral channel pending-owned under the
+/// signing identity so the huddle window's member-only channel poll
+/// resolves it before relay kind:39002 membership propagates; the end
+/// helper removes exactly that entry.
+#[test]
+fn end_clears_the_pending_owned_mark_for_the_signing_identity() {
+    let state = crate::app_state::build_app_state();
+    let my_pubkey = state
+        .signing_keys()
+        .expect("signable")
+        .public_key()
+        .to_hex();
+    let channel_id = "11111111-2222-3333-4444-555555555555";
+
+    state.mark_pending_owned_channel(&my_pubkey, channel_id);
+    assert!(state.is_pending_owned_channel(&my_pubkey, channel_id));
+
+    clear_pending_owned_huddle_channel(&state, channel_id);
+    assert!(!state.is_pending_owned_channel(&my_pubkey, channel_id));
+}
+
+/// In recovery mode (`identity_lost`) there is no signable identity; the
+/// clear helper must be a no-op rather than an error or panic, and the
+/// original identity's entry must survive untouched.
+#[test]
+fn clear_is_a_noop_without_a_signable_identity() {
+    let state = crate::app_state::build_app_state();
+    let my_pubkey = state
+        .signing_keys()
+        .expect("signable")
+        .public_key()
+        .to_hex();
+    let channel_id = "11111111-2222-3333-4444-555555555555";
+    state.mark_pending_owned_channel(&my_pubkey, channel_id);
+
+    state
+        .identity_lost
+        .store(true, std::sync::atomic::Ordering::Release);
+    clear_pending_owned_huddle_channel(&state, channel_id);
+
+    assert!(state.is_pending_owned_channel(&my_pubkey, channel_id));
+}

--- a/desktop/src-tauri/src/huddle/pending_owned_tests.rs
+++ b/desktop/src-tauri/src/huddle/pending_owned_tests.rs
@@ -3,45 +3,40 @@
 
 use super::clear_pending_owned_huddle_channel;
 
+const CREATOR_PK: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OTHER_PK: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const CHANNEL_ID: &str = "11111111-2222-3333-4444-555555555555";
+
 /// `start_huddle` marks the ephemeral channel pending-owned under the
-/// signing identity so the huddle window's member-only channel poll
-/// resolves it before relay kind:39002 membership propagates; the end
-/// helper removes exactly that entry.
+/// identity that signed the create, so the huddle window's member-only
+/// channel poll resolves it before relay kind:39002 membership propagates;
+/// the end helper removes that entry.
 #[test]
-fn end_clears_the_pending_owned_mark_for_the_signing_identity() {
+fn end_clears_the_creator_mark() {
     let state = crate::app_state::build_app_state();
-    let my_pubkey = state
-        .signing_keys()
-        .expect("signable")
-        .public_key()
-        .to_hex();
-    let channel_id = "11111111-2222-3333-4444-555555555555";
+    state.mark_pending_owned_channel(CREATOR_PK, CHANNEL_ID);
+    assert!(state.is_pending_owned_channel(CREATOR_PK, CHANNEL_ID));
 
-    state.mark_pending_owned_channel(&my_pubkey, channel_id);
-    assert!(state.is_pending_owned_channel(&my_pubkey, channel_id));
-
-    clear_pending_owned_huddle_channel(&state, channel_id);
-    assert!(!state.is_pending_owned_channel(&my_pubkey, channel_id));
+    clear_pending_owned_huddle_channel(&state, CHANNEL_ID);
+    assert!(!state.is_pending_owned_channel(CREATOR_PK, CHANNEL_ID));
 }
 
-/// In recovery mode (`identity_lost`) there is no signable identity; the
-/// clear helper must be a no-op rather than an error or panic, and the
-/// original identity's entry must survive untouched.
+/// The clear must remove the *creator's* mark even when the current signing
+/// identity is no longer the creator (in-process identity swap while the
+/// huddle ran) or is unavailable entirely (recovery mode). The archived
+/// channel's mark must not leak; other channels' entries must survive.
 #[test]
-fn clear_is_a_noop_without_a_signable_identity() {
+fn clear_removes_the_creator_mark_after_identity_swap_or_recovery() {
     let state = crate::app_state::build_app_state();
-    let my_pubkey = state
-        .signing_keys()
-        .expect("signable")
-        .public_key()
-        .to_hex();
-    let channel_id = "11111111-2222-3333-4444-555555555555";
-    state.mark_pending_owned_channel(&my_pubkey, channel_id);
+    state.mark_pending_owned_channel(CREATOR_PK, CHANNEL_ID);
+    state.mark_pending_owned_channel(OTHER_PK, "other-channel");
 
+    // Recovery mode: no signable identity at clear time.
     state
         .identity_lost
         .store(true, std::sync::atomic::Ordering::Release);
-    clear_pending_owned_huddle_channel(&state, channel_id);
+    clear_pending_owned_huddle_channel(&state, CHANNEL_ID);
 
-    assert!(state.is_pending_owned_channel(&my_pubkey, channel_id));
+    assert!(!state.is_pending_owned_channel(CREATOR_PK, CHANNEL_ID));
+    assert!(state.is_pending_owned_channel(OTHER_PK, "other-channel"));
 }


### PR DESCRIPTION
## Problem

Starting a huddle shows **"Select a channel to view messages"** in the huddle popup even though the private ephemeral channel was created and the huddle is live.

## Root cause

The huddle window resolves its ephemeral channel through the member-only channel poll. #6328 made that poll membership-only and deliberately excludes huddle windows from the open-directory fallback (huddle channels are private regardless). But `start_huddle` creates the backing channel directly and — unlike `create_channel` — never marks it in the pending-owned overlay (#1761). Until the relay's kind:39002 owner membership propagates, the window's poll resolves nothing and the channel screen falls into its empty state.

## Fix

- Mark the ephemeral channel pending-owned under the signing identity as soon as the relay accepts the create (same overlay `create_channel` uses; the poll already clears it once real membership is observed).
- Clear the mark on huddle end (`emit_end_and_archive`) and on start rollback, so an archived huddle channel never lingers classified as owned if the kind:39002 update never arrives.

12 lines of production change in `desktop/src-tauri/src/huddle/mod.rs` plus a 9-line helper; tests in a new `pending_owned_tests.rs` per the file-size ratchet.

## Validation

- `just desktop-tauri-test` — 2773 passed, 0 failed (includes 2 new tests)
- `just desktop-tauri-clippy`, `just desktop-tauri-fmt-check`, desktop file-size ratchet — clean

Acceptance: opening a huddle immediately renders the huddle channel timeline in the popup instead of the empty state, with no dependence on relay membership propagation timing.

Diagnosed and authored by Eva (agent) at Tyler Longwell's request.