### PR TITLE
refactor(db): move maintenance store ownership

### DIFF
--- a/crates/buzz-db/src/event.rs
+++ b/crates/buzz-db/src/event.rs
@@ -1697,6 +1697,27 @@ impl Db {
         Ok(result)
     }
 
+    /// Backfill `d_tag` for existing NIP-33 events (kind 30000–39999) that have `d_tag IS NULL`.
+    ///
+    /// Idempotent — safe to call on every startup. No-ops when all rows are already populated.
+    /// Runs a single UPDATE touching only NIP-33 rows with NULL d_tag.
+    #[datastore_span(name = "backfill_d_tags", system = "postgresql")]
+    pub async fn backfill_d_tags(&self) -> Result<u64> {
+        let result = sqlx::query(
+            "UPDATE events \
+             SET d_tag = COALESCE( \
+                 (SELECT elem->>1 FROM jsonb_array_elements(tags) AS elem \
+                  WHERE elem->>0 = 'd' LIMIT 1), \
+                 '' \
+             ) \
+             WHERE kind BETWEEN 30000 AND 39999 AND d_tag IS NULL \
+               AND community_write_allowed(community_id)",
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
     /// Soft-delete NIP-29 discovery events for a channel created by a specific relay pubkey.
     #[datastore_span(name = "soft_delete_discovery_events", system = "postgresql")]
     pub async fn soft_delete_discovery_events(

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -1138,33 +1138,6 @@ impl Db {
             }
         }
     }
-
-    /// Ensures monthly partitions exist for the next N months.
-    #[datastore_span(name = "ensure_future_partitions", system = "postgresql")]
-    pub async fn ensure_future_partitions(&self, months_ahead: u32) -> Result<()> {
-        partition::ensure_future_partitions(&self.pool, months_ahead).await
-    }
-
-    /// Backfill `d_tag` for existing NIP-33 events (kind 30000–39999) that have `d_tag IS NULL`.
-    ///
-    /// Idempotent — safe to call on every startup. No-ops when all rows are already populated.
-    /// Runs a single UPDATE touching only NIP-33 rows with NULL d_tag.
-    #[datastore_span(name = "backfill_d_tags", system = "postgresql")]
-    pub async fn backfill_d_tags(&self) -> Result<u64> {
-        let result = sqlx::query(
-            "UPDATE events \
-             SET d_tag = COALESCE( \
-                 (SELECT elem->>1 FROM jsonb_array_elements(tags) AS elem \
-                  WHERE elem->>0 = 'd' LIMIT 1), \
-                 '' \
-             ) \
-             WHERE kind BETWEEN 30000 AND 39999 AND d_tag IS NULL \
-               AND community_write_allowed(community_id)",
-        )
-        .execute(&self.pool)
-        .await?;
-        Ok(result.rows_affected())
-    }
 }
 
 #[cfg(test)]

--- a/crates/buzz-db/src/partition.rs
+++ b/crates/buzz-db/src/partition.rs
@@ -2,11 +2,13 @@
 //!
 //! Call `ensure_future_partitions` on startup and monthly via cron.
 
+use buzz_datastore_tracing::datastore_span;
 use chrono::{Datelike, TimeZone, Utc};
 use sqlx::{PgPool, Row};
 use tracing::info;
 
 use crate::error::{DbError, Result};
+use crate::Db;
 
 /// Tables that may be partition-managed. Allowlist prevents DDL injection.
 const PARTITIONED_TABLES: &[&str] = &["events", "delivery_log"];
@@ -53,6 +55,14 @@ pub async fn ensure_future_partitions(pool: &PgPool, months_ahead: u32) -> Resul
     }
 
     Ok(())
+}
+
+impl Db {
+    /// Ensures monthly partitions exist for the next N months.
+    #[datastore_span(name = "ensure_future_partitions", system = "postgresql")]
+    pub async fn ensure_future_partitions(&self, months_ahead: u32) -> Result<()> {
+        ensure_future_partitions(&self.pool, months_ahead).await
+    }
 }
 
 /// Validate that a partition suffix is digits and underscores only.


### PR DESCRIPTION
## Current reconstructed head

Exact base: `codex/issue-2-admin-moderation-store` at `102fca801dfdb3bab867deb4fab615718d03c6fc`  
Exact head: `codex/issue-2-maintenance-store` at `3ea91d34db1b9feee9ae73a71622e86fe828ccdb`

This current head removes `crates/buzz-db/tests/store_ownership.rs`; no replacement path-sensitive ownership test is introduced. Apart from removing that complete test-file diff, the production patch is byte-for-byte identical to the previously reviewed slice. This remains part of tracker #2 and the #17/#19 acceptance work.

Independent exact-head review from a separate clean Blox workstation found no issues. Current-head evidence passed formatting, strict `buzz-db` clippy, 111 non-PostgreSQL library tests with 200 PostgreSQL tests ignored, the observability source test, relay consumer compilation, exact ownership/unique-span review checks, and 3 focused partition validation unit tests (this slice moves no PostgreSQL test group) on native PostgreSQL where applicable.

## Summary

