### PR TITLE
refactor(db): move admin moderation store ownership

### DIFF
--- a/crates/buzz-db/src/admin_moderation.rs
+++ b/crates/buzz-db/src/admin_moderation.rs
@@ -4,12 +4,14 @@
 //! [`CommunityId`](buzz_core::CommunityId). Keep ordinary moderation reads in
 //! [`crate::moderation`] tenant-fenced.
 
+use buzz_datastore_tracing::datastore_span;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use sqlx::{PgPool, Row as _};
 use uuid::Uuid;
 
 use crate::error::Result;
+use crate::Db;
 
 /// Maximum rows accepted by one admin query.
 pub const MAX_PAGE_SIZE: i64 = 200;
@@ -284,11 +286,59 @@ fn row_to_feedback(row: sqlx::postgres::PgRow) -> Result<AdminFeedback> {
     })
 }
 
+impl Db {
+    /// List reports for the deployment-global read-only admin plane.
+    #[allow(clippy::too_many_arguments)]
+    #[datastore_span(name = "admin_list_reports", system = "postgresql")]
+    pub async fn admin_list_reports(
+        &self,
+        community_id: Option<Uuid>,
+        status: Option<&str>,
+        report_type: Option<&str>,
+        target_kind: Option<&str>,
+        after: Option<DateTime<Utc>>,
+        before: Option<DateTime<Utc>>,
+        cursor: Option<(DateTime<Utc>, Uuid)>,
+        limit: i64,
+    ) -> Result<Vec<AdminReport>> {
+        list_reports(
+            &self.pool,
+            community_id,
+            status,
+            report_type,
+            target_kind,
+            after,
+            before,
+            cursor,
+            limit,
+        )
+        .await
+    }
+
+    /// Fetch one report for the deployment-global read-only admin plane.
+    #[datastore_span(name = "admin_get_report", system = "postgresql")]
+    pub async fn admin_get_report(&self, id: Uuid) -> Result<Option<AdminReportDetail>> {
+        get_report(&self.pool, id).await
+    }
+
+    /// List feedback for the deployment-global read-only admin plane.
+    #[datastore_span(name = "admin_list_feedback", system = "postgresql")]
+    pub async fn admin_list_feedback(&self, limit: i64) -> Result<Vec<AdminFeedback>> {
+        list_feedback(&self.pool, limit).await
+    }
+
+    /// Fetch one feedback submission for the deployment-global admin plane.
+    #[datastore_span(name = "admin_get_feedback", system = "postgresql")]
+    pub async fn admin_get_feedback(&self, id: Uuid) -> Result<Option<AdminFeedback>> {
+        get_feedback(&self.pool, id).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    const TEST_DB_URL: &str = "postgres://buzz:buzz_dev@localhost:5432/buzz";
+    const TEST_DB_URL: &str = "postgres://buzz:buzz_dev@localhost:5432/buzz"; // sadscan:disable np.postgres.1
 
     async fn setup_pool() -> PgPool {
         let database_url = std::env::var("BUZZ_TEST_DATABASE_URL")

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -993,61 +993,6 @@ impl Db {
         })
     }
 
-    /// List reports for the deployment-global read-only admin plane.
-    #[allow(clippy::too_many_arguments)]
-    #[datastore_span(name = "admin_list_reports", system = "postgresql")]
-    pub async fn admin_list_reports(
-        &self,
-        community_id: Option<Uuid>,
-        status: Option<&str>,
-        report_type: Option<&str>,
-        target_kind: Option<&str>,
-        after: Option<DateTime<Utc>>,
-        before: Option<DateTime<Utc>>,
-        cursor: Option<(DateTime<Utc>, Uuid)>,
-        limit: i64,
-    ) -> Result<Vec<admin_moderation::AdminReport>> {
-        admin_moderation::list_reports(
-            &self.pool,
-            community_id,
-            status,
-            report_type,
-            target_kind,
-            after,
-            before,
-            cursor,
-            limit,
-        )
-        .await
-    }
-
-    /// Fetch one report for the deployment-global read-only admin plane.
-    #[datastore_span(name = "admin_get_report", system = "postgresql")]
-    pub async fn admin_get_report(
-        &self,
-        id: Uuid,
-    ) -> Result<Option<admin_moderation::AdminReportDetail>> {
-        admin_moderation::get_report(&self.pool, id).await
-    }
-
-    /// List feedback for the deployment-global read-only admin plane.
-    #[datastore_span(name = "admin_list_feedback", system = "postgresql")]
-    pub async fn admin_list_feedback(
-        &self,
-        limit: i64,
-    ) -> Result<Vec<admin_moderation::AdminFeedback>> {
-        admin_moderation::list_feedback(&self.pool, limit).await
-    }
-
-    /// Fetch one feedback submission for the deployment-global admin plane.
-    #[datastore_span(name = "admin_get_feedback", system = "postgresql")]
-    pub async fn admin_get_feedback(
-        &self,
-        id: Uuid,
-    ) -> Result<Option<admin_moderation::AdminFeedback>> {
-        admin_moderation::get_feedback(&self.pool, id).await
-    }
-
     /// Return the shared durable whole-community deletion adapter.
     pub fn deletion_store(&self) -> deletion::DeletionStore {
         deletion::DeletionStore::new(self.pool.clone())


### PR DESCRIPTION
## Current reconstructed head

Exact base: `codex/issue-2-usage-store` at `fad0f34b0d5abb9b24ac2c125e39654fec44c124`  
Exact head: `codex/issue-2-admin-moderation-store` at `102fca801dfdb3bab867deb4fab615718d03c6fc`

This current head removes `crates/buzz-db/tests/store_ownership.rs`; no replacement path-sensitive ownership test is introduced. Apart from removing that complete test-file diff, the production patch is byte-for-byte identical to the previously reviewed slice. This remains part of tracker #2 and the #17/#19 acceptance work.

Independent exact-head review from a separate clean Blox workstation found no issues. Current-head evidence passed formatting, strict `buzz-db` clippy, 111 non-PostgreSQL library tests with 200 PostgreSQL tests ignored, the observability source test, relay consumer compilation, exact ownership/unique-span review checks, and 3 admin-moderation PostgreSQL tests on native PostgreSQL where applicable.

## Summary

Continue [tracker #2](https://github.com/TheSentinel454/buzz/issues/2) by making `admin_moderation.rs` own the admin report and product-feedback read projections. Their records, SQL/parsers, and focused PostgreSQL tests already lived there; this child moves the four remaining `Db` methods and their datastore spans out of `lib.rs`.

The public `Db` API is unchanged. There is no dedicated domain issue for this slice; it completes another ledger item while advancing [#17](https://github.com/TheSentinel454/buzz/issues/17) and [#19](https://github.com/TheSentinel454/buzz/issues/19).

## Stack

- Tracker: [TheSentinel454/buzz#2](https://github.com/TheSentinel454/buzz/issues/2)
- Domain issue: none; admin moderation is a remaining tracker-led extraction
- Test ownership acceptance: [#17](https://github.com/TheSentinel454/buzz/issues/17)
- Span ownership acceptance: [#19](https://github.com/TheSentinel454/buzz/issues/19)
- Exact base: codex/issue-2-usage-store at 27378c8f13143efed9815abc17e4c7efba572d2f ([#6812](https://github.com/block/buzz/pull/6812))
- Exact head: codex/issue-2-admin-moderation-store at 7dbb399207515d12fc9b27036076e5d4f6bfb937

## Domain moved

- `admin_list_reports`
- `admin_get_report`
- `admin_list_feedback`
- `admin_get_feedback`
- Their four existing fixed-name PostgreSQL datastore spans

`crates/buzz-db/src/lib.rs` falls from 3,772 to 3,717 lines.

## Non-goals

- Admin HTTP/API behavior or authorization
- Moderation writes, product-feedback ingestion, records, SQL, row parsing, schema, pagination, filtering, or client-visible behavior changes
- Generic store traits, raw pool access, executor migration, or crate reorganization

## Risk

Low semantic risk. The four production methods and spans moved intact beside the records, parsers, SQL, and PostgreSQL tests they already used. Public signatures and query behavior are unchanged.

## Blox verification

Author workstation: `buzz-tornquist-issue-2-store-stack` (`2046520`), exact head `c684825860900357e017dd4102bc4df88dd6ec2e`.

- `cargo fmt --all --check`
- `git diff --check de6216580a94d060390ef8f319bad5ea7f242670..HEAD`
- `cargo clippy -p buzz-db --all-targets -- -D warnings`
- `cargo clippy -p buzz-relay --all-targets -- -D warnings`
- `cargo test -p buzz-db --lib`: 108 passed, 200 ignored
- `cargo test -p buzz-db --test observability_source`: 1 passed
- Native PostgreSQL 17.11, migrations 1–32 already applied: all 3 `admin_moderation::tests` passed
- `cargo test -p buzz-relay --lib`: 909 passed, 48 ignored
- Commit hooks passed without bypass; the disposable workstation has no user signing key, so the commit itself is unsigned

Independent exact-head Blox review: no findings. Fresh workstation `buzz-tornquist-pr-6813-review` (`2055307`) verified exact geometry and reproduced format/diff checks, DB and relay clippy, DB library (108 passed, 200 ignored), ownership (20), observability (1), all 3 native-PostgreSQL admin-moderation tests, and relay library (909 passed, 48 ignored). Review artifact SHA-256: `fbc410e0e70a7203f6eeec0d6ba655636ffc5c6b6e6cbafc6197d36f465e954d`.

## Remaining tracker work

Next: partition/event backfill maintenance, deletion-store facades, the remaining cross-domain helper audit, and the final runtime-boundary/test assessment.

## Superseded pre-comment restack verification

PR #6700 merged before publication completed. This layer was restacked onto current main through the exact parent named above; the final cumulative tip is 2ddcc8a29f95c8c8c9cb87bb6cf59335f2190fae. Cumulative author gates passed: formatting and diff checks; buzz-db and buzz-relay all-target clippy with -D warnings; DB lib 111 passed / 200 ignored; ownership 22/22; observability 1/1; the full isolated PostgreSQL domain matrix; and relay lib 910 passed / 49 ignored.

## Result

No findings.

## Exact revision and isolation

- Base: `d21fc19f455726960fff633b491d031697af6694`
- Head: `bcb1b423b7ac029759777209505800a757adc53b`
- Verified head parent and merge-base: exact base above
- Reviewer workstation: `buzz-tornquist-pr-6813-final-review` (`2057670`)

The fresh shallow workstation was clean and unclaimed, had no competing commands, and had no Buzz production relay credentials or ownership-report file.

## Review conclusions

- The four deployment-global admin moderation/feedback `Db` facades move intact into `admin_moderation.rs`.
- Optional tenant filters, cursor shape, bounded limits, returned records, SQL, and cross-tenant admin-plane semantics are unchanged.

## Verification

- Diff check and Rust formatting: passed.
- Buzz DB and relay all-target clippy with `-D warnings`: passed.
- Buzz DB library: 111 passed, 200 ignored.
- Native PostgreSQL 17.11, migrations complete: all three admin-moderation tests passed.
- Final detached head remained clean; no duplicate datastore-span names were found.

Artifacts: `pr-6813-final-review-artifacts.tgz`, SHA-256 `72e98d736d038895e354a04103b0f94b17d4de96cb1d05300e24c3c10c44d803`. Archive and internal checksums were verified locally.

## Comment-addressed restack

Review follow-up on #6777 removed only the low-value replaceable ownership source test. This PR was restacked onto its rewritten parent; its production patch is unchanged.

- Exact base: `27378c8f13143efed9815abc17e4c7efba572d2f`
- Exact head: `7dbb399207515d12fc9b27036076e5d4f6bfb937`
- Final cumulative tip: `6fa2f104d42c6ba85bdf62e7ccb74ceaf4a84f67`
- Per-layer patch-ID and tree audits confirm this PR’s production diff is unchanged from its pre-comment head.
- Cumulative Blox gate: formatting and diff checks; strict `buzz-db`/`buzz-relay` Clippy; DB lib 111 passed / 200 ignored; ownership 21/21; observability 1/1; every moved PostgreSQL test; relay lib 910 passed / 49 ignored.
- Independent re-review at this exact head: no findings; fresh exact-parent/head Blox review passed fmt/diff, strict `buzz-db`/`buzz-relay` Clippy, DB lib and current ownership/observability/unique-span guards, 3 admin-moderation PostgreSQL tests, and relay compilation.
