### PR TITLE
refactor(db): move archived identity store ownership

### DIFF
--- a/crates/buzz-db/src/archived_identities.rs
+++ b/crates/buzz-db/src/archived_identities.rs
@@ -6,10 +6,12 @@
 //! All pubkey and event ID values are lowercase hex strings.
 
 use buzz_core::CommunityId;
+use buzz_datastore_tracing::datastore_span;
 use chrono::{DateTime, Utc};
 use sqlx::{PgPool, Row as _};
 
 use crate::error::Result;
+use crate::Db;
 
 /// A single archived identity record.
 #[derive(Debug, Clone)]
@@ -124,11 +126,60 @@ fn row_to_archived_identity(
     })
 }
 
+impl Db {
+    /// Returns `true` if `pubkey` (64-char hex) is archived in `community_id`.
+    #[datastore_span(name = "is_archived", system = "postgresql")]
+    pub async fn is_archived(&self, community_id: CommunityId, pubkey: &str) -> Result<bool> {
+        is_archived(&self.pool, community_id, pubkey).await
+    }
+
+    /// Archives an identity in `community_id`. Returns `true` if inserted,
+    /// `false` if already archived.
+    #[allow(clippy::too_many_arguments)]
+    #[datastore_span(name = "archive", system = "postgresql")]
+    pub async fn archive(
+        &self,
+        community_id: CommunityId,
+        pubkey: &str,
+        consent_path: &str,
+        actor: &str,
+        reason: Option<&str>,
+        replaced_by: Option<&str>,
+        request_event_id: &str,
+    ) -> Result<bool> {
+        archive(
+            &self.pool,
+            community_id,
+            pubkey,
+            consent_path,
+            actor,
+            reason,
+            replaced_by,
+            request_event_id,
+        )
+        .await
+    }
+
+    /// Unarchives an identity from `community_id`. Returns `true` if deleted,
+    /// `false` if absent.
+    #[datastore_span(name = "unarchive", system = "postgresql")]
+    pub async fn unarchive(&self, community_id: CommunityId, pubkey: &str) -> Result<bool> {
+        unarchive(&self.pool, community_id, pubkey).await
+    }
+
+    /// Returns all identities archived in `community_id`, ordered by archive
+    /// time ascending.
+    #[datastore_span(name = "list_archived", system = "postgresql")]
+    pub async fn list_archived(&self, community_id: CommunityId) -> Result<Vec<ArchivedIdentity>> {
+        list_archived(&self.pool, community_id).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    const TEST_DB_URL: &str = "postgres://buzz:buzz_dev@localhost:5432/buzz";
+    const TEST_DB_URL: &str = "postgres://buzz:buzz_dev@localhost:5432/buzz"; // sadscan:disable np.postgres.1
 
     async fn setup_pool() -> PgPool {
         PgPool::connect(TEST_DB_URL)

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -1334,53 +1334,6 @@ impl Db {
         .await?;
         Ok(result.rows_affected())
     }
-
-    /// Returns `true` if `pubkey` (64-char hex) is archived in `community_id`.
-    #[datastore_span(name = "is_archived", system = "postgresql")]
-    pub async fn is_archived(&self, community_id: CommunityId, pubkey: &str) -> Result<bool> {
-        archived_identities::is_archived(&self.pool, community_id, pubkey).await
-    }
-
-    /// Archives an identity in `community_id`. Returns `true` if inserted, `false` if already archived.
-    #[allow(clippy::too_many_arguments)]
-    #[datastore_span(name = "archive", system = "postgresql")]
-    pub async fn archive(
-        &self,
-        community_id: CommunityId,
-        pubkey: &str,
-        consent_path: &str,
-        actor: &str,
-        reason: Option<&str>,
-        replaced_by: Option<&str>,
-        request_event_id: &str,
-    ) -> Result<bool> {
-        archived_identities::archive(
-            &self.pool,
-            community_id,
-            pubkey,
-            consent_path,
-            actor,
-            reason,
-            replaced_by,
-            request_event_id,
-        )
-        .await
-    }
-
-    /// Unarchives an identity from `community_id`. Returns `true` if deleted, `false` if absent.
-    #[datastore_span(name = "unarchive", system = "postgresql")]
-    pub async fn unarchive(&self, community_id: CommunityId, pubkey: &str) -> Result<bool> {
-        archived_identities::unarchive(&self.pool, community_id, pubkey).await
-    }
-
-    /// Returns all identities archived in `community_id`, ordered by archive time ascending.
-    #[datastore_span(name = "list_archived", system = "postgresql")]
-    pub async fn list_archived(
-        &self,
-        community_id: CommunityId,
-    ) -> Result<Vec<archived_identities::ArchivedIdentity>> {
-        archived_identities::list_archived(&self.pool, community_id).await
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Current reconstructed head

Exact base: `codex/issue-2-git-repo-store` at `dc73defc41030278821ce43478bbb222226141e7`  
Exact head: `codex/issue-2-archived-identities-store` at `c9841016d226d8c75463862d3617999cd3af1ec3`

This current head removes `crates/buzz-db/tests/store_ownership.rs`; no replacement path-sensitive ownership test is introduced. Apart from removing that complete test-file diff, the production patch is byte-for-byte identical to the previously reviewed slice. This remains part of tracker #2 and the #17/#19 acceptance work.

Independent exact-head review from a separate clean Blox workstation found no issues. Current-head evidence passed formatting, strict `buzz-db` clippy, 111 non-PostgreSQL library tests with 200 PostgreSQL tests ignored, the observability source test, relay consumer compilation, exact ownership/unique-span review checks, and 1 archived-identity PostgreSQL test on native PostgreSQL where applicable.

## Summary

Continue [tracker #2](https://github.com/TheSentinel454/buzz/issues/2) by making `archived_identities.rs` own the community-scoped archived-identity persistence boundary. `ArchivedIdentity`, row parsing, SQL, and the focused PostgreSQL isolation test already lived there; this child moves the remaining four `Db` methods and datastore spans out of `lib.rs` without changing public signatures or behavior.

This also advances [#17](https://github.com/TheSentinel454/buzz/issues/17) and [#19](https://github.com/TheSentinel454/buzz/issues/19) through single test and span ownership.

## Stack

- Tracker: [TheSentinel454/buzz#2](https://github.com/TheSentinel454/buzz/issues/2)
- Test ownership acceptance: [#17](https://github.com/TheSentinel454/buzz/issues/17)
- Span ownership acceptance: [#19](https://github.com/TheSentinel454/buzz/issues/19)
- Exact base: codex/issue-2-git-repo-store at 3f651b72d81ca6d6d051200c9384e189e36aeaf2 ([#6809](https://github.com/block/buzz/pull/6809))
- Exact head: codex/issue-2-archived-identities-store at 8d3042d25ff766b1e90979a016eb60aa04021562

## Domain moved

- Archived-state lookup, archive, unarchive, and ordered list facades
- All four existing fixed-name PostgreSQL datastore spans

`crates/buzz-db/src/lib.rs` falls from 3,985 to 3,938 lines.

## Non-goals

- Identity-archive relay validation, signed-event publication, or membership behavior
- Archive SQL, idempotency, ordering, schema, transaction, retry, timeout, or client-visible behavior changes
- Generic store traits, raw pool access, executor migration, or crate reorganization

## Risk

Small review surface and low semantic risk. The four facades and spans moved intact and call the same module-owned functions with the same pool, arguments, and return types. Existing SQL, parser, record, and community-isolation test are unchanged. The only extra source line is a secret-scanner suppression on the long-standing fake local test URL in the now-modified module.

## Blox verification

Author workstation: `buzz-tornquist-issue-2-store-stack` (`2046520`), exact head `33129b56f3cc319ce98f9400ef90412a558490e2`.

- `cargo fmt --all --check`
- `git diff --check c3ece0f59aebb6119cb0d942b614fe2d3dce35d4..HEAD`
- `cargo clippy -p buzz-db --all-targets -- -D warnings`
- `cargo clippy -p buzz-relay --all-targets -- -D warnings`
- `cargo test -p buzz-db --lib`: 108 passed, 200 ignored
- `cargo test -p buzz-db --test observability_source`: 1 passed
- Native PostgreSQL 17.11, migrations 1–32 already applied: archived-identity community-isolation test passed
- `cargo test -p buzz-relay --lib`: 909 passed, 48 ignored
- Signed commit hooks passed without bypass

Independent exact-head Blox review: no findings. Review artifacts were preserved before teardown.

## Remaining tracker work

Next: usage metrics and admin projections, partition/backfill maintenance, the remaining event mention helper, deletion/runtime ownership, and the final boundary/test audit.

## Superseded pre-comment restack verification

PR #6700 merged before publication completed. This layer was restacked onto current main through the exact parent named above; the final cumulative tip is 2ddcc8a29f95c8c8c9cb87bb6cf59335f2190fae. Cumulative author gates passed: formatting and diff checks; buzz-db and buzz-relay all-target clippy with -D warnings; DB lib 111 passed / 200 ignored; ownership 22/22; observability 1/1; the full isolated PostgreSQL domain matrix; and relay lib 910 passed / 49 ignored.

## Result

No findings.

## Exact revision and isolation

- Base: `6ab8bc04429d6596c91bcfc0bcf150f69ab2d17f`
- Head: `86bb22d686c88735e505b47710a5de5ceefcce8d`
- Verified head parent and merge-base: exact base above
- Reviewer workstation: `buzz-tornquist-pr-6811-final-review` (`2057666`)

The fresh shallow workstation was clean and unclaimed, had no competing commands, and had no Buzz production relay credentials or ownership-report file.

## Review conclusions

- The archive lookup, archive, unarchive, and list `Db` facades move intact into `archived_identities.rs`.
- Tenant inputs, hex-string API, consent/audit parameters, SQL, ordering, and result semantics are unchanged.
- Each operation retains one span; the guard proves one facade and one SQL function per method and a single `ArchivedIdentity` record owner.

## Verification

- Diff check and Rust formatting: passed.
- Buzz DB and relay all-target clippy with `-D warnings`: passed.
- Buzz DB library: 111 passed, 200 ignored.
- Native PostgreSQL 17.11, migrations complete: the community-scope archive lifecycle test passed.
- Final detached head remained clean; no duplicate datastore-span names were found.

Artifacts: `pr-6811-final-review-artifacts.tgz`, SHA-256 `0515ca029d005ce5e4578f35b02f31b7e31d762e54b319c1f902097c20910757`. Archive and internal checksums were verified locally.

## Comment-addressed restack

Review follow-up on #6777 removed only the low-value replaceable ownership source test. This PR was restacked onto its rewritten parent; its production patch is unchanged.

- Exact base: `3f651b72d81ca6d6d051200c9384e189e36aeaf2`
- Exact head: `8d3042d25ff766b1e90979a016eb60aa04021562`
- Final cumulative tip: `6fa2f104d42c6ba85bdf62e7ccb74ceaf4a84f67`
- Per-layer patch-ID and tree audits confirm this PR’s production diff is unchanged from its pre-comment head.
- Cumulative Blox gate: formatting and diff checks; strict `buzz-db`/`buzz-relay` Clippy; DB lib 111 passed / 200 ignored; ownership 21/21; observability 1/1; every moved PostgreSQL test; relay lib 910 passed / 49 ignored.
- Independent re-review at this exact head: no findings; fresh exact-parent/head Blox review passed fmt/diff, strict `buzz-db`/`buzz-relay` Clippy, DB lib and current ownership/observability/unique-span guards, 1 archived-identity PostgreSQL test, and relay compilation.
