### PR TITLE
refactor(db): move API token store ownership

### DIFF
--- a/crates/buzz-db/src/api_token.rs
+++ b/crates/buzz-db/src/api_token.rs
@@ -5,6 +5,9 @@ use sqlx::{PgPool, Row};
 use uuid::Uuid;
 
 use crate::error::{DbError, Result};
+use crate::Db;
+use buzz_core::CommunityId;
+use buzz_datastore_tracing::datastore_span;
 
 /// Create a new API token record. The caller is responsible for generating
 /// the raw token and computing its SHA-256 hash.
@@ -324,6 +327,284 @@ pub async fn revoke_all_tokens(
     Ok(result.rows_affected())
 }
 
+/// Token summary returned by [`Db::list_active_tokens`].
+#[derive(Debug, Clone)]
+pub struct TokenSummary {
+    /// Unique token identifier.
+    pub id: Uuid,
+    /// Human-readable token name.
+    pub name: String,
+    /// Compressed public key bytes of the token owner.
+    pub owner_pubkey: Vec<u8>,
+    /// Permission scopes granted to this token.
+    pub scopes: Vec<String>,
+    /// When the token was created.
+    pub created_at: DateTime<Utc>,
+    /// Optional expiry timestamp; `None` means no expiry.
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+/// A full API token record.
+#[derive(Debug, Clone)]
+pub struct ApiTokenRecord {
+    /// Unique token identifier.
+    pub id: Uuid,
+    /// SHA-256 hash of the raw token value.
+    pub token_hash: Vec<u8>,
+    /// Compressed public key bytes of the token owner.
+    pub owner_pubkey: Vec<u8>,
+    /// Human-readable token name.
+    pub name: String,
+    /// Permission scopes granted to this token.
+    pub scopes: Vec<String>,
+    /// Optional channel ID restrictions.
+    pub channel_ids: Option<Vec<Uuid>>,
+    /// When the token was created.
+    pub created_at: DateTime<Utc>,
+    /// Optional expiry timestamp.
+    pub expires_at: Option<DateTime<Utc>>,
+    /// When the token was last used.
+    pub last_used_at: Option<DateTime<Utc>>,
+    /// When the token was revoked.
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+fn parse_api_token_row(row: sqlx::postgres::PgRow) -> Result<ApiTokenRecord> {
+    let id: Uuid = row.try_get("id")?;
+
+    let scopes_json: serde_json::Value = row.try_get("scopes")?;
+    let scopes: Vec<String> = serde_json::from_value(scopes_json)
+        .map_err(|e| DbError::InvalidData(format!("scopes JSON: {e}")))?;
+
+    let channel_ids: Option<Vec<Uuid>> = {
+        let raw: Option<serde_json::Value> = row.try_get("channel_ids")?;
+        match raw {
+            None => None,
+            Some(v) => {
+                let strings: Vec<String> = serde_json::from_value(v)
+                    .map_err(|e| DbError::InvalidData(format!("channel_ids JSON: {e}")))?;
+                let uuids: std::result::Result<Vec<Uuid>, _> =
+                    strings.iter().map(|s| s.parse::<Uuid>()).collect();
+                Some(uuids.map_err(|e| DbError::InvalidData(format!("channel_ids UUID: {e}")))?)
+            }
+        }
+    };
+
+    Ok(ApiTokenRecord {
+        id,
+        token_hash: row.try_get("token_hash")?,
+        owner_pubkey: row.try_get("owner_pubkey")?,
+        name: row.try_get("name")?,
+        scopes,
+        channel_ids,
+        created_at: row.try_get("created_at")?,
+        expires_at: row.try_get("expires_at")?,
+        last_used_at: row.try_get("last_used_at")?,
+        revoked_at: row.try_get("revoked_at")?,
+    })
+}
+
+impl Db {
+    /// Create a new API token record.
+    #[allow(clippy::too_many_arguments)]
+    #[datastore_span(name = "create_api_token", system = "postgresql")]
+    pub async fn create_api_token(
+        &self,
+        community_id: CommunityId,
+        token_hash: &[u8],
+        owner_pubkey: &[u8],
+        name: &str,
+        scopes: &[String],
+        channel_ids: Option<&[Uuid]>,
+        expires_at: Option<DateTime<Utc>>,
+    ) -> Result<Uuid> {
+        create_api_token(
+            &self.pool,
+            *community_id.as_uuid(),
+            token_hash,
+            owner_pubkey,
+            name,
+            scopes,
+            channel_ids,
+            expires_at,
+        )
+        .await
+    }
+
+    /// Atomic conditional INSERT with 10-token limit (per (community, owner)).
+    #[allow(clippy::too_many_arguments)]
+    #[datastore_span(name = "create_api_token_if_under_limit", system = "postgresql")]
+    pub async fn create_api_token_if_under_limit(
+        &self,
+        community_id: CommunityId,
+        token_hash: &[u8],
+        owner_pubkey: &[u8],
+        name: &str,
+        scopes: &[String],
+        channel_ids: Option<&[Uuid]>,
+        expires_at: Option<DateTime<Utc>>,
+    ) -> Result<Option<Uuid>> {
+        create_api_token_if_under_limit(
+            &self.pool,
+            *community_id.as_uuid(),
+            token_hash,
+            owner_pubkey,
+            name,
+            scopes,
+            channel_ids,
+            expires_at,
+        )
+        .await
+    }
+
+    /// Look up an active (non-revoked) API token by its SHA-256 hash,
+    /// scoped to the request's community.
+    ///
+    /// See [`get_api_token_by_hash_including_revoked`] for the
+    /// row-44 conformance rationale — the `(community_id, token_hash)` key
+    /// is enforced both by the storage UNIQUE index and by this WHERE clause.
+    #[datastore_span(name = "get_api_token_by_hash", system = "postgresql")]
+    pub async fn get_api_token_by_hash(
+        &self,
+        community_id: CommunityId,
+        hash: &[u8],
+    ) -> Result<Option<ApiTokenRecord>> {
+        let row = sqlx::query(
+            r#"
+            SELECT id, token_hash, owner_pubkey, name, scopes, channel_ids,
+                   created_at, expires_at, last_used_at, revoked_at
+            FROM api_tokens
+            WHERE community_id = $1 AND token_hash = $2 AND revoked_at IS NULL
+            "#,
+        )
+        .bind(community_id.as_uuid())
+        .bind(hash)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match row {
+            None => Ok(None),
+            Some(r) => parse_api_token_row(r).map(Some),
+        }
+    }
+
+    /// Look up an API token by hash, including revoked, scoped to community.
+    #[datastore_span(
+        name = "get_api_token_by_hash_including_revoked",
+        system = "postgresql"
+    )]
+    pub async fn get_api_token_by_hash_including_revoked(
+        &self,
+        community_id: CommunityId,
+        hash: &[u8],
+    ) -> Result<Option<ApiTokenRecord>> {
+        get_api_token_by_hash_including_revoked(&self.pool, *community_id.as_uuid(), hash).await
+    }
+
+    /// Record a token usage (update `last_used_at`), scoped to community.
+    #[datastore_span(name = "touch_api_token", system = "postgresql")]
+    pub async fn touch_api_token(&self, community_id: CommunityId, hash: &[u8]) -> Result<()> {
+        sqlx::query(
+            "UPDATE api_tokens SET last_used_at = NOW() WHERE community_id = $1 AND token_hash = $2",
+        )
+        .bind(community_id.as_uuid())
+        .bind(hash)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Alias for [`Self::touch_api_token`].
+    pub async fn update_token_last_used(
+        &self,
+        community_id: CommunityId,
+        hash: &[u8],
+    ) -> Result<()> {
+        self.touch_api_token(community_id, hash).await
+    }
+
+    /// List all active (non-revoked) tokens in a community, newest first.
+    #[datastore_span(name = "list_active_tokens", system = "postgresql")]
+    pub async fn list_active_tokens(&self, community_id: CommunityId) -> Result<Vec<TokenSummary>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, name, owner_pubkey, scopes, created_at, expires_at
+            FROM api_tokens
+            WHERE community_id = $1 AND revoked_at IS NULL
+            ORDER BY created_at DESC
+            LIMIT 1000
+            "#,
+        )
+        .bind(community_id.as_uuid())
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let id: Uuid = row.try_get("id")?;
+            let scopes_json: serde_json::Value = row.try_get("scopes")?;
+            let scopes: Vec<String> = serde_json::from_value(scopes_json)
+                .map_err(|e| DbError::InvalidData(format!("scopes JSON: {e}")))?;
+
+            out.push(TokenSummary {
+                id,
+                name: row.try_get("name")?,
+                owner_pubkey: row.try_get("owner_pubkey")?,
+                scopes,
+                created_at: row.try_get("created_at")?,
+                expires_at: row.try_get("expires_at")?,
+            });
+        }
+        Ok(out)
+    }
+
+    /// List all tokens for a (community, owner) pair (including revoked).
+    #[datastore_span(name = "list_tokens_by_owner", system = "postgresql")]
+    pub async fn list_tokens_by_owner(
+        &self,
+        community_id: CommunityId,
+        pubkey: &[u8],
+    ) -> Result<Vec<ApiTokenRecord>> {
+        list_tokens_by_owner(&self.pool, *community_id.as_uuid(), pubkey).await
+    }
+
+    /// Revoke a single token by ID, scoped to (community, owner).
+    #[datastore_span(name = "revoke_token", system = "postgresql")]
+    pub async fn revoke_token(
+        &self,
+        community_id: CommunityId,
+        id: Uuid,
+        owner_pubkey: &[u8],
+        revoked_by: &[u8],
+    ) -> Result<bool> {
+        revoke_token(
+            &self.pool,
+            *community_id.as_uuid(),
+            id,
+            owner_pubkey,
+            revoked_by,
+        )
+        .await
+    }
+
+    /// Revoke all active tokens for a (community, owner) pair.
+    #[datastore_span(name = "revoke_all_tokens", system = "postgresql")]
+    pub async fn revoke_all_tokens(
+        &self,
+        community_id: CommunityId,
+        owner_pubkey: &[u8],
+        revoked_by: &[u8],
+    ) -> Result<u64> {
+        revoke_all_tokens(
+            &self.pool,
+            *community_id.as_uuid(),
+            owner_pubkey,
+            revoked_by,
+        )
+        .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     //! Row-44 conformance: API token lookups MUST be keyed on
@@ -344,7 +625,7 @@ mod tests {
     use crate::{ApiTokenRecord, Db};
     use sqlx::PgPool;
 
-    const TEST_DB_URL: &str = "postgres://buzz:buzz_dev@localhost:5432/buzz";
+    const TEST_DB_URL: &str = "postgres://buzz:buzz_dev@localhost:5432/buzz"; // sadscan:disable np.postgres.1 -- local test-only credentials
 
     async fn setup_db() -> Db {
         let pool = PgPool::connect(TEST_DB_URL)

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -78,6 +78,7 @@ pub mod user;
 /// Workflow, run, and approval persistence.
 pub mod workflow;
 
+pub use api_token::{ApiTokenRecord, TokenSummary};
 pub use community::{
     ArchivedCommunityRecord, CommunityRecord, CreateCommunityWithOwnerResult,
     CreatedCommunityRecord, EnsuredCommunityRecord, OwnedCommunityRecord,
@@ -574,23 +575,6 @@ impl Default for DbConfig {
             replica_read_max_age_ms: 0,
         }
     }
-}
-
-/// Token summary returned by [`Db::list_active_tokens`].
-#[derive(Debug, Clone)]
-pub struct TokenSummary {
-    /// Unique token identifier.
-    pub id: Uuid,
-    /// Human-readable token name.
-    pub name: String,
-    /// Compressed public key bytes of the token owner.
-    pub owner_pubkey: Vec<u8>,
-    /// Permission scopes granted to this token.
-    pub scopes: Vec<String>,
-    /// When the token was created.
-    pub created_at: DateTime<Utc>,
-    /// Optional expiry timestamp; `None` means no expiry.
-    pub expires_at: Option<DateTime<Utc>>,
 }
 
 impl Db {
@@ -2743,210 +2727,6 @@ impl Db {
         }
     }
 
-    /// Create a new API token record.
-    #[allow(clippy::too_many_arguments)]
-    #[datastore_span(name = "create_api_token", system = "postgresql")]
-    pub async fn create_api_token(
-        &self,
-        community_id: CommunityId,
-        token_hash: &[u8],
-        owner_pubkey: &[u8],
-        name: &str,
-        scopes: &[String],
-        channel_ids: Option<&[Uuid]>,
-        expires_at: Option<DateTime<Utc>>,
-    ) -> Result<Uuid> {
-        api_token::create_api_token(
-            &self.pool,
-            *community_id.as_uuid(),
-            token_hash,
-            owner_pubkey,
-            name,
-            scopes,
-            channel_ids,
-            expires_at,
-        )
-        .await
-    }
-
-    /// Atomic conditional INSERT with 10-token limit (per (community, owner)).
-    #[allow(clippy::too_many_arguments)]
-    #[datastore_span(name = "create_api_token_if_under_limit", system = "postgresql")]
-    pub async fn create_api_token_if_under_limit(
-        &self,
-        community_id: CommunityId,
-        token_hash: &[u8],
-        owner_pubkey: &[u8],
-        name: &str,
-        scopes: &[String],
-        channel_ids: Option<&[Uuid]>,
-        expires_at: Option<DateTime<Utc>>,
-    ) -> Result<Option<Uuid>> {
-        api_token::create_api_token_if_under_limit(
-            &self.pool,
-            *community_id.as_uuid(),
-            token_hash,
-            owner_pubkey,
-            name,
-            scopes,
-            channel_ids,
-            expires_at,
-        )
-        .await
-    }
-
-    /// Look up an active (non-revoked) API token by its SHA-256 hash,
-    /// scoped to the request's community.
-    ///
-    /// See [`api_token::get_api_token_by_hash_including_revoked`] for the
-    /// row-44 conformance rationale — the `(community_id, token_hash)` key
-    /// is enforced both by the storage UNIQUE index and by this WHERE clause.
-    #[datastore_span(name = "get_api_token_by_hash", system = "postgresql")]
-    pub async fn get_api_token_by_hash(
-        &self,
-        community_id: CommunityId,
-        hash: &[u8],
-    ) -> Result<Option<ApiTokenRecord>> {
-        let row = sqlx::query(
-            r#"
-            SELECT id, token_hash, owner_pubkey, name, scopes, channel_ids,
-                   created_at, expires_at, last_used_at, revoked_at
-            FROM api_tokens
-            WHERE community_id = $1 AND token_hash = $2 AND revoked_at IS NULL
-            "#,
-        )
-        .bind(community_id.as_uuid())
-        .bind(hash)
-        .fetch_optional(&self.pool)
-        .await?;
-
-        match row {
-            None => Ok(None),
-            Some(r) => parse_api_token_row(r).map(Some),
-        }
-    }
-
-    /// Look up an API token by hash, including revoked, scoped to community.
-    #[datastore_span(
-        name = "get_api_token_by_hash_including_revoked",
-        system = "postgresql"
-    )]
-    pub async fn get_api_token_by_hash_including_revoked(
-        &self,
-        community_id: CommunityId,
-        hash: &[u8],
-    ) -> Result<Option<ApiTokenRecord>> {
-        api_token::get_api_token_by_hash_including_revoked(
-            &self.pool,
-            *community_id.as_uuid(),
-            hash,
-        )
-        .await
-    }
-
-    /// Record a token usage (update `last_used_at`), scoped to community.
-    #[datastore_span(name = "touch_api_token", system = "postgresql")]
-    pub async fn touch_api_token(&self, community_id: CommunityId, hash: &[u8]) -> Result<()> {
-        sqlx::query(
-            "UPDATE api_tokens SET last_used_at = NOW() WHERE community_id = $1 AND token_hash = $2",
-        )
-        .bind(community_id.as_uuid())
-        .bind(hash)
-        .execute(&self.pool)
-        .await?;
-        Ok(())
-    }
-
-    /// Alias for [`Self::touch_api_token`].
-    pub async fn update_token_last_used(
-        &self,
-        community_id: CommunityId,
-        hash: &[u8],
-    ) -> Result<()> {
-        self.touch_api_token(community_id, hash).await
-    }
-
-    /// List all active (non-revoked) tokens in a community, newest first.
-    #[datastore_span(name = "list_active_tokens", system = "postgresql")]
-    pub async fn list_active_tokens(&self, community_id: CommunityId) -> Result<Vec<TokenSummary>> {
-        let rows = sqlx::query(
-            r#"
-            SELECT id, name, owner_pubkey, scopes, created_at, expires_at
-            FROM api_tokens
-            WHERE community_id = $1 AND revoked_at IS NULL
-            ORDER BY created_at DESC
-            LIMIT 1000
-            "#,
-        )
-        .bind(community_id.as_uuid())
-        .fetch_all(&self.pool)
-        .await?;
-
-        let mut out = Vec::with_capacity(rows.len());
-        for row in rows {
-            let id: Uuid = row.try_get("id")?;
-            let scopes_json: serde_json::Value = row.try_get("scopes")?;
-            let scopes: Vec<String> = serde_json::from_value(scopes_json)
-                .map_err(|e| DbError::InvalidData(format!("scopes JSON: {e}")))?;
-
-            out.push(TokenSummary {
-                id,
-                name: row.try_get("name")?,
-                owner_pubkey: row.try_get("owner_pubkey")?,
-                scopes,
-                created_at: row.try_get("created_at")?,
-                expires_at: row.try_get("expires_at")?,
-            });
-        }
-        Ok(out)
-    }
-
-    /// List all tokens for a (community, owner) pair (including revoked).
-    #[datastore_span(name = "list_tokens_by_owner", system = "postgresql")]
-    pub async fn list_tokens_by_owner(
-        &self,
-        community_id: CommunityId,
-        pubkey: &[u8],
-    ) -> Result<Vec<ApiTokenRecord>> {
-        api_token::list_tokens_by_owner(&self.pool, *community_id.as_uuid(), pubkey).await
-    }
-
-    /// Revoke a single token by ID, scoped to (community, owner).
-    #[datastore_span(name = "revoke_token", system = "postgresql")]
-    pub async fn revoke_token(
-        &self,
-        community_id: CommunityId,
-        id: Uuid,
-        owner_pubkey: &[u8],
-        revoked_by: &[u8],
-    ) -> Result<bool> {
-        api_token::revoke_token(
-            &self.pool,
-            *community_id.as_uuid(),
-            id,
-            owner_pubkey,
-            revoked_by,
-        )
-        .await
-    }
-
-    /// Revoke all active tokens for a (community, owner) pair.
-    #[datastore_span(name = "revoke_all_tokens", system = "postgresql")]
-    pub async fn revoke_all_tokens(
-        &self,
-        community_id: CommunityId,
-        owner_pubkey: &[u8],
-        revoked_by: &[u8],
-    ) -> Result<u64> {
-        api_token::revoke_all_tokens(
-            &self.pool,
-            *community_id.as_uuid(),
-            owner_pubkey,
-            revoked_by,
-        )
-        .await
-    }
-
     /// Create a new workflow.
     #[datastore_span(name = "create_workflow", system = "postgresql")]
     pub async fn create_workflow(
@@ -4166,31 +3946,6 @@ impl Db {
     }
 }
 
