### PR TITLE
fix: make managed agent initialization recoverable

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -112,6 +112,9 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `BUZZ_ACP_AGENT_ARGS` | no | `acp` | Agent arguments (comma-separated). |
 | `BUZZ_ACP_MCP_COMMAND` | no | `""` (empty) | Path to an optional MCP server binary to provide to the agent subprocess. |
 | `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
+| `BUZZ_ACP_INIT_TIMEOUT` | no | `60` | ACP `initialize` handshake budget in seconds. Independent from ordinary RPC/session timeouts. |
+| `BUZZ_ACP_INIT_RETRIES` | no | `0` | Bounded retries after a timed-out single-agent initialize. Range: 0–3. |
+| `BUZZ_ACP_INIT_RETRY_BACKOFF_MS` | no | `1000` | Initial initialize-retry delay in milliseconds; doubles on each retry. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
 

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -214,6 +214,10 @@ pub struct AcpClient {
     standard_usage: StandardUsageTracker,
     /// Known adapter identity for prompt-response usage mapping.
     standard_adapter: Option<StandardAdapterKind>,
+    /// Phase that exhausted the most recent non-prompt request budget.
+    /// Supervisors use this to distinguish a blocked stdin write from an agent
+    /// that accepted the request but did not complete the response in time.
+    last_request_timeout_site: Option<&'static str>,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -563,6 +567,7 @@ impl AcpClient {
             goose_usage: UsageTracker::default(),
             standard_usage: StandardUsageTracker::default(),
             standard_adapter,
+            last_request_timeout_site: None,
         })
     }
 
@@ -587,6 +592,11 @@ impl AcpClient {
         self.observer_agent_index
     }
 
+    /// Return the phase that exhausted the latest request budget, if any.
+    pub fn last_request_timeout_site(&self) -> Option<&'static str> {
+        self.last_request_timeout_site
+    }
+
     /// Emit a semantic event to the local observer feed, if enabled.
     pub fn observe(&self, kind: impl Into<String>, payload: serde_json::Value) {
         if let Some(observer) = &self.observer {
@@ -609,10 +619,24 @@ impl AcpClient {
     /// arm can choose [`ACP_STEER_METHOD`] for adapters that implement it.
     /// Parsed here rather than at each call site so no caller can forget it.
     pub async fn initialize(&mut self) -> Result<serde_json::Value, AcpError> {
+        self.initialize_with_timeout(Self::REQUEST_TIMEOUT).await
+    }
+
+    /// Send `initialize` with a caller-selected handshake budget.
+    ///
+    /// Initialization can legitimately include vendor CLI and MCP-server cold
+    /// starts, so supervisors may allow it more time without weakening the
+    /// ordinary non-prompt RPC timeout used by `session/new` and control calls.
+    pub async fn initialize_with_timeout(
+        &mut self,
+        timeout: std::time::Duration,
+    ) -> Result<serde_json::Value, AcpError> {
         // Requesting version 2 is an intentional temporary pin — we are squatting
         // on ACP v2 ahead of the upstream ACP RFD. Revisit when that RFD merges.
         let params = build_initialize_params();
-        let result = self.send_request("initialize", params).await?;
+        let result = self
+            .send_request_with_timeout("initialize", params, timeout, true)
+            .await?;
         self.steering_supported = result
             .pointer("/_meta/steering/supported")
             .and_then(|v| v.as_bool())
@@ -1098,6 +1122,17 @@ impl AcpClient {
         method: &str,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, AcpError> {
+        self.send_request_with_timeout(method, params, Self::REQUEST_TIMEOUT, false)
+            .await
+    }
+
+    async fn send_request_with_timeout(
+        &mut self,
+        method: &str,
+        params: serde_json::Value,
+        timeout: std::time::Duration,
+        total_budget: bool,
+    ) -> Result<serde_json::Value, AcpError> {
         let id = self.next_id;
         self.next_id += 1;
 
@@ -1110,18 +1145,40 @@ impl AcpClient {
 
         tracing::debug!(target: "acp::wire", "→ {}", &serde_json::to_string(&msg).unwrap_or_default());
 
-        // Wrap write + read in a single timeout so a hung agent can't block forever.
-        // We cannot use an async block that borrows `self` mutably across two awaits
-        // inside timeout(), so we sequence them with early-return on timeout.
-        let timeout = Self::REQUEST_TIMEOUT;
+        // Initialize keeps one wall-clock budget across both phases. A fresh
+        // full timeout for the read after a slow write would silently make its
+        // configured deadline as large as 2x the advertised value. Ordinary
+        // RPCs retain their historical per-phase behavior below.
+        self.last_request_timeout_site = None;
+        let request_started = tokio::time::Instant::now();
         match tokio::time::timeout(timeout, self.write_ndjson(&msg)).await {
-            Ok(result) => result?,
-            Err(_) => return Err(AcpError::Timeout(timeout)),
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                if matches!(&error, AcpError::WriteTimeout(_)) {
+                    self.last_request_timeout_site = Some("stdin_write");
+                }
+                return Err(error);
+            }
+            Err(_) => {
+                self.last_request_timeout_site = Some("stdin_write_budget");
+                return Err(AcpError::Timeout(timeout));
+            }
         }
 
-        match tokio::time::timeout(timeout, self.read_until_response(id)).await {
+        let remaining = if total_budget {
+            timeout.saturating_sub(request_started.elapsed())
+        } else {
+            // Preserve the historical ordinary-RPC behavior: the response gets
+            // the full 60-second REQUEST_TIMEOUT after the independently
+            // bounded stdin write. Only initialize opts into one total budget.
+            timeout
+        };
+        match tokio::time::timeout(remaining, self.read_until_response(id)).await {
             Ok(result) => result,
-            Err(_) => Err(AcpError::Timeout(timeout)),
+            Err(_) => {
+                self.last_request_timeout_site = Some("agent_response");
+                Err(AcpError::Timeout(timeout))
+            }
         }
     }
 
@@ -3027,6 +3084,49 @@ mod tests {
         AcpClient::spawn("bash", &["-c".into(), script.into()], &[], false)
             .await
             .expect("failed to spawn test script")
+    }
+
+    #[test]
+    fn ordinary_non_prompt_request_timeout_remains_sixty_seconds() {
+        assert_eq!(
+            AcpClient::REQUEST_TIMEOUT,
+            std::time::Duration::from_secs(60),
+            "session/new and other ordinary RPCs must keep their existing stuck-agent deadline"
+        );
+    }
+
+    #[tokio::test]
+    async fn initialize_uses_its_caller_selected_budget() {
+        let mut client = spawn_script(
+            r#"read -t 2 _init
+sleep 0.075
+echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":2,"agentInfo":{"name":"slow-init"}}}'
+sleep 1"#,
+        )
+        .await;
+
+        let result = client
+            .initialize_with_timeout(std::time::Duration::from_millis(250))
+            .await;
+        assert!(
+            result.is_ok(),
+            "slow initialize should fit its dedicated budget: {result:?}"
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn initialize_reports_its_dedicated_timeout_value() {
+        let mut client = spawn_script("read -t 2 _init; sleep 1").await;
+        let budget = std::time::Duration::from_millis(50);
+
+        let result = client.initialize_with_timeout(budget).await;
+        assert!(
+            matches!(result, Err(AcpError::Timeout(value)) if value == budget),
+            "initialize should report its own budget, got {result:?}"
+        );
+        assert_eq!(client.last_request_timeout_site(), Some("agent_response"));
+        client.shutdown().await;
     }
 
     #[cfg(unix)]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -26,6 +26,18 @@ use crate::filter::SubscriptionRule;
 /// Override via `--idle-timeout` / `BUZZ_ACP_IDLE_TIMEOUT`.
 pub(crate) const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 900;
 
+/// Default ACP initialize budget. Kept at the historical 60 seconds when the
+/// harness is launched directly; managed Desktop launches opt into a larger
+/// budget explicitly so standalone behavior does not change silently.
+pub(crate) const DEFAULT_INIT_TIMEOUT_SECS: u64 = 60;
+
+/// Direct harness launches preserve the historical single-attempt behavior.
+/// Supervisors that can surface lifecycle state may opt into bounded retries.
+pub(crate) const DEFAULT_INIT_RETRIES: u32 = 0;
+
+/// Delay before retrying a timed-out single-agent initialization.
+pub(crate) const DEFAULT_INIT_RETRY_BACKOFF_MILLIS: u64 = 1_000;
+
 /// Default absolute wall-clock cap per agent turn (2 hours).
 /// Override via `--max-turn-duration` / `BUZZ_ACP_MAX_TURN_DURATION`.
 pub(crate) const DEFAULT_MAX_TURN_DURATION_SECS: u64 = 7200;
@@ -271,6 +283,28 @@ pub struct CliArgs {
     /// Resets on any agent stdout activity.
     #[arg(long, env = "BUZZ_ACP_IDLE_TIMEOUT")]
     pub idle_timeout: Option<u64>,
+
+    /// Maximum seconds for the ACP initialize handshake only.
+    #[arg(long, env = "BUZZ_ACP_INIT_TIMEOUT")]
+    pub init_timeout: Option<u64>,
+
+    /// Retries after a timed-out single-agent initialize attempt.
+    #[arg(
+        long,
+        env = "BUZZ_ACP_INIT_RETRIES",
+        default_value_t = DEFAULT_INIT_RETRIES,
+        value_parser = clap::value_parser!(u32).range(0..=3)
+    )]
+    pub init_retries: u32,
+
+    /// Initial retry backoff in milliseconds (doubles per retry).
+    #[arg(
+        long,
+        env = "BUZZ_ACP_INIT_RETRY_BACKOFF_MS",
+        default_value_t = DEFAULT_INIT_RETRY_BACKOFF_MILLIS,
+        value_parser = clap::value_parser!(u64).range(1..=60_000)
+    )]
+    pub init_retry_backoff_ms: u64,
 
     /// Absolute wall-clock cap per turn (safety valve).
     #[arg(long, env = "BUZZ_ACP_MAX_TURN_DURATION", default_value_t = DEFAULT_MAX_TURN_DURATION_SECS)]
@@ -522,6 +556,9 @@ pub struct Config {
     pub agent_args: Vec<String>,
     pub mcp_command: String,
     pub idle_timeout_secs: u64,
+    pub init_timeout_secs: u64,
+    pub init_retries: u32,
+    pub init_retry_backoff_ms: u64,
     pub max_turn_duration_secs: u64,
     pub agents: u32,
     pub heartbeat_interval_secs: u64,
@@ -1021,6 +1058,15 @@ impl Config {
             }
         };
 
+        let init_timeout_secs = match args.init_timeout {
+            Some(0) => {
+                tracing::warn!("initialize timeout of 0 is invalid — using 1s minimum");
+                1
+            }
+            Some(value) => value,
+            None => DEFAULT_INIT_TIMEOUT_SECS,
+        };
+
         // idle_timeout must be strictly less than max_turn_duration. If idle_timeout
         // >= max_turn_duration, the absolute wall-clock cap would fire before the idle
         // timeout ever could, making idle_timeout a dead letter.
@@ -1098,6 +1144,9 @@ impl Config {
             agent_args,
             mcp_command: args.mcp_command,
             idle_timeout_secs,
+            init_timeout_secs,
+            init_retries: args.init_retries,
+            init_retry_backoff_ms: args.init_retry_backoff_ms,
             max_turn_duration_secs,
             agents: args.agents,
             heartbeat_interval_secs: heartbeat_interval,
@@ -1164,12 +1213,15 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} init_timeout={}s init_retries={} init_retry_backoff={}ms idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
             self.agent_args.join(" "),
             self.mcp_command,
+            self.init_timeout_secs,
+            self.init_retries,
+            self.init_retry_backoff_ms,
             self.idle_timeout_secs,
             self.max_turn_duration_secs,
             self.agents,
@@ -1479,6 +1531,9 @@ mod tests {
             agent_args: vec!["acp".into()],
             mcp_command: "".into(),
             idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
+            init_timeout_secs: DEFAULT_INIT_TIMEOUT_SECS,
+            init_retries: DEFAULT_INIT_RETRIES,
+            init_retry_backoff_ms: DEFAULT_INIT_RETRY_BACKOFF_MILLIS,
             max_turn_duration_secs: DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,
             heartbeat_interval_secs: 0,
@@ -2225,6 +2280,33 @@ channels = "ALL"
             "120",
         ]);
         assert_eq!(configured.exit_after_inactivity, 120);
+    }
+
+    #[test]
+    fn initialize_policy_defaults_remain_backward_compatible_and_accept_overrides() {
+        let key = "0".repeat(64);
+        let default = CliArgs::parse_from(["buzz-acp", "--private-key", &key]);
+        assert_eq!(default.init_timeout, None);
+        assert_eq!(default.init_retries, DEFAULT_INIT_RETRIES);
+        assert_eq!(
+            default.init_retry_backoff_ms,
+            DEFAULT_INIT_RETRY_BACKOFF_MILLIS
+        );
+
+        let configured = CliArgs::parse_from([
+            "buzz-acp",
+            "--private-key",
+            &key,
+            "--init-timeout",
+            "300",
+            "--init-retries",
+            "2",
+            "--init-retry-backoff-ms",
+            "2500",
+        ]);
+        assert_eq!(configured.init_timeout, Some(300));
+        assert_eq!(configured.init_retries, 2);
+        assert_eq!(configured.init_retry_backoff_ms, 2_500);
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4609,6 +4609,18 @@ async fn shutdown_agent_pool(pool: &mut AgentPool) {
     }
 }
 
+fn initialization_timeout_site(
+    error: &acp::AcpError,
+    last_request_timeout_site: Option<&'static str>,
+) -> &'static str {
+    match error {
+        acp::AcpError::Timeout(_) | acp::AcpError::WriteTimeout(_) => {
+            last_request_timeout_site.unwrap_or("initialize_budget")
+        }
+        _ => "not_a_timeout",
+    }
+}
+
 struct PoolStartup {
     agents: u32,
     init_timeout: Duration,
@@ -4746,12 +4758,8 @@ async fn initialize_agent_pool(
                     break;
                 }
                 Err(error) => {
-                    let timeout_site = match &error {
-                        acp::AcpError::Timeout(_) | acp::AcpError::WriteTimeout(_) => acp
-                            .last_request_timeout_site()
-                            .unwrap_or("initialize_budget"),
-                        _ => "agent_response",
-                    };
+                    let timeout_site =
+                        initialization_timeout_site(&error, acp.last_request_timeout_site());
                     let retryable = matches!(
                         &error,
                         acp::AcpError::Timeout(_) | acp::AcpError::WriteTimeout(_)
@@ -4865,6 +4873,33 @@ sleep 1"#
         );
         shutdown_agent_pool(&mut pool).await;
     }
+
+    #[tokio::test]
+    async fn json_rpc_initialize_error_is_not_labeled_as_a_timeout_phase() {
+        let args = vec![
+            "-c".to_string(),
+            r#"read _request
+echo '{"jsonrpc":"2.0","id":0,"error":{"code":-32600,"message":"bad initialize"}}'
+sleep 1"#
+                .to_string(),
+        ];
+        let mut acp = AcpClient::spawn("bash", &args, &[], false)
+            .await
+            .expect("JSON-RPC error fixture should spawn");
+
+        let error = acp
+            .initialize_with_timeout(Duration::from_secs(1))
+            .await
+            .expect_err("fixture initialize must return its JSON-RPC error");
+        assert!(matches!(
+            &error,
+            acp::AcpError::AgentError { code: -32600, .. }
+        ));
+        let timeout_site = initialization_timeout_site(&error, acp.last_request_timeout_site());
+        assert_eq!(timeout_site, "not_a_timeout");
+        assert!(!["stdin_write", "stdin_write_budget", "agent_response"].contains(&timeout_site));
+        acp.shutdown().await;
+    }
 }
 
 // ── spawn_and_init ────────────────────────────────────────────────────────────
@@ -4910,12 +4945,7 @@ async fn spawn_and_init(
         }
         Err(e) => {
             let init_duration = init_started.elapsed();
-            let timeout_site = match &e {
-                acp::AcpError::Timeout(_) | acp::AcpError::WriteTimeout(_) => acp
-                    .last_request_timeout_site()
-                    .unwrap_or("initialize_budget"),
-                _ => "agent_response",
-            };
+            let timeout_site = initialization_timeout_site(&e, acp.last_request_timeout_site());
             tracing::error!(
                 agent = agent_index,
                 init_duration_ms = init_duration.as_millis() as u64,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2458,10 +2458,13 @@ async fn tokio_main() -> Result<()> {
                 let args = config.agent_args.clone();
                 let env = config.persona_env_vars.clone();
                 let has_codex = config.has_generated_codex_config;
+                let init_timeout = Duration::from_secs(config.init_timeout_secs);
                 let observer = observer.clone();
                 let guard = RespawnGuard::new(idx, respawn_tx.clone());
                 respawn_tasks.spawn(async move {
-                    let result = spawn_and_init(&cmd, &args, &env, has_codex, idx, observer).await;
+                    let result =
+                        spawn_and_init(&cmd, &args, &env, has_codex, idx, init_timeout, observer)
+                            .await;
                     guard.send(result);
                 });
             }
@@ -4343,12 +4346,13 @@ fn recover_panicked_agent(
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
     let has_codex = config.has_generated_codex_config;
+    let init_timeout = Duration::from_secs(config.init_timeout_secs);
     let guard = RespawnGuard::new(i, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
         }
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, i, observer).await;
+        let result = spawn_and_init(&cmd, &args, &env, has_codex, i, init_timeout, observer).await;
         guard.send(result);
     });
 }
@@ -4554,6 +4558,7 @@ fn spawn_respawn_task(
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
     let has_codex = config.has_generated_codex_config;
+    let init_timeout = Duration::from_secs(config.init_timeout_secs);
     let guard = RespawnGuard::new(index, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         // Shutdown old agent (reap child, prevent zombie).
@@ -4565,7 +4570,8 @@ fn spawn_respawn_task(
             tokio::time::sleep(delay).await;
         }
 
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, index, observer).await;
+        let result =
+            spawn_and_init(&cmd, &args, &env, has_codex, index, init_timeout, observer).await;
         guard.send(result);
     });
 
@@ -4605,6 +4611,9 @@ async fn shutdown_agent_pool(pool: &mut AgentPool) {
 
 struct PoolStartup {
     agents: u32,
+    init_timeout: Duration,
+    init_retries: u32,
+    init_retry_backoff: Duration,
     command: String,
     args: Vec<String>,
     extra_env: Vec<(String, String)>,
@@ -4618,6 +4627,9 @@ impl PoolStartup {
     fn from_config(config: &Config, observer: Option<observer::ObserverHandle>) -> Self {
         Self {
             agents: config.agents,
+            init_timeout: Duration::from_secs(config.init_timeout_secs),
+            init_retries: config.init_retries,
+            init_retry_backoff: Duration::from_millis(config.init_retry_backoff_ms),
             command: config.agent_command.clone(),
             args: config.agent_args.clone(),
             extra_env: config.persona_env_vars.clone(),
@@ -4634,88 +4646,157 @@ async fn initialize_agent_pool(
     mut shutdown: Option<watch::Receiver<()>>,
 ) -> Result<AgentPool> {
     // One agent failing to start must not kill the whole pool.
-    // Attempt each spawn under a 60-second timeout; a partial pool is valid.
+    // A partial pool is valid. Single-agent bridges may opt into bounded
+    // timeout retries because otherwise the first miss is process-fatal.
     let mut agent_slots: Vec<Option<OwnedAgent>> = Vec::with_capacity(startup.agents as usize);
     for i in 0..startup.agents as usize {
-        let spawn_result = AcpClient::spawn(
-            &startup.command,
-            &startup.args,
-            &startup.extra_env,
-            startup.has_generated_codex_config,
-        )
-        .await;
-        match spawn_result {
-            Ok(mut acp) => {
-                acp.set_observer(startup.observer.clone(), i);
-                let initialize = tokio::time::timeout(Duration::from_secs(60), acp.initialize());
-                let initialize_result = match shutdown.as_mut() {
-                    Some(shutdown) => tokio::select! {
-                        biased;
-                        _ = shutdown.changed() => {
-                            acp.shutdown().await;
-                            shutdown_agent_slots(&mut agent_slots).await;
-                            return Err(anyhow::anyhow!("pool initialization cancelled by shutdown"));
-                        }
-                        result = initialize => result,
-                    },
-                    None => initialize.await,
-                };
-                match initialize_result {
-                    Ok(Ok(init_result)) => {
-                        tracing::info!(agent = i, "agent initialized: {init_result}");
-                        let protocol_version =
-                            init_result["protocolVersion"].as_u64().unwrap_or(1) as u32;
-                        tracing::info!(
-                            agent = i,
-                            name = init_result
-                                .get("agentInfo")
-                                .or_else(|| init_result.get("serverInfo"))
-                                .and_then(|info| info.get("name"))
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("unknown"),
-                            steering_supported = acp.steering_supported(),
-                            "agent initialized"
-                        );
-                        acp.observe(
-                            "agent_initialized",
-                            serde_json::json!({
-                                "agentIndex": i,
-                                "initializeResult": init_result,
-                            }),
-                        );
-                        let agent_name = normalized_agent_name(&init_result);
-                        agent_slots.push(Some(OwnedAgent {
-                            index: i,
-                            acp,
-                            state: SessionState::default(),
-                            model_capabilities: None,
-                            desired_model: startup.model.clone(),
-                            model_overridden: false,
-                            desired_model_request_id: None,
-                            desired_model_pending_ack: false,
-                            startup_effort: startup.effort_level.clone(),
-                            agent_name,
-                            goose_system_prompt_supported: None,
-                            protocol_version,
-                        }));
-                    }
-                    Ok(Err(e)) => {
-                        tracing::error!(agent = i, "agent initialize failed: {e}");
+        let max_attempts = if startup.agents == 1 {
+            startup.init_retries.saturating_add(1)
+        } else {
+            1
+        };
+        let mut initialized_slot = None;
+
+        for attempt in 0..max_attempts {
+            let spawn_result = AcpClient::spawn(
+                &startup.command,
+                &startup.args,
+                &startup.extra_env,
+                startup.has_generated_codex_config,
+            )
+            .await;
+            let mut acp = match spawn_result {
+                Ok(acp) => acp,
+                Err(error) => {
+                    tracing::error!(
+                        agent = i,
+                        attempt = attempt + 1,
+                        max_attempts,
+                        error = %error,
+                        "agent failed to spawn"
+                    );
+                    break;
+                }
+            };
+
+            acp.set_observer(startup.observer.clone(), i);
+            let init_started = tokio::time::Instant::now();
+            let initialize = acp.initialize_with_timeout(startup.init_timeout);
+            let initialize_result = match shutdown.as_mut() {
+                Some(shutdown) => tokio::select! {
+                    biased;
+                    _ = shutdown.changed() => {
                         acp.shutdown().await;
-                        agent_slots.push(None);
+                        shutdown_agent_slots(&mut agent_slots).await;
+                        return Err(anyhow::anyhow!("pool initialization cancelled by shutdown"));
                     }
-                    Err(_) => {
-                        tracing::error!(agent = i, "agent timed out during init (60s)");
-                        acp.shutdown().await;
-                        agent_slots.push(None);
+                    result = initialize => result,
+                },
+                None => initialize.await,
+            };
+            let init_duration = init_started.elapsed();
+
+            match initialize_result {
+                Ok(init_result) => {
+                    tracing::info!(
+                        agent = i,
+                        attempt = attempt + 1,
+                        init_duration_ms = init_duration.as_millis() as u64,
+                        init_budget_ms = startup.init_timeout.as_millis() as u64,
+                        "agent initialized: {init_result}"
+                    );
+                    let protocol_version =
+                        init_result["protocolVersion"].as_u64().unwrap_or(1) as u32;
+                    tracing::info!(
+                        agent = i,
+                        name = init_result
+                            .get("agentInfo")
+                            .or_else(|| init_result.get("serverInfo"))
+                            .and_then(|info| info.get("name"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown"),
+                        steering_supported = acp.steering_supported(),
+                        init_duration_ms = init_duration.as_millis() as u64,
+                        "agent initialized"
+                    );
+                    acp.observe(
+                        "agent_initialized",
+                        serde_json::json!({
+                            "agentIndex": i,
+                            "initializeResult": init_result,
+                            "initializeDurationMs": init_duration.as_millis() as u64,
+                            "initializeAttempt": attempt + 1,
+                        }),
+                    );
+                    let agent_name = normalized_agent_name(&init_result);
+                    initialized_slot = Some(OwnedAgent {
+                        index: i,
+                        acp,
+                        state: SessionState::default(),
+                        model_capabilities: None,
+                        desired_model: startup.model.clone(),
+                        model_overridden: false,
+                        desired_model_request_id: None,
+                        desired_model_pending_ack: false,
+                        startup_effort: startup.effort_level.clone(),
+                        agent_name,
+                        goose_system_prompt_supported: None,
+                        protocol_version,
+                    });
+                    break;
+                }
+                Err(error) => {
+                    let timeout_site = match &error {
+                        acp::AcpError::Timeout(_) | acp::AcpError::WriteTimeout(_) => acp
+                            .last_request_timeout_site()
+                            .unwrap_or("initialize_budget"),
+                        _ => "agent_response",
+                    };
+                    let retryable = matches!(
+                        &error,
+                        acp::AcpError::Timeout(_) | acp::AcpError::WriteTimeout(_)
+                    );
+                    let will_retry = retryable && attempt + 1 < max_attempts;
+                    tracing::error!(
+                        agent = i,
+                        attempt = attempt + 1,
+                        max_attempts,
+                        init_duration_ms = init_duration.as_millis() as u64,
+                        init_budget_ms = startup.init_timeout.as_millis() as u64,
+                        timeout_site,
+                        will_retry,
+                        error = %error,
+                        "agent initialize failed"
+                    );
+                    acp.shutdown().await;
+
+                    if !will_retry {
+                        break;
+                    }
+                    let multiplier = 1u32.checked_shl(attempt).unwrap_or(u32::MAX);
+                    let backoff = startup.init_retry_backoff.saturating_mul(multiplier);
+                    tracing::warn!(
+                        agent = i,
+                        next_attempt = attempt + 2,
+                        backoff_ms = backoff.as_millis() as u64,
+                        "retrying timed-out agent initialize"
+                    );
+                    match shutdown.as_mut() {
+                        Some(shutdown) => tokio::select! {
+                            biased;
+                            _ = shutdown.changed() => {
+                                shutdown_agent_slots(&mut agent_slots).await;
+                                return Err(anyhow::anyhow!("pool initialization cancelled by shutdown"));
+                            }
+                            _ = tokio::time::sleep(backoff) => {}
+                        },
+                        None => tokio::time::sleep(backoff).await,
                     }
                 }
             }
-            Err(e) => {
-                tracing::error!(agent = i, "agent failed to spawn: {e}");
-                agent_slots.push(None);
-            }
         }
+
+        agent_slots.push(initialized_slot);
     }
     let live_count = agent_slots.iter().filter(|slot| slot.is_some()).count();
     if live_count == 0 {
@@ -4735,6 +4816,57 @@ async fn initialize_agent_pool(
     Ok(AgentPool::from_slots(agent_slots))
 }
 
+#[cfg(test)]
+mod initialize_agent_pool_regression_tests {
+    use super::*;
+
+    /// Reproduces the incident shape at a short synthetic budget: one managed
+    /// bridge misses initialize on its first process, leaving a zero-live pool.
+    /// The repaired path must reap it, back off, respawn once, and become ready.
+    #[tokio::test]
+    async fn single_agent_timeout_retries_instead_of_killing_the_bridge() {
+        let marker = std::env::temp_dir().join(format!(
+            "buzz-acp-init-retry-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let marker_for_bash = marker.to_string_lossy().replace('\\', "/");
+        let script = format!(
+            r#"if [ ! -f '{marker_for_bash}' ]; then
+  touch '{marker_for_bash}'
+  read _request
+  sleep 2
+  exit 0
+fi
+read _request
+echo '{{"jsonrpc":"2.0","id":0,"result":{{"protocolVersion":2,"agentInfo":{{"name":"retry-test"}}}}}}'
+sleep 1"#
+        );
+        let startup = PoolStartup {
+            agents: 1,
+            // A one-second budget stays deterministic under the package-wide
+            // test load while the first child still exceeds it by 2x.
+            init_timeout: Duration::from_secs(1),
+            init_retries: 1,
+            init_retry_backoff: Duration::from_millis(10),
+            command: "bash".into(),
+            args: vec!["-c".into(), script],
+            extra_env: vec![],
+            has_generated_codex_config: false,
+            model: None,
+            effort_level: None,
+            observer: None,
+        };
+
+        let result = initialize_agent_pool(&startup, None).await;
+        let _ = std::fs::remove_file(&marker);
+        let mut pool = result.expect(
+            "a timed-out single-agent bridge should retry once instead of exiting with zero live agents",
+        );
+        shutdown_agent_pool(&mut pool).await;
+    }
+}
+
 // ── spawn_and_init ────────────────────────────────────────────────────────────
 /// Spawn an agent subprocess and run the MCP `initialize` handshake.
 ///
@@ -4746,6 +4878,7 @@ async fn spawn_and_init(
     extra_env: &[(String, String)],
     has_generated_codex_config: bool,
     agent_index: usize,
+    init_timeout: Duration,
     observer: Option<observer::ObserverHandle>,
 ) -> Result<(AcpClient, u32, String)> {
     let mut acp = AcpClient::spawn(command, args, extra_env, has_generated_codex_config)
@@ -4753,21 +4886,44 @@ async fn spawn_and_init(
         .map_err(|e| anyhow::anyhow!("failed to spawn agent: {e}"))?;
     acp.set_observer(observer, agent_index);
 
-    match acp.initialize().await {
+    let init_started = tokio::time::Instant::now();
+    match acp.initialize_with_timeout(init_timeout).await {
         Ok(init_result) => {
-            tracing::info!("agent initialized: {init_result}");
+            let init_duration = init_started.elapsed();
+            tracing::info!(
+                agent = agent_index,
+                init_duration_ms = init_duration.as_millis() as u64,
+                init_budget_ms = init_timeout.as_millis() as u64,
+                "agent initialized: {init_result}"
+            );
             let protocol_version = init_result["protocolVersion"].as_u64().unwrap_or(1) as u32;
             acp.observe(
                 "agent_initialized",
                 serde_json::json!({
                     "agentIndex": agent_index,
                     "initializeResult": init_result,
+                    "initializeDurationMs": init_duration.as_millis() as u64,
                 }),
             );
             let agent_name = normalized_agent_name(&init_result);
             Ok((acp, protocol_version, agent_name))
         }
         Err(e) => {
+            let init_duration = init_started.elapsed();
+            let timeout_site = match &e {
+                acp::AcpError::Timeout(_) | acp::AcpError::WriteTimeout(_) => acp
+                    .last_request_timeout_site()
+                    .unwrap_or("initialize_budget"),
+                _ => "agent_response",
+            };
+            tracing::error!(
+                agent = agent_index,
+                init_duration_ms = init_duration.as_millis() as u64,
+                init_budget_ms = init_timeout.as_millis() as u64,
+                timeout_site,
+                error = %e,
+                "agent initialize failed"
+            );
             // Explicitly shut down the spawned child to prevent zombie/leak.
             // Drop only does start_kill + try_wait (best-effort); shutdown()
             // does start_kill + bounded wait (guaranteed reap).
@@ -6761,6 +6917,9 @@ mod build_mcp_servers_tests {
             agent_args: vec!["acp".into()],
             mcp_command: "test-mcp-server".into(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
+            init_timeout_secs: config::DEFAULT_INIT_TIMEOUT_SECS,
+            init_retries: config::DEFAULT_INIT_RETRIES,
+            init_retry_backoff_ms: config::DEFAULT_INIT_RETRY_BACKOFF_MILLIS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,
             heartbeat_interval_secs: 0,
@@ -6985,6 +7144,9 @@ mod error_outcome_emission_tests {
             agent_args: vec![],
             mcp_command: "test-mcp-server".into(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
+            init_timeout_secs: config::DEFAULT_INIT_TIMEOUT_SECS,
+            init_retries: config::DEFAULT_INIT_RETRIES,
+            init_retry_backoff_ms: config::DEFAULT_INIT_RETRY_BACKOFF_MILLIS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,
             heartbeat_interval_secs: 0,

--- a/desktop/src-tauri/src/managed_agents/restore.rs
+++ b/desktop/src-tauri/src/managed_agents/restore.rs
@@ -89,7 +89,7 @@ pub fn backfill_persona_snapshots(app: &tauri::AppHandle) -> Result<(), String> 
 ///
 /// Split into three phases to minimise lock contention with the frontend:
 ///   A (under lock): sync process state, cleanup, collect agents to start
-///   B (no locks):   resolve commands and spawn processes in parallel
+///   B (no store/runtime locks): resolve commands and spawn processes serially
 ///   C (re-lock):    write back PIDs and status to records on disk
 pub async fn restore_managed_agents_on_launch(
     app: &tauri::AppHandle,
@@ -288,75 +288,65 @@ pub async fn restore_managed_agents_on_launch(
         return Ok(());
     }
 
-    // ── Phase B (transition lock held): resolve commands and spawn in parallel ──
-    let spawn_results: Vec<AgentSpawnResult> = std::thread::scope(|scope| {
-        let owner_hex_ref = owner_hex.as_deref();
-        let handles: Vec<_> = agents_to_start
-            .iter()
-            .filter(|_| !shutdown_started.load(Ordering::SeqCst))
-            .map(|record| {
-                let handle = scope.spawn(move || {
-                    let workspace_relay =
-                        crate::relay::relay_ws_url_with_override(&app.state::<AppState>());
-                    let relay_url = crate::relay::effective_agent_relay_url(
-                        &record.relay_url,
-                        &workspace_relay,
-                    );
-                    let outcome =
-                        match super::ManagedAgentRuntimeKey::new(record.pubkey.clone(), &relay_url)
-                        {
-                            Ok(key) => {
-                                // F2: if a concurrent startup reconcile already
-                                // tracked a live child for this exact pair during
-                                // the Phase A window, leave it alone. Mirrors the
-                                // live-child guard in `start_pair`.
-                                let already_live = app
-                                    .state::<AppState>()
-                                    .managed_agent_processes
-                                    .lock()
-                                    .ok()
-                                    .and_then(|mut runtimes| {
-                                        runtimes.get_mut(&key).map(|runtime| {
-                                            runtime.child.try_wait().ok().flatten().is_none()
-                                        })
-                                    })
-                                    .unwrap_or(false);
-                                if already_live {
-                                    SpawnOutcome::Skipped
-                                } else {
-                                    match super::terminate_untracked_pair_runtime(app, &key)
-                                        .and_then(|()| {
-                                            // F1: restore spawns lazy, matching
-                                            // reconcile and manual start. Eager on
-                                            // restore buys nothing — a crashed
-                                            // mid-turn session is not resumed by an
-                                            // eager child — and silently reintroduces
-                                            // N idle brains on every launch.
-                                            spawn_agent_child(
-                                                app,
-                                                record,
-                                                &key.relay_url,
-                                                true,
-                                                owner_hex_ref,
-                                            )
-                                        }) {
-                                        Ok(process) => {
-                                            SpawnOutcome::Spawned(key, Box::new(process))
-                                        }
-                                        Err(error) => SpawnOutcome::Failed(error),
-                                    }
-                                }
-                            }
-                            Err(error) => SpawnOutcome::Failed(error),
-                        };
-                    (record.pubkey.clone(), outcome)
-                });
-                handle
-            })
-            .collect();
+    // ── Phase B (transition lock held): resolve and spawn serially ────────────
+    // Launch restore previously spawned every harness concurrently. Even though
+    // restored harnesses are lazy, their first wakes can cluster and reproduce
+    // the same MCP-heavy initialization contention. Keep one deterministic
+    // spawn lane and add a small bounded stagger between candidates. The
+    // initialize-only 300s budget + retry in spawn_agent_child is the hard
+    // safety net; this stagger simply avoids creating the burst in the first
+    // place.
+    let owner_hex_ref = owner_hex.as_deref();
+    let mut spawn_results: Vec<AgentSpawnResult> = Vec::with_capacity(agents_to_start.len());
+    for (position, record) in agents_to_start.iter().enumerate() {
+        if shutdown_started.load(Ordering::SeqCst) {
+            break;
+        }
+        if position > 0 {
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            if shutdown_started.load(Ordering::SeqCst) {
+                break;
+            }
+        }
 
-        handles.into_iter().map(|h| h.join().unwrap()).collect()
-    });
+        let workspace_relay =
+            crate::relay::relay_ws_url_with_override(&app.state::<AppState>());
+        let relay_url =
+            crate::relay::effective_agent_relay_url(&record.relay_url, &workspace_relay);
+        let outcome = match super::ManagedAgentRuntimeKey::new(record.pubkey.clone(), &relay_url) {
+            Ok(key) => {
+                // F2: if a concurrent startup reconcile already tracked a live
+                // child for this exact pair during the Phase A window, leave it
+                // alone. Mirrors the live-child guard in `start_pair`.
+                let already_live = app
+                    .state::<AppState>()
+                    .managed_agent_processes
+                    .lock()
+                    .ok()
+                    .and_then(|mut runtimes| {
+                        runtimes
+                            .get_mut(&key)
+                            .map(|runtime| runtime.child.try_wait().ok().flatten().is_none())
+                    })
+                    .unwrap_or(false);
+                if already_live {
+                    SpawnOutcome::Skipped
+                } else {
+                    match super::terminate_untracked_pair_runtime(app, &key).and_then(|()| {
+                        // F1: restore spawns lazy, matching reconcile and manual
+                        // start. Eager restore would silently reintroduce N idle
+                        // brains on every launch.
+                        spawn_agent_child(app, record, &key.relay_url, true, owner_hex_ref)
+                    }) {
+                        Ok(process) => SpawnOutcome::Spawned(key, Box::new(process)),
+                        Err(error) => SpawnOutcome::Failed(error),
+                    }
+                }
+            }
+            Err(error) => SpawnOutcome::Failed(error),
+        };
+        spawn_results.push((record.pubkey.clone(), outcome));
+    }
 
     if spawn_results.is_empty() {
         return Ok(());

--- a/desktop/src-tauri/src/managed_agents/restore.rs
+++ b/desktop/src-tauri/src/managed_agents/restore.rs
@@ -1,30 +1,178 @@
 use super::{
     find_managed_agent_mut, kill_stale_tracked_processes, load_managed_agents, load_personas,
     save_managed_agents, spawn_agent_child, sync_managed_agent_processes, BackendKind,
-    ManagedAgentProcess,
 };
 use crate::app_state::AppState;
 use crate::util;
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 use tauri::Manager;
 
-/// Outcome of a Phase B spawn attempt for one restore candidate.
+const RESTORE_SPAWN_STAGGER: Duration = Duration::from_secs(1);
+const RESTORE_SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Pace restore candidates without blocking a Tokio worker.
 ///
-/// `Skipped` covers the case where a concurrently-running startup reconcile
-/// already spawned and tracked this exact pair during the Phase A window (the
-/// transition lock is only held from Phase B onward). Restore must then leave
-/// that live child alone rather than terminate-and-respawn it — mirroring the
-/// live-child guard in `start_pair` (`runtime_commands.rs`). Without this,
-/// restore would kill reconcile's lazy child by its receipt and replace it with
-/// an eager one, flipping the pair's laziness on a startup race.
-enum SpawnOutcome {
-    /// Boxed: the spawned process carries its full spawn-config snapshot, so an
-    /// inline variant would make every `Skipped`/`Failed` outcome pay for it.
-    Spawned(super::ManagedAgentRuntimeKey, Box<ManagedAgentProcess>),
-    Skipped,
-    Failed(String),
+/// The spawn closure owns the heavyweight AppHandle/relay/process work. Keeping
+/// only ordering, pacing, and shutdown policy here makes the scheduler directly
+/// testable and ensures no synchronous runtime-transition guard crosses an
+/// await point.
+async fn run_serial_restore_schedule<T, R, E, Shutdown, Spawn, SpawnFuture>(
+    candidates: &[T],
+    stagger: Duration,
+    mut shutdown_started: Shutdown,
+    mut spawn: Spawn,
+) -> Result<Vec<R>, E>
+where
+    Shutdown: FnMut() -> bool,
+    Spawn: FnMut(&T) -> SpawnFuture,
+    SpawnFuture: Future<Output = Result<R, E>>,
+{
+    let mut results = Vec::with_capacity(candidates.len());
+
+    for (position, candidate) in candidates.iter().enumerate() {
+        if shutdown_started() {
+            break;
+        }
+
+        if position > 0 {
+            let deadline = tokio::time::Instant::now() + stagger;
+            loop {
+                if shutdown_started() {
+                    return Ok(results);
+                }
+                let now = tokio::time::Instant::now();
+                if now >= deadline {
+                    break;
+                }
+                tokio::time::sleep(
+                    deadline
+                        .saturating_duration_since(now)
+                        .min(RESTORE_SHUTDOWN_POLL_INTERVAL),
+                )
+                .await;
+            }
+            if shutdown_started() {
+                break;
+            }
+        }
+
+        results.push(spawn(candidate).await?);
+    }
+
+    Ok(results)
 }
-type AgentSpawnResult = (String, SpawnOutcome);
+
+/// Spawn and register one restore candidate as a single synchronous runtime
+/// transition. The scheduler awaits only between calls, so shutdown can never
+/// observe a spawned-but-untracked child.
+fn restore_one_candidate(
+    app: &tauri::AppHandle,
+    state: &AppState,
+    candidate: &super::ManagedAgentRecord,
+    owner_hex: Option<&str>,
+    shutdown_started: &AtomicBool,
+) -> Result<Option<(String, String)>, String> {
+    let _restore_transition = state
+        .managed_agent_runtime_transition
+        .lock()
+        .map_err(|error| error.to_string())?;
+    if shutdown_started.load(Ordering::SeqCst) {
+        return Ok(None);
+    }
+
+    // Phase A is only a launch-order snapshot. Reload under the same locks used
+    // by record mutations and runtime transitions so a user disabling,
+    // deleting, or manually starting this agent during a stagger wins over the
+    // stale candidate. Keep the store lock through spawn and registration,
+    // matching `start_pair`, so the revalidated record cannot change midway.
+    let _store_guard = state
+        .managed_agents_store_lock
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let mut records = load_managed_agents(app)?;
+    let Some(record_index) = records
+        .iter()
+        .position(|record| record.pubkey == candidate.pubkey)
+    else {
+        return Ok(None);
+    };
+    let record = records[record_index].clone();
+    if !record.start_on_app_launch || record.backend != BackendKind::Local {
+        return Ok(None);
+    }
+    if record.runtime_pid.is_some_and(super::process_is_running) {
+        return Ok(None);
+    }
+
+    let workspace_relay = crate::relay::relay_ws_url_with_override(&app.state::<AppState>());
+    let relay_url = crate::relay::effective_agent_relay_url(&record.relay_url, &workspace_relay);
+    let key = match super::ManagedAgentRuntimeKey::new(record.pubkey.clone(), &relay_url) {
+        Ok(key) => key,
+        Err(error) => {
+            records[record_index].updated_at = util::now_iso();
+            records[record_index].last_error = Some(error);
+            save_managed_agents(app, &records)?;
+            return Ok(None);
+        }
+    };
+    let mut runtimes = state
+        .managed_agent_processes
+        .lock()
+        .map_err(|error| error.to_string())?;
+    if runtimes
+        .get_mut(&key)
+        .is_some_and(|runtime| runtime.child.try_wait().ok().flatten().is_none())
+    {
+        return Ok(None);
+    }
+    runtimes.remove(&key);
+
+    let mut process = match super::terminate_untracked_pair_runtime(app, &key).and_then(|()| {
+        // Restore spawns lazy, matching reconcile and manual start. Eager
+        // restore would silently reintroduce N idle brains on every launch.
+        spawn_agent_child(app, &record, &key.relay_url, true, owner_hex)
+    }) {
+        Ok(process) => process,
+        Err(error) => {
+            records[record_index].updated_at = util::now_iso();
+            records[record_index].last_error = Some(error);
+            save_managed_agents(app, &records)?;
+            return Ok(None);
+        }
+    };
+
+    let now = util::now_iso();
+    let receipt = super::ManagedAgentRuntimeReceipt {
+        key: key.clone(),
+        pid: process.child.id(),
+        desktop_instance_id: super::current_instance_id(app),
+        started_at: now.clone(),
+    };
+    if let Err(error) = super::write_agent_runtime_receipt(app, &receipt) {
+        let _ = super::terminate_process(process.child.id());
+        let _ = process.child.wait();
+        records[record_index].updated_at = now;
+        records[record_index].last_error = Some(error);
+        save_managed_agents(app, &records)?;
+        return Ok(None);
+    }
+
+    let stored_record = &mut records[record_index];
+    stored_record.updated_at = now.clone();
+    stored_record.runtime_pid = None;
+    stored_record.last_started_at = Some(now);
+    stored_record.last_stopped_at = None;
+    stored_record.last_exit_code = None;
+    stored_record.last_error = None;
+    runtimes.insert(
+        key.clone(),
+        super::ManagedAgentPairRuntime::starting(process),
+    );
+    save_managed_agents(app, &records)?;
+    Ok(Some((record.pubkey, key.relay_url)))
+}
 
 /// Backfill the pinned persona snapshot for pre-existing agents created before
 /// the record became the spawn source of truth. Runs once at launch, before
@@ -87,10 +235,11 @@ pub fn backfill_persona_snapshots(app: &tauri::AppHandle) -> Result<(), String> 
 
 /// Restore managed agents that were running before the app was closed.
 ///
-/// Split into three phases to minimise lock contention with the frontend:
-///   A (under lock): sync process state, cleanup, collect agents to start
-///   B (no store/runtime locks): resolve commands and spawn processes serially
-///   C (re-lock):    write back PIDs and status to records on disk
+/// Split into three phases to keep pacing asynchronous without sacrificing
+/// runtime atomicity:
+///   A (under lock): snapshot eligible restore candidates
+///   B (paced):      revalidate, spawn, and register each candidate atomically
+///   C (under lock): collect profile reconciliation data
 pub async fn restore_managed_agents_on_launch(
     app: &tauri::AppHandle,
     shutdown_started: &AtomicBool,
@@ -206,15 +355,15 @@ pub async fn restore_managed_agents_on_launch(
             };
             let Some(persona) = personas_for_snapshot.iter().find(|p| p.id == persona_id) else {
                 // Orphaned: no current persona to re-snapshot from. Leave the
-                // record as-is — `spawn_agent_child` (Phase B below) refuses to
-                // spawn it and Phase C persists the refusal to `last_error`.
+                // record as-is — Phase B revalidates and `spawn_agent_child`
+                // persists any refusal to `last_error`.
                 continue;
             };
             super::persona_events::apply_persona_snapshot(record, persona);
             record.updated_at = util::now_iso();
             changed = true;
         }
-        // Re-collect to_start from the updated records so Phase B spawns the refreshed config.
+        // Re-collect to_start so Phase B receives the refreshed config snapshot.
         agents_to_start = records
             .iter()
             .filter(|r| agents_to_start.iter().any(|s| s.pubkey == r.pubkey))
@@ -231,7 +380,7 @@ pub async fn restore_managed_agents_on_launch(
     }
 
     // Snapshot the workspace owner pubkey once for the legacy auth_tag fallback.
-    // Read outside the per-agent spawn loop so all parallel spawns see the same
+    // Read outside the per-agent spawn loop so every serial spawn sees the same
     // value and we don't lock `state.keys` repeatedly.
     let owner_hex: Option<String> = state
         .keys
@@ -276,19 +425,7 @@ pub async fn restore_managed_agents_on_launch(
         return Ok(());
     }
 
-    // Serialize spawning and runtime registration with shutdown cleanup. The
-    // shutdown flag is rechecked after taking the lock so shutdown either
-    // prevents this transition or waits until every child is tracked and can
-    // be terminated.
-    let restore_transition = state
-        .managed_agent_runtime_transition
-        .lock()
-        .map_err(|error| error.to_string())?;
-    if shutdown_started.load(Ordering::SeqCst) {
-        return Ok(());
-    }
-
-    // ── Phase B (transition lock held): resolve and spawn serially ────────────
+    // ── Phase B: pace serial spawn-and-register transactions ────────────────
     // Launch restore previously spawned every harness concurrently. Even though
     // restored harnesses are lazy, their first wakes can cluster and reproduce
     // the same MCP-heavy initialization contention. Keep one deterministic
@@ -297,122 +434,35 @@ pub async fn restore_managed_agents_on_launch(
     // safety net; this stagger simply avoids creating the burst in the first
     // place.
     let owner_hex_ref = owner_hex.as_deref();
-    let mut spawn_results: Vec<AgentSpawnResult> = Vec::with_capacity(agents_to_start.len());
-    for (position, record) in agents_to_start.iter().enumerate() {
-        if shutdown_started.load(Ordering::SeqCst) {
-            break;
-        }
-        if position > 0 {
-            std::thread::sleep(std::time::Duration::from_secs(1));
-            if shutdown_started.load(Ordering::SeqCst) {
-                break;
-            }
-        }
+    let successfully_spawned = run_serial_restore_schedule(
+        &agents_to_start,
+        RESTORE_SPAWN_STAGGER,
+        || shutdown_started.load(Ordering::SeqCst),
+        |record| {
+            std::future::ready(restore_one_candidate(
+                app,
+                &state,
+                record,
+                owner_hex_ref,
+                shutdown_started,
+            ))
+        },
+    )
+    .await?
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>();
 
-        let workspace_relay =
-            crate::relay::relay_ws_url_with_override(&app.state::<AppState>());
-        let relay_url =
-            crate::relay::effective_agent_relay_url(&record.relay_url, &workspace_relay);
-        let outcome = match super::ManagedAgentRuntimeKey::new(record.pubkey.clone(), &relay_url) {
-            Ok(key) => {
-                // F2: if a concurrent startup reconcile already tracked a live
-                // child for this exact pair during the Phase A window, leave it
-                // alone. Mirrors the live-child guard in `start_pair`.
-                let already_live = app
-                    .state::<AppState>()
-                    .managed_agent_processes
-                    .lock()
-                    .ok()
-                    .and_then(|mut runtimes| {
-                        runtimes
-                            .get_mut(&key)
-                            .map(|runtime| runtime.child.try_wait().ok().flatten().is_none())
-                    })
-                    .unwrap_or(false);
-                if already_live {
-                    SpawnOutcome::Skipped
-                } else {
-                    match super::terminate_untracked_pair_runtime(app, &key).and_then(|()| {
-                        // F1: restore spawns lazy, matching reconcile and manual
-                        // start. Eager restore would silently reintroduce N idle
-                        // brains on every launch.
-                        spawn_agent_child(app, record, &key.relay_url, true, owner_hex_ref)
-                    }) {
-                        Ok(process) => SpawnOutcome::Spawned(key, Box::new(process)),
-                        Err(error) => SpawnOutcome::Failed(error),
-                    }
-                }
-            }
-            Err(error) => SpawnOutcome::Failed(error),
-        };
-        spawn_results.push((record.pubkey.clone(), outcome));
-    }
-
-    if spawn_results.is_empty() {
+    if successfully_spawned.is_empty() {
         return Ok(());
     }
 
-    // ── Phase C (re-acquire lock): write back PIDs and status to records ──
+    // ── Phase C: collect profile reconciliation data ────────────────────────
     let _store_guard = state
         .managed_agents_store_lock
         .lock()
         .map_err(|error| error.to_string())?;
-    let mut records = load_managed_agents(app)?;
-    let mut runtimes = state
-        .managed_agent_processes
-        .lock()
-        .map_err(|error| error.to_string())?;
-
-    let mut successfully_spawned: Vec<(String, String)> = Vec::new();
-
-    for (pubkey, outcome) in spawn_results {
-        match outcome {
-            // Skipped means a concurrent reconcile already owns a live child for
-            // this pair; leave its runtime and record state untouched.
-            SpawnOutcome::Skipped => continue,
-            SpawnOutcome::Spawned(key, mut process) => {
-                let Ok(record) = find_managed_agent_mut(&mut records, &pubkey) else {
-                    continue;
-                };
-                let now = util::now_iso();
-                let receipt = super::ManagedAgentRuntimeReceipt {
-                    key: key.clone(),
-                    pid: process.child.id(),
-                    desktop_instance_id: super::current_instance_id(app),
-                    started_at: now.clone(),
-                };
-                if let Err(error) = super::write_agent_runtime_receipt(app, &receipt) {
-                    let _ = super::terminate_process(process.child.id());
-                    let _ = process.child.wait();
-                    record.updated_at = now;
-                    record.last_error = Some(error);
-                    continue;
-                }
-                record.updated_at = now.clone();
-                record.runtime_pid = None;
-                record.last_started_at = Some(now);
-                record.last_stopped_at = None;
-                record.last_exit_code = None;
-                record.last_error = None;
-                runtimes.insert(
-                    key.clone(),
-                    super::ManagedAgentPairRuntime::starting(*process),
-                );
-                // Carry the spawn key's relay into profile reconciliation so
-                // the background task queries/publishes on the relay this
-                // spawn was actually keyed to — not whatever workspace is
-                // active when the task eventually executes.
-                successfully_spawned.push((pubkey, key.relay_url.clone()));
-            }
-            SpawnOutcome::Failed(error) => {
-                let Ok(record) = find_managed_agent_mut(&mut records, &pubkey) else {
-                    continue;
-                };
-                record.updated_at = util::now_iso();
-                record.last_error = Some(error);
-            }
-        }
-    }
+    let records = load_managed_agents(app)?;
 
     // Collect profile reconciliation data for successfully spawned agents before
     // releasing the lock. This mirrors the fire-and-forget pattern in
@@ -449,10 +499,7 @@ pub async fn restore_managed_agents_on_launch(
             })
             .collect();
 
-    save_managed_agents(app, &records)?;
-    drop(runtimes);
     drop(_store_guard);
-    drop(restore_transition);
 
     // ── Profile reconciliation (fire-and-forget) ────────────────────────────
     // Spawn background tasks to ensure each restored agent's kind:0 profile is
@@ -521,6 +568,80 @@ pub(crate) fn spawn_pending_profile_reconciliations(app: &tauri::AppHandle, work
                 ),
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod restore_schedule_tests {
+    use super::run_serial_restore_schedule;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    };
+    use std::time::Duration;
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn preserves_input_order_and_awaits_exactly_n_minus_one_staggers() {
+        let candidates = [3u8, 1, 2];
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let observed_by_spawn = Arc::clone(&observed);
+        let started = tokio::time::Instant::now();
+
+        let results = run_serial_restore_schedule(
+            &candidates,
+            Duration::from_millis(10),
+            || false,
+            move |candidate| {
+                observed_by_spawn.lock().unwrap().push(*candidate);
+                std::future::ready(Ok::<u8, ()>(*candidate))
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(results, candidates);
+        assert_eq!(*observed.lock().unwrap(), candidates);
+        assert_eq!(
+            tokio::time::Instant::now().duration_since(started),
+            Duration::from_millis(20),
+            "three candidates require two awaited staggers and no leading delay"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn shutdown_before_scheduling_spawns_nothing() {
+        let shutdown = AtomicBool::new(true);
+        let results = run_serial_restore_schedule(
+            &[1u8, 2, 3],
+            Duration::from_millis(10),
+            || shutdown.load(Ordering::SeqCst),
+            |candidate| std::future::ready(Ok::<u8, ()>(*candidate)),
+        )
+        .await
+        .unwrap();
+
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn shutdown_during_stagger_leaves_remaining_candidates_unspawned() {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_for_task = Arc::clone(&shutdown);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            shutdown_for_task.store(true, Ordering::SeqCst);
+        });
+
+        let results = run_serial_restore_schedule(
+            &[1u8, 2, 3],
+            Duration::from_millis(10),
+            || shutdown.load(Ordering::SeqCst),
+            |candidate| std::future::ready(Ok::<u8, ()>(*candidate)),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(results, [1]);
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -15,6 +15,28 @@ use crate::{
 };
 
 use super::claude_config::{apply_claude_model_env, apply_effort_env};
+
+// The harness itself keeps its historical 60-second / zero-retry defaults for
+// direct CLI callers. Desktop opts into a wider, bounded initialize-only budget
+// because managed agents commonly boot several MCP servers during initialize.
+// 300 seconds is a conservative product judgment, not a duration inferred from
+// the right-censored 60-second incident data. Actual durations are logged by
+// buzz-acp so this value can be tuned from completed handshakes.
+const DESKTOP_INIT_TIMEOUT_SECONDS: u64 = 300;
+const DESKTOP_INIT_RETRIES: u32 = 1;
+const DESKTOP_INIT_RETRY_BACKOFF_MILLIS: u64 = 1_000;
+
+fn apply_desktop_init_policy(command: &mut std::process::Command) {
+    command.env(
+        "BUZZ_ACP_INIT_TIMEOUT",
+        DESKTOP_INIT_TIMEOUT_SECONDS.to_string(),
+    );
+    command.env("BUZZ_ACP_INIT_RETRIES", DESKTOP_INIT_RETRIES.to_string());
+    command.env(
+        "BUZZ_ACP_INIT_RETRY_BACKOFF_MS",
+        DESKTOP_INIT_RETRY_BACKOFF_MILLIS.to_string(),
+    );
+}
 mod path;
 pub(in crate::managed_agents) use path::build_augmented_path;
 pub(crate) use path::{compose_path_entries, should_skip_claude_executable, should_use_inherited};
@@ -679,6 +701,11 @@ pub fn spawn_agent_child(
     }
     let acp_n = super::acp_agents_value(effective_command, record.parallelism);
     command.env("BUZZ_ACP_AGENTS", acp_n);
+    // Initialize has its own policy. These Desktop defaults are written before
+    // descriptor.env below, so an explicit per-runtime/persona/agent setting
+    // remains authoritative and can tune the budget without changing the
+    // ordinary non-prompt/session RPC timeout.
+    apply_desktop_init_policy(&mut command);
     command.env("BUZZ_ACP_MULTIPLE_EVENT_HANDLING", "steer");
     command.env("BUZZ_ACP_DEDUP", "queue");
     if let Some(meta) = runtime_meta {

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -1,7 +1,31 @@
 use crate::managed_agents::known_acp_runtime;
+use std::collections::HashMap;
 
 #[path = "cli_tests.rs"]
 mod cli_tests;
+
+#[test]
+fn desktop_managed_agents_use_a_bounded_initialize_only_policy() {
+    let mut command = std::process::Command::new("ignored");
+    super::apply_desktop_init_policy(&mut command);
+    let env: HashMap<String, String> = command
+        .get_envs()
+        .filter_map(|(key, value)| {
+            Some((
+                key.to_string_lossy().into_owned(),
+                value?.to_string_lossy().into_owned(),
+            ))
+        })
+        .collect();
+    assert_eq!(env.get("BUZZ_ACP_INIT_TIMEOUT").map(String::as_str), Some("300"));
+    assert_eq!(env.get("BUZZ_ACP_INIT_RETRIES").map(String::as_str), Some("1"));
+    assert_eq!(
+        env.get("BUZZ_ACP_INIT_RETRY_BACKOFF_MS")
+            .map(String::as_str),
+        Some("1000")
+    );
+    assert!(!env.contains_key("BUZZ_ACP_REQUEST_TIMEOUT"));
+}
 
 // ── desktop binary name tests ───────────────────────────────────────────
 

--- a/desktop/src/features/agents/lib/friendlyAgentLastError.test.mjs
+++ b/desktop/src/features/agents/lib/friendlyAgentLastError.test.mjs
@@ -5,9 +5,26 @@ import {
   friendlyAgentLastError,
   friendlyTurnErrorCopy,
   CLI_ACP_INTERNAL_ERROR_COPY,
+  AGENT_INIT_TIMEOUT_COPY,
   MODEL_NOT_FOUND_COPY,
   RELAY_MESH_DENIED_COPY,
 } from "./friendlyAgentLastError.ts";
+
+test("outer initialize timeout is surfaced as an actionable startup error", () => {
+  assert.deepEqual(
+    friendlyAgentLastError("agent timed out during init (60s)"),
+    { severity: "generic", copy: AGENT_INIT_TIMEOUT_COPY },
+  );
+});
+
+test("inner initialize request timeout is surfaced as the same startup error", () => {
+  assert.deepEqual(
+    friendlyAgentLastError(
+      "agent initialize failed: Request timeout — agent did not respond within 60s",
+    ),
+    { severity: "generic", copy: AGENT_INIT_TIMEOUT_COPY },
+  );
+});
 
 test("null lastError → null", () => {
   assert.equal(friendlyAgentLastError(null), null);

--- a/desktop/src/features/agents/lib/friendlyAgentLastError.ts
+++ b/desktop/src/features/agents/lib/friendlyAgentLastError.ts
@@ -48,6 +48,8 @@ export const CLI_ACP_INTERNAL_ERROR_COPY =
 const EMBEDDED_CODE_RE = /^Agent reported error \(code (-?\d+)\): /;
 /** Bare form of the standard JSON-RPC -32603 message (after stripping the ACP wrapper prefix). */
 const BARE_INTERNAL_ERROR = "Internal error";
+export const AGENT_INIT_TIMEOUT_COPY =
+  "Agent startup timed out while its tools were initializing. Buzz will retry once; if it still fails, start fewer agents at the same time and review the agent log.";
 
 function recoverEmbeddedCode(trimmed: string): {
   code: number;
@@ -68,6 +70,15 @@ export function friendlyAgentLastError(
   if (raw == null) return null;
   const trimmed = raw.trim();
   if (trimmed.length === 0) return null;
+
+  const lower = trimmed.toLowerCase();
+  if (
+    lower.includes("timed out during init") ||
+    (lower.includes("agent initialize failed") &&
+      lower.includes("request timeout"))
+  ) {
+    return { severity: "generic", copy: AGENT_INIT_TIMEOUT_COPY };
+  }
 
   // Structured code first; a code embedded in the message string is the
   // same signal recovered from a record that lost the field.


### PR DESCRIPTION
## Summary

- make managed-agent ACP initialization timeout configurable and retry a failed single-agent start within a bounded policy
- configure Desktop-managed agents for a 300-second initialize timeout with one retry and a one-second backoff
- serialize Desktop restore starts with shutdown-aware cancellation and clearer initialization errors

## Verification

Exact PR commit: `e057f198dd22e6b514cc2dbaafb26c8b9bbf3b1a`

- patch-equivalent replay of the two reviewed v0.5.18 fix commits onto current `block/buzz:main`
- native Windows restore scheduler tests: 3/3 passed
- native Windows Tauri `cargo check --workspace --all-targets`: passed
- native Windows `cargo clippy -p buzz-acp --all-targets -- -D warnings`: passed
- Desktop frontend tests: 5,510/5,510 passed
- Desktop TypeScript typecheck: passed

The full `buzz-acp` suite is not claimed from this Windows host: its Bash fixtures resolved through incompatible Windows/WSL path handling. Upstream Linux CI is the authority for that remaining gate.

## Rollout separation

This PR branch targets current upstream `main` (Buzz Desktop 0.5.20). John's separately published rollout branch remains pinned to tested Desktop v0.5.18 commit `858a8e00ecb7b72509a7a800e56f33d07b55b4b9`; artifacts from this PR branch will not be installed on that machine.

Originating Buzz channel: `a5c95a87-da79-4cf3-9faf-4375bbb8d5cb`
Originating thread: `0b1079da0ba1e585451ca48ae027d64bce1e21301d4494675dc60d57474e6dda`