### PR TITLE
refactor(db): move relay invite store ownership

### DIFF
--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -1335,54 +1335,6 @@ impl Db {
         Ok(result.rows_affected())
     }
 
-    /// Mints a v2 use-limited relay invite. The plaintext code is returned
-    /// exactly once; only its SHA-256 hash is persisted.
-    ///
-    /// `max_uses` is `None` for unlimited or `Some(1..=10000)`.
-    /// `ttl_secs` must be in the shared invite lifetime range.
-    #[datastore_span(name = "mint_relay_invite", system = "postgresql")]
-    pub async fn mint_relay_invite(
-        &self,
-        community: CommunityId,
-        created_by: &str,
-        ttl_secs: u64,
-        max_uses: Option<i32>,
-    ) -> Result<relay_invite::MintedInvite> {
-        relay_invite::mint_relay_invite(&self.pool, community, created_by, ttl_secs, max_uses).await
-    }
-
-    /// Delete one bounded batch of invites expired before `cutoff`.
-    #[datastore_span(name = "reap_expired_relay_invites", system = "postgresql")]
-    pub async fn reap_expired_relay_invites(
-        &self,
-        cutoff: chrono::DateTime<chrono::Utc>,
-    ) -> Result<u64> {
-        relay_invite::reap_expired_relay_invites(&self.pool, cutoff).await
-    }
-
-    /// Atomically claims a v2 relay invite. The full redemption (membership
-    /// insert, policy evidence, use_count increment) runs in one PostgreSQL
-    /// transaction with `FOR UPDATE` on the invite row.
-    ///
-    /// `token_hash` is the SHA-256 of the presented v2 code (32 bytes).
-    #[datastore_span(name = "claim_relay_invite", system = "postgresql")]
-    pub async fn claim_relay_invite(
-        &self,
-        community: CommunityId,
-        token_hash: &[u8; 32],
-        claimer_pubkey: &str,
-        policy_version: Option<&str>,
-    ) -> Result<relay_invite::ClaimOutcome> {
-        relay_invite::claim_relay_invite(
-            &self.pool,
-            community,
-            token_hash,
-            claimer_pubkey,
-            policy_version,
-        )
-        .await
-    }
-
     /// Sidecar an accepted product-feedback event, idempotent by event id.
     #[datastore_span(name = "insert_product_feedback", system = "postgresql")]
     pub async fn insert_product_feedback(

--- a/crates/buzz-db/src/relay_invite.rs
+++ b/crates/buzz-db/src/relay_invite.rs
@@ -21,11 +21,12 @@ use buzz_core::invite::{
     encode_v2_code, hash_v2_code, MAX_INVITE_TTL_SECS, MAX_INVITE_USES, MIN_INVITE_TTL_SECS,
     V2_SECRET_LEN,
 };
+use buzz_datastore_tracing::datastore_span;
 use chrono::{DateTime, Utc};
 use sqlx::{PgPool, Row as _};
 
 use crate::error::Result;
-use crate::CommunityId;
+use crate::{CommunityId, Db};
 
 /// Outcome of a v2 invite claim. Expected invalid/expired/exhausted states are
 /// typed variants so the relay layer can map them to distinct HTTP responses
@@ -378,6 +379,53 @@ pub async fn claim_relay_invite(
         use_count: new_use_count,
         uses_remaining: new_uses_remaining,
     })
