### PR TITLE
refactor(db): move deletion store ownership

### DIFF
--- a/crates/buzz-db/src/deletion.rs
+++ b/crates/buzz-db/src/deletion.rs
@@ -17,6 +17,7 @@ use sqlx::{AssertSqlSafe, PgConnection, PgPool, Postgres, Row, Transaction};
 use uuid::Uuid;
 
 use crate::error::{DbError, Result};
+use crate::Db;
 
 /// Default PostgreSQL lease duration for one claimed deletion request.
 pub const DEFAULT_LEASE_DURATION: Duration = Duration::from_secs(60);
@@ -625,6 +626,23 @@ pub struct ServingLeaseStats {
 #[derive(Clone)]
 pub struct DeletionStore {
     pool: PgPool,
+}
+
+impl Db {
+    /// Validate the minimum deletion fence catalog required by serving paths.
+    pub async fn validate_deletion_serving_catalog(&self) -> Result<()> {
+        self.deletion_store().validate_serving_catalog().await
+    }
+
+    /// Validate the exact live community-deletion tenant catalog for destruction.
+    pub async fn validate_deletion_catalog(&self) -> Result<()> {
+        self.deletion_store().validate_catalog().await
+    }
+
+    /// Return the shared durable whole-community deletion adapter.
+    pub fn deletion_store(&self) -> DeletionStore {
+        DeletionStore::new(self.pool.clone())
+    }
 }
 
 impl DeletionStore {

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -954,16 +954,6 @@ impl Db {
         sqlx::query("SELECT 1").execute(&self.pool).await.is_ok()
     }
 
-    /// Validate the minimum deletion fence catalog required by serving paths.
-    pub async fn validate_deletion_serving_catalog(&self) -> Result<()> {
-        self.deletion_store().validate_serving_catalog().await
-    }
-
-    /// Validate the exact live community-deletion tenant catalog for destruction.
-    pub async fn validate_deletion_catalog(&self) -> Result<()> {
-        self.deletion_store().validate_catalog().await
-    }
-
     /// Returns pool utilisation stats for metrics emission.
     ///
     /// `size`  — total connections (idle + active)
@@ -991,11 +981,6 @@ impl Db {
             idle: p.num_idle() as u32,
             max: self.read_max_connections,
         })
-    }
-
-    /// Return the shared durable whole-community deletion adapter.
-    pub fn deletion_store(&self) -> deletion::DeletionStore {
-        deletion::DeletionStore::new(self.pool.clone())
     }
 
     /// Begin a database transaction for atomic multi-statement operations.


### PR DESCRIPTION
## Current reconstructed head

Exact base: `codex/issue-2-maintenance-store` at `3ea91d34db1b9feee9ae73a71622e86fe828ccdb`  
Exact head: `codex/issue-2-deletion-store` at `cd091640b461e15b1a852e5dccc77d063763302a`

This current head removes `crates/buzz-db/tests/store_ownership.rs`; no replacement path-sensitive ownership test is introduced. Apart from removing that complete test-file diff, the production patch is byte-for-byte identical to the previously reviewed slice. This remains part of tracker #2 and the #17/#19 acceptance work.

Independent exact-head review from a separate clean Blox workstation found no issues. Current-head evidence passed formatting, strict `buzz-db` clippy, 111 non-PostgreSQL library tests with 200 PostgreSQL tests ignored, the observability source test, relay consumer compilation, exact ownership/unique-span review checks, and 20 deletion PostgreSQL tests on native PostgreSQL where applicable.

## Summary

