### PR TITLE
feat(pairing-cli): `source --nsec -` reads the key from stdin, never argv

### DIFF
--- a/crates/buzz-pairing-cli/src/main.rs
+++ b/crates/buzz-pairing-cli/src/main.rs
@@ -3,9 +3,17 @@
 //! # Usage
 //!
 //! ```text
-//! buzz-pair source --relay wss://relay.example.com [--nsec nsec1...]
+//! buzz-pair source --relay wss://relay.example.com [--nsec nsec1...|--nsec -]
 //! buzz-pair target [--relay wss://relay.example.com]
 //! buzz-pair test-vectors
+//! ```
+//!
+//! `--nsec -` reads the key from the first line of stdin instead of argv, so it
+//! never lands in the world-readable `/proc/<pid>/cmdline`. Everything after
+//! that first line is still the session's stdin (the y/n SAS answer):
+//!
+//! ```text
+//! { printf '%s\n' "$nsec"; cat; } | buzz-pair source --nsec - --relay wss://...
 //! ```
 //!
 //! The `source` subcommand acts as the secret-holding device; `target` acts
@@ -50,7 +58,9 @@ enum Cmd {
         #[arg(long, default_value = "wss://relay.damus.io")]
         relay: String,
 
-        /// nsec (bech32) of the key to transfer. If omitted, generates a test key.
+        /// nsec (bech32) of the key to transfer, or '-' to read the nsec from
+        /// the first line of stdin (keeps the key out of argv, which is
+        /// world-readable in /proc/PID/cmdline). If omitted, generates a test key.
         #[arg(long)]
         nsec: Option<String>,
     },
@@ -578,12 +588,28 @@ fn parse_relay_event(text: &str, sub_id: &str) -> Option<Event> {
 ///
 /// If `nsec` is provided, parse it as bech32 and return the raw nsec string.
 /// Otherwise generate a fresh test key and return its nsec.
+///
+/// The literal `-` means "read the nsec from the first line of stdin", so the
+/// key never appears in argv.
 fn resolve_payload(nsec: Option<String>) -> Result<(Zeroizing<String>, PayloadType), CliError> {
     match nsec {
         Some(s) => {
+            // `--nsec -` takes the key from the first line of stdin. An argv
+            // element is world-readable in /proc/<pid>/cmdline for the whole
+            // life of the process, and a `source` session waits up to 120s for
+            // the target, so passing the key literally exposes it for that
+            // whole window. The read goes through the same buffered
+            // `io::stdin()` handle the SAS prompt uses, a line at a time, so
+            // the y/n answer is simply the next line.
+            let s = if s == "-" {
+                Zeroizing::new(read_line()?)
+            } else {
+                Zeroizing::new(s)
+            };
             // Validate it parses as a secret key.
-            let _sk = SecretKey::parse(&s).map_err(|e| CliError::InvalidNsec(e.to_string()))?;
-            Ok((Zeroizing::new(s), PayloadType::Nsec))
+            let _sk =
+                SecretKey::parse(s.as_str()).map_err(|e| CliError::InvalidNsec(e.to_string()))?;
+            Ok((s, PayloadType::Nsec))
         }
         None => {
             let keys = Keys::generate();


### PR DESCRIPTION
## Summary

`buzz-pair source` transfers a real secret key, and today its only form is `--nsec <bech32>` — an argv element. argv is world-readable in `/proc/<pid>/cmdline` for the entire life of the process, which for a `source` session is up to the 120s it spends waiting for the target to appear. Any local user, and anything that snapshots the process table, gets the key.

`--nsec -` takes the key from the first line of stdin instead. It is read before any session I/O and through the same buffered `io::stdin()` handle the SAS prompt already uses, a line at a time, so the interactive y/n answer is simply the next line and the existing flow is unchanged:

```
{ printf '%s\n' "$nsec"; cat; } | buzz-pair source --nsec - --relay wss://...
```

`--nsec <bech32>` keeps working exactly as before; this only adds the `-` form. The clap help text names both `-` and the word stdin, so a caller can probe `source --help` and refuse to hand a key to a build that does not support it.

### Related issue

None found — I searched open issues and PRs for stdin/argv key handling in the pairing CLI and turned up nothing. The closest neighbour is #2610 (`test(pairing-cli): add unit coverage for buzz-pairing-cli`), which is adjacent rather than overlapping.

Note for whoever triages: this touches the same `resolve_payload` function as my other pairing-cli PR (the HTTPS pairing fix). They are independent and either can be taken alone — whichever lands second takes a small textual conflict, and I will rebase it.

### Testing

- Manual: piping a key in with `--nsec -` pairs normally and the SAS prompt still reads the next stdin line; `--nsec <bech32>` is byte-for-byte the previous behaviour; `ps`/`/proc/<pid>/cmdline` during a live `source` session holds the literal `-` and no key material.
- `rustfmt --check` clean; lint, unit tests, the Windows build and the cross-compile matrix ran green on this exact tree in my own CI before opening.
- **No unit test, deliberately, and I would rather say so than paper over it**: the read goes through the process-global `io::stdin()` handle, so covering it means either injecting a `BufRead` into `resolve_payload` — a refactor that would collide with the other pairing-cli PR — or driving the built binary from an integration test. Say which you would prefer and I will add it here.

No UI surface is touched.

The branch is based on `f88cda9eb`, which is behind `main`; `crates/buzz-pairing-cli/src/main.rs` has not been touched upstream since, so it applies cleanly.
