### PR TITLE
refactor(db): move git registry store ownership

### DIFF
--- a/crates/buzz-db/src/git_repo.rs
+++ b/crates/buzz-db/src/git_repo.rs
@@ -16,10 +16,11 @@
 //! idempotent re-announce (same owner) from a collision (different owner), and
 //! backs the per-pubkey quota via `COUNT`.
 
+use buzz_datastore_tracing::datastore_span;
 use sqlx::{PgPool, Row as _};
 
 use crate::error::Result;
-use crate::CommunityId;
+use crate::{CommunityId, Db};
 
 /// Outcome of a name-reservation attempt.
 ///
@@ -179,12 +180,62 @@ pub async fn release_repo_name(
     Ok(result.rows_affected())
 }
 
+impl Db {
+    /// Return the current owner of git repo name `repo_id` in `community`, or
+    /// `None` if unreserved. See [`repo_name_owner`].
+    #[datastore_span(name = "repo_name_owner", system = "postgresql")]
+    pub async fn repo_name_owner(
+        &self,
+        community: CommunityId,
+        repo_id: &str,
+    ) -> Result<Option<String>> {
+        repo_name_owner(&self.pool, community, repo_id).await
+    }
+
+    /// Reserve a git repo name for `owner_pubkey` in `community` (NIP-34).
+    ///
+    /// See [`reserve_repo_name`] for the outcome semantics. The per-pubkey
+    /// quota is enforced by the caller against `count_repos_for_owner`.
+    #[datastore_span(name = "reserve_repo_name", system = "postgresql")]
+    pub async fn reserve_repo_name(
+        &self,
+        community: CommunityId,
+        repo_id: &str,
+        owner_pubkey: &str,
+    ) -> Result<ReserveOutcome> {
+        reserve_repo_name(&self.pool, community, repo_id, owner_pubkey).await
+    }
+
+    /// Count git repos reserved by `owner_pubkey` in `community` (quota check).
+    #[datastore_span(name = "count_repos_for_owner", system = "postgresql")]
+    pub async fn count_repos_for_owner(
+        &self,
+        community: CommunityId,
+        owner_pubkey: &str,
+    ) -> Result<i64> {
+        count_repos_for_owner(&self.pool, community, owner_pubkey).await
+    }
+
+    /// Release a git repo name reservation held by `owner_pubkey` (rollback).
+    ///
+    /// Returns the number of rows removed (0 or 1). See [`release_repo_name`].
+    #[datastore_span(name = "release_repo_name", system = "postgresql")]
+    pub async fn release_repo_name(
+        &self,
+        community: CommunityId,
+        repo_id: &str,
+        owner_pubkey: &str,
+    ) -> Result<u64> {
+        release_repo_name(&self.pool, community, repo_id, owner_pubkey).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use uuid::Uuid;
 
-    const TEST_DB_URL: &str = "postgres://buzz:buzz_dev@localhost:5432/buzz";
+    const TEST_DB_URL: &str = "postgres://buzz:buzz_dev@localhost:5432/buzz"; // sadscan:disable np.postgres.1
 
     async fn setup_pool() -> PgPool {
         let database_url = std::env::var("BUZZ_TEST_DATABASE_URL")

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -1335,54 +1335,6 @@ impl Db {
         Ok(result.rows_affected())
     }
 
-    /// Return the current owner of git repo name `repo_id` in `community`, or
-    /// `None` if unreserved. See [`git_repo::repo_name_owner`].
-    #[datastore_span(name = "repo_name_owner", system = "postgresql")]
-    pub async fn repo_name_owner(
-        &self,
-        community: CommunityId,
-        repo_id: &str,
-    ) -> Result<Option<String>> {
-        git_repo::repo_name_owner(&self.pool, community, repo_id).await
-    }
-
-    /// Reserve a git repo name for `owner_pubkey` in `community` (NIP-34).
-    ///
-    /// See [`git_repo::reserve_repo_name`] for the outcome semantics. The
-    /// per-pubkey quota is enforced by the caller against `count_repos_for_owner`.
-    #[datastore_span(name = "reserve_repo_name", system = "postgresql")]
-    pub async fn reserve_repo_name(
-        &self,
-        community: CommunityId,
-        repo_id: &str,
-        owner_pubkey: &str,
-    ) -> Result<git_repo::ReserveOutcome> {
-        git_repo::reserve_repo_name(&self.pool, community, repo_id, owner_pubkey).await
-    }
-
-    /// Count git repos reserved by `owner_pubkey` in `community` (quota check).
-    #[datastore_span(name = "count_repos_for_owner", system = "postgresql")]
-    pub async fn count_repos_for_owner(
-        &self,
-        community: CommunityId,
-        owner_pubkey: &str,
-    ) -> Result<i64> {
-        git_repo::count_repos_for_owner(&self.pool, community, owner_pubkey).await
-    }
-
-    /// Release a git repo name reservation held by `owner_pubkey` (rollback).
-    ///
-    /// Returns the number of rows removed (0 or 1). See [`git_repo::release_repo_name`].
-    #[datastore_span(name = "release_repo_name", system = "postgresql")]
-    pub async fn release_repo_name(
-        &self,
-        community: CommunityId,
-        repo_id: &str,
-        owner_pubkey: &str,
-    ) -> Result<u64> {
-        git_repo::release_repo_name(&self.pool, community, repo_id, owner_pubkey).await
-    }
-
     /// Returns `true` if `pubkey` (64-char hex) is archived in `community_id`.
     #[datastore_span(name = "is_archived", system = "postgresql")]
     pub async fn is_archived(&self, community_id: CommunityId, pubkey: &str) -> Result<bool> {


### PR DESCRIPTION
## Current reconstructed head

Exact base: `codex/issue-2-moderation-store` at `a0a4afc5317bb15e02f77a169ca359e8af289e28`  
Exact head: `codex/issue-2-git-repo-store` at `dc73defc41030278821ce43478bbb222226141e7`

This current head removes `crates/buzz-db/tests/store_ownership.rs`; no replacement path-sensitive ownership test is introduced. Apart from removing that complete test-file diff, the production patch is byte-for-byte identical to the previously reviewed slice. This remains part of tracker #2 and the #17/#19 acceptance work.

Independent exact-head review from a separate clean Blox workstation found no issues. Current-head evidence passed formatting, strict `buzz-db` clippy, 111 non-PostgreSQL library tests with 200 PostgreSQL tests ignored, the observability source test, relay consumer compilation, exact ownership/unique-span review checks, and 4 Git-registry PostgreSQL tests on native PostgreSQL where applicable.

## Summary

Continue [tracker #2](https://github.com/TheSentinel454/buzz/issues/2) by making `git_repo.rs` own the Git repository-name registry persistence boundary. `ReserveOutcome`, the SQL implementation, and focused PostgreSQL tests already lived there; this child moves the remaining four `Db` methods and datastore spans out of `lib.rs` without changing public signatures or behavior.

This also advances [#17](https://github.com/TheSentinel454/buzz/issues/17) and [#19](https://github.com/TheSentinel454/buzz/issues/19) through single test and span ownership.

## Stack

- Tracker: [TheSentinel454/buzz#2](https://github.com/TheSentinel454/buzz/issues/2)
- Test ownership acceptance: [#17](https://github.com/TheSentinel454/buzz/issues/17)
- Span ownership acceptance: [#19](https://github.com/TheSentinel454/buzz/issues/19)
- Exact base: codex/issue-2-moderation-store at f87152c1c0d3f9ab460e5b54711af41b43da0e28 ([#6808](https://github.com/block/buzz/pull/6808))
- Exact head: codex/issue-2-git-repo-store at 3f651b72d81ca6d6d051200c9384e189e36aeaf2

## Domain moved

- Repository-name owner lookup, reservation, per-owner count, and release facades
- All four existing fixed-name PostgreSQL datastore spans

`crates/buzz-db/src/lib.rs` falls from 4,033 to 3,985 lines.

## Non-goals

- Git object storage, manifest, transport, policy, or relay behavior
- Registry SQL, quota, reservation race, rollback, schema, locking, transaction, retry, timeout, or client-visible behavior changes
- Generic store traits, raw pool access, executor migration, or crate reorganization

## Risk

Small review surface and low semantic risk. The four facades and spans moved intact and call the same module-owned functions with the same pool, arguments, and return types. Existing SQL and focused tests are unchanged. The only extra source line is a secret-scanner suppression on the long-standing fake local test URL in the now-modified module.

## Blox verification

Author workstation: `buzz-tornquist-issue-2-store-stack` (`2046520`), exact head `c3ece0f59aebb6119cb0d942b614fe2d3dce35d4`.

- `cargo fmt --all --check`
- `git diff --check 5fd23b4bd81d9db24c2ac4ad29a7ff74590de700..HEAD`
- `cargo clippy -p buzz-db --all-targets -- -D warnings`
- `cargo clippy -p buzz-relay --all-targets -- -D warnings`
- `cargo test -p buzz-db --lib`: 108 passed, 200 ignored
- `cargo test -p buzz-db --test observability_source`: 1 passed
- Native PostgreSQL 17.11, migrations 1–32 already applied: all 4 Git-registry PostgreSQL tests passed
- `cargo test -p buzz-relay --lib`: 909 passed, 48 ignored
- Signed commit hooks passed without bypass

Independent exact-head Blox review: no findings. Review artifacts were preserved before teardown.

## Remaining tracker work

Next: archived identities, then usage/admin/maintenance, deletion ownership, and the final runtime-boundary/test audit.

## Superseded pre-comment restack verification

PR #6700 merged before publication completed. This layer was restacked onto current main through the exact parent named above; the final cumulative tip is 2ddcc8a29f95c8c8c9cb87bb6cf59335f2190fae. Cumulative author gates passed: formatting and diff checks; buzz-db and buzz-relay all-target clippy with -D warnings; DB lib 111 passed / 200 ignored; ownership 22/22; observability 1/1; the full isolated PostgreSQL domain matrix; and relay lib 910 passed / 49 ignored.

## Result

No findings.

## Exact revision and isolation

- Base: `da6d86cb4f46504edd3d860571e670d07b2f2023`
- Head: `6ab8bc04429d6596c91bcfc0bcf150f69ab2d17f`
- Verified head parent and merge-base: exact base above
- Reviewer workstation: `buzz-tornquist-pr-6809-final-review` (`2057664`)

The fresh shallow workstation was clean and unclaimed, had no competing commands, and had no Buzz production relay credentials or ownership-report file.

## Review conclusions

- The repo-owner lookup, reservation, quota count, and owner-scoped release facades move intact into `git_repo.rs`.
- Reservation/collision/idempotency SQL and community scoping are unchanged. Each public logical operation retains one fixed-label datastore span.

## Verification

- Diff check and Rust formatting: passed.
- Buzz DB and relay all-target clippy with `-D warnings`: passed.
- Buzz DB library: 111 passed, 200 ignored.
- Native PostgreSQL 17.11, migrations complete: all four git-repository tests passed.
- Final detached head remained clean; no duplicate datastore-span names were found.

Artifacts: `pr-6809-final-review-artifacts.tgz`, SHA-256 `d389bffa772b51c34f8b4345d5fa4d200dfa32d9020a967505eccea72b1e38dc`. Archive and internal checksums were verified locally.

## Comment-addressed restack

Review follow-up on #6777 removed only the low-value replaceable ownership source test. This PR was restacked onto its rewritten parent; its production patch is unchanged.

- Exact base: `f87152c1c0d3f9ab460e5b54711af41b43da0e28`
- Exact head: `3f651b72d81ca6d6d051200c9384e189e36aeaf2`
- Final cumulative tip: `6fa2f104d42c6ba85bdf62e7ccb74ceaf4a84f67`
- Per-layer patch-ID and tree audits confirm this PR’s production diff is unchanged from its pre-comment head.
- Cumulative Blox gate: formatting and diff checks; strict `buzz-db`/`buzz-relay` Clippy; DB lib 111 passed / 200 ignored; ownership 21/21; observability 1/1; every moved PostgreSQL test; relay lib 910 passed / 49 ignored.
- Independent re-review at this exact head: no findings; fresh exact-parent/head Blox review passed fmt/diff, strict `buzz-db`/`buzz-relay` Clippy, DB lib and current ownership/observability/unique-span guards, 4 Git-registry PostgreSQL tests, and relay compilation.
