### PR TITLE
refactor(db): move usage store ownership

### DIFF
--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -93,11 +93,12 @@ pub use error::{DbError, Result};
 pub use event::{EventQuery, DEFAULT_MAX_PAGE_LIMIT};
 pub use reaction::ReactionEventInsertOutcome;
 pub use reminder::DueReminder;
+pub use usage::UsageMetricsLeader;
 
 use buzz_datastore_tracing::datastore_span;
 use chrono::{DateTime, Utc};
-use sqlx::postgres::{PgConnection, PgPoolOptions};
-use sqlx::{Connection, PgPool, QueryBuilder};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, QueryBuilder};
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -511,27 +512,6 @@ pub struct DbPoolStats {
     pub idle: u32,
     /// Pool ceiling — the `max_connections` value set at construction.
     pub max: u32,
-}
-
-/// Owns the detached Postgres session holding the relay usage-metrics advisory lock.
-///
-/// The connection deliberately does not return to the main pool: session advisory
-/// locks must remain bound to this exact physical connection, and the poller
-/// pings it before each leader-only collection tick.
-pub struct UsageMetricsLeader {
-    connection: PgConnection,
-}
-
-impl UsageMetricsLeader {
-    /// Returns whether the lock-owning session is still reachable.
-    ///
-    /// Bounded to 5 seconds — a blackholed connection (no RST) would otherwise
-    /// stall the entire poller tick until the OS TCP timeout.
-    pub async fn is_live(&mut self) -> bool {
-        tokio::time::timeout(std::time::Duration::from_secs(5), self.connection.ping())
-            .await
-            .is_ok_and(|r| r.is_ok())
-    }
 }
 
 /// Configuration for the Postgres connection pool.
@@ -1013,32 +993,6 @@ impl Db {
         })
     }
 
-    /// Try to acquire the detached session advisory lock for relay usage metrics.
-    ///
-    /// The returned guard owns the exact connection that acquired the lock. It is
-    /// detached from the shared pool so a stable leader neither returns a locked
-    /// session to other callers nor permanently consumes a pool slot. Dropping the
-    /// guard closes the connection and releases the session-scoped lock.
-    #[datastore_span(name = "try_lock_usage_metrics", system = "postgresql")]
-    pub async fn try_lock_usage_metrics(
-        &self,
-        lock_key: i64,
-    ) -> Result<Option<UsageMetricsLeader>> {
-        let mut connection =
-            observability::acquire(&self.pool, observability::PoolRole::Writer).await?;
-        let acquired = sqlx::query_scalar::<_, bool>("SELECT pg_try_advisory_lock($1)")
-            .bind(lock_key)
-            .fetch_one(&mut *connection)
-            .await?;
-        if acquired {
-            Ok(Some(UsageMetricsLeader {
-                connection: connection.detach(),
-            }))
-        } else {
-            Ok(None)
-        }
-    }
-
     /// List reports for the deployment-global read-only admin plane.
     #[allow(clippy::too_many_arguments)]
     #[datastore_span(name = "admin_list_reports", system = "postgresql")]
