### PR TITLE
feat(sidebar): prioritize unread DMs in overflow navigation

### DIFF
--- a/desktop/src/features/sidebar/lib/useOffscreenActivityChannelIds.test.mjs
+++ b/desktop/src/features/sidebar/lib/useOffscreenActivityChannelIds.test.mjs
@@ -26,6 +26,20 @@ test("keeps every unread channel navigable while adding working activity", () =>
   ]);
 });
 
+test("keeps working-only channels out of message overflow prioritization", () => {
+  const activity = getOffscreenActivityChannelIds({
+    activeWorkingByChannelId: new Map([["read-working-dm", {}]]),
+    previewActivityChannelIds: new Set(),
+    unreadChannelIds: new Set(["unread-channel"]),
+  });
+
+  assert.deepEqual([...activity.messageChannelIds], ["unread-channel"]);
+  assert.deepEqual(
+    [...activity.channelIds],
+    ["unread-channel", "read-working-dm"],
+  );
+});
+
 test("uses an activity-neutral overflow label when work contributes", () => {
   assert.equal(
     getSidebarActivityOverflowLabel({ activityCount: 2, messageCount: 1 }),

--- a/desktop/src/features/sidebar/lib/useSidebarActivityOverflow.ts
+++ b/desktop/src/features/sidebar/lib/useSidebarActivityOverflow.ts
@@ -33,6 +33,8 @@ export function useSidebarActivityOverflow({
 
   return {
     ...activityOverflow,
+    unreadMessageAboveChannelIds: messageOverflow.unreadAboveChannelIds,
+    unreadMessageBelowChannelIds: messageOverflow.unreadBelowChannelIds,
     unreadAboveLabel: getSidebarActivityOverflowLabel({
       activityCount: activityOverflow.unreadAboveCount,
       messageCount: messageOverflow.unreadAboveCount,

--- a/desktop/src/features/sidebar/lib/useUnreadOverflow.test.mjs
+++ b/desktop/src/features/sidebar/lib/useUnreadOverflow.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { deriveUnreadOverflow } from "./useUnreadOverflow.ts";
+
+const root = {
+  getBoundingClientRect: () => ({ height: 100, top: 50 }),
+};
+
+function entry(channelId, top, isIntersecting = false) {
+  return {
+    element: {
+      getAttribute: (name) => (name === "data-channel-id" ? channelId : null),
+      getBoundingClientRect: () => ({ top }),
+    },
+    isIntersecting,
+  };
+}
+
+describe("deriveUnreadOverflow", () => {
+  it("orders offscreen channels by position", () => {
+    const result = deriveUnreadOverflow(
+      [
+        entry("below-2", 180),
+        entry("above-2", 0),
+        entry("below-1", 160),
+        entry("above-1", 20),
+      ],
+      root,
+    );
+
+    assert.deepEqual(result.unreadAboveChannelIds, ["above-1", "above-2"]);
+    assert.deepEqual(result.unreadBelowChannelIds, ["below-1", "below-2"]);
+    assert.equal(result.unreadAboveCount, 2);
+    assert.equal(result.unreadBelowCount, 2);
+  });
+
+  it("deduplicates repeated sidebar rows for the same channel", () => {
+    const result = deriveUnreadOverflow(
+      [entry("starred", 170), entry("starred", 240)],
+      root,
+    );
+
+    assert.deepEqual(result.unreadBelowChannelIds, ["starred"]);
+    assert.equal(result.unreadBelowCount, 1);
+  });
+
+  it("does not count a duplicate row when the same channel is visible", () => {
+    const result = deriveUnreadOverflow(
+      [entry("starred", 80, true), entry("starred", 240)],
+      root,
+    );
+
+    assert.deepEqual(result.unreadBelowChannelIds, []);
+    assert.equal(result.unreadBelowCount, 0);
+  });
+
+  it("ignores visible rows", () => {
+    const result = deriveUnreadOverflow(
+      [entry("visible", 80, true), entry("below", 180)],
+      root,
+    );
+
+    assert.deepEqual(result.unreadBelowChannelIds, ["below"]);
+  });
+});

--- a/desktop/src/features/sidebar/lib/useUnreadOverflow.ts
+++ b/desktop/src/features/sidebar/lib/useUnreadOverflow.ts
@@ -10,11 +10,15 @@ type UnreadDirection = "above" | "below";
 type UnreadOverflowCounts = {
   unreadAboveCount: number;
   unreadBelowCount: number;
+  unreadAboveChannelIds: string[];
+  unreadBelowChannelIds: string[];
 };
 
 const EMPTY_COUNTS: UnreadOverflowCounts = {
   unreadAboveCount: 0,
   unreadBelowCount: 0,
+  unreadAboveChannelIds: [],
+  unreadBelowChannelIds: [],
 };
 
 function getChannelId(element: Element): string | null {
@@ -71,34 +75,65 @@ function findNextUnreadElement({
   return nextElement;
 }
 
-function deriveCounts(
-  visibilityById: Map<string, VisibilityEntry>,
+export function deriveUnreadOverflow(
+  entries: Iterable<VisibilityEntry>,
   root: HTMLDivElement,
 ): UnreadOverflowCounts {
-  let unreadAboveCount = 0;
-  let unreadBelowCount = 0;
-
+  const unreadAbove = new Map<string, number>();
+  const unreadBelow = new Map<string, number>();
+  const visibleChannelIds = new Set<string>();
   const rootHeight = root.getBoundingClientRect().height;
 
-  for (const entry of visibilityById.values()) {
+  for (const entry of entries) {
+    const channelId = getChannelId(entry.element);
+    if (!channelId) continue;
+    if (entry.isIntersecting) {
+      visibleChannelIds.add(channelId);
+      continue;
+    }
+
     const top = getRelativeTop(entry.element, root);
 
-    if (entry.isIntersecting) continue;
-
     if (top < 0) {
-      unreadAboveCount += 1;
+      unreadAbove.set(
+        channelId,
+        Math.max(unreadAbove.get(channelId) ?? -Infinity, top),
+      );
     } else if (top > rootHeight) {
-      unreadBelowCount += 1;
+      unreadBelow.set(
+        channelId,
+        Math.min(unreadBelow.get(channelId) ?? Infinity, top),
+      );
     }
   }
 
-  return { unreadAboveCount, unreadBelowCount };
+  for (const channelId of visibleChannelIds) {
+    unreadAbove.delete(channelId);
+    unreadBelow.delete(channelId);
+  }
+
+  const byPosition = (left: [string, number], right: [string, number]) =>
+    left[1] - right[1];
+  const unreadAboveChannelIds = [...unreadAbove.entries()]
+    .sort((left, right) => byPosition(right, left))
+    .map(([channelId]) => channelId);
+  const unreadBelowChannelIds = [...unreadBelow.entries()]
+    .sort(byPosition)
+    .map(([channelId]) => channelId);
+
+  return {
+    unreadAboveCount: unreadAboveChannelIds.length,
+    unreadBelowCount: unreadBelowChannelIds.length,
+    unreadAboveChannelIds,
+    unreadBelowChannelIds,
+  };
 }
 
 export function useUnreadOverflow(args: {
   scrollRef: React.RefObject<HTMLDivElement | null>;
   unreadChannelIds: ReadonlySet<string>;
 }): UnreadOverflowCounts & {
+  scrollToChannel: (channelId: string) => void;
   scrollToNextAbove: () => void;
   scrollToNextBelow: () => void;
 } {
@@ -117,15 +152,15 @@ export function useUnreadOverflow(args: {
     }
 
     let intersectionObserver: IntersectionObserver | null = null;
-    const visibilityById = new Map<string, VisibilityEntry>();
+    const visibilityByElement = new Map<HTMLElement, VisibilityEntry>();
 
     const updateCounts = () => {
-      setCounts(deriveCounts(visibilityById, root));
+      setCounts(deriveUnreadOverflow(visibilityByElement.values(), root));
     };
 
     const bindUnreadRows = () => {
       intersectionObserver?.disconnect();
-      visibilityById.clear();
+      visibilityByElement.clear();
 
       intersectionObserver = new IntersectionObserver(
         (entries) => {
@@ -135,8 +170,9 @@ export function useUnreadOverflow(args: {
               continue;
             }
 
-            visibilityById.set(channelId, {
-              element: entry.target as HTMLElement,
+            const element = entry.target as HTMLElement;
+            visibilityByElement.set(element, {
+              element,
               isIntersecting: entry.isIntersecting,
             });
           }
@@ -150,7 +186,7 @@ export function useUnreadOverflow(args: {
         const channelId = getChannelId(element);
         if (!channelId) continue;
 
-        visibilityById.set(channelId, {
+        visibilityByElement.set(element, {
           element,
           isIntersecting: false,
         });
@@ -192,8 +228,20 @@ export function useUnreadOverflow(args: {
     })?.scrollIntoView({ behavior: "smooth", block: "center" });
   }, [scrollRef]);
 
+  const scrollToChannel = React.useCallback(
+    (channelId: string) => {
+      const root = scrollRef.current;
+      if (!root) return;
+      getUnreadElements(root, unreadChannelIdsRef.current)
+        .find((element) => getChannelId(element) === channelId)
+        ?.scrollIntoView({ behavior: "smooth", block: "center" });
+    },
+    [scrollRef],
+  );
+
   return {
     ...counts,
+    scrollToChannel,
     scrollToNextAbove,
     scrollToNextBelow,
   };

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -37,7 +37,7 @@ import {
   MoreUnreadButton,
   preferredUnreadTarget,
 } from "@/features/sidebar/ui/MoreUnreadButton";
-import { unreadChannelCountLabel } from "@/shared/ui/UnreadPill";
+import { unreadCountLabel } from "@/shared/ui/UnreadPill";
 import { SidebarSection } from "@/features/sidebar/ui/SidebarSection";
 import {
   ChannelGroupSection,
@@ -516,9 +516,7 @@ export function AppSidebar({
           {unreadAboveCount > 0 ? (
             <MoreUnreadButton
               count={unreadAboveCount}
-              label={
-                unreadAboveLabel ?? unreadChannelCountLabel(unreadAboveCount)
-              }
+              label={unreadAboveLabel ?? unreadCountLabel(unreadAboveCount)}
               onClick={scrollToNextAbove}
               position="top"
               testId="sidebar-more-unread-above"
@@ -792,9 +790,7 @@ export function AppSidebar({
               bottomClassName="bottom-full"
               count={unreadBelowCount}
               dmPreviews={unreadDmPreviewsBelow}
-              label={
-                unreadBelowLabel ?? unreadChannelCountLabel(unreadBelowCount)
-              }
+              label={unreadBelowLabel ?? unreadCountLabel(unreadBelowCount)}
               onClick={() =>
                 nextUnreadDmBelowId
                   ? scrollToChannel(nextUnreadDmBelowId)

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -33,7 +33,11 @@ import {
   AppSidebarPinnedHeader,
   AppSidebarPrimaryMenu,
 } from "@/features/sidebar/ui/AppSidebarPinnedHeader";
-import { MoreUnreadButton } from "@/features/sidebar/ui/MoreUnreadButton";
+import {
+  MoreUnreadButton,
+  preferredUnreadTarget,
+} from "@/features/sidebar/ui/MoreUnreadButton";
+import { unreadChannelCountLabel } from "@/shared/ui/UnreadPill";
 import { SidebarSection } from "@/features/sidebar/ui/SidebarSection";
 import {
   ChannelGroupSection,
@@ -148,7 +152,7 @@ export function AppSidebar({
   const scrollRef = React.useRef<HTMLDivElement>(null);
   useSidebarScrollLock(scrollRef);
   // biome-ignore format: keep compact to stay within file size limit
-  const { scrollToNextAbove, scrollToNextBelow, unreadAboveCount, unreadBelowCount, unreadAboveLabel, unreadBelowLabel } = useSidebarActivityOverflow({ activeWorkingByChannelId, previewActivityChannelIds, scrollRef, unreadChannelIds });
+  const { scrollToChannel, scrollToNextAbove, scrollToNextBelow, unreadAboveCount, unreadBelowCount, unreadBelowChannelIds, unreadAboveLabel, unreadBelowLabel } = useSidebarActivityOverflow({ activeWorkingByChannelId, previewActivityChannelIds, scrollRef, unreadChannelIds });
 
   React.useEffect(() => {
     const scrollElement = scrollRef.current;
@@ -390,6 +394,31 @@ export function AppSidebar({
       ),
     [directMessages, dmChannelLabels, sortModeFor],
   );
+  const unreadDmPreviewsBelow = React.useMemo(
+    () =>
+      unreadBelowChannelIds.flatMap((channelId) => {
+        const channel = directMessages.find(
+          (candidate) => candidate.id === channelId,
+        );
+        const participant = dmParticipantsByChannelId[channelId]?.[0];
+        if (!channel || !participant) return [];
+        return [
+          {
+            accessibleLabel: participant.label,
+            avatarUrl: participant.avatarUrl,
+            channelId,
+            label: dmChannelLabels[channelId] ?? participant.label,
+          },
+        ];
+      }),
+    [
+      directMessages,
+      dmChannelLabels,
+      dmParticipantsByChannelId,
+      unreadBelowChannelIds,
+    ],
+  );
+  const nextUnreadDmBelowId = preferredUnreadTarget(unreadDmPreviewsBelow);
   const sidebarLoadingShape = useSidebarLoadingShape({
     activeCommunityId: activeCommunity?.id,
     currentPubkey,
@@ -487,7 +516,9 @@ export function AppSidebar({
           {unreadAboveCount > 0 ? (
             <MoreUnreadButton
               count={unreadAboveCount}
-              label={unreadAboveLabel}
+              label={
+                unreadAboveLabel ?? unreadChannelCountLabel(unreadAboveCount)
+              }
               onClick={scrollToNextAbove}
               position="top"
               testId="sidebar-more-unread-above"
@@ -760,8 +791,15 @@ export function AppSidebar({
             <MoreUnreadButton
               bottomClassName="bottom-full"
               count={unreadBelowCount}
-              label={unreadBelowLabel}
-              onClick={scrollToNextBelow}
+              dmPreviews={unreadDmPreviewsBelow}
+              label={
+                unreadBelowLabel ?? unreadChannelCountLabel(unreadBelowCount)
+              }
+              onClick={() =>
+                nextUnreadDmBelowId
+                  ? scrollToChannel(nextUnreadDmBelowId)
+                  : scrollToNextBelow()
+              }
               position="bottom"
               testId="sidebar-more-unread-below"
             />

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -34,6 +34,7 @@ import {
   AppSidebarPrimaryMenu,
 } from "@/features/sidebar/ui/AppSidebarPinnedHeader";
 import {
+  canPreviewUnreadDm,
   MoreUnreadButton,
   preferredUnreadTarget,
 } from "@/features/sidebar/ui/MoreUnreadButton";
@@ -152,7 +153,7 @@ export function AppSidebar({
   const scrollRef = React.useRef<HTMLDivElement>(null);
   useSidebarScrollLock(scrollRef);
   // biome-ignore format: keep compact to stay within file size limit
-  const { scrollToChannel, scrollToNextAbove, scrollToNextBelow, unreadAboveCount, unreadBelowCount, unreadBelowChannelIds, unreadAboveLabel, unreadBelowLabel } = useSidebarActivityOverflow({ activeWorkingByChannelId, previewActivityChannelIds, scrollRef, unreadChannelIds });
+  const { scrollToChannel, scrollToNextAbove, scrollToNextBelow, unreadAboveCount, unreadBelowCount, unreadMessageBelowChannelIds, unreadAboveLabel, unreadBelowLabel } = useSidebarActivityOverflow({ activeWorkingByChannelId, previewActivityChannelIds, scrollRef, unreadChannelIds });
 
   React.useEffect(() => {
     const scrollElement = scrollRef.current;
@@ -396,12 +397,22 @@ export function AppSidebar({
   );
   const unreadDmPreviewsBelow = React.useMemo(
     () =>
-      unreadBelowChannelIds.flatMap((channelId) => {
+      unreadMessageBelowChannelIds.flatMap((channelId) => {
         const channel = directMessages.find(
           (candidate) => candidate.id === channelId,
         );
-        const participant = dmParticipantsByChannelId[channelId]?.[0];
-        if (!channel || !participant) return [];
+        const participants = dmParticipantsByChannelId[channelId];
+        const participant = participants?.[0];
+        if (
+          !channel ||
+          !participant ||
+          !canPreviewUnreadDm(
+            channel.participantPubkeys.length,
+            participants?.length ?? 0,
+          )
+        ) {
+          return [];
+        }
         return [
           {
             accessibleLabel: participant.label,
@@ -415,7 +426,7 @@ export function AppSidebar({
       directMessages,
       dmChannelLabels,
       dmParticipantsByChannelId,
-      unreadBelowChannelIds,
+      unreadMessageBelowChannelIds,
     ],
   );
   const nextUnreadDmBelowId = preferredUnreadTarget(unreadDmPreviewsBelow);

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -429,8 +429,13 @@ export function AppSidebar({
       unreadMessageBelowChannelIds,
     ],
   );
+  const unreadDmChannelIds = React.useMemo(
+    () => new Set(directMessages.map(({ id }) => id)),
+    [directMessages],
+  );
   const nextUnreadDmBelowId = preferredUnreadTarget(
     unreadMessageBelowChannelIds,
+    unreadDmChannelIds,
   );
   const sidebarLoadingShape = useSidebarLoadingShape({
     activeCommunityId: activeCommunity?.id,

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -429,7 +429,9 @@ export function AppSidebar({
       unreadMessageBelowChannelIds,
     ],
   );
-  const nextUnreadDmBelowId = preferredUnreadTarget(unreadDmPreviewsBelow);
+  const nextUnreadDmBelowId = preferredUnreadTarget(
+    unreadMessageBelowChannelIds,
+  );
   const sidebarLoadingShape = useSidebarLoadingShape({
     activeCommunityId: activeCommunity?.id,
     currentPubkey,
@@ -808,6 +810,7 @@ export function AppSidebar({
                   : scrollToNextBelow()
               }
               position="bottom"
+              targetChannelId={nextUnreadDmBelowId}
               testId="sidebar-more-unread-below"
             />
           ) : null}

--- a/desktop/src/features/sidebar/ui/MoreUnreadButton.test.mjs
+++ b/desktop/src/features/sidebar/ui/MoreUnreadButton.test.mjs
@@ -20,7 +20,7 @@ function preview(channelId, label = channelId, avatarUrl = null) {
 }
 
 describe("MoreUnreadButton model", () => {
-  it("shows three avatars until overflow requires a +N chip", () => {
+  it("caps the stack at three avatars without a numeric overflow chip", () => {
     assert.deepEqual(
       visibleUnreadDmPreviews([preview("a"), preview("b"), preview("c")]).map(
         ({ channelId }) => channelId,
@@ -34,7 +34,7 @@ describe("MoreUnreadButton model", () => {
         preview("c"),
         preview("d"),
       ]).map(({ channelId }) => channelId),
-      ["a", "b"],
+      ["a", "b", "c"],
     );
   });
 
@@ -43,14 +43,14 @@ describe("MoreUnreadButton model", () => {
     assert.equal(preferredUnreadTarget([], "nearer"), "nearer");
   });
 
-  it("announces the DM target and honest channel count", () => {
+  it("announces the DM target and message count", () => {
     assert.equal(
       unreadDmAccessibleLabel({
         count: 2,
         dmPreviews: [preview("dm", "Alice")],
         position: "bottom",
       }),
-      "Go to unread direct message from Alice. 2 unread channels below.",
+      "Go to unread direct message from Alice. 2 new messages below.",
     );
     assert.equal(
       unreadDmAccessibleLabel({
@@ -58,11 +58,11 @@ describe("MoreUnreadButton model", () => {
         dmPreviews: [],
         position: "top",
       }),
-      "1 unread channel above",
+      "1 new message above",
     );
   });
 
-  it("renders a decorative channel-keyed stack, overflow, and immediate fallback", () => {
+  it("renders a decorative right-to-left stack with immediate fallback", () => {
     const markup = renderToStaticMarkup(
       MoreUnreadButton({
         count: 5,
@@ -78,15 +78,27 @@ describe("MoreUnreadButton model", () => {
       }),
     );
 
+    assert.match(markup, /class="[^"]*overflow-hidden[^"]*"/);
     assert.match(
       markup,
-      /aria-label="Go to unread direct message from Alice\. 5 unread channels below\."/,
+      /<span class="min-w-0 truncate">5 new messages<\/span>/,
     );
+    assert.match(
+      markup,
+      /aria-label="Go to unread direct message from Alice\. 5 new messages below\."/,
+    );
+    assert.doesNotMatch(markup, />Next<\/span>/);
+    assert.match(markup, />·<\/span>/);
     assert.match(markup, /<span aria-hidden="true"/);
     assert.match(markup, /data-testid="sidebar-unread-dm-avatar-dm-one"/);
     assert.match(markup, /data-testid="sidebar-unread-dm-avatar-dm-two"/);
-    assert.doesNotMatch(markup, /sidebar-unread-dm-avatar-dm-three/);
-    assert.match(markup, />\+2<\/span>/);
+    assert.match(markup, /data-testid="sidebar-unread-dm-avatar-dm-three"/);
+    assert.doesNotMatch(markup, /sidebar-unread-dm-avatar-dm-four/);
+    assert.doesNotMatch(markup, />\+\d+<\/span>/);
+    const stackOrder = [...markup.matchAll(/style="z-index:(\d+)"/g)].map(
+      ([, zIndex]) => Number(zIndex),
+    );
+    assert.deepEqual(stackOrder, [3, 2, 1]);
   });
 
   it("keeps channel-based previews distinct for repeated participants", () => {

--- a/desktop/src/features/sidebar/ui/MoreUnreadButton.test.mjs
+++ b/desktop/src/features/sidebar/ui/MoreUnreadButton.test.mjs
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import {
+  canPreviewUnreadDm,
   MoreUnreadButton,
   preferredUnreadTarget,
   unreadDmAccessibleLabel,
@@ -20,6 +21,12 @@ function preview(channelId, label = channelId, avatarUrl = null) {
 }
 
 describe("MoreUnreadButton model", () => {
+  it("previews only honest one-to-one DM identities", () => {
+    assert.equal(canPreviewUnreadDm(2, 1), true);
+    assert.equal(canPreviewUnreadDm(3, 2), false);
+    assert.equal(canPreviewUnreadDm(2, 0), false);
+  });
+
   it("caps the stack at three avatars without a numeric overflow chip", () => {
     assert.deepEqual(
       visibleUnreadDmPreviews([preview("a"), preview("b"), preview("c")]).map(
@@ -51,6 +58,15 @@ describe("MoreUnreadButton model", () => {
         position: "bottom",
       }),
       "Go to unread direct message from Alice. 2 new messages below.",
+    );
+    assert.equal(
+      unreadDmAccessibleLabel({
+        count: 2,
+        dmPreviews: [preview("dm", "Alice")],
+        label: "2 new activity",
+        position: "bottom",
+      }),
+      "Go to unread direct message from Alice. 2 new activity below.",
     );
     assert.equal(
       unreadDmAccessibleLabel({

--- a/desktop/src/features/sidebar/ui/MoreUnreadButton.test.mjs
+++ b/desktop/src/features/sidebar/ui/MoreUnreadButton.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  MoreUnreadButton,
+  preferredUnreadTarget,
+  unreadDmAccessibleLabel,
+  visibleUnreadDmPreviews,
+} from "./MoreUnreadButton.tsx";
+
+function preview(channelId, label = channelId, avatarUrl = null) {
+  return {
+    accessibleLabel: label,
+    avatarUrl,
+    channelId,
+    label,
+  };
+}
+
+describe("MoreUnreadButton model", () => {
+  it("shows three avatars until overflow requires a +N chip", () => {
+    assert.deepEqual(
+      visibleUnreadDmPreviews([preview("a"), preview("b"), preview("c")]).map(
+        ({ channelId }) => channelId,
+      ),
+      ["a", "b", "c"],
+    );
+    assert.deepEqual(
+      visibleUnreadDmPreviews([
+        preview("a"),
+        preview("b"),
+        preview("c"),
+        preview("d"),
+      ]).map(({ channelId }) => channelId),
+      ["a", "b"],
+    );
+  });
+
+  it("uses the preview channel as the advertised navigation target", () => {
+    assert.equal(preferredUnreadTarget([preview("dm")], "nearer"), "dm");
+    assert.equal(preferredUnreadTarget([], "nearer"), "nearer");
+  });
+
+  it("announces the DM target and honest channel count", () => {
+    assert.equal(
+      unreadDmAccessibleLabel({
+        count: 2,
+        dmPreviews: [preview("dm", "Alice")],
+        position: "bottom",
+      }),
+      "Go to unread direct message from Alice. 2 unread channels below.",
+    );
+    assert.equal(
+      unreadDmAccessibleLabel({
+        count: 1,
+        dmPreviews: [],
+        position: "top",
+      }),
+      "1 unread channel above",
+    );
+  });
+
+  it("renders a decorative channel-keyed stack, overflow, and immediate fallback", () => {
+    const markup = renderToStaticMarkup(
+      MoreUnreadButton({
+        count: 5,
+        dmPreviews: [
+          preview("dm-one", "Alice", "https://example.com/alice.png"),
+          preview("dm-two", "Alice"),
+          preview("dm-three", "Group DM"),
+          preview("dm-four", "Dana"),
+        ],
+        onClick() {},
+        position: "bottom",
+        testId: "more-unread",
+      }),
+    );
+
+    assert.match(
+      markup,
+      /aria-label="Go to unread direct message from Alice\. 5 unread channels below\."/,
+    );
+    assert.match(markup, /<span aria-hidden="true"/);
+    assert.match(markup, /data-testid="sidebar-unread-dm-avatar-dm-one"/);
+    assert.match(markup, /data-testid="sidebar-unread-dm-avatar-dm-two"/);
+    assert.doesNotMatch(markup, /sidebar-unread-dm-avatar-dm-three/);
+    assert.match(markup, />\+2<\/span>/);
+  });
+
+  it("keeps channel-based previews distinct for repeated participants", () => {
+    const previews = [preview("dm-one", "Alice"), preview("dm-two", "Alice")];
+    assert.deepEqual(
+      visibleUnreadDmPreviews(previews).map(({ channelId }) => channelId),
+      ["dm-one", "dm-two"],
+    );
+  });
+});

--- a/desktop/src/features/sidebar/ui/MoreUnreadButton.test.mjs
+++ b/desktop/src/features/sidebar/ui/MoreUnreadButton.test.mjs
@@ -45,17 +45,21 @@ describe("MoreUnreadButton model", () => {
     );
   });
 
-  it("uses the preview channel as the advertised navigation target", () => {
-    assert.equal(preferredUnreadTarget([preview("dm")], "nearer"), "dm");
-    assert.equal(preferredUnreadTarget([], "nearer"), "nearer");
+  it("keeps navigation ordering independent from avatar eligibility", () => {
+    assert.equal(
+      preferredUnreadTarget(["near-group", "far-previewable", "channel"]),
+      "near-group",
+    );
+    assert.equal(preferredUnreadTarget([]), undefined);
   });
 
-  it("announces the DM target and message count", () => {
+  it("announces a DM identity only when it matches the navigation target", () => {
     assert.equal(
       unreadDmAccessibleLabel({
         count: 2,
         dmPreviews: [preview("dm", "Alice")],
         position: "bottom",
+        targetChannelId: "dm",
       }),
       "Go to unread direct message from Alice. 2 new messages below.",
     );
@@ -65,8 +69,18 @@ describe("MoreUnreadButton model", () => {
         dmPreviews: [preview("dm", "Alice")],
         label: "2 new activity",
         position: "bottom",
+        targetChannelId: "dm",
       }),
       "Go to unread direct message from Alice. 2 new activity below.",
+    );
+    assert.equal(
+      unreadDmAccessibleLabel({
+        count: 2,
+        dmPreviews: [preview("far-previewable", "Alice")],
+        position: "bottom",
+        targetChannelId: "near-group",
+      }),
+      "2 new messages below",
     );
     assert.equal(
       unreadDmAccessibleLabel({
@@ -90,6 +104,7 @@ describe("MoreUnreadButton model", () => {
         ],
         onClick() {},
         position: "bottom",
+        targetChannelId: "dm-one",
         testId: "more-unread",
       }),
     );

--- a/desktop/src/features/sidebar/ui/MoreUnreadButton.test.mjs
+++ b/desktop/src/features/sidebar/ui/MoreUnreadButton.test.mjs
@@ -45,12 +45,28 @@ describe("MoreUnreadButton model", () => {
     );
   });
 
-  it("keeps navigation ordering independent from avatar eligibility", () => {
+  it("selects the first ordered DM independently from avatar eligibility", () => {
+    const dmChannelIds = new Set(["near-group", "far-previewable"]);
+
     assert.equal(
-      preferredUnreadTarget(["near-group", "far-previewable", "channel"]),
+      preferredUnreadTarget(
+        ["near-group", "far-previewable", "channel"],
+        dmChannelIds,
+      ),
       "near-group",
     );
-    assert.equal(preferredUnreadTarget([]), undefined);
+    assert.equal(
+      preferredUnreadTarget(
+        ["near-channel", "near-group", "far-previewable"],
+        dmChannelIds,
+      ),
+      "near-group",
+    );
+    assert.equal(
+      preferredUnreadTarget(["near-channel", "far-channel"], dmChannelIds),
+      "near-channel",
+    );
+    assert.equal(preferredUnreadTarget([], dmChannelIds), undefined);
   });
 
   it("announces a DM identity only when it matches the navigation target", () => {

--- a/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
+++ b/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
@@ -9,6 +9,13 @@ export type UnreadDmPreview = {
   label: string;
 };
 
+export function canPreviewUnreadDm(
+  participantPubkeyCount: number,
+  resolvedParticipantCount: number,
+) {
+  return participantPubkeyCount === 2 && resolvedParticipantCount === 1;
+}
+
 export function visibleUnreadDmPreviews(dmPreviews: UnreadDmPreview[]) {
   return dmPreviews.slice(0, 3);
 }
@@ -16,16 +23,19 @@ export function visibleUnreadDmPreviews(dmPreviews: UnreadDmPreview[]) {
 export function unreadDmAccessibleLabel({
   count,
   dmPreviews,
+  label,
   position,
 }: {
   count: number;
   dmPreviews: UnreadDmPreview[];
+  label?: string;
   position: "top" | "bottom";
 }) {
   const direction = position === "top" ? "above" : "below";
+  const resolvedLabel = label ?? unreadCountLabel(count);
   return dmPreviews[0]
-    ? `Go to unread direct message from ${dmPreviews[0].accessibleLabel}. ${unreadCountLabel(count)} ${direction}.`
-    : `${unreadCountLabel(count)} ${direction}`;
+    ? `Go to unread direct message from ${dmPreviews[0].accessibleLabel}. ${resolvedLabel} ${direction}.`
+    : `${resolvedLabel} ${direction}`;
 }
 
 export function preferredUnreadTarget(
@@ -59,6 +69,7 @@ export function MoreUnreadButton({
   const accessibleLabel = unreadDmAccessibleLabel({
     count,
     dmPreviews,
+    label: resolvedLabel,
     position,
   });
 

--- a/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
+++ b/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
@@ -1,6 +1,6 @@
 import { topChromeInset } from "@/shared/layout/chromeLayout";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
-import { UnreadPill, unreadChannelCountLabel } from "@/shared/ui/UnreadPill";
+import { UnreadPill, unreadCountLabel } from "@/shared/ui/UnreadPill";
 
 export type UnreadDmPreview = {
   accessibleLabel: string;
@@ -10,8 +10,7 @@ export type UnreadDmPreview = {
 };
 
 export function visibleUnreadDmPreviews(dmPreviews: UnreadDmPreview[]) {
-  const maxVisibleAvatars = dmPreviews.length > 3 ? 2 : 3;
-  return dmPreviews.slice(0, maxVisibleAvatars);
+  return dmPreviews.slice(0, 3);
 }
 
 export function unreadDmAccessibleLabel({
@@ -23,9 +22,10 @@ export function unreadDmAccessibleLabel({
   dmPreviews: UnreadDmPreview[];
   position: "top" | "bottom";
 }) {
+  const direction = position === "top" ? "above" : "below";
   return dmPreviews[0]
-    ? `Go to unread direct message from ${dmPreviews[0].accessibleLabel}. ${unreadChannelCountLabel(count, position)}.`
-    : unreadChannelCountLabel(count, position);
+    ? `Go to unread direct message from ${dmPreviews[0].accessibleLabel}. ${unreadCountLabel(count)} ${direction}.`
+    : `${unreadCountLabel(count)} ${direction}`;
 }
 
 export function preferredUnreadTarget(
@@ -55,8 +55,7 @@ export function MoreUnreadButton({
   const positionClassName =
     position === "top" ? topChromeInset.top : bottomClassName;
   const visibleDmPreviews = visibleUnreadDmPreviews(dmPreviews);
-  const dmOverflowCount = dmPreviews.length - visibleDmPreviews.length;
-  const resolvedLabel = label ?? unreadChannelCountLabel(count);
+  const resolvedLabel = label ?? unreadCountLabel(count);
   const accessibleLabel = unreadDmAccessibleLabel({
     count,
     dmPreviews,
@@ -75,23 +74,29 @@ export function MoreUnreadButton({
         label={resolvedLabel}
         leading={
           visibleDmPreviews.length > 0 ? (
-            <span aria-hidden="true" className="flex shrink-0 -space-x-1.5">
-              {visibleDmPreviews.map((preview) => (
-                <UserAvatar
-                  avatarUrl={preview.avatarUrl}
-                  className="ring-2 ring-primary"
-                  displayName={preview.label}
-                  fallbackDelayMs={0}
-                  key={preview.channelId}
-                  size="xs"
-                  testId={`sidebar-unread-dm-avatar-${preview.channelId}`}
-                />
-              ))}
-              {dmOverflowCount > 0 ? (
-                <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary-foreground px-1 text-3xs font-semibold text-primary ring-2 ring-primary">
-                  +{dmOverflowCount}
-                </span>
-              ) : null}
+            <span
+              aria-hidden="true"
+              className="flex shrink-0 items-center gap-1.5"
+            >
+              <span className="flex -space-x-1.5">
+                {visibleDmPreviews.map((preview, index) => (
+                  <span
+                    className="relative"
+                    key={preview.channelId}
+                    style={{ zIndex: visibleDmPreviews.length - index }}
+                  >
+                    <UserAvatar
+                      avatarUrl={preview.avatarUrl}
+                      className="ring-2 ring-primary"
+                      displayName={preview.label}
+                      fallbackDelayMs={0}
+                      size="xs"
+                      testId={`sidebar-unread-dm-avatar-${preview.channelId}`}
+                    />
+                  </span>
+                ))}
+              </span>
+              <span>·</span>
             </span>
           ) : undefined
         }

--- a/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
+++ b/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
@@ -1,9 +1,44 @@
 import { topChromeInset } from "@/shared/layout/chromeLayout";
-import { UnreadPill, unreadCountLabel } from "@/shared/ui/UnreadPill";
+import { UserAvatar } from "@/shared/ui/UserAvatar";
+import { UnreadPill, unreadChannelCountLabel } from "@/shared/ui/UnreadPill";
+
+export type UnreadDmPreview = {
+  accessibleLabel: string;
+  avatarUrl: string | null;
+  channelId: string;
+  label: string;
+};
+
+export function visibleUnreadDmPreviews(dmPreviews: UnreadDmPreview[]) {
+  const maxVisibleAvatars = dmPreviews.length > 3 ? 2 : 3;
+  return dmPreviews.slice(0, maxVisibleAvatars);
+}
+
+export function unreadDmAccessibleLabel({
+  count,
+  dmPreviews,
+  position,
+}: {
+  count: number;
+  dmPreviews: UnreadDmPreview[];
+  position: "top" | "bottom";
+}) {
+  return dmPreviews[0]
+    ? `Go to unread direct message from ${dmPreviews[0].accessibleLabel}. ${unreadChannelCountLabel(count, position)}.`
+    : unreadChannelCountLabel(count, position);
+}
+
+export function preferredUnreadTarget(
+  dmPreviews: UnreadDmPreview[],
+  nearestChannelId?: string,
+) {
+  return dmPreviews[0]?.channelId ?? nearestChannelId;
+}
 
 export function MoreUnreadButton({
   bottomClassName = "bottom-0",
   count,
+  dmPreviews = [],
   label,
   onClick,
   position,
@@ -11,6 +46,7 @@ export function MoreUnreadButton({
 }: {
   bottomClassName?: string;
   count: number;
+  dmPreviews?: UnreadDmPreview[];
   label?: string;
   onClick: () => void;
   position: "top" | "bottom";
@@ -18,15 +54,47 @@ export function MoreUnreadButton({
 }) {
   const positionClassName =
     position === "top" ? topChromeInset.top : bottomClassName;
+  const visibleDmPreviews = visibleUnreadDmPreviews(dmPreviews);
+  const dmOverflowCount = dmPreviews.length - visibleDmPreviews.length;
+  const resolvedLabel = label ?? unreadChannelCountLabel(count);
+  const accessibleLabel = unreadDmAccessibleLabel({
+    count,
+    dmPreviews,
+    position,
+  });
 
   return (
     <div
-      className={`pointer-events-none absolute inset-x-0 z-10 flex justify-center py-1 ${positionClassName}`}
+      className={`pointer-events-none absolute inset-x-0 z-10 flex justify-center px-2 py-1 ${positionClassName}`}
     >
       <UnreadPill
+        accessibleLabel={accessibleLabel}
+        className="max-w-full"
         direction={position === "top" ? "up" : "down"}
         emphasis="primary"
-        label={label ?? unreadCountLabel(count)}
+        label={resolvedLabel}
+        leading={
+          visibleDmPreviews.length > 0 ? (
+            <span aria-hidden="true" className="flex shrink-0 -space-x-1.5">
+              {visibleDmPreviews.map((preview) => (
+                <UserAvatar
+                  avatarUrl={preview.avatarUrl}
+                  className="ring-2 ring-primary"
+                  displayName={preview.label}
+                  fallbackDelayMs={0}
+                  key={preview.channelId}
+                  size="xs"
+                  testId={`sidebar-unread-dm-avatar-${preview.channelId}`}
+                />
+              ))}
+              {dmOverflowCount > 0 ? (
+                <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary-foreground px-1 text-3xs font-semibold text-primary ring-2 ring-primary">
+                  +{dmOverflowCount}
+                </span>
+              ) : null}
+            </span>
+          ) : undefined
+        }
         onClick={onClick}
         testId={testId}
       />

--- a/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
+++ b/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
@@ -25,24 +25,26 @@ export function unreadDmAccessibleLabel({
   dmPreviews,
   label,
   position,
+  targetChannelId,
 }: {
   count: number;
   dmPreviews: UnreadDmPreview[];
   label?: string;
   position: "top" | "bottom";
+  targetChannelId?: string;
 }) {
   const direction = position === "top" ? "above" : "below";
   const resolvedLabel = label ?? unreadCountLabel(count);
-  return dmPreviews[0]
-    ? `Go to unread direct message from ${dmPreviews[0].accessibleLabel}. ${resolvedLabel} ${direction}.`
+  const targetPreview = dmPreviews.find(
+    ({ channelId }) => channelId === targetChannelId,
+  );
+  return targetPreview
+    ? `Go to unread direct message from ${targetPreview.accessibleLabel}. ${resolvedLabel} ${direction}.`
     : `${resolvedLabel} ${direction}`;
 }
 
-export function preferredUnreadTarget(
-  dmPreviews: UnreadDmPreview[],
-  nearestChannelId?: string,
-) {
-  return dmPreviews[0]?.channelId ?? nearestChannelId;
+export function preferredUnreadTarget(unreadChannelIds: string[]) {
+  return unreadChannelIds[0];
 }
 
 export function MoreUnreadButton({
@@ -52,6 +54,7 @@ export function MoreUnreadButton({
   label,
   onClick,
   position,
+  targetChannelId,
   testId,
 }: {
   bottomClassName?: string;
@@ -60,6 +63,7 @@ export function MoreUnreadButton({
   label?: string;
   onClick: () => void;
   position: "top" | "bottom";
+  targetChannelId?: string;
   testId: string;
 }) {
   const positionClassName =
@@ -71,6 +75,7 @@ export function MoreUnreadButton({
     dmPreviews,
     label: resolvedLabel,
     position,
+    targetChannelId,
   });
 
   return (

--- a/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
+++ b/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
@@ -43,8 +43,14 @@ export function unreadDmAccessibleLabel({
     : `${resolvedLabel} ${direction}`;
 }
 
-export function preferredUnreadTarget(unreadChannelIds: string[]) {
-  return unreadChannelIds[0];
+export function preferredUnreadTarget(
+  unreadChannelIds: string[],
+  dmChannelIds: ReadonlySet<string>,
+) {
+  return (
+    unreadChannelIds.find((channelId) => dmChannelIds.has(channelId)) ??
+    unreadChannelIds[0]
+  );
 }
 
 export function MoreUnreadButton({

--- a/desktop/src/shared/ui/UnreadPill.tsx
+++ b/desktop/src/shared/ui/UnreadPill.tsx
@@ -1,4 +1,5 @@
 import { ArrowDown, ArrowUp } from "lucide-react";
+import type { ReactNode } from "react";
 
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
@@ -6,30 +7,48 @@ import { Button } from "@/shared/ui/button";
 const UNREAD_PILL_CLASS =
   "pointer-events-auto h-7 min-h-7 gap-1.5 rounded-full border-border/70 bg-background/95 px-2 py-1 text-2xs font-medium tracking-[0.02em] text-muted-foreground/70 shadow-xs backdrop-blur-sm hover:bg-muted/70 hover:text-foreground [&_svg]:size-4";
 const PRIMARY_UNREAD_PILL_CLASS =
-  "pointer-events-auto h-7 min-h-7 gap-1.5 rounded-full px-2 py-1 text-xs font-medium shadow-sm [&_svg]:size-4";
+  "pointer-events-auto h-7 min-h-7 max-w-[calc(100%_-_1rem)] gap-1.5 rounded-full px-2 py-1 text-xs font-medium shadow-sm [&_svg]:size-4";
 
 export function unreadCountLabel(count: number) {
   return `${count} new message${count === 1 ? "" : "s"}`;
 }
 
+export function unreadChannelCountLabel(
+  count: number,
+  position?: "top" | "bottom",
+) {
+  const direction = position
+    ? ` ${position === "top" ? "above" : "below"}`
+    : "";
+  return `${count} unread channel${count === 1 ? "" : "s"}${direction}`;
+}
+
 export function UnreadPill({
+  accessibleLabel,
+  className,
   direction,
   emphasis = "default",
   label,
+  leading,
   onClick,
   testId,
 }: {
+  accessibleLabel?: string;
+  className?: string;
   direction: "up" | "down";
   emphasis?: "default" | "primary";
   label: string;
+  leading?: ReactNode;
   onClick: () => void;
   testId: string;
 }) {
   const Arrow = direction === "up" ? ArrowUp : ArrowDown;
   return (
     <Button
+      aria-label={accessibleLabel}
       className={cn(
         emphasis === "primary" ? PRIMARY_UNREAD_PILL_CLASS : UNREAD_PILL_CLASS,
+        className,
       )}
       data-testid={testId}
       onClick={onClick}
@@ -38,6 +57,7 @@ export function UnreadPill({
       variant={emphasis === "primary" ? "default" : "outline"}
     >
       <Arrow aria-hidden />
+      {leading}
       {label}
     </Button>
   );

--- a/desktop/src/shared/ui/UnreadPill.tsx
+++ b/desktop/src/shared/ui/UnreadPill.tsx
@@ -7,20 +7,10 @@ import { Button } from "@/shared/ui/button";
 const UNREAD_PILL_CLASS =
   "pointer-events-auto h-7 min-h-7 gap-1.5 rounded-full border-border/70 bg-background/95 px-2 py-1 text-2xs font-medium tracking-[0.02em] text-muted-foreground/70 shadow-xs backdrop-blur-sm hover:bg-muted/70 hover:text-foreground [&_svg]:size-4";
 const PRIMARY_UNREAD_PILL_CLASS =
-  "pointer-events-auto h-7 min-h-7 max-w-[calc(100%_-_1rem)] gap-1.5 rounded-full px-2 py-1 text-xs font-medium shadow-sm [&_svg]:size-4";
+  "pointer-events-auto h-7 min-h-7 max-w-[calc(100%_-_1rem)] overflow-hidden gap-1.5 rounded-full px-2 py-1 text-xs font-medium shadow-sm [&_svg]:size-4";
 
 export function unreadCountLabel(count: number) {
   return `${count} new message${count === 1 ? "" : "s"}`;
-}
-
-export function unreadChannelCountLabel(
-  count: number,
-  position?: "top" | "bottom",
-) {
-  const direction = position
-    ? ` ${position === "top" ? "above" : "below"}`
-    : "";
-  return `${count} unread channel${count === 1 ? "" : "s"}${direction}`;
 }
 
 export function UnreadPill({
@@ -58,7 +48,7 @@ export function UnreadPill({
     >
       <Arrow aria-hidden />
       {leading}
-      {label}
+      <span className="min-w-0 truncate">{label}</span>
     </Button>
   );
 }

--- a/desktop/src/shared/ui/UserAvatar.tsx
+++ b/desktop/src/shared/ui/UserAvatar.tsx
@@ -67,6 +67,7 @@ export function UserAvatar({
       // Animated avatars carry their own backdrop disc and transparent
       // surroundings — any container fill would flatten the pop-out.
       className={cn(sizeClasses[size], !animated && "shadow-xs", className)}
+      data-testid={testId}
       onMouseEnter={animated ? () => setIsHovered(true) : undefined}
       onMouseLeave={animated ? () => setIsHovered(false) : undefined}
     >


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Users can see which unread direct messages are waiting offscreen and jump to the most relevant one first.

**Problem:** The sidebar overflow control treated every offscreen unread conversation alike, so an unread DM could be hidden behind channel activity with no visible clue about who was waiting.

**Solution:** Prioritize the first offscreen unread DM, preview up to three senders with avatars, and keep the arrow, avatars, separator, and message count intact while only the trailing phrase truncates in narrow sidebars.

<details>
<summary>File changes</summary>

**desktop/src/features/sidebar/lib/useUnreadOverflow.ts**
Adds ordered DM preview data to unread-overflow calculations while preserving the sidebar's existing visibility and direction rules.

**desktop/src/features/sidebar/lib/useUnreadOverflow.test.mjs**
Covers DM prioritization, ordering, offscreen filtering, and channel-only fallback behavior.

**desktop/src/features/sidebar/ui/AppSidebar.tsx**
Passes unread DM previews into the lower overflow control and navigates to the preferred DM before the next unread channel.

**desktop/src/features/sidebar/ui/MoreUnreadButton.tsx**
Renders the frontmost-first avatar stack, accessible DM target label, middot separator, and message-count treatment.

**desktop/src/features/sidebar/ui/MoreUnreadButton.test.mjs**
Locks the three-avatar cap, stacking order, preferred target, fallback, accessible copy, and truncation structure.

**desktop/src/shared/ui/UnreadPill.tsx**
Contains the primary pill and allows only its trailing label to ellipsize under width pressure.

**desktop/src/shared/ui/UserAvatar.tsx**
Allows the sidebar preview stack to identify each rendered avatar in regression coverage.

</details>

## Reproduction steps

1. Open enough sidebar conversations that unread items fall below the visible area.
2. Leave one or more offscreen DMs unread, along with unread channels.
3. Confirm the bottom overflow pill shows up to three overlapping DM avatars followed by a middot and the total new-message count.
4. Select the pill and confirm it navigates to the first offscreen unread DM rather than the nearest unread channel.
5. Resize the sidebar from 420px through 300px to 220px and confirm the arrow, avatars, middot, and full numeric count remain visible; only `new messages` may ellipsize.
6. Repeat with channel-only unread overflow and confirm the control keeps its channel fallback behavior without avatars.

## Screenshots

Built-UI matrix with 100px of visible space beyond the sidebar edge. All images are hosted through `pr-screenshots`.

| State | 220px min | 300px default | 420px max | Result |
| --- | --- | --- | --- | --- |
| Channel-only · 13 | ![Channel-only · 13 at 220px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/01.png) | ![Channel-only · 13 at 300px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/02.png) | ![Channel-only · 13 at 420px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/03.png) | Full label throughout. |
| Channel-only · 999 | ![Channel-only · 999 at 220px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/04.png) | ![Channel-only · 999 at 300px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/05.png) | ![Channel-only · 999 at 420px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/06.png) | Full label throughout. |
| One DM only · 1 | ![One DM only · 1 at 220px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/07.png) | ![One DM only · 1 at 300px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/08.png) | ![One DM only · 1 at 420px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/09.png) | Full label throughout. |
| One DM + channels · 99 | ![One DM + channels · 99 at 220px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/10.png) | ![One DM + channels · 99 at 300px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/11.png) | ![One DM + channels · 99 at 420px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/12.png) | Full label throughout. |
| Two DMs only · 2 | ![Two DMs only · 2 at 220px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/13.png) | ![Two DMs only · 2 at 300px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/14.png) | ![Two DMs only · 2 at 420px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/15.png) | Full label throughout. |
| Two DMs + channels · 47 | ![Two DMs + channels · 47 at 220px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/16.png) | ![Two DMs + channels · 47 at 300px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/17.png) | ![Two DMs + channels · 47 at 420px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/18.png) | Full label throughout. |
| Three DMs + channels · 128 | ![Three DMs + channels · 128 at 220px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/19.png) | ![Three DMs + channels · 128 at 300px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/20.png) | ![Three DMs + channels · 128 at 420px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/21.png) | 220px: `128 new messa…`; full at 300/420. |
| Three DMs + channels · 999 | ![Three DMs + channels · 999 at 220px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/22.png) | ![Three DMs + channels · 999 at 300px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/23.png) | ![Three DMs + channels · 999 at 420px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/24.png) | 220px: `999 new mess…`; full at 300/420. |
| Three DMs + channels · 9,999 | ![Three DMs + channels · 9,999 at 220px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/25.png) | ![Three DMs + channels · 9,999 at 300px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/26.png) | ![Three DMs + channels · 9,999 at 420px](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6842/27.png) | 220px: `9,999 new mes…`; full at 300/420. |

**Matrix result:** 27/27 states remain contained. Exactly 3/27 states ellipsize—all are three-avatar cases at 220px. The arrow, all avatars, middot, and complete numeric value remain visible; only the trailing `new messages` phrase yields.

## Validation

- Desktop unit suite: 5,517 passed
- TypeScript: passed
- Biome on all seven changed files: passed
- Pre-push desktop checks, typecheck, tests, file-size, and branch-skew gates: passed
- 27-state built-UI matrix capture: 27/27 contained; only the three 220px three-avatar states truncate, and only the trailing phrase
- `git diff --check`: passed