-/// A full API token record.
-#[derive(Debug, Clone)]
-pub struct ApiTokenRecord {
-    /// Unique token identifier.
-    pub id: Uuid,
-    /// SHA-256 hash of the raw token value.
-    pub token_hash: Vec<u8>,
-    /// Compressed public key bytes of the token owner.
-    pub owner_pubkey: Vec<u8>,
-    /// Human-readable token name.
-    pub name: String,
-    /// Permission scopes granted to this token.
-    pub scopes: Vec<String>,
-    /// Optional channel ID restrictions.
-    pub channel_ids: Option<Vec<Uuid>>,
-    /// When the token was created.
-    pub created_at: DateTime<Utc>,
-    /// Optional expiry timestamp.
-    pub expires_at: Option<DateTime<Utc>>,
-    /// When the token was last used.
-    pub last_used_at: Option<DateTime<Utc>>,
-    /// When the token was revoked.
-    pub revoked_at: Option<DateTime<Utc>>,
-}
-
 /// An entry in the pubkey allowlist.
 #[derive(Debug, Clone)]
 pub struct AllowlistEntry {
@@ -4202,41 +3957,6 @@ pub struct AllowlistEntry {
     pub added_at: DateTime<Utc>,
     /// Optional note.
     pub note: Option<String>,
-}
-
-fn parse_api_token_row(row: sqlx::postgres::PgRow) -> Result<ApiTokenRecord> {
-    let id: Uuid = row.try_get("id")?;
-
-    let scopes_json: serde_json::Value = row.try_get("scopes")?;
-    let scopes: Vec<String> = serde_json::from_value(scopes_json)
-        .map_err(|e| DbError::InvalidData(format!("scopes JSON: {e}")))?;
-
-    let channel_ids: Option<Vec<Uuid>> = {
-        let raw: Option<serde_json::Value> = row.try_get("channel_ids")?;
-        match raw {
-            None => None,
-            Some(v) => {
-                let strings: Vec<String> = serde_json::from_value(v)
-                    .map_err(|e| DbError::InvalidData(format!("channel_ids JSON: {e}")))?;
-                let uuids: std::result::Result<Vec<Uuid>, _> =
-                    strings.iter().map(|s| s.parse::<Uuid>()).collect();
-                Some(uuids.map_err(|e| DbError::InvalidData(format!("channel_ids UUID: {e}")))?)
-            }
-        }
-    };
-
-    Ok(ApiTokenRecord {
-        id,
-        token_hash: row.try_get("token_hash")?,
-        owner_pubkey: row.try_get("owner_pubkey")?,
-        name: row.try_get("name")?,
-        scopes,
-        channel_ids,
-        created_at: row.try_get("created_at")?,
-        expires_at: row.try_get("expires_at")?,
-        last_used_at: row.try_get("last_used_at")?,
-        revoked_at: row.try_get("revoked_at")?,
-    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Current reconstructed head

Exact base: `codex/issue-7-channel-membership-store` at `8ad0782ee311f5f51b714494ce750c5937f127cc`  
Exact head: `codex/issue-12-api-token-store` at `efd769903a0aab75961453ab247bef923f64ac38`

This current head removes `crates/buzz-db/tests/store_ownership.rs`; no replacement path-sensitive ownership test is introduced. Apart from removing that complete test-file diff, the production patch is byte-for-byte identical to the previously reviewed slice. This remains part of tracker #2 and the #17/#19 acceptance work.

Independent exact-head review from a separate clean Blox workstation found no issues. Current-head evidence passed formatting, strict `buzz-db` clippy, 111 non-PostgreSQL library tests with 200 PostgreSQL tests ignored, the observability source test, relay consumer compilation, exact ownership/unique-span review checks, and 2 API-token PostgreSQL tests on native PostgreSQL where applicable.

## Why
Complete the API-token half of [tracker #2](https://github.com/TheSentinel454/buzz/issues/2) and [domain issue #12](https://github.com/TheSentinel454/buzz/issues/12) while keeping `Db` as the stable public facade. This child stacks on the channel/membership extraction in #6782.

## What
- Move `ApiTokenRecord`, `TokenSummary`, `parse_api_token_row`, every API-token `Db` method, inline SQL, focused tests, and datastore spans into `api_token.rs`
- Preserve every public `Db` signature and crate-root record export
- Preserve validation, JSON parsing, community scoping, token limits, revocation behavior, and the existing `update_token_last_used` alias-to-`touch_api_token` single-span behavior

## Stack
- Exact base: codex/issue-7-channel-membership-store at 25138bfd6588e046170dbdbc4ed953bdc3cf7ed1 ([#6782](https://github.com/block/buzz/pull/6782))
- Exact head: codex/issue-12-api-token-store at 7798ea83fe393cdc457577bb09a4fd7546b9722b
- Tracker: https://github.com/TheSentinel454/buzz/issues/2
- Domain: https://github.com/TheSentinel454/buzz/issues/12
- Test/span acceptance: https://github.com/TheSentinel454/buzz/issues/17 and https://github.com/TheSentinel454/buzz/issues/19

## Non-goals
- No SQL, schema, validation, retry, timeout, transaction, or client-visible behavior changes
- No consolidation of authentication allowlisting with API tokens or NIP-43 relay membership
- No store traits, domain-handle redesign, broad `PgExecutor` migration, raw pool accessor, new crate, or directory-wide reorganization
- No changes to, retargeting of, or merge action on parent PRs or PR #6700

## Risk Assessment
Low. This is a direct ownership move. The usage-update alias deliberately retains only the `touch_api_token` span to avoid nesting.

## Blox Verification
Author workstation: `buzz-tornquist-issue-2-store-stack` (`2046520`), exact head `677b81eea1c2c69e540670e907c3bda4a2993fd6`.

- `cargo fmt --all --check` — passed
- `cargo clippy -p buzz-db -p buzz-relay --all-targets -- -D warnings` — passed
- Native PostgreSQL: `cargo test -p buzz-db api_token::tests:: -- --ignored --test-threads=1` — 2 passed
- Relay public-path/all-target compilation is covered by the relay clippy invocation
- Commit-time formatting, sadscan, attribution, and sign-off hooks — passed

Independent exact-head review: `buzz-tornquist-pr-6783-review` (`2048930`) found no critical, important, or minor issues. The reviewer confirmed unchanged SQL/binds/validation/scoping and exactly one span per logical operation, including no alias span for `update_token_last_used`.

Generated with Codex

## Superseded pre-comment restack verification

PR #6700 merged before publication completed. This layer was restacked onto current main through the exact parent named above; the final cumulative tip is 2ddcc8a29f95c8c8c9cb87bb6cf59335f2190fae. Cumulative author gates passed: formatting and diff checks; buzz-db and buzz-relay all-target clippy with -D warnings; DB lib 111 passed / 200 ignored; ownership 22/22; observability 1/1; the full isolated PostgreSQL domain matrix; and relay lib 910 passed / 49 ignored.

- Workstation: `buzz-tornquist-pr-6783-final-review` (`2057621`), fresh shallow checkout
- Base: `fa09b6c81c4db3b3e1940a2117a97ab2186e49f7`
- Head: `e69f4e7180eae47d96c56012f9cbea966da584e2`
- Findings: none

Reviewed API-token records, row parsing, SQL, `Db` wrappers, tests, and spans as a single move to `api_token.rs`. Community scoping, JSON/UUID validation errors, token limits, revocation behavior, and method signatures are unchanged. Crate-root type re-exports preserve established consumers. The uninstrumented alias continues to reuse `touch_api_token` so one logical operation produces one span.

Verification: format and diff checks passed; `buzz-db --all-targets` clippy passed with `-D warnings`; DB lib tests passed (111 passed, 200 PostgreSQL tests ignored); ownership (3/3) and observability (1/1) guards passed; both API-token PostgreSQL tests passed on native PostgreSQL 17 with migrations 1-32 successful; relay lib test target compiled successfully. Final worktree was detached at the exact head and clean.

Complete evidence archive SHA-256: `a05380cbf4f9b1671bee1bdffe78ebae390c792b87e497233310e35d1f193fa8`.

## Comment-addressed restack

Review follow-up on #6777 removed only the low-value replaceable ownership source test. This PR was restacked onto its rewritten parent; its production patch is unchanged.

- Exact base: `25138bfd6588e046170dbdbc4ed953bdc3cf7ed1`
- Exact head: `7798ea83fe393cdc457577bb09a4fd7546b9722b`
- Final cumulative tip: `6fa2f104d42c6ba85bdf62e7ccb74ceaf4a84f67`
- Per-layer patch-ID and tree audits confirm this PR’s production diff is unchanged from its pre-comment head.
- Cumulative Blox gate: formatting and diff checks; strict `buzz-db`/`buzz-relay` Clippy; DB lib 111 passed / 200 ignored; ownership 21/21; observability 1/1; every moved PostgreSQL test; relay lib 910 passed / 49 ignored.
- Independent re-review at this exact head: no findings; fresh exact-parent/head Blox review passed fmt/diff, strict Clippy, DB lib 111 passed / 200 ignored, current ownership/observability guards, 2 API-token PostgreSQL tests, and relay compilation.