Continue [tracker #2](https://github.com/TheSentinel454/buzz/issues/2) by moving the two remaining startup-maintenance `Db` facades to the modules that own their invariants: monthly partition creation to `partition.rs`, and NIP-33 `d_tag` materialization to `event.rs`.

The public `Db` API is unchanged. There is no dedicated domain issue for this tightly coupled maintenance slice; it completes two remaining ledger items while advancing [#17](https://github.com/TheSentinel454/buzz/issues/17) and [#19](https://github.com/TheSentinel454/buzz/issues/19).

## Stack

- Tracker: [TheSentinel454/buzz#2](https://github.com/TheSentinel454/buzz/issues/2)
- Domain issue: none; startup partition/event maintenance is tracker-led
- Test ownership acceptance: [#17](https://github.com/TheSentinel454/buzz/issues/17)
- Span ownership acceptance: [#19](https://github.com/TheSentinel454/buzz/issues/19)
- Exact base: codex/issue-2-admin-moderation-store at 7dbb399207515d12fc9b27036076e5d4f6bfb937 ([#6813](https://github.com/block/buzz/pull/6813))
- Exact head: codex/issue-2-maintenance-store at fcb55abb9018f03c74bb4ec52b32422ad253e62f

## Domain moved

- `Db::ensure_future_partitions` and its existing datastore span to `partition.rs`, beside the partition allowlist, validation, DDL implementation, and focused tests
- `Db::backfill_d_tags`, its unchanged event-table SQL, and its existing datastore span to `event.rs`

`crates/buzz-db/src/lib.rs` falls from 3,717 to 3,690 lines.

## Non-goals

- Startup ordering, scheduling, logging, or error handling in the relay
- Partition ranges/allowlist/DDL, `d_tag` backfill SQL or event semantics, schema, locking, retries, timeouts, or client-visible behavior changes
- Moving general event-insertion materialization helpers
- Generic store traits, raw pool access, executor migration, or crate reorganization

## Risk

Low semantic risk. Both public facades and their fixed-name spans moved intact; each continues to call or execute the same module-owned implementation using the same writer pool. No tests or production SQL changed.

## Blox verification

Author workstation: `buzz-tornquist-issue-2-store-stack` (`2046520`), exact head `197549b3a28f2604d164208c4dd16e979458bb6c`.

- `cargo fmt --all --check`
- `git diff --check c684825860900357e017dd4102bc4df88dd6ec2e..HEAD`
- `cargo clippy -p buzz-db --all-targets -- -D warnings`
- `cargo clippy -p buzz-relay --all-targets -- -D warnings`
- `cargo test -p buzz-db --lib`: 108 passed, 200 ignored, including all three partition validation tests and event materialization unit coverage
- `cargo test -p buzz-db --test observability_source`: 1 passed
- `cargo test -p buzz-relay --lib`: 909 passed, 48 ignored
- Commit hooks passed without bypass; the disposable workstation has no user signing key, so the commit itself is unsigned

Independent exact-head Blox review: pending.

## Remaining tracker work

Next: deletion-store facades, the remaining cross-domain helper audit, and the final runtime-boundary/test assessment.

## Superseded pre-comment restack verification

PR #6700 merged before publication completed. This layer was restacked onto current main through the exact parent named above; the final cumulative tip is 2ddcc8a29f95c8c8c9cb87bb6cf59335f2190fae. Cumulative author gates passed: formatting and diff checks; buzz-db and buzz-relay all-target clippy with -D warnings; DB lib 111 passed / 200 ignored; ownership 22/22; observability 1/1; the full isolated PostgreSQL domain matrix; and relay lib 910 passed / 49 ignored.

## Result

No findings.

## Exact revision and isolation

- Base: `bcb1b423b7ac029759777209505800a757adc53b`
- Head: `5c314af38a0707e5f932b6627ea688d1ac7c9d33`
- Verified head parent and merge-base: exact base above
- Reviewer workstation: `buzz-tornquist-pr-6814-final-review` (`2057668`)

The fresh shallow workstation was clean and unclaimed, had no competing commands, and had no Buzz production relay credentials or ownership-report file.

## Review conclusions

- `ensure_future_partitions` moves to `partition.rs`; `backfill_d_tags` and its unchanged NIP-33 UPDATE move to `event.rs`.
- Both public signatures, delegation/SQL, error behavior, fixed span names, and one-span ownership are preserved.
- The guard proves the maintenance facades no longer remain in `lib.rs`. At this head, its only remaining datastore spans are the runtime `read_session_query_events` and `migrate` spans.

## Verification

- Diff check and Rust formatting: passed.
- Buzz DB and relay all-target clippy with `-D warnings`: passed.
- Buzz DB library: 111 passed, 200 ignored.
- Native PostgreSQL 17.11, migrations complete: three partition validation tests passed.
- An external exact-head facade probe invoked `Db::ensure_future_partitions(0)` and `Db::backfill_d_tags()` successfully against the migrated database (`maintenance_backfilled=0`).
- Final detached head remained clean; no duplicate datastore-span names were found.

Artifacts: `pr-6814-final-review-artifacts.tgz`, SHA-256 `f16c5917bd9b238b332f6f4ecc0db49169c6455ddf1652baab170b8bfa715875`. Archive and internal checksums were verified locally.

## Comment-addressed restack

Review follow-up on #6777 removed only the low-value replaceable ownership source test. This PR was restacked onto its rewritten parent; its production patch is unchanged.

- Exact base: `7dbb399207515d12fc9b27036076e5d4f6bfb937`
- Exact head: `fcb55abb9018f03c74bb4ec52b32422ad253e62f`
- Final cumulative tip: `6fa2f104d42c6ba85bdf62e7ccb74ceaf4a84f67`
- Per-layer patch-ID and tree audits confirm this PR’s production diff is unchanged from its pre-comment head.
- Cumulative Blox gate: formatting and diff checks; strict `buzz-db`/`buzz-relay` Clippy; DB lib 111 passed / 200 ignored; ownership 21/21; observability 1/1; every moved PostgreSQL test; relay lib 910 passed / 49 ignored.
- Independent re-review at this exact head: no findings; fresh exact-parent/head Blox review passed fmt/diff, strict `buzz-db`/`buzz-relay` Clippy, DB lib and current ownership/observability/unique-span guards, 3 maintenance PostgreSQL tests, relay compilation, and the exact-head facade probe.
