### PR TITLE
test(db): seed canonical large roster fixture

### DIFF
--- a/crates/buzz-db/src/feed.rs
+++ b/crates/buzz-db/src/feed.rs
@@ -904,8 +904,19 @@ mod tests {
 
         // 11,000 rows x 6 binds = 66,000 > 65,535: overflows a single statement.
         let mention_count = 11_000usize;
+        sqlx::query(
+            "INSERT INTO channel_members (community_id, channel_id, pubkey, role) \
+             SELECT $1, $2, decode(lpad(to_hex(n), 64, '0'), 'hex'), 'member' \
+             FROM generate_series(1, $3) n",
+        )
+        .bind(community.as_uuid())
+        .bind(channel)
+        .bind(mention_count as i64)
+        .execute(&pool)
+        .await
+        .expect("insert canonical roster members");
         let tags: Vec<Tag> = (1..=mention_count)
-            .map(|n| Tag::parse(["p", &format!("{n:064x}")]).expect("p tag"))
+            .map(|n| Tag::parse(["p", &format!("{n:064x}"), "", "member"]).expect("p tag"))
             .collect();
         let event = store_feed_event(&pool, community, 39002, "", Some(channel), tags).await;
 


### PR DESCRIPTION
## Current reconstructed head

Exact base: `codex/issue-2-reaction-store` at `e2c71f5df1647e8a583ed3070c01fe7eb2bb85b3`  
Exact head: `codex/issue-2-feed-roster-test-fixtures` at `6fbb4cb7814f8d94cd438997141d2a1633d41907`

This current head removes `crates/buzz-db/tests/store_ownership.rs`; no replacement path-sensitive ownership test is introduced. Apart from removing that complete test-file diff, the production patch is byte-for-byte identical to the previously reviewed slice. This remains part of tracker #2 and the #17/#19 acceptance work.

Independent exact-head review from a separate clean Blox workstation found no issues. Current-head evidence passed formatting, strict `buzz-db` clippy, 111 non-PostgreSQL library tests with 200 PostgreSQL tests ignored, the observability source test, relay consumer compilation, exact ownership/unique-span review checks, and 1 large-roster feed PostgreSQL regression test on native PostgreSQL where applicable.

## Summary

Make the 11,000-member feed mention-indexing regression fixture canonical under migration 0032 before the feed store extraction adds more ownership to `feed.rs`.

The test now seeds the matching `channel_members` rows and emits four-field kind-39002 `p` tags with the authoritative `member` role. Its bind-parameter-cap assertion and 11,000-row scale are unchanged.

## Stack

- Exact base: codex/issue-2-reaction-store at 19f2b86a063cecd1521eb003225ec76acb5d8bf3 ([#6792](https://github.com/block/buzz/pull/6792))
- Exact head: codex/issue-2-feed-roster-test-fixtures at f18b0d3fdc45610d375637c2585d8ae589762735
- Structural tracker: TheSentinel454/buzz#2
- Domain issue: none; test-only prerequisite for the feed slice
- Acceptance: TheSentinel454/buzz#17 and TheSentinel454/buzz#19
- Next: `codex/issue-2-feed-store`

## Why separate

The existing ignored test is red against a freshly migrated current `main`: migration 0032 rejects its legacy two-field roster tags before `insert_mentions` is exercised. The feed extraction PR is intended to move ownership without behavior changes, so this fixture correction is isolated in its own reviewable commit.

## Non-goals

- No production Rust or SQL changes.
- No schema, lock, transaction, timeout, retry, API, or client-visible behavior changes.
- No change to mention-index insertion or batching.
- No feed store ownership movement; that remains in the child PR.

## Risk

Low and test-only. The fixture still creates 11,000 unique mentions, exceeds the single-statement bind cap at six binds per row, and asserts every mention is indexed.

## Blox verification

Author workstation: `buzz-tornquist-issue-2-store-stack` (`2046520`), native PostgreSQL 17.11.

- Red before the change on a freshly migrated database: the focused test failed with migration 0032's `kind 39002 roster contains an invalid p tag` constraint.
- `cargo fmt --all --check`: pass
- `git diff --check`: pass
- `cargo clippy -p buzz-db --all-targets -- -D warnings`: pass
- `feed::tests::insert_mentions_indexes_rosters_past_bind_parameter_cap`: pass
- Cumulative exact-tip PostgreSQL matrix: pass

## Superseded pre-comment restack verification

PR #6700 merged before publication completed. This layer was restacked onto current main through the exact parent named above; the final cumulative tip is 2ddcc8a29f95c8c8c9cb87bb6cf59335f2190fae. Cumulative author gates passed: formatting and diff checks; buzz-db and buzz-relay all-target clippy with -D warnings; DB lib 111 passed / 200 ignored; ownership 22/22; observability 1/1; the full isolated PostgreSQL domain matrix; and relay lib 910 passed / 49 ignored.

## Outcome

No actionable findings.

Reviewed the exact range `b87cec6d690119721e2ef3ac34e6ba57b41099c7..ed21d81e7fe1fa7606c6e67412b788cc6df12916` on fresh Blox workstation `buzz-tornquist-pr-6820-final-review` (ID `2057635`). The head is the direct child of the exact base. The test-only change seeds `channel_members` with the same 11,000 deterministic pubkeys emitted in four-field canonical roster `p` tags; it restores the large-roster bind-cap regression without changing production behavior.

## Verification

- `cargo fmt --all --check`, range/worktree `git diff --check`, and clean-tree checks passed.
- `cargo clippy -p buzz-db --all-targets -- -D warnings` passed.
- Non-PostgreSQL feed tests: 22 passed, 4 ignored.
- `cargo test -p buzz-relay --lib --no-run` passed.
- Native PostgreSQL 17: `feed::tests::insert_mentions_indexes_rosters_past_bind_parameter_cap` passed with the current migrations.
- Final detached HEAD and merge-base were rechecked; the repository remained clean.

No code edits, commits, pushes, comments, or PR mutations were made. Buzz relay credentials were unavailable, so the private guide, ownership report, and workstream-channel updates were unavailable under the documented fallback. The workstation was deleted after artifacts were transferred.

## Artifacts

- Diff SHA-256: `4df56ed54eb6b5bba06fd26354e1937b40fddf785759dce475b10de6c67e4ad6`
- Verification log SHA-256: `931f2a86c0aaf54f51c1c70a6df0b359a759cdd40ceec22684628e679c72d806`
- Artifact archive SHA-256: `481b8bd4a98e1db2da8b2425f981109cbcaced6d11960083703ee1a4eed229ac`

## Comment-addressed restack

Review follow-up on #6777 removed only the low-value replaceable ownership source test. This PR was restacked onto its rewritten parent; its production patch is unchanged.

- Exact base: `19f2b86a063cecd1521eb003225ec76acb5d8bf3`
- Exact head: `f18b0d3fdc45610d375637c2585d8ae589762735`
- Final cumulative tip: `6fa2f104d42c6ba85bdf62e7ccb74ceaf4a84f67`
- Per-layer patch-ID and tree audits confirm this PR’s production diff is unchanged from its pre-comment head.
- Cumulative Blox gate: formatting and diff checks; strict `buzz-db`/`buzz-relay` Clippy; DB lib 111 passed / 200 ignored; ownership 21/21; observability 1/1; every moved PostgreSQL test; relay lib 910 passed / 49 ignored.
- Independent re-review at this exact head: no findings; fresh exact-parent/head Blox review passed fmt/diff, strict `buzz-db` Clippy, current ownership/observability guards, feed tests (22 passed / 4 ignored), the moved large-roster PostgreSQL fixture, and relay compilation.