Continue [tracker #2](https://github.com/TheSentinel454/buzz/issues/2) by making `deletion.rs` own the three remaining whole-community deletion facades: the serving-catalog validator, exact destruction-catalog validator, and `DeletionStore` construction.

The public `Db` API is unchanged. The cross-domain `insert_event_with_serving_write_guard` transaction remains in `lib.rs`, where it composes the deletion lease, event insertion, commit, and mention indexing. There is no dedicated domain issue for this slice; it advances [#17](https://github.com/TheSentinel454/buzz/issues/17) and [#19](https://github.com/TheSentinel454/buzz/issues/19).

## Stack

- Tracker: [TheSentinel454/buzz#2](https://github.com/TheSentinel454/buzz/issues/2)
- Domain issue: none; deletion facade ownership is tracker-led
- Test ownership acceptance: [#17](https://github.com/TheSentinel454/buzz/issues/17)
- Span ownership acceptance: [#19](https://github.com/TheSentinel454/buzz/issues/19)
- Exact base: codex/issue-2-maintenance-store at fcb55abb9018f03c74bb4ec52b32422ad253e62f ([#6814](https://github.com/block/buzz/pull/6814))
- Exact head: codex/issue-2-deletion-store at 6fa2f104d42c6ba85bdf62e7ccb74ceaf4a84f67

## Domain moved

- `Db::validate_deletion_serving_catalog`
- `Db::validate_deletion_catalog`
- `Db::deletion_store`

`crates/buzz-db/src/lib.rs` falls from 3,690 to 3,675 lines.

## Non-goals

- Deletion lifecycle records, stages, catalog manifests, SQL, locking, leases, retry/checkpoint behavior, timeouts, schema, or client-visible behavior changes
- Moving the cross-domain `insert_event_with_serving_write_guard` transaction or exposing the raw pool
- Generic store traits, executor migration, or crate reorganization

## Risk

Low semantic risk. The three public facades moved intact beside `DeletionStore`; all validation and construction calls remain identical.

## Blox verification

Author workstation: `buzz-tornquist-issue-2-store-stack` (`2046520`), exact head `9e5f0ebbea9148fa77efc4c915a93d489816837c`.

- `cargo fmt --all --check`
- `git diff --check 197549b3a28f2604d164208c4dd16e979458bb6c..HEAD`
- `cargo clippy -p buzz-db --all-targets -- -D warnings`
- `cargo clippy -p buzz-relay --all-targets -- -D warnings`
- `cargo test -p buzz-db --lib`: 108 passed, 200 ignored
- `cargo test -p buzz-db --test observability_source`: 1 passed
- Native PostgreSQL 17.11, migrations 1–32 already applied: all 20 `deletion::postgres_tests` passed
- `cargo test -p buzz-relay --lib -- --test-threads=1`: 909 passed, 48 ignored
- The parallel relay suite twice reached 908/957 before the unrelated mesh-demo echo test returned its known timeout-shaped 504; that exact test passed immediately in isolation, and the complete single-threaded suite passed
- Commit hooks passed without bypass; the disposable workstation has no user signing key, so the commit itself is unsigned

Independent exact-head Blox review: pending.

## Remaining tracker work

Next: the final cross-domain/runtime audit, irreducible `lib.rs` assessment, and cumulative verification.

## Superseded pre-comment restack verification

PR #6700 merged before publication completed. This layer was restacked onto current main through the exact parent named above; the final cumulative tip is 2ddcc8a29f95c8c8c9cb87bb6cf59335f2190fae. Cumulative author gates passed: formatting and diff checks; buzz-db and buzz-relay all-target clippy with -D warnings; DB lib 111 passed / 200 ignored; ownership 22/22; observability 1/1; the full isolated PostgreSQL domain matrix; and relay lib 910 passed / 49 ignored.

## Result

No findings.

## Exact revision and isolation

- Base: `5c314af38a0707e5f932b6627ea688d1ac7c9d33`
- Head: `2ddcc8a29f95c8c8c9cb87bb6cf59335f2190fae`
- Verified head parent and merge-base: exact base above
- Reviewer workstation: `buzz-tornquist-pr-6815-final-review` (`2057667`)

The fresh shallow workstation was clean and unclaimed, had no competing commands, and had no Buzz production relay credentials or ownership-report file.

## Review conclusions

- The deletion store accessor and two catalog-validation facades move intact into `deletion.rs`; public paths, return types, validation delegation, and error propagation are unchanged.
- The cross-domain `insert_event_with_serving_write_guard` remains in `lib.rs`, preserving the runtime/event/deletion transaction boundary.
- No SQL, lock, transaction, retry, timeout, or instrumentation code changes in this patch. The guard proves single facade ownership and retention of the cross-domain runtime helper.
- Final `lib.rs` is 3,675 physical lines and contains only the `read_session_query_events` and `migrate` datastore spans.

## Verification

- Diff check and Rust formatting: passed.
- Buzz DB and relay all-target clippy with `-D warnings`: passed.
- Buzz DB library: 111 passed, 200 ignored.
- Native PostgreSQL 17.11, migrations complete: all 20 deletion PostgreSQL tests passed.
- An external exact-head facade probe successfully invoked both deletion catalog-validation facades on the migrated database.
- Final detached head remained clean; no duplicate datastore-span names were found.

Artifacts: `pr-6815-final-review-artifacts.tgz`, SHA-256 `bc524bce098a9206edca1fc5be22126d00f91425ccecc0e9de32e8ab65f6cf45`. Archive and internal checksums were verified locally.

## Comment-addressed restack

Review follow-up on #6777 removed only the low-value replaceable ownership source test. This PR was restacked onto its rewritten parent; its production patch is unchanged.

- Exact base: `fcb55abb9018f03c74bb4ec52b32422ad253e62f`
- Exact head: `6fa2f104d42c6ba85bdf62e7ccb74ceaf4a84f67`
- Final cumulative tip: `6fa2f104d42c6ba85bdf62e7ccb74ceaf4a84f67`
- Per-layer patch-ID and tree audits confirm this PR’s production diff is unchanged from its pre-comment head.
- Cumulative Blox gate: formatting and diff checks; strict `buzz-db`/`buzz-relay` Clippy; DB lib 111 passed / 200 ignored; ownership 21/21; observability 1/1; every moved PostgreSQL test; relay lib 910 passed / 49 ignored.
- Independent re-review at this exact head: no findings; fresh exact-parent/head Blox review passed fmt/diff, strict `buzz-db`/`buzz-relay` Clippy, DB lib 111 passed / 200 ignored, ownership 21/21, observability 1/1, unique spans, all 20 deletion PostgreSQL tests, relay compilation, and the exact-head facade probe.