@@ -1092,74 +1046,6 @@ impl Db {
         id: Uuid,
     ) -> Result<Option<admin_moderation::AdminFeedback>> {
         admin_moderation::get_feedback(&self.pool, id).await
-    }
-
-    /// Return total number of communities on this relay.
-    #[datastore_span(name = "usage_community_count", system = "postgresql")]
-    pub async fn usage_community_count(&self) -> Result<i64> {
-        usage::community_count(&self.pool).await
-    }
-
-    /// Return per-community user counts split by human/agent.
-    #[datastore_span(name = "usage_user_counts", system = "postgresql")]
-    pub async fn usage_user_counts(&self) -> Result<Vec<usage::CommunityUserCounts>> {
-        usage::user_counts(&self.pool).await
-    }
-
-    /// Return per-community channel counts by type.
-    #[datastore_span(name = "usage_channel_counts", system = "postgresql")]
-    pub async fn usage_channel_counts(&self) -> Result<Vec<usage::CommunityChannelCount>> {
-        usage::channel_counts(&self.pool).await
-    }
-
-    /// Return per-community kind=9 message counts.
-    #[datastore_span(name = "usage_message_counts", system = "postgresql")]
-    pub async fn usage_message_counts(&self) -> Result<Vec<usage::CommunityMessageCount>> {
-        usage::message_counts(&self.pool).await
-    }
-
-    /// Return per-community relay-member counts by role.
-    #[datastore_span(name = "usage_relay_member_counts", system = "postgresql")]
-    pub async fn usage_relay_member_counts(&self) -> Result<Vec<usage::CommunityMemberCount>> {
-        usage::relay_member_counts(&self.pool).await
-    }
-
-    /// Return per-community workflow counts by status.
-    #[datastore_span(name = "usage_workflow_counts", system = "postgresql")]
-    pub async fn usage_workflow_counts(&self) -> Result<Vec<usage::CommunityWorkflowCount>> {
-        usage::workflow_counts(&self.pool).await
-    }
-
-    /// Return per-community git-repo counts.
-    #[datastore_span(name = "usage_git_repo_counts", system = "postgresql")]
-    pub async fn usage_git_repo_counts(&self) -> Result<Vec<usage::CommunityGitRepoCount>> {
-        usage::git_repo_counts(&self.pool).await
-    }
-
-    /// Return per-community distinct active-user counts for a given SQL interval.
-    ///
-    /// `interval_sql` must be a trusted literal such as `"1 day"` or `"7 days"`.
-    #[datastore_span(name = "usage_active_user_counts", system = "postgresql")]
-    pub async fn usage_active_user_counts(
-        &self,
-        interval_sql: &'static str,
-    ) -> Result<Vec<usage::CommunityActiveUsers>> {
-        usage::active_user_counts(&self.pool, interval_sql).await
-    }
-
-    /// Return per-community active-channel counts for a given SQL interval.
-    #[datastore_span(name = "usage_active_channel_counts", system = "postgresql")]
-    pub async fn usage_active_channel_counts(
-        &self,
-        interval_sql: &'static str,
-    ) -> Result<Vec<usage::CommunityActiveChannels>> {
-        usage::active_channel_counts(&self.pool, interval_sql).await
-    }
-
-    /// Return all community id → host mappings.
-    #[datastore_span(name = "usage_community_hosts", system = "postgresql")]
-    pub async fn usage_community_hosts(&self) -> Result<Vec<usage::CommunityHost>> {
-        usage::community_hosts(&self.pool).await
     }
 
     /// Return the shared durable whole-community deletion adapter.
