### PR TITLE
Add RepoCloud deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ By default the app connects to `ws://localhost:3000`. To point it at a relay you
 
 ### I want my own hosted relay
 
-To run a relay for your team without managing servers, you can deploy one to Railway in a click:
+To run a relay for your team without managing servers, you can deploy one to Railway or RepoCloud in a click:
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/buzz-relay-block)
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ To run a relay for your team without managing servers, you can deploy one to Rai
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/buzz-relay-block)
 
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Buzz/)
+
 See [here](https://engineering.block.xyz/blog/run-your-own-buzz-relay) for details.
 
 ### I work at Block


### PR DESCRIPTION
Added RepoCloud as a one-click deployment option alongside the existing Railway button in the "I want my own hosted relay" section.

RepoCloud offers an easy way to deploy Buzz with one click at reduced cost.