### PR TITLE
fix(pairing-cli): send the JSON envelope the apps decode, and stop panicking on wss://

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,6 +1175,7 @@ dependencies = [
  "futures-util",
  "hex",
  "nostr 0.44.7",
+ "rustls",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/buzz-pairing-cli/Cargo.toml
+++ b/crates/buzz-pairing-cli/Cargo.toml
@@ -23,3 +23,7 @@ hex = { workspace = true }
 clap = { version = "4", features = ["derive", "env"] }
 thiserror = { workspace = true }
 zeroize = { workspace = true }
+# Both ring and aws-lc-rs are present in the workspace tree, so
+# rustls cannot select a process-level CryptoProvider on its own and every
+# wss:// relay PANICS at connect. Pin one explicitly, install it in main().
+rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/crates/buzz-pairing-cli/src/main.rs
+++ b/crates/buzz-pairing-cli/src/main.rs
@@ -4,9 +4,22 @@
 //!
 //! ```text
 //! buzz-pair source --relay wss://relay.example.com [--nsec nsec1...]
+//!                  [--envelope-relay https://relay.example.com]
 //! buzz-pair target [--relay wss://relay.example.com]
 //! buzz-pair test-vectors
 //! ```
+//!
+//! # Payload shape
+//!
+//! By default `source` transfers a bare bech32 `nsec1...` string
+//! ([`PayloadType::Nsec`]). The Buzz **mobile** app does not accept that: its
+//! `_processPayload` begins with `jsonDecode(payload) as Map<String, dynamic>`,
+//! so a bare nsec dies on the leading `n` with
+//! `FormatException: Unexpected character (at character 1)`.
+//!
+//! Passing `--envelope-relay <https url>` switches the payload to the JSON
+//! envelope the mobile app — and the desktop app, its real counterpart —
+//! actually decodes: `{"relayUrl","pubkey","nsec"}` as [`PayloadType::Custom`].
 //!
 //! The `source` subcommand acts as the secret-holding device; `target` acts
 //! as the receiving device. Together they exercise the full NIP-AB protocol
@@ -53,6 +66,13 @@ enum Cmd {
         /// nsec (bech32) of the key to transfer. If omitted, generates a test key.
         #[arg(long)]
         nsec: Option<String>,
+
+        /// Emit the mobile/desktop JSON envelope `{relayUrl,pubkey,nsec}` instead
+        /// of a bare nsec. The value is the `https://` URL of the Buzz relay the
+        /// paired device should join; it becomes the envelope's `relayUrl`, and is
+        /// distinct from `--relay`, which is the ephemeral pairing relay.
+        #[arg(long, value_name = "HTTPS_URL")]
+        envelope_relay: Option<String>,
     },
 
     /// Act as the target device (scans QR code, receives the secret).
@@ -96,6 +116,14 @@ enum CliError {
 
 #[tokio::main]
 async fn main() {
+    // Without this, every wss:// pairing relay panics inside
+    // rustls ("Could not automatically determine the process-level
+    // CryptoProvider") because both ring and aws-lc-rs are in the workspace
+    // tree. Plain ws:// never reaches this code path, which is why interop
+    // testing against a plaintext spike relay could not have found it.
+    // Idempotent: the Err just means a provider was already installed.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let cli = Cli::parse();
     if let Err(e) = run(cli.command).await {
         eprintln!("error: {e}");
@@ -105,15 +133,23 @@ async fn main() {
 
 async fn run(cmd: Cmd) -> Result<(), CliError> {
     match cmd {
-        Cmd::Source { relay, nsec } => cmd_source(relay, nsec).await,
+        Cmd::Source {
+            relay,
+            nsec,
+            envelope_relay,
+        } => cmd_source(relay, nsec, envelope_relay).await,
         Cmd::Target { relay, show_secret } => cmd_target(relay, show_secret).await,
         Cmd::TestVectors => cmd_test_vectors(),
     }
 }
 
-async fn cmd_source(relay_url: String, nsec: Option<String>) -> Result<(), CliError> {
+async fn cmd_source(
+    relay_url: String,
+    nsec: Option<String>,
+    envelope_relay: Option<String>,
+) -> Result<(), CliError> {
     // Resolve the payload to transfer.
-    let (payload_str, payload_type) = resolve_payload(nsec)?;
+    let (payload_str, payload_type) = resolve_payload(nsec, envelope_relay)?;
 
     // Create pairing session.
     let (mut session, qr) = PairingSession::new_source(relay_url.clone());
@@ -574,16 +610,48 @@ fn parse_relay_event(text: &str, sub_id: &str) -> Option<Event> {
     serde_json::from_value(arr[2].clone()).ok()
 }
 
+/// Build the JSON pairing envelope the Buzz apps decode.
+///
+/// Exactly the three fields `_processPayload` reads
+/// (`mobile/lib/features/pairing/pairing_provider.dart`), in the same shape the
+/// desktop app sends (`desktop/src-tauri/src/commands/pairing.rs`):
+///
+/// ```json
+/// { "relayUrl": "https://…", "pubkey": "<64-char hex>", "nsec": "nsec1…" }
+/// ```
+///
+/// `pubkey` is derived from `nsec` rather than taken separately — the two must
+/// describe one identity, and deriving it removes the chance of them drifting.
+fn build_envelope(relay_url: &str, nsec: &str) -> Result<Zeroizing<String>, CliError> {
+    let sk = SecretKey::parse(nsec).map_err(|e| CliError::InvalidNsec(e.to_string()))?;
+    let keys = Keys::new(sk);
+    Ok(Zeroizing::new(
+        serde_json::json!({
+            "relayUrl": relay_url,
+            "pubkey": keys.public_key().to_hex(),
+            "nsec": nsec,
+        })
+        .to_string(),
+    ))
+}
+
 /// Resolve the payload to send.
 ///
-/// If `nsec` is provided, parse it as bech32 and return the raw nsec string.
-/// Otherwise generate a fresh test key and return its nsec.
-fn resolve_payload(nsec: Option<String>) -> Result<(Zeroizing<String>, PayloadType), CliError> {
-    match nsec {
+/// If `nsec` is provided, parse it as bech32; otherwise generate a fresh test key.
+///
+/// With `envelope_relay` set, the payload is the JSON envelope
+/// ([`PayloadType::Custom`]) the Buzz apps decode. Without it, the payload stays
+/// the bare bech32 nsec ([`PayloadType::Nsec`]) — unchanged upstream behaviour,
+/// which is correct for CLI-to-CLI interop testing and wrong for the apps.
+fn resolve_payload(
+    nsec: Option<String>,
+    envelope_relay: Option<String>,
+) -> Result<(Zeroizing<String>, PayloadType), CliError> {
+    let nsec = match nsec {
         Some(s) => {
             // Validate it parses as a secret key.
             let _sk = SecretKey::parse(&s).map_err(|e| CliError::InvalidNsec(e.to_string()))?;
-            Ok((Zeroizing::new(s), PayloadType::Nsec))
+            Zeroizing::new(s)
         }
         None => {
             let keys = Keys::generate();
@@ -592,8 +660,24 @@ fn resolve_payload(nsec: Option<String>) -> Result<(Zeroizing<String>, PayloadTy
                 .to_bech32()
                 .map_err(|e| CliError::InvalidNsec(e.to_string()))?;
             println!("(no --nsec provided; using generated test key)");
-            Ok((Zeroizing::new(nsec_str), PayloadType::Nsec))
+            Zeroizing::new(nsec_str)
         }
+    };
+
+    match envelope_relay {
+        Some(relay) => {
+            // Gate 2 of `_processPayload` rejects any non-https URL in a release
+            // build. Warn at mint time rather than let it surface on a handset as
+            // a second, unrelated-looking failure.
+            if !relay.starts_with("https://") {
+                eprintln!(
+                    "warning: --envelope-relay {relay} is not https:// — \
+                     release builds of the Buzz app will reject it (debug builds allow it)"
+                );
+            }
+            Ok((build_envelope(&relay, &nsec)?, PayloadType::Custom))
+        }
+        None => Ok((nsec, PayloadType::Nsec)),
     }
 }
 
@@ -620,4 +704,130 @@ fn hex_to_32(s: &str) -> Result<[u8; 32], CliError> {
     bytes
         .try_into()
         .map_err(|_| CliError::Other(format!("expected 32 bytes, got wrong length for '{s}'")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Map, Value};
+
+    const RELAY: &str = "https://relay.example.com";
+
+    fn fresh_nsec() -> String {
+        Keys::generate().secret_key().to_bech32().unwrap()
+    }
+
+    /// Stand-in for gate 1 of the mobile app's `_processPayload`:
+    /// `jsonDecode(payload) as Map<String, dynamic>`. Dart throws
+    /// `FormatException` where this returns `Err`.
+    fn json_decode_as_map(payload: &str) -> Result<Map<String, Value>, serde_json::Error> {
+        serde_json::from_str::<Map<String, Value>>(payload)
+    }
+
+    /// The defect this change exists to fix, pinned so it cannot come back
+    /// silently: the default payload is a bare bech32 nsec, and the app's very
+    /// first step cannot decode it. Character 1 is the `n` of `nsec1`.
+    #[test]
+    fn bare_nsec_payload_fails_the_apps_first_gate() {
+        let nsec = fresh_nsec();
+        let (payload, ty) = resolve_payload(Some(nsec.clone()), None).unwrap();
+
+        assert!(matches!(ty, PayloadType::Nsec));
+        assert!(payload.starts_with("nsec1"));
+        assert!(
+            json_decode_as_map(&payload).is_err(),
+            "a bare nsec must not be JSON — this is the FormatException the mobile app raises"
+        );
+    }
+
+    /// The fix: with `--envelope-relay`, gate 1 passes and the map carries
+    /// exactly the three fields `_processPayload` reads.
+    #[test]
+    fn envelope_payload_clears_the_apps_first_gate() {
+        let nsec = fresh_nsec();
+        let (payload, ty) = resolve_payload(Some(nsec.clone()), Some(RELAY.to_string())).unwrap();
+
+        assert!(matches!(ty, PayloadType::Custom));
+        let map = json_decode_as_map(&payload).expect("envelope must jsonDecode as a map");
+
+        assert_eq!(map.len(), 3, "exactly three fields, no extras: {map:?}");
+        assert_eq!(map["relayUrl"], Value::String(RELAY.to_string()));
+        assert_eq!(map["nsec"], Value::String(nsec.clone()));
+
+        // `relayUrl` non-null is the app's own second check inside gate 1.
+        assert!(map["relayUrl"].is_string());
+    }
+
+    /// `pubkey` must belong to the transferred `nsec`. A fresh or stale key here
+    /// decodes fine and then strands the device on a community it cannot sign for.
+    #[test]
+    fn envelope_pubkey_is_derived_from_the_transferred_nsec() {
+        let nsec = fresh_nsec();
+        let expected = Keys::new(SecretKey::parse(&nsec).unwrap())
+            .public_key()
+            .to_hex();
+
+        let (payload, _) = resolve_payload(Some(nsec), Some(RELAY.to_string())).unwrap();
+        let map = json_decode_as_map(&payload).unwrap();
+
+        assert_eq!(map["pubkey"], Value::String(expected));
+        assert_eq!(
+            map["pubkey"].as_str().unwrap().len(),
+            64,
+            "pubkey is 64-char hex, not npub — the app stores it as Community.pubkey"
+        );
+    }
+
+    /// The generated-key path (no `--nsec`) must produce a coherent envelope too,
+    /// not just the explicit-key path.
+    #[test]
+    fn generated_key_envelope_is_internally_consistent() {
+        let (payload, ty) = resolve_payload(None, Some(RELAY.to_string())).unwrap();
+
+        assert!(matches!(ty, PayloadType::Custom));
+        let map = json_decode_as_map(&payload).unwrap();
+        let nsec = map["nsec"].as_str().unwrap();
+        let derived = Keys::new(SecretKey::parse(nsec).unwrap())
+            .public_key()
+            .to_hex();
+
+        assert_eq!(map["pubkey"], Value::String(derived));
+    }
+
+    /// Upstream CLI-to-CLI interop behaviour must be untouched when the flag is
+    /// absent — this crate is still the NIP-AB interop tool.
+    #[test]
+    fn absent_flag_leaves_upstream_behaviour_unchanged() {
+        let nsec = fresh_nsec();
+        let (payload, ty) = resolve_payload(Some(nsec.clone()), None).unwrap();
+
+        assert!(matches!(ty, PayloadType::Nsec));
+        assert_eq!(&*payload, &nsec);
+    }
+
+    /// An unparseable nsec must be rejected at mint time, not shipped inside a
+    /// well-formed envelope that only fails three gates later on the handset.
+    #[test]
+    fn invalid_nsec_is_rejected_before_an_envelope_is_built() {
+        assert!(build_envelope(RELAY, "nsec1notarealkey").is_err());
+        assert!(resolve_payload(Some("definitely-not-bech32".into()), Some(RELAY.into())).is_err());
+    }
+
+    /// Unicode and empty relay URLs must not corrupt the JSON — serde escapes
+    /// them, and Dart's `jsonDecode` reads them back byte-identically.
+    #[test]
+    fn odd_relay_urls_stay_well_formed_json() {
+        let nsec = fresh_nsec();
+        for relay in [
+            "",
+            "https://relay.exämple.com/pä†h",
+            "https://a.com/\"quote\"",
+        ] {
+            let payload = build_envelope(relay, &nsec).unwrap();
+            let map = json_decode_as_map(&payload)
+                .unwrap_or_else(|e| panic!("relay {relay:?} broke the envelope: {e}"));
+            assert_eq!(map["relayUrl"], Value::String(relay.to_string()));
+            assert_eq!(map.len(), 3);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Two defects that together made it impossible to pair a handset with the mobile app against an HTTPS relay. Both were measured against a live relay.

**1. The payload the CLI sends is not the payload the apps decode.**

`resolve_payload` returned a bare bech32 nsec as `PayloadType::Nsec` in both arms. Mobile `_processPayload` begins with `jsonDecode(payload) as Map<String, dynamic>`, and nothing in `mobile/lib` branches on `payload_type`, so a bare nsec dies on the leading `n` with `FormatException: Unexpected character (at character 1)` — verbatim what a real store build produced on a real handset.

`--envelope-relay <https url>` now emits the same shape the desktop client sends (`desktop/src-tauri/src/commands/pairing.rs:145-148`, `PayloadType::Custom` at :215): `{"relayUrl","pubkey","nsec"}`. `pubkey` is **derived from the transferred nsec** so the two cannot drift. Without the flag the payload is unchanged, so CLI-to-CLI interop testing keeps working exactly as before.

**2. `wss://` panicked before any pairing could start.**

```
thread 'main' panicked at rustls-0.23.42/src/crypto/mod.rs:249:14
Could not automatically determine the process-level CryptoProvider
```

Both `ring` and `aws-lc-rs` are reachable in the workspace, so rustls refuses to choose. Plain `ws://` never reaches that code path — which is why interop testing done entirely against a plaintext relay was structurally blind to it: the defect exists only past the TLS an HTTPS deployment adds. This pins the `ring` provider and installs it at the top of `main()`. `Cargo.lock` records the new direct `rustls` dependency; without that one hunk the tree does not build under `--locked`.

### Related issue

No issue opened for this. There are open PRs for each half, and I would rather point at them than pretend otherwise:

- The rustls half: **#4153** and **#2839** (both `fix(pairing-cli): install rustls crypto provider`, same crate, same three files), plus the wider reports #2666, #2552 and #2457.
- The payload half: **#4757** (`fix(pairing): CLI payload format mismatch + mobile ws:// scheme rejection`), which also edits `mobile/lib/.../pairing_provider.dart`.

This PR differs in fixing both halves inside the pairing CLI only — no mobile-side change — with the envelope behind an opt-in flag so existing CLI-to-CLI flows are untouched, the pubkey derived rather than passed in, and unit coverage for the decode gate. If a maintainer would rather land #4153/#2839 plus #4757, close this — the important thing is that a handset can pair over HTTPS.

### Testing

- 7 new unit tests in `crates/buzz-pairing-cli/src/main.rs`: that a bare nsec fails the apps' first `jsonDecode` gate and the envelope clears it, that the envelope pubkey is derived from the transferred nsec, that a generated key stays internally consistent, that the absent flag leaves current behaviour unchanged, that an invalid nsec is rejected before an envelope is built, and that odd relay URLs stay well-formed JSON.
- `cargo test -p buzz-pairing-cli --locked` — 7/7 green on the pinned 1.95.0 toolchain. Worth flagging for the maintainers: `just test-unit` enumerates packages by hand and does not include `buzz-pairing-cli`, so these tests are compiled by `clippy --all-targets` but never run by any job. That is a gap in this repo's CI, not in this PR, and I am happy to open a separate one adding the package to the recipe.
- End-to-end pairing of a handset against a live HTTPS relay, which is where both defects were found.
- `rustfmt --check` clean on the changed files; lint, unit tests, the Windows build and the cross-compile matrix ran green on this exact tree in my own CI before opening.

No UI surface is touched.

The branch is based on `f88cda9eb`, which is behind `main`. Neither pairing-cli file has been touched upstream since, and the `Cargo.lock` hunk is a single line inside an otherwise unchanged `buzz-pairing-cli` block, so it applies cleanly. Happy to rebase on request.