@@ -1340,7 +1226,6 @@ impl Db {
 mod tests {
     use super::*;
     use buzz_core::CommunityId;
-    use sqlx::postgres::PgPoolOptions;
     use sqlx::PgPool;
     use uuid::Uuid;
 
@@ -1675,57 +1560,6 @@ mod tests {
         .expect("read C watermark");
         assert_eq!(watermark.0.timestamp(), base as i64 + 3);
         assert_eq!(watermark.1, c.id.as_bytes().as_slice());
-    }
-
-    #[tokio::test]
-    #[ignore = "requires Postgres"]
-    async fn test_usage_metrics_lock_has_single_owner_and_releases_on_drop() {
-        // Use a private scratch database — not the shared TEST_DATABASE_URL.
-        // Postgres advisory locks are per-database; hardcoding the production
-        // USAGE_METRICS_LOCK_KEY (0x4255_5A5A_4D45_5452) on the shared test DB
-        // races any live buzz-relay on the same database (see #3619).
-        let admin_url = std::env::var("TEST_DATABASE_URL").unwrap_or_else(|_| TEST_DB_URL.into());
-        let admin = PgPoolOptions::new()
-            .max_connections(1)
-            .connect(&admin_url)
-            .await
-            .expect("connect admin to create scratch db");
-        let (pool, scratch_name) = create_scratch_db(&admin, "usage_metrics_lock").await;
-        let first = Db::from_pool(pool.clone());
-        let second = Db::from_pool(pool.clone());
-        // Same key as production (`buzz-relay` USAGE_METRICS_LOCK_KEY) — safe here
-        // because the scratch DB is empty of other holders.
-        let key = 0x4255_5A5A_4D45_5452;
-
-        let mut leader = first
-            .try_lock_usage_metrics(key)
-            .await
-            .expect("first lock attempt")
-            .expect("first database handle becomes leader");
-        assert!(leader.is_live().await, "lock owner remains reachable");
-        assert!(
-            second
-                .try_lock_usage_metrics(key)
-                .await
-                .expect("second lock attempt")
-                .is_none(),
-            "another session cannot become leader while the guard exists"
-        );
-
-        drop(leader);
-        assert!(
-            second
-                .try_lock_usage_metrics(key)
-                .await
-                .expect("lock attempt after leader drop")
-                .is_some(),
-            "dropping the detached session releases its advisory lock"
-        );
-
-        // Release any remaining session state before DROP DATABASE.
-        drop(first);
-        drop(second);
-        drop_scratch_db(&admin, pool, &scratch_name).await;
     }
 
     // ---- Read-replica routing ------------------------------------------------

--- a/crates/buzz-db/src/usage.rs
+++ b/crates/buzz-db/src/usage.rs
@@ -12,9 +12,34 @@
 //! Returned structs are plain data; the caller (relay poller) maps them
 //! to Prometheus labels and calls `metrics::gauge!(...).set(...)`.
 
-use crate::error::Result;
-use sqlx::PgPool;
+use buzz_datastore_tracing::datastore_span;
+use sqlx::postgres::PgConnection;
+use sqlx::{Connection as _, PgPool};
 use uuid::Uuid;
+
+use crate::error::Result;
+use crate::{observability, Db};
+
+/// Owns the detached Postgres session holding the relay usage-metrics advisory lock.
+///
+/// The connection deliberately does not return to the main pool: session advisory
+/// locks must remain bound to this exact physical connection, and the poller
+/// pings it before each leader-only collection tick.
+pub struct UsageMetricsLeader {
+    connection: PgConnection,
+}
+
+impl UsageMetricsLeader {
+    /// Returns whether the lock-owning session is still reachable.
+    ///
+    /// Bounded to 5 seconds — a blackholed connection (no RST) would otherwise
+    /// stall the entire poller tick until the OS TCP timeout.
+    pub async fn is_live(&mut self) -> bool {
+        tokio::time::timeout(std::time::Duration::from_secs(5), self.connection.ping())
+            .await
+            .is_ok_and(|r| r.is_ok())
+    }
+}
 
 /// Total number of communities registered on this relay.
 pub async fn community_count(pool: &PgPool) -> Result<i64> {
@@ -354,19 +379,194 @@ pub async fn community_hosts(pool: &PgPool) -> Result<Vec<CommunityHost>> {
         .collect())
 }
 
+impl Db {
+    /// Try to acquire the detached session advisory lock for relay usage metrics.
+    ///
+    /// The returned guard owns the exact connection that acquired the lock. It is
+    /// detached from the shared pool so a stable leader neither returns a locked
+    /// session to other callers nor permanently consumes a pool slot. Dropping the
+    /// guard closes the connection and releases the session-scoped lock.
+    #[datastore_span(name = "try_lock_usage_metrics", system = "postgresql")]
+    pub async fn try_lock_usage_metrics(
+        &self,
+        lock_key: i64,
+    ) -> Result<Option<UsageMetricsLeader>> {
+        let mut connection =
+            observability::acquire(&self.pool, observability::PoolRole::Writer).await?;
+        let acquired = sqlx::query_scalar::<_, bool>("SELECT pg_try_advisory_lock($1)")
+            .bind(lock_key)
+            .fetch_one(&mut *connection)
+            .await?;
+        if acquired {
+            Ok(Some(UsageMetricsLeader {
+                connection: connection.detach(),
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Return total number of communities on this relay.
+    #[datastore_span(name = "usage_community_count", system = "postgresql")]
+    pub async fn usage_community_count(&self) -> Result<i64> {
+        community_count(&self.pool).await
+    }
+
+    /// Return per-community user counts split by human/agent.
+    #[datastore_span(name = "usage_user_counts", system = "postgresql")]
+    pub async fn usage_user_counts(&self) -> Result<Vec<CommunityUserCounts>> {
+        user_counts(&self.pool).await
+    }
+
+    /// Return per-community channel counts by type.
+    #[datastore_span(name = "usage_channel_counts", system = "postgresql")]
+    pub async fn usage_channel_counts(&self) -> Result<Vec<CommunityChannelCount>> {
+        channel_counts(&self.pool).await
+    }
+
+    /// Return per-community kind=9 message counts.
+    #[datastore_span(name = "usage_message_counts", system = "postgresql")]
+    pub async fn usage_message_counts(&self) -> Result<Vec<CommunityMessageCount>> {
+        message_counts(&self.pool).await
+    }
+
+    /// Return per-community relay-member counts by role.
+    #[datastore_span(name = "usage_relay_member_counts", system = "postgresql")]
+    pub async fn usage_relay_member_counts(&self) -> Result<Vec<CommunityMemberCount>> {
+        relay_member_counts(&self.pool).await
+    }
+
+    /// Return per-community workflow counts by status.
+    #[datastore_span(name = "usage_workflow_counts", system = "postgresql")]
+    pub async fn usage_workflow_counts(&self) -> Result<Vec<CommunityWorkflowCount>> {
+        workflow_counts(&self.pool).await
+    }
+
+    /// Return per-community git-repo counts.
+    #[datastore_span(name = "usage_git_repo_counts", system = "postgresql")]
+    pub async fn usage_git_repo_counts(&self) -> Result<Vec<CommunityGitRepoCount>> {
+        git_repo_counts(&self.pool).await
+    }
+
+    /// Return per-community distinct active-user counts for a given SQL interval.
+    ///
+    /// `interval_sql` must be a trusted literal such as `"1 day"` or `"7 days"`.
+    #[datastore_span(name = "usage_active_user_counts", system = "postgresql")]
+    pub async fn usage_active_user_counts(
+        &self,
+        interval_sql: &'static str,
+    ) -> Result<Vec<CommunityActiveUsers>> {
+        active_user_counts(&self.pool, interval_sql).await
+    }
+
+    /// Return per-community active-channel counts for a given SQL interval.
+    #[datastore_span(name = "usage_active_channel_counts", system = "postgresql")]
+    pub async fn usage_active_channel_counts(
+        &self,
+        interval_sql: &'static str,
+    ) -> Result<Vec<CommunityActiveChannels>> {
+        active_channel_counts(&self.pool, interval_sql).await
+    }
+
+    /// Return all community id → host mappings.
+    #[datastore_span(name = "usage_community_hosts", system = "postgresql")]
+    pub async fn usage_community_hosts(&self) -> Result<Vec<CommunityHost>> {
+        community_hosts(&self.pool).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use buzz_core::CommunityId;
     use nostr::Keys;
+    use sqlx::postgres::PgPoolOptions;
     use sqlx::PgPool;
 
-    const TEST_DB_URL: &str = "postgres://buzz:buzz_dev@localhost:5432/buzz";
+    const TEST_DB_URL: &str = "postgres://buzz:buzz_dev@localhost:5432/buzz"; // sadscan:disable np.postgres.1
 
     async fn get_pool() -> PgPool {
         PgPool::connect(TEST_DB_URL)
             .await
             .expect("connect to test DB")
+    }
+
+    async fn create_scratch_db(admin: &PgPool, prefix: &str) -> (PgPool, String) {
+        let name = format!("{}_{}", prefix, Uuid::new_v4().simple());
+        sqlx::query(sqlx::AssertSqlSafe(format!("CREATE DATABASE {name}")))
+            .execute(admin)
+            .await
+            .expect("create scratch db");
+        let base = std::env::var("TEST_DATABASE_URL").unwrap_or_else(|_| TEST_DB_URL.into());
+        let idx = base.rfind('/').expect("db url has a path segment");
+        let scratch_url = format!("{}/{}", &base[..idx], name);
+        let pool = PgPool::connect(&scratch_url)
+            .await
+            .expect("connect scratch db");
+        crate::migration::run_migrations(&pool)
+            .await
+            .expect("migrate scratch db");
+        (pool, name)
+    }
+
+    async fn drop_scratch_db(admin: &PgPool, pool: PgPool, name: &str) {
+        pool.close().await;
+        let _ = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "DROP DATABASE IF EXISTS {name} WITH (FORCE)"
+        )))
+        .execute(admin)
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn test_usage_metrics_lock_has_single_owner_and_releases_on_drop() {
+        // Use a private scratch database — not the shared TEST_DATABASE_URL.
+        // Postgres advisory locks are per-database; hardcoding the production
+        // USAGE_METRICS_LOCK_KEY (0x4255_5A5A_4D45_5452) on the shared test DB
+        // races any live buzz-relay on the same database (see #3619).
+        let admin_url = std::env::var("TEST_DATABASE_URL").unwrap_or_else(|_| TEST_DB_URL.into());
+        let admin = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&admin_url)
+            .await
+            .expect("connect admin to create scratch db");
+        let (pool, scratch_name) = create_scratch_db(&admin, "usage_metrics_lock").await;
+        let first = Db::from_pool(pool.clone());
+        let second = Db::from_pool(pool.clone());
+        // Same key as production (`buzz-relay` USAGE_METRICS_LOCK_KEY) — safe here
+        // because the scratch DB is empty of other holders.
+        let key = 0x4255_5A5A_4D45_5452;
+
+        let mut leader = first
+            .try_lock_usage_metrics(key)
+            .await
+            .expect("first lock attempt")
+            .expect("first database handle becomes leader");
+        assert!(leader.is_live().await, "lock owner remains reachable");
+        assert!(
+            second
+                .try_lock_usage_metrics(key)
+                .await
+                .expect("second lock attempt")
+                .is_none(),
+            "another session cannot become leader while the guard exists"
+        );
+
+        drop(leader);
+        assert!(
+            second
+                .try_lock_usage_metrics(key)
+                .await
+                .expect("lock attempt after leader drop")
+                .is_some(),
+            "dropping the detached session releases its advisory lock"
+        );
+
+        // Release any remaining session state before DROP DATABASE.
+        drop(first);
+        drop(second);
+        drop_scratch_db(&admin, pool, &scratch_name).await;
     }
 
     fn random_pubkey() -> Vec<u8> {


### PR DESCRIPTION
## Current reconstructed head

Exact base: `codex/issue-2-archived-identities-store` at `c9841016d226d8c75463862d3617999cd3af1ec3`  
Exact head: `codex/issue-2-usage-store` at `fad0f34b0d5abb9b24ac2c125e39654fec44c124`

This current head removes `crates/buzz-db/tests/store_ownership.rs`; no replacement path-sensitive ownership test is introduced. Apart from removing that complete test-file diff, the production patch is byte-for-byte identical to the previously reviewed slice. This remains part of tracker #2 and the #17/#19 acceptance work.

Independent exact-head review from a separate clean Blox workstation found no issues. Current-head evidence passed formatting, strict `buzz-db` clippy, 111 non-PostgreSQL library tests with 200 PostgreSQL tests ignored, the observability source test, relay consumer compilation, exact ownership/unique-span review checks, and 9 usage PostgreSQL tests on native PostgreSQL where applicable.

## Summary

Continue [tracker #2](https://github.com/TheSentinel454/buzz/issues/2) by making `usage.rs` own usage rollups and the usage-poller advisory-lock lifecycle. The rollup records, SQL, and focused PostgreSQL tests already lived there; this child moves the ten rollup `Db` methods, `UsageMetricsLeader`, `try_lock_usage_metrics`, its focused scratch-database test, and all eleven datastore spans out of `lib.rs`.

The existing crate-root `UsageMetricsLeader` API is preserved with a re-export. This also advances [#17](https://github.com/TheSentinel454/buzz/issues/17) and [#19](https://github.com/TheSentinel454/buzz/issues/19).

## Stack

- Tracker: [TheSentinel454/buzz#2](https://github.com/TheSentinel454/buzz/issues/2)
- Test ownership acceptance: [#17](https://github.com/TheSentinel454/buzz/issues/17)
- Span ownership acceptance: [#19](https://github.com/TheSentinel454/buzz/issues/19)
- Exact base: codex/issue-2-archived-identities-store at 8d3042d25ff766b1e90979a016eb60aa04021562 ([#6811](https://github.com/block/buzz/pull/6811))
- Exact head: codex/issue-2-usage-store at 27378c8f13143efed9815abc17e4c7efba572d2f

## Domain moved

- Ten usage rollup facades: community, user, channel, message, relay-member, workflow, Git-repository, active-user, active-channel, and community-host queries
- Detached-session advisory-lock acquisition and `UsageMetricsLeader`
- The advisory-lock single-owner/release test, now beside the usage poller store boundary; its local scratch-database setup preserves isolation from any live poller
- All eleven existing fixed-name PostgreSQL datastore spans

`crates/buzz-db/src/lib.rs` falls from 3,938 to 3,772 lines.

## Non-goals

- Prometheus label emission or relay poll scheduling
- Usage SQL, interval literals, classification, advisory-lock key, detached-connection lifetime, timeouts, schema, or client-visible behavior changes
- Generic store traits, raw pool access, executor migration, or crate reorganization

## Risk

Moderate review surface and low semantic risk. Production methods and spans moved intact. The detached physical connection remains acquired through the PR #6700 observability wrapper and retains the same five-second liveness timeout and drop-to-unlock behavior. Focused test setup is now module-local but creates, migrates, and drops the same isolated scratch database.

## Blox verification

Author workstation: `buzz-tornquist-issue-2-store-stack` (`2046520`), exact head `de6216580a94d060390ef8f319bad5ea7f242670`.

- `cargo fmt --all --check`
- `git diff --check 33129b56f3cc319ce98f9400ef90412a558490e2..HEAD`
- `cargo clippy -p buzz-db --all-targets -- -D warnings`
- `cargo clippy -p buzz-relay --all-targets -- -D warnings`
- `cargo test -p buzz-db --lib`: 108 passed, 200 ignored
- `cargo test -p buzz-db --test observability_source`: 1 passed
- Native PostgreSQL 17.11, migrations 1–32 already applied: all 9 usage tests passed, including detached-session advisory-lock ownership/release in an isolated scratch database
- `cargo test -p buzz-relay --lib`: 909 passed, 48 ignored
- Commit hooks passed without bypass; the disposable workstation had no user signing key, so the commit itself is unsigned

Independent exact-head Blox review: no findings. Fresh workstation `buzz-tornquist-pr-6812-review` (`2055068`) verified exact geometry and reproduced format/diff checks, DB and relay clippy, DB library (108 passed, 200 ignored), ownership (19), observability (1), all 9 native-PostgreSQL usage tests, and relay library (909 passed, 48 ignored). Review artifact SHA-256: `0927b1f96c52254622403b52cdf302fe9733e3c9683fe891e2619da88641bca0`.

## Remaining tracker work

Next: admin moderation projections, partition/event backfill maintenance, deletion-store facades, the remaining cross-domain helper audit, and the final runtime-boundary/test assessment.

## Superseded pre-comment restack verification

PR #6700 merged before publication completed. This layer was restacked onto current main through the exact parent named above; the final cumulative tip is 2ddcc8a29f95c8c8c9cb87bb6cf59335f2190fae. Cumulative author gates passed: formatting and diff checks; buzz-db and buzz-relay all-target clippy with -D warnings; DB lib 111 passed / 200 ignored; ownership 22/22; observability 1/1; the full isolated PostgreSQL domain matrix; and relay lib 910 passed / 49 ignored.

## Result

No findings.

## Exact revision and isolation

- Base: `86bb22d686c88735e505b47710a5de5ceefcce8d`
- Head: `d21fc19f455726960fff633b491d031697af6694`
- Verified head parent and merge-base: exact base above
- Reviewer workstation: `buzz-tornquist-pr-6812-final-review` (`2057669`)

The fresh shallow workstation was clean and unclaimed, had no competing commands, and had no Buzz production relay credentials or ownership-report file.

## Review conclusions

- `UsageMetricsLeader`, its bounded liveness check, the detached advisory-lock acquisition, all ten usage-query facades, and the focused lock test move together into `usage.rs`.
- The crate-root `UsageMetricsLeader` re-export preserves the consumer path. Advisory-lock SQL, observed writer acquisition, physical-connection detachment, timeout, and drop-release semantics are unchanged.
- Query SQL and public result types were already domain-owned and remain unchanged. Eleven moved logical operations retain one span apiece.

## Verification

- Diff check and Rust formatting: passed.
- Buzz DB and relay all-target clippy with `-D warnings`: passed.
- Buzz DB library: 111 passed, 200 ignored.
- Native PostgreSQL 17.11, migrations complete: all nine usage tests passed, including single-owner advisory lock and release-on-drop.
- Final detached head remained clean; no duplicate datastore-span names were found.

Artifacts: `pr-6812-final-review-artifacts.tgz`, SHA-256 `244c3cc095319a622bfd204c5c7bc472f4a0ad403cbe97d5620b4f852625bcd6`. Archive and internal checksums were verified locally.

## Comment-addressed restack

Review follow-up on #6777 removed only the low-value replaceable ownership source test. This PR was restacked onto its rewritten parent; its production patch is unchanged.

- Exact base: `8d3042d25ff766b1e90979a016eb60aa04021562`
- Exact head: `27378c8f13143efed9815abc17e4c7efba572d2f`
- Final cumulative tip: `6fa2f104d42c6ba85bdf62e7ccb74ceaf4a84f67`
- Per-layer patch-ID and tree audits confirm this PR’s production diff is unchanged from its pre-comment head.
- Cumulative Blox gate: formatting and diff checks; strict `buzz-db`/`buzz-relay` Clippy; DB lib 111 passed / 200 ignored; ownership 21/21; observability 1/1; every moved PostgreSQL test; relay lib 910 passed / 49 ignored.
- Independent re-review at this exact head: no findings; fresh exact-parent/head Blox review passed fmt/diff, strict `buzz-db`/`buzz-relay` Clippy, DB lib and current ownership/observability/unique-span guards, 9 usage PostgreSQL tests, and relay compilation.