+}
+
+impl Db {
+    /// Mints a v2 use-limited relay invite. The plaintext code is returned
+    /// exactly once; only its SHA-256 hash is persisted.
+    ///
+    /// `max_uses` is `None` for unlimited or `Some(1..=10000)`.
+    /// `ttl_secs` must be in the shared invite lifetime range.
+    #[datastore_span(name = "mint_relay_invite", system = "postgresql")]
+    pub async fn mint_relay_invite(
+        &self,
+        community: CommunityId,
+        created_by: &str,
+        ttl_secs: u64,
+        max_uses: Option<i32>,
+    ) -> Result<MintedInvite> {
+        mint_relay_invite(&self.pool, community, created_by, ttl_secs, max_uses).await
+    }
+
+    /// Delete one bounded batch of invites expired before `cutoff`.
+    #[datastore_span(name = "reap_expired_relay_invites", system = "postgresql")]
+    pub async fn reap_expired_relay_invites(&self, cutoff: DateTime<Utc>) -> Result<u64> {
+        reap_expired_relay_invites(&self.pool, cutoff).await
+    }
+
+    /// Atomically claims a v2 relay invite. The full redemption (membership
+    /// insert, policy evidence, use_count increment) runs in one PostgreSQL
+    /// transaction with `FOR UPDATE` on the invite row.
+    ///
+    /// `token_hash` is the SHA-256 of the presented v2 code (32 bytes).
+    #[datastore_span(name = "claim_relay_invite", system = "postgresql")]
+    pub async fn claim_relay_invite(
+        &self,
+        community: CommunityId,
+        token_hash: &[u8; 32],
+        claimer_pubkey: &str,
+        policy_version: Option<&str>,
+    ) -> Result<ClaimOutcome> {
+        claim_relay_invite(
+            &self.pool,
+            community,
+            token_hash,
+            claimer_pubkey,
+            policy_version,
+        )
+        .await
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Current reconstructed head

Exact base: `codex/issue-2-relay-members-store` at `349a3d9bff5a9b292ef61fea1705f155ea1c405d`  
Exact head: `codex/issue-2-relay-invite-store` at `0452a07daf6f244438bb7c2f8ad4bfea81ddee16`

This current head removes `crates/buzz-db/tests/store_ownership.rs`; no replacement path-sensitive ownership test is introduced. Apart from removing that complete test-file diff, the production patch is byte-for-byte identical to the previously reviewed slice. This remains part of tracker #2 and the #17/#19 acceptance work.

Independent exact-head review from a separate clean Blox workstation found no issues. Current-head evidence passed formatting, strict `buzz-db` clippy, 111 non-PostgreSQL library tests with 200 PostgreSQL tests ignored, the observability source test, relay consumer compilation, exact ownership/unique-span review checks, and 8 relay-invite PostgreSQL tests on native PostgreSQL where applicable.

## Summary

Continue [tracker #2](https://github.com/TheSentinel454/buzz/issues/2) by making `relay_invite.rs` own the durable v2 relay-invite persistence boundary. `ClaimOutcome`, `MintedInvite`, validation, SQL, transaction/locking behavior, and focused tests already lived there; this child moves the three remaining `Db` APIs and datastore spans out of `lib.rs`.

## Stack

- Tracker: [TheSentinel454/buzz#2](https://github.com/TheSentinel454/buzz/issues/2)
- Test ownership acceptance: [#17](https://github.com/TheSentinel454/buzz/issues/17)
- Span ownership acceptance: [#19](https://github.com/TheSentinel454/buzz/issues/19)
- Exact base: codex/issue-2-relay-members-store at 75a5146da1e7886e7ad7e5a957e56288d42e8d61 ([#6804](https://github.com/block/buzz/pull/6804))
- Exact head: codex/issue-2-relay-invite-store at 849b81729ebbf0a92e755fea220187db4ed816ae

## Domain moved

- `Db::mint_relay_invite`
- `Db::reap_expired_relay_invites`
- `Db::claim_relay_invite`
- Their existing datastore spans, unchanged names and fixed labels

`crates/buzz-db/src/lib.rs` falls from 4,259 to 4,211 lines.

## Non-goals

- Canonical relay-membership or authentication-allowlist behavior
- Invite validation, token hashing, retention, fence, SQL, locking, transaction, retry, or response semantics
- Generic store traits, raw pool access, executor migration, or crate reorganization

## Risk

Small review surface and low semantic risk. The three facades and spans moved intact and still call the same module-owned functions with the same pool, arguments, and return types. The full claim transaction—including `FOR UPDATE`, membership insertion, policy evidence, and use-count update—is unchanged.

## Blox verification

Author workstation: `buzz-tornquist-issue-2-store-stack` (`2046520`), exact head `5a497a98cefd2dd531f8bde48b5b5ee2c4cb4362`.

- `cargo fmt --all --check`
- `git diff --check 14924657e84d5d516fb0022e0681cbe18391ea77..HEAD`
- `cargo clippy -p buzz-db --all-targets -- -D warnings`
- `cargo clippy -p buzz-relay --all-targets -- -D warnings`
- `cargo test -p buzz-db --lib`: 108 passed, 200 ignored
- `cargo test -p buzz-db --test observability_source`: 1 passed
- Native PostgreSQL 17.11, migrations 1–32 already applied: all 8 relay-invite PostgreSQL tests passed
- `cargo test -p buzz-relay --lib`: 909 passed, 48 ignored
- Signed commit hooks passed

Independent exact-head Blox review: no findings. Review artifacts were preserved before teardown.

## Remaining tracker work

Next: moderation/product feedback, then git registry and archived identities, usage/admin/maintenance, deletion ownership, and the final runtime-boundary audit.

## Superseded pre-comment restack verification

PR #6700 merged before publication completed. This layer was restacked onto current main through the exact parent named above; the final cumulative tip is 2ddcc8a29f95c8c8c9cb87bb6cf59335f2190fae. Cumulative author gates passed: formatting and diff checks; buzz-db and buzz-relay all-target clippy with -D warnings; DB lib 111 passed / 200 ignored; ownership 22/22; observability 1/1; the full isolated PostgreSQL domain matrix; and relay lib 910 passed / 49 ignored.

## Outcome

No actionable findings.

Reviewed exact direct-parent range `245c08f24df4e77c0e8486f9aa7abcc70d784e7b..dd7e3c290792b1a68cc73225af87a494ae35d271` on fresh Blox workstation `buzz-tornquist-pr-6805-final-review` (ID `2057730`). The three relay-invite wrappers and spans move beside the invite SQL and records without changing validation bounds, token hashing, claim transaction/locking, typed outcomes, or public signatures.

## Verification

- Formatting, range/worktree diff checks, touched-crate clippy, and clean-tree checks passed.
- Non-PostgreSQL relay-invite tests: 1 passed, 8 ignored.
- Relay consumer compile passed.
- Native PostgreSQL 17: all 8 relay-invite tests passed, including final-slot concurrency, tenant scope, policy rollback, retention fencing, and use limits.
- Exact head and merge-base were rechecked.

No code edits or external mutations were made. Buzz relay credentials/ownership reporting were unavailable under the documented fallback. The workstation was deleted after artifact transfer.

## Artifacts

- Diff SHA-256: `a1c4894779f7428dd40f785256f614f6f8c98d4d91c9e4b013aa312b70012581`
- Verification log SHA-256: `80d4512d8587b07dd8b832e16412d8d588060067fe10c9f97ecc12ac7547ee15`
- Artifact archive SHA-256: `8bd5402553edd0d8d7adac8d6902927c592dbba047447f81cdaae9e2029f1098`

## Comment-addressed restack

Review follow-up on #6777 removed only the low-value replaceable ownership source test. This PR was restacked onto its rewritten parent; its production patch is unchanged.

- Exact base: `75a5146da1e7886e7ad7e5a957e56288d42e8d61`
- Exact head: `849b81729ebbf0a92e755fea220187db4ed816ae`
- Final cumulative tip: `6fa2f104d42c6ba85bdf62e7ccb74ceaf4a84f67`
- Per-layer patch-ID and tree audits confirm this PR’s production diff is unchanged from its pre-comment head.
- Cumulative Blox gate: formatting and diff checks; strict `buzz-db`/`buzz-relay` Clippy; DB lib 111 passed / 200 ignored; ownership 21/21; observability 1/1; every moved PostgreSQL test; relay lib 910 passed / 49 ignored.
- Independent re-review at this exact head: no findings; fresh exact-parent/head Blox review passed fmt/diff, strict `buzz-db` Clippy, current ownership/observability guards, relay-invite tests (1 unit plus 8 PostgreSQL), and relay compilation.
