### PR TITLE
feat(workflows): add user-defined slash command macros

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -529,7 +529,10 @@ steps:
 
 Note: Both `TriggerDef` and `ActionDef` use serde internally-tagged enums. Triggers use `on:` as the tag field; actions use `action:` as the tag field. Fields are flattened into the parent struct, not nested.
 
-**4 trigger types:** `message_posted`, `reaction_added`, `schedule`, `webhook`
+**6 trigger types:** `message_posted`, `slash_command`, `reaction_added`,
+`diff_posted`, `schedule`, `webhook`. A `slash_command` trigger owns an exact
+bare command such as `/new-task`; mention-prefixed commands remain ACP runtime
+commands. The argument tail is available as `{{trigger.args}}`.
 
 **7 action types:**
 
@@ -543,7 +546,9 @@ Note: Both `TriggerDef` and `ActionDef` use serde internally-tagged enums. Trigg
 | `request_approval` | Suspend execution; fields: `from`, `message`, `timeout` (default 24h) |
 | `delay` | Pause execution (max 300 seconds) |
 
-**Template variables:** `{{trigger.text}}`, `{{trigger.author}}`, `{{steps.ID.output.FIELD}}`. Single-pass resolution (not recursive). Unknown variables left as literal text.
+**Template variables:** `{{trigger.text}}`, `{{trigger.author}}`,
+`{{trigger.command}}`, `{{trigger.args}}`, `{{steps.ID.output.FIELD}}`.
+Single-pass resolution (not recursive). Unknown variables left as literal text.
 
 **Condition evaluation:** `evalexpr` with `HashMapContext`. Dot notation converted to underscores (`trigger.text` → `trigger_text`). Custom functions registered: `str_contains`, `str_starts_with`, `str_ends_with`, `str_len`. 100ms timeout prevents adversarial expressions from blocking.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Agents are part of the room, not haunted cron jobs.
 | Relay, channels, threads, DMs, canvases, media, search, audit log | Mobile clients (iOS + Android, Flutter) | Web-of-trust reputation across relays |
 | Desktop app (Tauri + React) | Workflow approval gates (infra exists, glue still drying) | Push notifications |
 | `buzz-cli` (agent-first, JSON in / JSON out) + ACP harness (Goose, Codex, Claude Code) | Huddle lifecycle events | Culture features |
-| YAML workflows: message / reaction / schedule / webhook triggers | | |
+| YAML workflows: message / slash-command / reaction / diff / schedule / webhook triggers | | |
 | Git events (NIP-34: patches, repo announcements, status) | | |
 | Git hosting backend | | |
 

--- a/crates/buzz-workflow/src/executor.rs
+++ b/crates/buzz-workflow/src/executor.rs
@@ -41,6 +41,14 @@ pub struct TriggerContext {
     /// NIP-10 `reply`/`root` marker e-tag). Lets a `message_posted` filter
     /// select only top-level messages via `trigger_is_reply == false`.
     pub is_reply: bool,
+    /// Matched slash command name without the leading slash. Empty for other
+    /// trigger types.
+    #[serde(default)]
+    pub command: String,
+    /// Text following the matched slash command, trimmed at both ends. Empty
+    /// when the command has no arguments or for other trigger types.
+    #[serde(default)]
+    pub args: String,
     /// Arbitrary webhook body fields (webhook trigger).
     pub webhook_fields: HashMap<String, String>,
 }
@@ -58,6 +66,8 @@ impl TriggerContext {
             "timestamp" => Some(&self.timestamp),
             "emoji" => Some(&self.emoji),
             "message_id" => Some(&self.message_id),
+            "command" => Some(&self.command),
+            "args" => Some(&self.args),
             other => self.webhook_fields.get(other).map(|s| s.as_str()),
         }
     }
