### PR TITLE
refactor(db): move product feedback store ownership

### DIFF
--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -1335,25 +1335,6 @@ impl Db {
         Ok(result.rows_affected())
     }
 
-    /// Sidecar an accepted product-feedback event, idempotent by event id.
-    #[datastore_span(name = "insert_product_feedback", system = "postgresql")]
-    pub async fn insert_product_feedback(
-        &self,
-        community: CommunityId,
-        feedback: product_feedback::NewProductFeedback<'_>,
-    ) -> Result<Uuid> {
-        product_feedback::insert(&self.pool, community, feedback).await
-    }
-
-    /// List product feedback across the deployment, newest first.
-    #[datastore_span(name = "list_product_feedback", system = "postgresql")]
-    pub async fn list_product_feedback(
-        &self,
-        limit: i64,
-    ) -> Result<Vec<product_feedback::ProductFeedbackRecord>> {
-        product_feedback::list(&self.pool, limit).await
-    }
-
     /// Insert a tenant-scoped NIP-56 report row, idempotent by report event id.
     #[datastore_span(name = "insert_moderation_report", system = "postgresql")]
     pub async fn insert_moderation_report(

--- a/crates/buzz-db/src/product_feedback.rs
+++ b/crates/buzz-db/src/product_feedback.rs
@@ -3,12 +3,13 @@
 //! Feedback retains its source [`CommunityId`] as provenance, but is not a
 //! community moderation concern and is never inserted into the events table.
 
+use buzz_datastore_tracing::datastore_span;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use sqlx::{PgPool, Row as _};
 use uuid::Uuid;
 
-use crate::{error::Result, CommunityId};
+use crate::{error::Result, CommunityId, Db};
 
 /// Validated fields from an accepted product-feedback event.
 #[derive(Debug, Clone)]
@@ -115,6 +116,24 @@ pub async fn list(pool: &PgPool, limit: i64) -> Result<Vec<ProductFeedbackRecord
             })
         })
         .collect()
