### PR TITLE
acp: heartbeat wakes a sleeping lazy pool

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2240,6 +2240,10 @@ async fn tokio_main() -> Result<()> {
         None
     };
     let mut heartbeat_in_flight = false;
+    // A heartbeat tick that lands while a lazy pool is asleep must wake it:
+    // otherwise heartbeats only fire inside message-woken windows and the
+    // configured interval silently never runs on quiet agents.
+    let mut heartbeat_wake_pending = false;
 
     let mut presence_heartbeat = if config.presence_enabled {
         let interval = Duration::from_secs(60);
@@ -2409,7 +2413,7 @@ async fn tokio_main() -> Result<()> {
         // busy spin — whenever the queued work drained after a failed wake.
         let mut lazy_wake_work_pending = false;
         if config.lazy_pool && !pool_ready {
-            lazy_wake_work_pending = queue.has_flushable_work();
+            lazy_wake_work_pending = queue.has_flushable_work() || heartbeat_wake_pending;
             if let Some(attempt) = pool_lifecycle
                 .start_wake_if_due(lazy_wake_work_pending, tokio::time::Instant::now())
             {
@@ -3077,7 +3081,15 @@ async fn tokio_main() -> Result<()> {
                 } => {
                     let _ = result_rx;
                     if !pool_ready {
-                        tracing::debug!("heartbeat_skipped_pool_not_ready");
+                        if config.lazy_pool {
+                            // Request a pool wake; the lazy-wake gate at the top
+                            // of the loop consumes this flag, and the Wake(Ok)
+                            // handler dispatches the deferred heartbeat.
+                            heartbeat_wake_pending = true;
+                            tracing::info!("heartbeat_wake_requested (lazy pool asleep)");
+                        } else {
+                            tracing::debug!("heartbeat_skipped_pool_not_ready");
+                        }
                     } else if queue.has_flushable_work() {
                         tracing::debug!("heartbeat_skipped_events");
                         for (channel_id, thread_tags) in
@@ -3391,6 +3403,15 @@ async fn tokio_main() -> Result<()> {
                             dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
                         {
                             typing_channels.insert(channel_id, thread_tags);
+                        }
+                        if heartbeat_wake_pending {
+                            heartbeat_wake_pending = false;
+                            // Deliver the heartbeat this wake was requested for;
+                            // if real work grabbed every slot, the pool is awake
+                            // now and the next tick fires normally.
+                            if !queue.has_flushable_work() && pool.any_idle() {
+                                dispatch_heartbeat(&mut pool, &ctx, &mut heartbeat_in_flight);
+                            }
                         }
                     }
                     Err(error) => {


### PR DESCRIPTION
With --lazy-pool, a heartbeat tick that landed while the pool was asleep
was skipped at DEBUG level and nothing ever woke the pool for it — on a
quiet agent the configured heartbeat interval silently never ran. In an
eight-agent deployment, seven had not heartbeated for days before this
surfaced; the only healthy one was simply the chattiest.

The tick now sets heartbeat_wake_pending, the lazy-wake gate treats that
flag as pending work, and the Wake(Ok) handler dispatches the deferred
heartbeat once the pool is ready (unless real queued work claimed the
slots — the pool is awake then, so the next tick fires normally).

Observed after deploy: all seven sleeping agents logged
heartbeat_wake_requested -> heartbeat_fired on their first tick.

