### PR TITLE
refactor(db): extract authentication allowlist store

### DIFF
--- a/crates/buzz-db/src/allowlist.rs
+++ b/crates/buzz-db/src/allowlist.rs
@@ -1,0 +1,209 @@
+//! Community-scoped authentication allowlist persistence.
+//!
+//! This store is distinct from NIP-43 relay membership. Membership backfill
+//! orchestration remains with the relay-membership invariant owner.
+
+use buzz_core::CommunityId;
+use buzz_datastore_tracing::datastore_span;
+use chrono::{DateTime, Utc};
+use sqlx::Row;
+
+use crate::error::Result;
+use crate::Db;
+
+/// An entry in the pubkey allowlist.
+#[derive(Debug, Clone)]
+pub struct AllowlistEntry {
+    /// The allowed pubkey.
+    pub pubkey: Vec<u8>,
+    /// Who added this entry.
+    pub added_by: Vec<u8>,
+    /// When the entry was added.
+    pub added_at: DateTime<Utc>,
+    /// Optional note.
+    pub note: Option<String>,
+}
+
+impl Db {
+    /// Check if a pubkey is in the allowlist for `community`.
+    #[datastore_span(name = "is_pubkey_allowed", system = "postgresql")]
+    pub async fn is_pubkey_allowed(&self, community: CommunityId, pubkey: &[u8]) -> Result<bool> {
+        let row = sqlx::query(
+            "SELECT COUNT(*) as cnt FROM pubkey_allowlist WHERE community_id = $1 AND pubkey = $2",
+        )
+        .bind(community.as_uuid())
+        .bind(pubkey)
+        .fetch_one(&self.pool)
+        .await?;
+        let cnt: i64 = row.try_get("cnt")?;
+        Ok(cnt > 0)
+    }
+
+    /// Check if the community allowlist has any entries (i.e. is enforcement active).
+    #[datastore_span(name = "has_allowlist_entries", system = "postgresql")]
+    pub async fn has_allowlist_entries(&self, community: CommunityId) -> Result<bool> {
+        let row =
+            sqlx::query("SELECT COUNT(*) as cnt FROM pubkey_allowlist WHERE community_id = $1")
+                .bind(community.as_uuid())
+                .fetch_one(&self.pool)
+                .await?;
+        let cnt: i64 = row.try_get("cnt")?;
+        Ok(cnt > 0)
+    }
+
+    /// Add a pubkey to the community allowlist.
+    #[datastore_span(name = "add_to_allowlist", system = "postgresql")]
+    pub async fn add_to_allowlist(
+        &self,
+        community: CommunityId,
+        pubkey: &[u8],
+        added_by: &[u8],
+        note: Option<&str>,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            "INSERT INTO pubkey_allowlist (community_id, pubkey, added_by, note) VALUES ($1, $2, $3, $4) \
+             ON CONFLICT DO NOTHING",
+        )
+        .bind(community.as_uuid())
+        .bind(pubkey)
+        .bind(added_by)
+        .bind(note)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Remove a pubkey from the community allowlist.
+    #[datastore_span(name = "remove_from_allowlist", system = "postgresql")]
+    pub async fn remove_from_allowlist(
+        &self,
+        community: CommunityId,
+        pubkey: &[u8],
+    ) -> Result<bool> {
+        let result =
+            sqlx::query("DELETE FROM pubkey_allowlist WHERE community_id = $1 AND pubkey = $2")
+                .bind(community.as_uuid())
+                .bind(pubkey)
+                .execute(&self.pool)
+                .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// List all pubkeys in the community allowlist.
+    #[datastore_span(name = "list_allowlist", system = "postgresql")]
+    pub async fn list_allowlist(&self, community: CommunityId) -> Result<Vec<AllowlistEntry>> {
+        let rows = sqlx::query(
+            "SELECT pubkey, added_by, added_at, note FROM pubkey_allowlist WHERE community_id = $1 ORDER BY added_at DESC",
+        )
+        .bind(community.as_uuid())
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            out.push(AllowlistEntry {
+                pubkey: row.try_get("pubkey")?,
+                added_by: row.try_get("added_by")?,
+                added_at: row.try_get("added_at")?,
+                note: row.try_get("note")?,
+            });
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    const TEST_DB_URL: &str = "postgres://buzz:buzz_dev@localhost:5432/buzz"; // sadscan:disable np.postgres.1 -- local test-only credentials
+
+    async fn setup_db() -> Db {
+        let database_url =
+            std::env::var("TEST_DATABASE_URL").unwrap_or_else(|_| TEST_DB_URL.into());
+        let pool = PgPool::connect(&database_url)
+            .await
+            .expect("connect to test DB");
+        Db::from_pool(pool)
+    }
+
+    async fn make_community(pool: &PgPool) -> Uuid {
+        let id = Uuid::new_v4();
+        let host = format!("communities-of-channels-{}.example", id.simple());
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(id)
+            .bind(host)
+            .execute(pool)
+            .await
+            .expect("insert community");
+        id
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn allowlist_is_scoped_to_community() {
+        let db = setup_db().await;
+        let community_a = CommunityId::from_uuid(make_community(&db.pool).await);
+        let community_b = CommunityId::from_uuid(make_community(&db.pool).await);
+        let pubkey = [7u8; 32];
+        let added_by = [9u8; 32];
+
+        assert!(db
+            .add_to_allowlist(community_a, &pubkey, &added_by, Some("a-only"))
+            .await
+            .expect("add allowlist row"));
+        assert!(!db
+            .add_to_allowlist(community_a, &pubkey, &added_by, Some("duplicate"))
+            .await
+            .expect("duplicate allowlist row is idempotent"));
+
+        assert!(
+            db.is_pubkey_allowed(community_a, &pubkey)
+                .await
+                .expect("allowlist check A"),
+            "pubkey added to A must be allowed in A"
+        );
+        assert!(
+            !db.is_pubkey_allowed(community_b, &pubkey)
+                .await
+                .expect("allowlist check B"),
+            "pubkey added only to A must not be allowed in B"
+        );
+        assert!(db
+            .has_allowlist_entries(community_a)
+            .await
+            .expect("A has entries"));
+        assert!(!db
+            .has_allowlist_entries(community_b)
+            .await
+            .expect("B has no entries"));
+
+        let listed = db
+            .list_allowlist(community_a)
+            .await
+            .expect("list A allowlist");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].pubkey, pubkey);
+
+        assert!(
+            !db.remove_from_allowlist(community_b, &pubkey)
+                .await
+                .expect("remove from B is no-op"),
+            "removing from B must not delete A's row"
+        );
+        assert!(db
+            .is_pubkey_allowed(community_a, &pubkey)
+            .await
+            .expect("A still allowed after B remove"));
+        assert!(db
+            .remove_from_allowlist(community_a, &pubkey)
+            .await
+            .expect("remove from A"));
+        assert!(!db
+            .is_pubkey_allowed(community_a, &pubkey)
+            .await
+            .expect("A not allowed after remove"));
+    }
+}

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -26,6 +26,8 @@
 
 /// Explicit deployment-global admin report reads.
 pub mod admin_moderation;
+/// Community-scoped authentication allowlist persistence.
+pub mod allowlist;
 /// API token storage and lookup.
 pub mod api_token;
 /// Relay-scoped archived identity persistence (NIP-IA).
@@ -78,6 +80,7 @@ pub mod user;
 /// Workflow, run, and approval persistence.
 pub mod workflow;
 
+pub use allowlist::AllowlistEntry;
 pub use api_token::{ApiTokenRecord, TokenSummary};
 pub use community::{
     ArchivedCommunityRecord, CommunityRecord, CreateCommunityWithOwnerResult,
@@ -3157,92 +3160,6 @@ impl Db {
         Ok(result.rows_affected())
     }
 
-    /// Check if a pubkey is in the allowlist for `community`.
-    #[datastore_span(name = "is_pubkey_allowed", system = "postgresql")]
-    pub async fn is_pubkey_allowed(&self, community: CommunityId, pubkey: &[u8]) -> Result<bool> {
-        let row = sqlx::query(
-            "SELECT COUNT(*) as cnt FROM pubkey_allowlist WHERE community_id = $1 AND pubkey = $2",
-        )
-        .bind(community.as_uuid())
-        .bind(pubkey)
-        .fetch_one(&self.pool)
-        .await?;
-        let cnt: i64 = row.try_get("cnt")?;
-        Ok(cnt > 0)
-    }
-
-    /// Check if the community allowlist has any entries (i.e. is enforcement active).
-    #[datastore_span(name = "has_allowlist_entries", system = "postgresql")]
-    pub async fn has_allowlist_entries(&self, community: CommunityId) -> Result<bool> {
-        let row =
-            sqlx::query("SELECT COUNT(*) as cnt FROM pubkey_allowlist WHERE community_id = $1")
-                .bind(community.as_uuid())
-                .fetch_one(&self.pool)
-                .await?;
-        let cnt: i64 = row.try_get("cnt")?;
-        Ok(cnt > 0)
-    }
-
-    /// Add a pubkey to the community allowlist.
-    #[datastore_span(name = "add_to_allowlist", system = "postgresql")]
-    pub async fn add_to_allowlist(
-        &self,
-        community: CommunityId,
-        pubkey: &[u8],
-        added_by: &[u8],
-        note: Option<&str>,
-    ) -> Result<bool> {
-        let result = sqlx::query(
-            "INSERT INTO pubkey_allowlist (community_id, pubkey, added_by, note) VALUES ($1, $2, $3, $4) \
-             ON CONFLICT DO NOTHING",
-        )
-        .bind(community.as_uuid())
-        .bind(pubkey)
-        .bind(added_by)
-        .bind(note)
-        .execute(&self.pool)
-        .await?;
-        Ok(result.rows_affected() > 0)
-    }
-
-    /// Remove a pubkey from the community allowlist.
-    #[datastore_span(name = "remove_from_allowlist", system = "postgresql")]
-    pub async fn remove_from_allowlist(
-        &self,
-        community: CommunityId,
-        pubkey: &[u8],
-    ) -> Result<bool> {
-        let result =
-            sqlx::query("DELETE FROM pubkey_allowlist WHERE community_id = $1 AND pubkey = $2")
-                .bind(community.as_uuid())
-                .bind(pubkey)
-                .execute(&self.pool)
-                .await?;
-        Ok(result.rows_affected() > 0)
-    }
-
-    /// List all pubkeys in the community allowlist.
-    #[datastore_span(name = "list_allowlist", system = "postgresql")]
-    pub async fn list_allowlist(&self, community: CommunityId) -> Result<Vec<AllowlistEntry>> {
-        let rows = sqlx::query(
-            "SELECT pubkey, added_by, added_at, note FROM pubkey_allowlist WHERE community_id = $1 ORDER BY added_at DESC",
-        )
-        .bind(community.as_uuid())
-        .fetch_all(&self.pool)
-        .await?;
-
-        let mut out = Vec::with_capacity(rows.len());
-        for row in rows {
-            out.push(AllowlistEntry {
-                pubkey: row.try_get("pubkey")?,
-                added_by: row.try_get("added_by")?,
-                added_at: row.try_get("added_at")?,
-                note: row.try_get("note")?,
-            });
-        }
-        Ok(out)
-    }
-
     /// Returns `true` if `pubkey` (64-char hex) is a member of `community`.
     ///
     /// Replica-routed on the bounded arm — the one PERMISSION read routed by
@@ -3946,19 +3863,6 @@ impl Db {
     }
 }
 
-/// An entry in the pubkey allowlist.
-#[derive(Debug, Clone)]
-pub struct AllowlistEntry {
-    /// The allowed pubkey.
-    pub pubkey: Vec<u8>,
-    /// Who added this entry.
-    pub added_by: Vec<u8>,
-    /// When the entry was added.
-    pub added_at: DateTime<Utc>,
-    /// Optional note.
-    pub note: Option<String>,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4418,72 +4322,6 @@ mod tests {
         drop(first);
         drop(second);
         drop_scratch_db(&admin, pool, &scratch_name).await;
-    }
-
-    #[tokio::test]
-    #[ignore = "requires Postgres"]
-    async fn allowlist_is_scoped_to_community() {
-        let db = setup_db().await;
-        let community_a = CommunityId::from_uuid(make_community(&db.pool).await);
-        let community_b = CommunityId::from_uuid(make_community(&db.pool).await);
-        let pubkey = [7u8; 32];
-        let added_by = [9u8; 32];
-
-        assert!(db
-            .add_to_allowlist(community_a, &pubkey, &added_by, Some("a-only"))
-            .await
-            .expect("add allowlist row"));
-        assert!(!db
-            .add_to_allowlist(community_a, &pubkey, &added_by, Some("duplicate"))
-            .await
-            .expect("duplicate allowlist row is idempotent"));
-
-        assert!(
-            db.is_pubkey_allowed(community_a, &pubkey)
-                .await
-                .expect("allowlist check A"),
-            "pubkey added to A must be allowed in A"
-        );
-        assert!(
-            !db.is_pubkey_allowed(community_b, &pubkey)
-                .await
-                .expect("allowlist check B"),
-            "pubkey added only to A must not be allowed in B"
-        );
-        assert!(db
-            .has_allowlist_entries(community_a)
-            .await
-            .expect("A has entries"));
-        assert!(!db
-            .has_allowlist_entries(community_b)
-            .await
-            .expect("B has no entries"));
-
-        let listed = db
-            .list_allowlist(community_a)
-            .await
-            .expect("list A allowlist");
-        assert_eq!(listed.len(), 1);
-        assert_eq!(listed[0].pubkey, pubkey);
-
-        assert!(
-            !db.remove_from_allowlist(community_b, &pubkey)
-                .await
-                .expect("remove from B is no-op"),
-            "removing from B must not delete A's row"
-        );
-        assert!(db
-            .is_pubkey_allowed(community_a, &pubkey)
-            .await
-            .expect("A still allowed after B remove"));
-        assert!(db
-            .remove_from_allowlist(community_a, &pubkey)
-            .await
-            .expect("remove from A"));
-        assert!(!db
-            .is_pubkey_allowed(community_a, &pubkey)
-            .await
-            .expect("A not allowed after remove"));
     }
 
     /// BUG-5 regression: the `reactions` table is community-scoped


### PR DESCRIPTION
## Current reconstructed head

Exact base: `codex/issue-12-api-token-store` at `efd769903a0aab75961453ab247bef923f64ac38`  
Exact head: `codex/issue-12-allowlist-store` at `7ae63f6be2f3f1265b976f37756f3ca0caaffa59`

This current head removes `crates/buzz-db/tests/store_ownership.rs`; no replacement path-sensitive ownership test is introduced. Apart from removing that complete test-file diff, the production patch is byte-for-byte identical to the previously reviewed slice. This remains part of tracker #2 and the #17/#19 acceptance work.

Independent exact-head review from a separate clean Blox workstation found no issues. Current-head evidence passed formatting, strict `buzz-db` clippy, 111 non-PostgreSQL library tests with 200 PostgreSQL tests ignored, the observability source test, relay consumer compilation, exact ownership/unique-span review checks, and 1 allowlist PostgreSQL test on native PostgreSQL where applicable.

## Why
Complete the authentication-allowlist half of [tracker #2](https://github.com/TheSentinel454/buzz/issues/2) and [domain issue #12](https://github.com/TheSentinel454/buzz/issues/12) while keeping `Db` as the stable public facade. This child stacks on the API-token extraction in #6783.

## What
- Add a dedicated `allowlist.rs` owner for `AllowlistEntry`, every allowlist `Db` method, inline SQL, focused tests, and datastore spans
- Preserve every public `Db` signature and the crate-root `AllowlistEntry` export
- Preserve community scoping, UPSERT/delete behavior, timestamps, row parsing, and validation/error behavior
- Keep NIP-43 relay membership and migration/backfill orchestration outside this authentication-allowlist module

## Stack
- Exact base: codex/issue-12-api-token-store at 7798ea83fe393cdc457577bb09a4fd7546b9722b ([#6783](https://github.com/block/buzz/pull/6783))
- Exact head: codex/issue-12-allowlist-store at fa88a642a7aa10ce74f8cea692653e50b427f89e
- Tracker: https://github.com/TheSentinel454/buzz/issues/2
- Domain: https://github.com/TheSentinel454/buzz/issues/12
- Test/span acceptance: https://github.com/TheSentinel454/buzz/issues/17 and https://github.com/TheSentinel454/buzz/issues/19

## Non-goals
- No SQL, schema, validation, retry, timeout, transaction, or client-visible behavior changes
- No consolidation of authentication allowlisting with NIP-43 relay membership
- No movement of cross-domain migration/backfill orchestration
- No store traits, domain-handle redesign, broad `PgExecutor` migration, raw pool accessor, new crate, or directory-wide reorganization
- No changes to, retargeting of, or merge action on parent PRs or PR #6700

## Risk Assessment
Low. This is a direct ownership move. The guard also prevents relay-membership backfill orchestration from drifting into the authentication allowlist owner.

## Blox Verification
Author workstation: `buzz-tornquist-issue-2-store-stack` (`2046520`), exact head `f30633fc37d9b44860db5644418e066a917dc113`.

- `cargo fmt --all --check` — passed
- `cargo clippy -p buzz-db -p buzz-relay --all-targets -- -D warnings` — passed
- Native PostgreSQL: `cargo test -p buzz-db allowlist::tests:: -- --ignored --test-threads=1` — 1 passed
- Relay public-path/all-target compilation is covered by the relay clippy invocation
- Commit-time formatting, sadscan, attribution, and sign-off hooks — passed

Independent exact-head review: `buzz-tornquist-pr-6784-review` (`2049132`) found no critical, important, or minor issues. The reviewer confirmed exact production method/test equivalence, one span per operation, and that NIP-43 backfill remains relay-membership owned.

Generated with Codex

## Superseded pre-comment restack verification

PR #6700 merged before publication completed. This layer was restacked onto current main through the exact parent named above; the final cumulative tip is 2ddcc8a29f95c8c8c9cb87bb6cf59335f2190fae. Cumulative author gates passed: formatting and diff checks; buzz-db and buzz-relay all-target clippy with -D warnings; DB lib 111 passed / 200 ignored; ownership 22/22; observability 1/1; the full isolated PostgreSQL domain matrix; and relay lib 910 passed / 49 ignored.

- Workstation: `buzz-tornquist-pr-6784-final-review` (`2057622`), fresh shallow checkout
- Base: `e69f4e7180eae47d96c56012f9cbea966da584e2`
- Head: `b7347e78843d7b63e3cb383da7cbf5ffc956d4f0`
- Findings: none

Reviewed the authentication allowlist extraction. `AllowlistEntry`, community-scoped SQL, `Db` wrappers, test, and datastore spans move together to `allowlist.rs`; crate-root compatibility is retained. The module remains separate from NIP-43 relay membership and introduces no migration or backfill ownership change.

Verification: format and diff checks passed; `buzz-db --all-targets` clippy passed with `-D warnings`; DB lib tests passed (111 passed, 200 PostgreSQL tests ignored); ownership (4/4) and observability (1/1) guards passed; the allowlist PostgreSQL isolation test passed on native PostgreSQL 17 with migrations 1-32 successful; relay lib test target compiled successfully. Final worktree was detached at the exact head and clean.

Complete evidence archive SHA-256: `a8fd059c66d343e4d98850cb67747a41cb8c6161f98f74f3577ec6cc547fab63`.

## Comment-addressed restack

Review follow-up on #6777 removed only the low-value replaceable ownership source test. This PR was restacked onto its rewritten parent; its production patch is unchanged.

- Exact base: `7798ea83fe393cdc457577bb09a4fd7546b9722b`
- Exact head: `fa88a642a7aa10ce74f8cea692653e50b427f89e`
- Final cumulative tip: `6fa2f104d42c6ba85bdf62e7ccb74ceaf4a84f67`
- Per-layer patch-ID and tree audits confirm this PR’s production diff is unchanged from its pre-comment head.
- Cumulative Blox gate: formatting and diff checks; strict `buzz-db`/`buzz-relay` Clippy; DB lib 111 passed / 200 ignored; ownership 21/21; observability 1/1; every moved PostgreSQL test; relay lib 910 passed / 49 ignored.
- Independent re-review at this exact head: no findings; fresh exact-parent/head Blox review passed fmt/diff, strict Clippy, DB lib 111 passed / 200 ignored, current ownership/observability guards, 1 allowlist PostgreSQL test, and relay compilation.