+}
+
+impl Db {
+    /// Sidecar an accepted product-feedback event, idempotent by event id.
+    #[datastore_span(name = "insert_product_feedback", system = "postgresql")]
+    pub async fn insert_product_feedback(
+        &self,
+        community: CommunityId,
+        feedback: NewProductFeedback<'_>,
+    ) -> Result<Uuid> {
+        insert(&self.pool, community, feedback).await
+    }
+
+    /// List product feedback across the deployment, newest first.
+    #[datastore_span(name = "list_product_feedback", system = "postgresql")]
+    pub async fn list_product_feedback(&self, limit: i64) -> Result<Vec<ProductFeedbackRecord>> {
+        list(&self.pool, limit).await
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Current reconstructed head

Exact base: `codex/issue-2-relay-invite-store` at `0452a07daf6f244438bb7c2f8ad4bfea81ddee16`  
Exact head: `codex/issue-2-product-feedback-store` at `011301f32318163a2291a537f3d4184f4f39e9dd`

This current head removes `crates/buzz-db/tests/store_ownership.rs`; no replacement path-sensitive ownership test is introduced. Apart from removing that complete test-file diff, the production patch is byte-for-byte identical to the previously reviewed slice. This remains part of tracker #2 and the #17/#19 acceptance work.

Independent exact-head review from a separate clean Blox workstation found no issues. Current-head evidence passed formatting, strict `buzz-db` clippy, 111 non-PostgreSQL library tests with 200 PostgreSQL tests ignored, the observability source test, relay consumer compilation, exact ownership/unique-span review checks, and 1 product-feedback PostgreSQL test on native PostgreSQL where applicable.

## Summary

Continue [tracker #2](https://github.com/TheSentinel454/buzz/issues/2) by making `product_feedback.rs` own deployment-level product-feedback persistence. The records, SQL, row parsing, provenance behavior, and focused PostgreSQL test already lived there; this child moves the two remaining `Db` APIs and datastore spans out of `lib.rs`.

## Stack

- Tracker: [TheSentinel454/buzz#2](https://github.com/TheSentinel454/buzz/issues/2)
- Test ownership acceptance: [#17](https://github.com/TheSentinel454/buzz/issues/17)
- Span ownership acceptance: [#19](https://github.com/TheSentinel454/buzz/issues/19)
- Exact base: codex/issue-2-relay-invite-store at 849b81729ebbf0a92e755fea220187db4ed816ae ([#6805](https://github.com/block/buzz/pull/6805))
- Exact head: codex/issue-2-product-feedback-store at 64fa6de401a9a14f2aa5da3dd13beac19942a944

## Domain moved

- `Db::insert_product_feedback`
- `Db::list_product_feedback`
- Both existing datastore spans, unchanged names and fixed labels

`crates/buzz-db/src/lib.rs` falls from 4,211 to 4,192 lines.

## Non-goals

- Moderation reports, restrictions, or audit actions; they remain a separate next child
- Product-feedback validation, idempotency, provenance, SQL, schema, ordering, or response behavior
- Generic store traits, raw pool access, executor migration, or crate reorganization

## Risk

Small review surface and low semantic risk. Both facades and spans moved intact and still call the same module-owned SQL functions with the same pool, arguments, return types, and global-list semantics. The first-community provenance invariant remains unchanged and covered by native PostgreSQL.

## Blox verification

Author workstation: `buzz-tornquist-issue-2-store-stack` (`2046520`), exact head `c007b0fdf7e213c8a1120c65a37dbf999d2e320d`.

- `cargo fmt --all --check`
- `git diff --check 5a497a98cefd2dd531f8bde48b5b5ee2c4cb4362..HEAD`
- `cargo clippy -p buzz-db --all-targets -- -D warnings`
- `cargo clippy -p buzz-relay --all-targets -- -D warnings`
- `cargo test -p buzz-db --lib`: 108 passed, 200 ignored
- `cargo test -p buzz-db --test observability_source`: 1 passed
- Native PostgreSQL 17.11, migrations 1–32 already applied: product-feedback provenance test passed
- `cargo test -p buzz-relay --lib`: 909 passed, 48 ignored
- Signed commit hooks passed

Independent exact-head Blox review: no findings. Review artifacts were preserved before teardown.

## Remaining tracker work

Next: moderation, then git registry and archived identities, usage/admin/maintenance, deletion ownership, and the final runtime-boundary audit.

## Superseded pre-comment restack verification

PR #6700 merged before publication completed. This layer was restacked onto current main through the exact parent named above; the final cumulative tip is 2ddcc8a29f95c8c8c9cb87bb6cf59335f2190fae. Cumulative author gates passed: formatting and diff checks; buzz-db and buzz-relay all-target clippy with -D warnings; DB lib 111 passed / 200 ignored; ownership 22/22; observability 1/1; the full isolated PostgreSQL domain matrix; and relay lib 910 passed / 49 ignored.

## Result

No findings.

## Exact revision and isolation

- Base: `dd7e3c290792b1a68cc73225af87a494ae35d271`
- Head: `6ae5893c36429f778105285ce77fc890ad5e3c67`
- Verified head parent and merge-base: exact base above
- Reviewer workstation: `buzz-tornquist-pr-6806-final-review` (`2057662`)

The fresh shallow workstation was clean and unclaimed, had no competing commands, and had no Buzz production relay credentials or ownership-report file.

## Review conclusions

- The two product-feedback `Db` facades move unchanged into `product_feedback.rs`; public arguments, return types, delegation, idempotency, ordering, and error propagation remain compatible.
- Product-feedback SQL and row parsing are unchanged. Both fixed-label datastore spans retain their exact names and have one owner.
- The new guard proves the methods, spans, and public records are absent from `lib.rs` and singly owned by the domain module.

## Verification

- `git diff --check` and `cargo fmt --all --check`: passed.
- `cargo clippy -p buzz-db --all-targets -- -D warnings`: passed.
- `cargo clippy -p buzz-relay --all-targets -- -D warnings`: passed.
- `cargo test -p buzz-db --lib`: 111 passed, 200 ignored.
- Native PostgreSQL 17.11, migrations complete: focused product-feedback test 1 passed.
- Final detached head remained clean; no duplicate datastore-span names were found.

Artifacts: `pr-6806-final-review-artifacts.tgz`, SHA-256 `12e1ee762615464189ec68494a42b90324c4b3b507b392ed2d421b66c3e6feb7`. Archive and internal checksums were verified locally.

## Comment-addressed restack

Review follow-up on #6777 removed only the low-value replaceable ownership source test. This PR was restacked onto its rewritten parent; its production patch is unchanged.

- Exact base: `849b81729ebbf0a92e755fea220187db4ed816ae`
- Exact head: `64fa6de401a9a14f2aa5da3dd13beac19942a944`
- Final cumulative tip: `6fa2f104d42c6ba85bdf62e7ccb74ceaf4a84f67`
- Per-layer patch-ID and tree audits confirm this PR’s production diff is unchanged from its pre-comment head.
- Cumulative Blox gate: formatting and diff checks; strict `buzz-db`/`buzz-relay` Clippy; DB lib 111 passed / 200 ignored; ownership 21/21; observability 1/1; every moved PostgreSQL test; relay lib 910 passed / 49 ignored.
- Independent re-review at this exact head: no findings; fresh exact-parent/head Blox review passed fmt/diff, strict `buzz-db`/`buzz-relay` Clippy, DB lib and current ownership/observability/unique-span guards, 1 product-feedback PostgreSQL test, and relay compilation.