@@ -217,6 +227,8 @@ fn apply_filter(value: String, filter: &str) -> Result<String, WorkflowError> {
 /// | `trigger.timestamp`               | `trigger_timestamp`       |
 /// | `trigger.emoji`                   | `trigger_emoji`           |
 /// | `trigger.message_id`              | `trigger_message_id`      |
+/// | `trigger.command`                 | `trigger_command`         |
+/// | `trigger.args`                    | `trigger_args`            |
 /// | `trigger.is_reply`                | `trigger_is_reply` (bool) |
 /// | `steps.STEP_ID.output.FIELD`      | `steps_STEP_ID_output_FIELD` |
 ///
@@ -298,6 +310,8 @@ pub fn build_eval_context(
         ("trigger_timestamp", trigger_ctx.timestamp.as_str()),
         ("trigger_emoji", trigger_ctx.emoji.as_str()),
         ("trigger_message_id", trigger_ctx.message_id.as_str()),
+        ("trigger_command", trigger_ctx.command.as_str()),
+        ("trigger_args", trigger_ctx.args.as_str()),
     ];
 
     for (name, val) in &trigger_fields {
@@ -1311,6 +1325,8 @@ mod tests {
             emoji: "fire".to_owned(),
             message_id: "event-id-hex".to_owned(),
             is_reply: false,
+            command: "new-task".to_owned(),
+            args: "Build feature XYZ".to_owned(),
             webhook_fields: HashMap::new(),
         }
     }
@@ -1327,6 +1343,18 @@ mod tests {
         let ctx = make_trigger();
         let out = resolve_template("By {{trigger.author}}", &ctx, &HashMap::new()).unwrap();
         assert_eq!(out, "By abc123def456");
+    }
+
+    #[test]
+    fn resolve_slash_command_fields() {
+        let ctx = make_trigger();
+        let out = resolve_template(
+            "/{{trigger.command}} dispatched: {{trigger.args}}",
+            &ctx,
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert_eq!(out, "/new-task dispatched: Build feature XYZ");
     }
 
     #[test]
@@ -1416,6 +1444,19 @@ mod tests {
             evaluate_condition("str_contains(trigger_text, \"P1\")", &ctx, &HashMap::new())
                 .await
                 .unwrap();
+        assert!(result);
+    }
+
+    #[tokio::test]
+    async fn condition_can_filter_slash_command_and_args() {
+        let ctx = make_trigger();
+        let result = evaluate_condition(
+            "trigger_command == \"new-task\" && str_contains(trigger_args, \"feature XYZ\")",
+            &ctx,
+            &HashMap::new(),
+        )
+        .await
+        .unwrap();
         assert!(result);
     }
 

--- a/crates/buzz-workflow/src/lib.rs
+++ b/crates/buzz-workflow/src/lib.rs
@@ -359,14 +359,6 @@ impl WorkflowEngine {
 
         let trigger_ctx = build_trigger_context(event);
 
-        let trigger_ctx_json: serde_json::Value = match serde_json::to_value(&trigger_ctx) {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::error!("Failed to serialize trigger context: {e}");
-                return Ok(());
-            }
-        };
-
         for workflow in workflows.iter() {
             let def: WorkflowDef = match serde_json::from_value(workflow.definition.clone()) {
                 Ok(d) => d,
@@ -380,9 +372,24 @@ impl WorkflowEngine {
                 continue;
             }
 
-            if !should_fire_workflow(&def, &trigger_ctx, workflow.id).await {
+            let Some(workflow_trigger_ctx) =
+                trigger_context_for_workflow(&def.trigger, &trigger_ctx)
+            else {
+                continue;
+            };
+
+            if !should_fire_workflow(&def, &workflow_trigger_ctx, workflow.id).await {
                 continue;
             }
+
+            let trigger_ctx_json: serde_json::Value =
+                match serde_json::to_value(&workflow_trigger_ctx) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::error!("Failed to serialize trigger context: {e}");
+                        continue;
+                    }
+                };
 
             // SEC-006: recheck the owner's *current* channel authority
             // immediately before run creation. The cached workflow list can be
@@ -427,7 +434,7 @@ impl WorkflowEngine {
 
             let engine = Arc::clone(self);
             let def_clone = def.clone();
-            let ctx_clone = trigger_ctx.clone();
+            let ctx_clone = workflow_trigger_ctx;
 
             tokio::spawn(async move {
                 let result =
@@ -904,7 +911,8 @@ async fn should_fire_workflow(
     let filter = match &def.trigger {
         TriggerDef::MessagePosted { filter }
         | TriggerDef::ReactionAdded { filter, .. }
-        | TriggerDef::DiffPosted { filter } => filter.as_ref(),
+        | TriggerDef::DiffPosted { filter }
+        | TriggerDef::SlashCommand { filter, .. } => filter.as_ref(),
         TriggerDef::Schedule { .. } | TriggerDef::Webhook => None,
     };
     if let Some(expr) = filter {
@@ -928,6 +936,42 @@ async fn should_fire_workflow(
     }
 
     true
+}
+
+/// Prepare the per-workflow trigger context after kind-level matching.
+///
+/// Ordinary event triggers reuse the base context unchanged. Slash commands
+/// additionally require an exact bare command token and expose the parsed name
+/// and argument tail as `trigger.command` / `trigger.args`. A leading mention
+/// never matches, preserving `@Agent /command` for ACP pass-through.
+fn trigger_context_for_workflow(
+    trigger: &TriggerDef,
+    base: &executor::TriggerContext,
+) -> Option<executor::TriggerContext> {
+    let TriggerDef::SlashCommand { command, .. } = trigger else {
+        return Some(base.clone());
+    };
+
+    let args = match_slash_command(&base.text, command)?;
+    let mut context = base.clone();
+    context.command.clone_from(command);
+    context.args = args;
+    Some(context)
+}
+
+/// Match `/name` or `/name <args>` at the start of a message.
+///
+/// Leading whitespace is ignored, matching ACP command handling. The command
+/// token must end at whitespace or end-of-input, so `/new-task-extra` cannot
+/// accidentally invoke `new-task`.
+fn match_slash_command(content: &str, expected: &str) -> Option<String> {
+    let after_slash = content.trim_start().strip_prefix('/')?;
+    let remainder = after_slash.strip_prefix(expected)?;
+    match remainder.chars().next() {
+        None => Some(String::new()),
+        Some(c) if c.is_whitespace() => Some(remainder.trim().to_owned()),
+        Some(_) => None,
+    }
 }
 
 /// Build a [`executor::TriggerContext`] from a [`buzz_core::StoredEvent`].
@@ -998,6 +1042,8 @@ pub fn build_trigger_context(event: &buzz_core::StoredEvent) -> executor::Trigge
         emoji,
         message_id,
         is_reply: event_is_reply(&event.event),
+        command: String::new(),
+        args: String::new(),
         webhook_fields: HashMap::new(),
     }
 }
@@ -1041,6 +1087,7 @@ fn trigger_matches_event(trigger: &TriggerDef, kind_u32: u32) -> bool {
         TriggerDef::MessagePosted { .. } => kind_u32 == KIND_STREAM_MESSAGE,
         TriggerDef::ReactionAdded { .. } => kind_u32 == KIND_REACTION,
         TriggerDef::DiffPosted { .. } => kind_u32 == KIND_STREAM_MESSAGE_DIFF,
+        TriggerDef::SlashCommand { .. } => kind_u32 == KIND_STREAM_MESSAGE,
         // Schedule and Webhook triggers are not fired by channel events.
         TriggerDef::Schedule { .. } | TriggerDef::Webhook => false,
     }
@@ -1355,6 +1402,66 @@ steps:
             &trigger,
             buzz_core::kind::KIND_REACTION
         ));
+    }
+
+    #[test]
+    fn slash_command_matches_stream_message_kind_only() {
+        let trigger = TriggerDef::SlashCommand {
+            command: "new-task".to_owned(),
+            filter: None,
+        };
+        assert!(trigger_matches_event(
+            &trigger,
+            buzz_core::kind::KIND_STREAM_MESSAGE
+        ));
+        assert!(!trigger_matches_event(
+            &trigger,
+            buzz_core::kind::KIND_REACTION
+        ));
+    }
+
+    #[test]
+    fn slash_command_requires_exact_bare_token_and_extracts_args() {
+        assert_eq!(
+            match_slash_command("/new-task Build feature XYZ", "new-task"),
+            Some("Build feature XYZ".to_owned())
+        );
+        assert_eq!(
+            match_slash_command("  /new-task\nBuild feature XYZ  ", "new-task"),
+            Some("Build feature XYZ".to_owned())
+        );
+        assert_eq!(
+            match_slash_command("/new-task", "new-task"),
+            Some(String::new())
+        );
+        assert_eq!(
+            match_slash_command("/new-task-extra nope", "new-task"),
+            None
+        );
+        assert_eq!(
+            match_slash_command("@Hermes /new-task nope", "new-task"),
+            None,
+            "mention-prefixed commands belong to ACP pass-through"
+        );
+        assert_eq!(match_slash_command("see /new-task", "new-task"), None);
+    }
+
+    #[test]
+    fn slash_command_populates_per_workflow_trigger_context() {
+        let trigger = TriggerDef::SlashCommand {
+            command: "new-task".to_owned(),
+            filter: None,
+        };
+        let base = executor::TriggerContext {
+            text: "/new-task Build feature XYZ".to_owned(),
+            author: "abc123".to_owned(),
+            ..Default::default()
+        };
+
+        let context = trigger_context_for_workflow(&trigger, &base).expect("should match");
+        assert_eq!(context.command, "new-task");
+        assert_eq!(context.args, "Build feature XYZ");
+        assert_eq!(context.author, "abc123");
     }
 
     #[test]

--- a/crates/buzz-workflow/src/schema.rs
+++ b/crates/buzz-workflow/src/schema.rs
@@ -57,6 +57,18 @@ pub enum TriggerDef {
         #[serde(default)]
         filter: Option<String>,
     },
+    /// Fires when a stream message starts with an exact bare slash command.
+    ///
+    /// The configured name omits the leading slash (`new-task`, not
+    /// `/new-task`). Mention-prefixed commands such as `@Agent /review` are
+    /// intentionally left to ACP command pass-through and do not match.
+    SlashCommand {
+        /// Lowercase command name: ASCII alphanumeric plus internal hyphens.
+        command: String,
+        /// Optional evalexpr filter over the command trigger context.
+        #[serde(default)]
+        filter: Option<String>,
+    },
     /// Fires on a cron schedule.
     Schedule {
         /// Cron expression (UTC). Mutually exclusive with `interval`.
@@ -221,6 +233,7 @@ impl WorkflowDef {
             TriggerDef::MessagePosted { .. }
                 | TriggerDef::ReactionAdded { .. }
                 | TriggerDef::DiffPosted { .. }
+                | TriggerDef::SlashCommand { .. }
         );
         if !trigger_has_message {
             for step in &self.steps {
@@ -233,12 +246,16 @@ impl WorkflowDef {
                 ) {
                     return Err(WorkflowError::InvalidDefinition(format!(
                         "step '{}': reply_in_thread requires a message-based trigger \
-                         (message_posted, reaction_added, or diff_posted); \
+                         (message_posted, reaction_added, diff_posted, or slash_command); \
                          schedule and webhook triggers have no message to reply to",
                         step.id
                     )));
                 }
             }
+        }
+
+        if let TriggerDef::SlashCommand { command, .. } = &self.trigger {
+            validate_slash_command_name(command)?;
         }
 
         if let TriggerDef::Schedule { cron, interval } = &self.trigger {
@@ -276,6 +293,32 @@ impl WorkflowDef {
 
         Ok(())
     }
+}
+
+/// Validate a workflow-owned slash command name.
+///
+/// Names omit the leading slash and use a deliberately narrow portable shape:
+/// lowercase ASCII letters/digits with optional internal hyphens. This keeps
+/// matching deterministic across Desktop, mobile, CLI, and ACP runtimes.
+fn validate_slash_command_name(command: &str) -> Result<(), WorkflowError> {
+    let valid_len = (1..=64).contains(&command.len());
+    let mut chars = command.chars();
+    let valid_first = chars
+        .next()
+        .is_some_and(|c| c.is_ascii_lowercase() || c.is_ascii_digit());
+    let valid_chars = chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-');
+    let valid_last = command
+        .chars()
+        .last()
+        .is_some_and(|c| c.is_ascii_lowercase() || c.is_ascii_digit());
+
+    if valid_len && valid_first && valid_chars && valid_last {
+        return Ok(());
+    }
+
+    Err(WorkflowError::InvalidDefinition(format!(
+        "slash command '{command}' is invalid: use 1-64 lowercase ASCII letters/digits with optional internal hyphens, without the leading slash"
+    )))
 }
 
 /// Validate a cron expression using the `cron` crate.
@@ -345,6 +388,56 @@ mod tests {
             }
             other => panic!("unexpected trigger: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_slash_command_trigger() {
+        let yaml = "name: New Task\ntrigger:\n  on: slash_command\n  command: new-task\n  filter: 'trigger_author == \"abc123\"'\nsteps:\n  - id: dispatch\n    action: send_message\n    text: '@Planner /plan {{trigger.args}}'\n    reply_in_thread: true\n";
+        let (def, json) = parse_yaml(yaml).expect("parse failed");
+        match &def.trigger {
+            TriggerDef::SlashCommand { command, filter } => {
+                assert_eq!(command, "new-task");
+                assert_eq!(filter.as_deref(), Some("trigger_author == \"abc123\""));
+            }
+            other => panic!("unexpected trigger: {other:?}"),
+        }
+
+        let reparsed: WorkflowDef = serde_json::from_str(&json).expect("json round-trip");
+        assert!(matches!(
+            reparsed.trigger,
+            TriggerDef::SlashCommand { ref command, .. } if command == "new-task"
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_slash_command_names() {
+        for command in [
+            "",
+            "/new-task",
+            "New-task",
+            "new_task",
+            "-new-task",
+            "new-task-",
+            "new task",
+        ] {
+            let yaml = format!(
+                "name: Invalid command\ntrigger:\n  on: slash_command\n  command: '{command}'\nsteps:\n  - id: s1\n    action: delay\n    duration: 1s\n"
+            );
+            let err = parse_yaml(&yaml).expect_err(command);
+            assert!(
+                matches!(err, WorkflowError::InvalidDefinition(_)),
+                "unexpected error for {command:?}: {err}"
+            );
+        }
+
+        let too_long = "a".repeat(65);
+        let yaml = format!(
+            "name: Invalid command\ntrigger:\n  on: slash_command\n  command: '{too_long}'\nsteps:\n  - id: s1\n    action: delay\n    duration: 1s\n"
+        );
+        assert!(matches!(
+            parse_yaml(&yaml),
+            Err(WorkflowError::InvalidDefinition(_))
+        ));
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/nest.rs
+++ b/desktop/src-tauri/src/managed_agents/nest.rs
@@ -52,7 +52,7 @@ const NEST_AGENTS_VERSION: u32 = 4;
 
 /// Template content version for SKILL.md.
 /// Bump this when changing `nest_skill.md` to trigger refresh on existing installs.
-const NEST_SKILL_VERSION: u32 = 5;
+const NEST_SKILL_VERSION: u32 = 6;
 
 const BEGIN_MARKER: &str = "<!-- BEGIN BUZZ MANAGED";
 const END_MARKER: &str = "<!-- END BUZZ MANAGED -->";

--- a/desktop/src-tauri/src/managed_agents/nest_skill.md
+++ b/desktop/src-tauri/src/managed_agents/nest_skill.md
@@ -2,9 +2,8 @@
 name: buzz-cli
 description: >
   Buzz CLI for relay operations: owner-reviewed agent drafts, messaging,
-  channels, DMs, users, workflows, feed, reactions, canvas, social, repos,
-  uploads, and agent memory.
-version: 1
+  channels, DMs, users, workflows and slash-command macros, feed, reactions,
+  canvas, social, repos, uploads, and agent memory.
 ---
 
 # Buzz CLI Skill
@@ -108,6 +107,62 @@ buzz messages send --channel <UUID> \
 ## Workflow Inputs
 
 `workflows trigger --workflow <UUID> --inputs '<json>'` passes input variables as the trigger event's content. Omit `--inputs` for parameterless workflows.
+
+## Workflow Macros
+
+When a user asks to create, change, or remove a named macro or chat shortcut,
+model it as a channel-scoped workflow with a `slash_command` trigger. The user
+supplies the behavior in ordinary language; translate it into workflow steps
+and use the current Buzz `[Context]` channel UUID. Ask one concise question only
+when the requested command name or outcome is genuinely missing.
+
+Command names omit the leading slash and must contain 1–64 lowercase ASCII
+letters or digits with optional internal hyphens. A bare `/name ...` message
+invokes the workflow. `@Agent /name ...` remains an agent-runtime command and
+does not invoke the workflow. The text after the command is available as
+`{{trigger.args}}`:
+
+```yaml
+name: New task
+trigger:
+  on: slash_command
+  command: new-task
+steps:
+  - id: plan
+    action: send_message
+    text: "@Planner /plan {{trigger.args}}"
+    reply_in_thread: true
+  - id: review
+    action: send_message
+    text: "@Reviewer /review {{trigger.args}}"
+    reply_in_thread: true
+```
+
+For agent fan-out, use the exact channel-member display name as plain
+`@Name` text at the start of each message; do not wrap mentions in Markdown.
+Put each agent's own command immediately after its mention. Prefer threaded
+replies so the original macro invocation and dispatched work stay together.
+
+Before writing, run `buzz workflows list --channel <UUID>` and inspect existing
+definitions for the same `slash_command` name:
+
+- No match: `buzz workflows create --channel <UUID> --yaml '<definition>'`.
+- One match: update that workflow instead of creating a duplicate; run
+  `buzz workflows update --help` for the current flags.
+- Multiple matches: stop and report the conflicting workflow IDs. Do not choose
+  one or trigger all of them silently.
+
+For a removal request, delete the single matching workflow with
+`buzz workflows delete --workflow <UUID>`. If none exists, report that without
+writing; if several exist, use the same conflict stop above.
+
+Both create and update accept `--yaml -` to read the definition from stdin.
+Prefer that path when the YAML contains quotes or shell metacharacters rather
+than trying to embed a complex definition in one shell argument.
+
+Creating or updating the macro does not authorize running it. Report the saved
+command and its actions, but do not invoke it unless the user separately asks.
+Never put credentials or other secrets in workflow YAML or command arguments.
 
 ## Feed Filtering
 

--- a/desktop/src/features/workflows/ui/WorkflowCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowCard.tsx
@@ -7,6 +7,7 @@ import {
   MessageCircle,
   MessageSquare,
   SmilePlus,
+  SquareTerminal,
   Timer,
   Webhook,
   Zap,
@@ -50,6 +51,7 @@ const TRIGGER_ICONS: Record<string, LucideIcon> = {
   diff_posted: GitPullRequest,
   message_posted: MessageSquare,
   reaction_added: SmilePlus,
+  slash_command: SquareTerminal,
   schedule: CalendarClock,
   webhook: Webhook,
 };
@@ -68,6 +70,7 @@ const TRIGGER_ACCENTS: Record<string, string> = {
   diff_posted: "border-violet-400/30 bg-violet-600 text-white",
   message_posted: "border-blue-400/30 bg-blue-600 text-white",
   reaction_added: "border-pink-400/30 bg-pink-600 text-white",
+  slash_command: "border-cyan-400/30 bg-cyan-600 text-white",
   schedule: "border-emerald-400/30 bg-emerald-600 text-white",
   webhook: "border-orange-300/30 bg-orange-500 text-white",
 };

--- a/desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx
@@ -6,6 +6,7 @@ import {
   GitPullRequest,
   MessageSquare,
   Plus,
+  SquareTerminal,
   SmilePlus,
   Trash2,
   Webhook,
@@ -35,6 +36,7 @@ import { useWorkflowTriggerPresentation } from "./useWorkflowTriggerPresentation
 import { compactWorkflowTriggerDescription } from "./workflowTriggerDescription";
 import { workflowStepDescription } from "./workflowStepDescription";
 import { WorkflowScheduleFields } from "./WorkflowScheduleFields";
+import { WorkflowSlashCommandFields } from "./WorkflowSlashCommandFields";
 import { WorkflowStepCard } from "./WorkflowStepCard";
 import {
   parseConditionExpressions,
@@ -49,6 +51,7 @@ import {
   SELECTABLE_TRIGGER_TYPES,
   TRIGGER_LABELS,
   formStateToYaml,
+  isTriggerConfigValid,
   nextStepId,
   supportsMessageTextCondition,
   withTriggerType,
@@ -100,6 +103,10 @@ function TriggerConfigFields({
           value={reactionConditionValue(trigger)}
           workflowChannelId={workflowChannelId}
         />
+      );
+    case "slash_command":
+      return (
+        <WorkflowSlashCommandFields {...{ disabled, onUpdate, trigger }} />
       );
     case "webhook":
       return (
@@ -386,10 +393,13 @@ export const WorkflowFormBuilder = React.forwardRef<
     triggerConditionDrafts.every(
       (condition) => !conditionValueError(condition.field, condition.value),
     );
+  const triggerValid = isTriggerConfigValid(formState.trigger);
 
   React.useEffect(() => {
-    onValidityChange?.(mode !== "form" || conditionDraftsValid);
-  }, [conditionDraftsValid, mode, onValidityChange]);
+    onValidityChange?.(
+      mode !== "form" || (conditionDraftsValid && triggerValid),
+    );
+  }, [conditionDraftsValid, mode, onValidityChange, triggerValid]);
   const selectedNode =
     selectedRouteNode?.type === "trigger" ||
     (selectedRouteNode?.type === "step" &&
@@ -640,6 +650,7 @@ export const WorkflowFormBuilder = React.forwardRef<
     diff_posted: GitPullRequest,
     message_posted: MessageSquare,
     reaction_added: SmilePlus,
+    slash_command: SquareTerminal,
     schedule: CalendarClock,
     webhook: Webhook,
   }[formState.trigger.on];

--- a/desktop/src/features/workflows/ui/WorkflowSlashCommandFields.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowSlashCommandFields.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+
+import { Input } from "@/shared/ui/input";
+import {
+  SLASH_COMMAND_NAME_PATTERN,
+  type TriggerConfig,
+} from "./workflowFormTypes";
+
+export function WorkflowSlashCommandFields({
+  disabled,
+  onUpdate,
+  trigger,
+}: {
+  disabled?: boolean;
+  onUpdate: (trigger: TriggerConfig) => void;
+  trigger: TriggerConfig;
+}) {
+  const inputId = React.useId();
+  const helpId = `${inputId}-help`;
+  const command = trigger.command ?? "";
+  const commandValid = SLASH_COMMAND_NAME_PATTERN.test(command);
+
+  return (
+    <div className="space-y-1.5">
+      <label className="text-xs font-medium text-foreground" htmlFor={inputId}>
+        Command
+      </label>
+      <div className="flex items-center gap-2">
+        <span aria-hidden="true" className="text-sm text-muted-foreground">
+          /
+        </span>
+        <Input
+          aria-describedby={helpId}
+          aria-invalid={!commandValid}
+          aria-label="Slash command name"
+          autoCapitalize="none"
+          autoComplete="off"
+          disabled={disabled}
+          id={inputId}
+          maxLength={64}
+          onChange={(event) =>
+            onUpdate({ ...trigger, command: event.target.value })
+          }
+          placeholder="new-task"
+          spellCheck={false}
+          value={command}
+        />
+      </div>
+      {commandValid ? (
+        <p className="text-xs text-muted-foreground" id={helpId}>
+          Bare /{command} messages run this workflow; commands after an @mention
+          still go to that agent.
+        </p>
+      ) : (
+        <p className="text-xs text-destructive" id={helpId}>
+          Use 1–64 lowercase letters or digits with optional internal hyphens.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/workflows/ui/workflowConditionExpression.ts
+++ b/desktop/src/features/workflows/ui/workflowConditionExpression.ts
@@ -35,6 +35,10 @@ const FIELDS_BY_TRIGGER: Record<TriggerType, ConditionField[]> = {
     { label: "Message text", value: "trigger_text" },
     AUTHOR_FIELD,
   ],
+  slash_command: [
+    { label: "Command arguments", value: "trigger_args" },
+    AUTHOR_FIELD,
+  ],
   diff_posted: [{ label: "Diff text", value: "trigger_text" }, AUTHOR_FIELD],
   reaction_added: [
     { label: "Reaction emoji", value: "trigger_emoji" },

--- a/desktop/src/features/workflows/ui/workflowDefinition.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowDefinition.test.mjs
@@ -32,6 +32,19 @@ test("reads only direct trigger and first-action types for card icons", () => {
 test("builds a plain-language workflow card label", () => {
   assert.equal(
     getWorkflowCardLabel({
+      trigger: { on: "slash_command", command: "new-task" },
+      steps: [
+        {
+          action: "send_message",
+          text: "@Planner /plan {{trigger.args}}",
+        },
+      ],
+    }),
+    "When /new-task is entered, send “@Planner /plan {{trigger.args}}”",
+  );
+
+  assert.equal(
+    getWorkflowCardLabel({
       trigger: { on: "message_posted" },
       steps: [{ action: "send_message", text: "Deploying now" }],
     }),

--- a/desktop/src/features/workflows/ui/workflowDefinition.ts
+++ b/desktop/src/features/workflows/ui/workflowDefinition.ts
@@ -108,6 +108,7 @@ export function getWorkflowTriggerConfig(
     emoji: nonEmptyString(trigger.emoji) ?? undefined,
     cron: nonEmptyString(trigger.cron) ?? undefined,
     interval: nonEmptyString(trigger.interval) ?? undefined,
+    command: nonEmptyString(trigger.command) ?? undefined,
   };
 }
 
@@ -149,6 +150,12 @@ function getTriggerCardClause(
       return nonEmptyString(trigger.filter)
         ? "When a matching message is posted"
         : "When a message is posted";
+    case "slash_command": {
+      const command = nonEmptyString(trigger.command);
+      return command
+        ? `When /${command} is entered`
+        : "When a slash command is entered";
+    }
     case "reaction_added": {
       const emoji = nonEmptyString(presentedReaction ?? trigger.emoji);
       return emoji

--- a/desktop/src/features/workflows/ui/workflowFormTypes.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowFormTypes.test.mjs
@@ -5,6 +5,7 @@ import { parse as parseYaml } from "yaml";
 import {
   formStateToYaml,
   isThreadReplyEligibleTrigger,
+  isTriggerConfigValid,
   supportsMessageTextCondition,
   withTriggerType,
   yamlToFormState,
@@ -47,6 +48,7 @@ function sendMessageState(overrides) {
 test("message-text conditions are limited to message-bearing triggers", () => {
   assert.equal(supportsMessageTextCondition("message_posted"), true);
   assert.equal(supportsMessageTextCondition("diff_posted"), true);
+  assert.equal(supportsMessageTextCondition("slash_command"), false);
   assert.equal(supportsMessageTextCondition("reaction_added"), false);
   assert.equal(supportsMessageTextCondition("webhook"), false);
   assert.equal(supportsMessageTextCondition("schedule"), false);
@@ -54,6 +56,7 @@ test("message-text conditions are limited to message-bearing triggers", () => {
 
 const acceptedFixtures = [
   `name: Notify\ntrigger:\n  on: message_posted\nsteps:\n  - id: notify_1\n    action: send_message\n    text: hello\n`,
+  `name: New task\ntrigger:\n  on: slash_command\n  command: new-task\nsteps:\n  - id: plan\n    action: send_message\n    text: '@Planner /plan {{trigger.args}}'\n    reply_in_thread: true\n`,
   `name: React\ndescription: React to a message\nenabled: false\ntrigger:\n  on: reaction_added\n  emoji: eyes\n  filter: trigger_message_id == "abc123"\nsteps:\n  - id: react\n    name: Add reaction\n    timeout_secs: 30\n    action: add_reaction\n    emoji: white_check_mark\n`,
   `name: Webhook\ntrigger:\n  on: webhook\nsteps:\n  - id: call\n    action: call_webhook\n    url: https://example.com/hook\n    method: PATCH\n    headers:\n      Authorization: secret\n      X-Trace: trace\n    body: '{"ok":true}'\n`,
   `name: Legacy actions\ntrigger:\n  on: diff_posted\n  filter: str_contains(trigger_text, "deploy")\nsteps:\n  - id: dm\n    action: send_dm\n    to: abc123\n    text: hello\n  - id: approval\n    action: request_approval\n    from: manager\n    message: Approve?\n    timeout: 24h\n  - id: topic\n    action: set_channel_topic\n    topic: Deployed\n  - id: wait\n    action: delay\n    duration: 5m\n`,
@@ -140,6 +143,33 @@ test("invalid IDs, shapes, and scalar types are refused", () => {
   for (const [name, yaml] of cases) {
     assert.equal(yamlToFormState(yaml).ok, false, name);
   }
+});
+
+test("slash command names use the backend's portable command shape", () => {
+  for (const command of [
+    "",
+    "/new-task",
+    "New-task",
+    "new_task",
+    "-new-task",
+    "new-task-",
+    "new task",
+    "a".repeat(65),
+  ]) {
+    const yaml = `name: Invalid\ntrigger: { on: slash_command, command: '${command}' }\nsteps: [{ id: s1, action: delay, duration: 1s }]\n`;
+    assert.equal(yamlToFormState(yaml).ok, false, command);
+  }
+
+  const switched = withTriggerType(DEFAULT_FORM_STATE, "slash_command");
+  assert.deepEqual(switched.trigger, {
+    on: "slash_command",
+    command: "new-task",
+  });
+  assert.equal(isTriggerConfigValid(switched.trigger), true);
+  assert.equal(
+    isTriggerConfigValid({ on: "slash_command", command: "Bad Name" }),
+    false,
+  );
 });
 
 test("step condition capabilities stay in YAML mode", () => {
@@ -287,6 +317,7 @@ test("invalid reply_in_thread values are refused rather than normalized", () => 
 
 test("reply_in_thread eligibility follows trigger capability", () => {
   assert.equal(isThreadReplyEligibleTrigger("message_posted"), true);
+  assert.equal(isThreadReplyEligibleTrigger("slash_command"), true);
   assert.equal(isThreadReplyEligibleTrigger("schedule"), false);
   assert.equal(isThreadReplyEligibleTrigger("webhook"), false);
 });

--- a/desktop/src/features/workflows/ui/workflowFormTypes.ts
+++ b/desktop/src/features/workflows/ui/workflowFormTypes.ts
@@ -8,12 +8,23 @@ import {
 
 export const TRIGGER_TYPES = [
   "message_posted",
+  "slash_command",
   "reaction_added",
   "diff_posted",
   "webhook",
   "schedule",
 ] as const;
 export type TriggerType = (typeof TRIGGER_TYPES)[number];
+
+export const SLASH_COMMAND_NAME_PATTERN =
+  /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+
+export function isTriggerConfigValid(trigger: TriggerConfig): boolean {
+  return (
+    trigger.on !== "slash_command" ||
+    SLASH_COMMAND_NAME_PATTERN.test(trigger.command ?? "")
+  );
+}
 
 export function supportsMessageTextCondition(
   triggerType: TriggerType,
@@ -23,6 +34,7 @@ export function supportsMessageTextCondition(
 
 export const SELECTABLE_TRIGGER_TYPES = [
   "message_posted",
+  "slash_command",
   "reaction_added",
   "diff_posted",
   "webhook",
@@ -52,6 +64,7 @@ export type TriggerConfig = {
   emoji?: string;
   cron?: string;
   interval?: string;
+  command?: string;
 };
 
 export type HeaderFormState = {
@@ -100,6 +113,7 @@ export const DEFAULT_FORM_STATE: WorkflowFormState = {
 
 export const TRIGGER_LABELS: Record<TriggerType, string> = {
   message_posted: "Message Posted",
+  slash_command: "Slash Command",
   reaction_added: "Reaction Added",
   diff_posted: "Diff Posted",
   webhook: "Webhook",
@@ -206,7 +220,10 @@ export function withTriggerType(
 ): WorkflowFormState {
   return {
     ...state,
-    trigger: { on: triggerType },
+    trigger:
+      triggerType === "slash_command"
+        ? { on: triggerType, command: "new-task" }
+        : { on: triggerType },
     // Clear threaded-reply state on every step, not just send_message ones:
     // a hidden `replyInThread` on a step whose action was changed away from
     // send_message would otherwise resurrect when the action is switched back.
@@ -227,6 +244,9 @@ export function formStateToYaml(state: WorkflowFormState): string {
     state.trigger.filter
   ) {
     trigger.filter = state.trigger.filter;
+  }
+  if (state.trigger.on === "slash_command" && state.trigger.command) {
+    trigger.command = state.trigger.command;
   }
   if (state.trigger.on === "reaction_added" && state.trigger.emoji) {
     trigger.emoji = state.trigger.emoji;
@@ -284,6 +304,7 @@ const TOP_LEVEL_KEYS = new Set([
 ]);
 const TRIGGER_KEYS: Record<TriggerType, ReadonlySet<string>> = {
   message_posted: new Set(["on", "filter"]),
+  slash_command: new Set(["on", "command"]),
   reaction_added: new Set(["on", "emoji", "filter"]),
   diff_posted: new Set(["on", "filter"]),
   webhook: new Set(["on"]),
@@ -431,7 +452,13 @@ export function yamlToFormState(
         error: `Unsupported ${triggerOn} trigger field "${triggerUnknown}" — use the YAML editor`,
       };
     }
-    for (const key of ["filter", "emoji", "cron", "interval"] as const) {
+    for (const key of [
+      "filter",
+      "emoji",
+      "cron",
+      "interval",
+      "command",
+    ] as const) {
       const error = optionalOwnedStringError(rawTrigger, key, `trigger.${key}`);
       if (error) {
         return {
@@ -464,12 +491,26 @@ export function yamlToFormState(
         }
       }
     }
+    if (triggerOn === "slash_command") {
+      const command = rawTrigger.command;
+      if (
+        typeof command !== "string" ||
+        !SLASH_COMMAND_NAME_PATTERN.test(command)
+      ) {
+        return {
+          ok: false,
+          error:
+            "trigger.command must be 1–64 lowercase letters or digits with optional internal hyphens",
+        };
+      }
+    }
     const trigger: TriggerConfig = {
       on: triggerOn,
       filter: rawTrigger.filter as string | undefined,
       emoji: rawTrigger.emoji as string | undefined,
       cron: rawTrigger.cron as string | undefined,
       interval: rawTrigger.interval as string | undefined,
+      command: rawTrigger.command as string | undefined,
     };
 
     if (!Array.isArray(parsed.steps)) {

--- a/desktop/src/features/workflows/ui/workflowTemplateVariables.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowTemplateVariables.test.mjs
@@ -64,6 +64,15 @@ test("offers only outputs available in every runtime shape", () => {
   assert.ok(!variables.includes("steps.react.output.response"));
 });
 
+test("offers parsed command fields to slash-command workflows", () => {
+  const variables = workflowTemplateVariables("slash_command", []).map(
+    ({ value }) => value,
+  );
+  assert.ok(variables.includes("trigger.command"));
+  assert.ok(variables.includes("trigger.args"));
+  assert.ok(variables.includes("trigger.author"));
+});
+
 test("keeps prior-step ordering and ignores unsafe step IDs", () => {
   const variables = workflowTemplateVariables("webhook", [
     { id: "first", action: "delay" },

--- a/desktop/src/features/workflows/ui/workflowTemplateVariables.ts
+++ b/desktop/src/features/workflows/ui/workflowTemplateVariables.ts
@@ -64,6 +64,20 @@ function triggerVariables(
         },
         ...COMMON_EVENT_VARIABLES,
       ];
+    case "slash_command":
+      return [
+        {
+          value: "trigger.args",
+          description: "Text after the command",
+          group: "Trigger",
+        },
+        {
+          value: "trigger.command",
+          description: "Command name",
+          group: "Trigger",
+        },
+        ...COMMON_EVENT_VARIABLES,
+      ];
     case "diff_posted":
       return [
         { value: "trigger.text", description: "Diff text", group: "Trigger" },

--- a/desktop/src/features/workflows/ui/workflowTriggerDescription.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowTriggerDescription.test.mjs
@@ -216,4 +216,11 @@ test("keeps the base label for unfiltered and custom triggers", () => {
     }),
     "Message posted",
   );
+  assert.equal(
+    workflowTriggerDescription({
+      on: "slash_command",
+      command: "new-task",
+    }),
+    "Command /new-task",
+  );
 });

--- a/desktop/src/features/workflows/ui/workflowTriggerDescription.ts
+++ b/desktop/src/features/workflows/ui/workflowTriggerDescription.ts
@@ -124,6 +124,9 @@ export function workflowTriggerDescription(
     omitUnresolvedReferences?: boolean;
   } = {},
 ): string {
+  if (trigger.on === "slash_command") {
+    return trigger.command ? `Command /${trigger.command}` : "Slash command";
+  }
   const baseLabel =
     EVENT_PHRASES[trigger.on as keyof typeof EVENT_PHRASES] ??
     TRIGGER_LABELS[trigger.on];


### PR DESCRIPTION
## Summary

- adds a first-class `slash_command` workflow trigger for exact bare commands
- exposes the matched name and argument tail as `{{trigger.command}}` and `{{trigger.args}}`
- preserves `@Agent /command` as ACP pass-through
- adds Desktop workflow-form authoring, validation, labels, icons, and template-variable discovery
- refreshes the bundled `buzz-cli` skill so managed agents can create, update, remove, and collision-check macros from natural-language requests

Closes #6785.

## Example

```yaml
name: New task
trigger:
  on: slash_command
  command: new-task
steps:
  - id: plan
    action: send_message
    text: "@Planner /plan {{trigger.args}}"
    reply_in_thread: true
  - id: review
    action: send_message
    text: "@Reviewer /review {{trigger.args}}"
    reply_in_thread: true
```

`/new-task Build feature XYZ` runs the workflow with `trigger.args = Build feature XYZ`. `/new-task-extra` does not match, and `@Hermes /new-task ...` remains an agent-runtime command.

## Design notes

No new event kind or execution path is introduced. The trigger reuses stored kind-9 messages, the existing workflow engine, existing action authorization, loop suppression, and `buzz workflows create/update/delete` CLI.

This does not weaken ACP author policy. Default owner-only wake behavior for workflow-generated agent mentions remains tracked independently in #3858 and its competing fix PRs. Composer autocomplete is likewise separate (#2528, #5700, #6567).

## Verification

- `cargo test -p buzz-workflow` — 176 passed, 2 Postgres-only ignored
- `cargo clippy -p buzz-workflow --all-targets -- -D warnings`
- `cargo check -p buzz-relay`
- `pnpm --dir desktop test` — 5,456 passed
- `pnpm --dir desktop typecheck`
- focused workflow UI tests — 46 passed
- `just desktop-check`
- `just fmt-check`
- `just file-size-check`
- bundled skill validated with the OpenAI skill validator

Environment-limited checks:

- Desktop Tauri Rust tests cannot compile on this host because GTK/GObject development packages are absent.
- Repository-wide `just check-compile` reaches an unrelated OpenSSL native dependency and stops because `openssl.pc` is absent. The narrower relay and workflow compile checks pass.