### PR TITLE
fix(desktop): resolve exact typed mentions on space

### DIFF
--- a/desktop/src/features/forum/ui/ForumComposer.tsx
+++ b/desktop/src/features/forum/ui/ForumComposer.tsx
@@ -6,6 +6,7 @@ import { buildOutgoingMessage } from "@/features/messages/lib/imetaMediaMarkdown
 import { useChannelLinks } from "@/features/messages/lib/useChannelLinks";
 import type { ChannelSuggestion } from "@/features/messages/lib/useChannelLinks";
 import { useMediaUpload } from "@/features/messages/lib/useMediaUpload";
+import { isMentionCodeContext } from "@/features/messages/lib/mentionCodeContext";
 import { useMentions } from "@/features/messages/lib/useMentions";
 import {
   hasMentionClipboardHtml,
@@ -323,7 +324,9 @@ export function ForumComposer({
         return;
       }
 
-      const { handled, suggestion } = mentions.handleMentionKeyDown(event);
+      const { handled, suggestion } = mentions.handleMentionKeyDown(event, {
+        isCodeContext: () => isMentionCodeContext(richText.editor),
+      });
       if (handled) {
         if (suggestion) {
           applyMentionInsert(suggestion);
@@ -343,6 +346,7 @@ export function ForumComposer({
       channelLinks.handleChannelKeyDown,
       applyChannelInsert,
       mentions.handleMentionKeyDown,
+      richText.editor,
       applyMentionInsert,
       linkEditor.isCardOpen,
       linkEditor.focusCardFirstControl,

--- a/desktop/src/features/messages/lib/buildMentionCandidates.test.mjs
+++ b/desktop/src/features/messages/lib/buildMentionCandidates.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildMentionCandidates } from "./buildMentionCandidates.ts";
+
+const MEMBER_PUBKEY = "a".repeat(64);
+const AGENT_PUBKEY = "b".repeat(64);
+const ARCHIVED_PUBKEY = "c".repeat(64);
+const SEARCHED_PUBKEY = "d".repeat(64);
+
+function input(overrides = {}) {
+  return {
+    activeAgentPubkeys: new Set(),
+    activePersonaById: new Map(),
+    activePersonas: [],
+    canSearchGlobalUsers: false,
+    currentPubkey: null,
+    isArchived: () => false,
+    managedAgentDirectoryReady: true,
+    managedAgentNamesByPubkey: new Map(),
+    managedAgentPersonaIds: new Set(),
+    managedAgentPersonaIdsByPubkey: new Map(),
+    managedAgents: [],
+    memberPubkeys: new Set(),
+    members: [],
+    mentionableAgentPubkeys: new Set(),
+    personaNameByPubkey: new Map(),
+    profiles: undefined,
+    relayAgentDirectoryReady: true,
+    relayAgentNamesByPubkey: new Map(),
+    relayAgents: [],
+    userSearchResults: [],
+    ...overrides,
+  };
+}
+
+test("a roster entry and its relay agent record coalesce into one candidate", () => {
+  const candidates = buildMentionCandidates(
+    input({
+      members: [
+        { pubkey: AGENT_PUBKEY, displayName: null, isAgent: true, role: "bot" },
+      ],
+      mentionableAgentPubkeys: new Set([AGENT_PUBKEY]),
+      relayAgents: [
+        {
+          pubkey: AGENT_PUBKEY,
+          name: "Scout",
+          ownerPubkey: null,
+          status: "online",
+        },
+      ],
+    }),
+  );
+
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].pubkey, AGENT_PUBKEY);
+  // The roster contributes membership, the directory contributes the name.
+  assert.equal(candidates[0].isMember, true);
+  assert.equal(candidates[0].displayName, "Scout");
+  assert.equal(candidates[0].isActiveAgent, true);
+});
+
+test("archived identities never become candidates", () => {
+  const candidates = buildMentionCandidates(
+    input({
+      isArchived: (pubkey) => pubkey === ARCHIVED_PUBKEY,
+      members: [
+        { pubkey: MEMBER_PUBKEY, displayName: "Ada", isAgent: false },
+        { pubkey: ARCHIVED_PUBKEY, displayName: "Gone", isAgent: false },
+      ],
+    }),
+  );
+
+  assert.deepEqual(
+    candidates.map((candidate) => candidate.pubkey),
+    [MEMBER_PUBKEY],
+  );
+});
+
+test("an agent outside the mentionable set is hidden once its directory is ready", () => {
+  const relayAgents = [
+    { pubkey: AGENT_PUBKEY, name: "Scout", ownerPubkey: null, status: "away" },
+  ];
+
+  assert.deepEqual(buildMentionCandidates(input({ relayAgents })), []);
+  assert.equal(
+    buildMentionCandidates(
+      input({ mentionableAgentPubkeys: new Set([AGENT_PUBKEY]), relayAgents }),
+    ).length,
+    1,
+  );
+});
+
+test("active personas join unless a managed agent already carries them", () => {
+  const activePersonas = [
+    { id: "planner", displayName: "Planner", avatarUrl: null, isActive: true },
+  ];
+
+  const standalone = buildMentionCandidates(input({ activePersonas }));
+  assert.equal(standalone.length, 1);
+  assert.equal(standalone[0].kind, "persona");
+  assert.equal(standalone[0].personaId, "planner");
+
+  assert.deepEqual(
+    buildMentionCandidates(
+      input({ activePersonas, managedAgentPersonaIds: new Set(["planner"]) }),
+    ),
+    [],
+  );
+});
+
+test("global search results join only while global search is enabled", () => {
+  const userSearchResults = [
+    {
+      pubkey: SEARCHED_PUBKEY,
+      displayName: "Dana",
+      isAgent: false,
+      nip05Handle: null,
+      ownerPubkey: null,
+    },
+  ];
+
+  assert.deepEqual(buildMentionCandidates(input({ userSearchResults })), []);
+
+  const searched = buildMentionCandidates(
+    input({ canSearchGlobalUsers: true, userSearchResults }),
+  );
+  assert.equal(searched.length, 1);
+  assert.equal(searched[0].displayName, "Dana");
+  assert.equal(searched[0].isGlobalSearchResult, true);
+});

--- a/desktop/src/features/messages/lib/buildMentionCandidates.ts
+++ b/desktop/src/features/messages/lib/buildMentionCandidates.ts
@@ -1,0 +1,240 @@
+import {
+  coalesceAgentAutocompleteCandidates,
+  coalesceAutocompleteCandidatesByKey,
+  shouldHideAgentFromMentions,
+} from "@/features/agents/lib/agentAutocompleteEligibility";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import type {
+  AgentPersona,
+  ChannelMember,
+  ManagedAgent,
+  RelayAgent,
+  UserSearchResult,
+} from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import {
+  formatSearchUserDisplayName,
+  formatSearchUserSecondaryLabel,
+  globalSearchIdentityKey,
+  type MentionCandidate,
+  mentionCandidateLabel,
+} from "./mentionCandidates";
+
+/** Directories and rosters the mention picker merges into one candidate list. */
+export type BuildMentionCandidatesInput = {
+  activeAgentPubkeys: ReadonlySet<string>;
+  activePersonaById: ReadonlyMap<string, AgentPersona>;
+  /** Already narrowed to `isActive` personas. */
+  activePersonas: readonly AgentPersona[];
+  canSearchGlobalUsers: boolean;
+  currentPubkey: string | null;
+  isArchived: (pubkey: string) => boolean;
+  managedAgentDirectoryReady: boolean;
+  managedAgentNamesByPubkey: ReadonlyMap<string, string>;
+  managedAgentPersonaIds: ReadonlySet<string>;
+  managedAgentPersonaIdsByPubkey: ReadonlyMap<string, string>;
+  managedAgents: readonly ManagedAgent[] | undefined;
+  memberPubkeys: ReadonlySet<string>;
+  members: readonly ChannelMember[] | undefined;
+  mentionableAgentPubkeys: ReadonlySet<string>;
+  personaNameByPubkey: ReadonlyMap<string, string>;
+  profiles: UserProfileLookup | undefined;
+  relayAgentDirectoryReady: boolean;
+  relayAgentNamesByPubkey: ReadonlyMap<string, string>;
+  relayAgents: readonly RelayAgent[] | undefined;
+  userSearchResults: readonly UserSearchResult[];
+};
+
+/**
+ * Merge the channel roster, agent directories, global people search, and
+ * standalone personas into the deduplicated candidate list the mention
+ * autocomplete ranks. Archived identities and agents the viewer may not
+ * mention are dropped; identities appearing in several sources are coalesced
+ * into a single entry that keeps the richest field from each.
+ */
+export function buildMentionCandidates({
+  activeAgentPubkeys,
+  activePersonaById,
+  activePersonas,
+  canSearchGlobalUsers,
+  currentPubkey,
+  isArchived,
+  managedAgentDirectoryReady,
+  managedAgentNamesByPubkey,
+  managedAgentPersonaIds,
+  managedAgentPersonaIdsByPubkey,
+  managedAgents,
+  memberPubkeys,
+  members,
+  mentionableAgentPubkeys,
+  personaNameByPubkey,
+  profiles,
+  relayAgentDirectoryReady,
+  relayAgentNamesByPubkey,
+  relayAgents,
+  userSearchResults,
+}: BuildMentionCandidatesInput): MentionCandidate[] {
+  const candidatesByPubkey = new Map<string, MentionCandidate>();
+  const addCandidate = (candidate: MentionCandidate & { pubkey: string }) => {
+    const pubkey = normalizePubkey(candidate.pubkey);
+    if (isArchived(pubkey)) {
+      return;
+    }
+    if (
+      shouldHideAgentFromMentions({
+        isAgent: candidate.isAgent === true,
+        pubkey,
+        mentionableAgentPubkeys,
+        directoryReady:
+          candidate.isManagedAgent === true
+            ? managedAgentDirectoryReady
+            : relayAgentDirectoryReady,
+      })
+    ) {
+      return;
+    }
+    const current = candidatesByPubkey.get(pubkey);
+    if (!current) {
+      candidatesByPubkey.set(pubkey, { ...candidate, pubkey });
+      return;
+    }
+    candidatesByPubkey.set(pubkey, {
+      ...current,
+      avatarUrl: current.avatarUrl ?? candidate.avatarUrl ?? null,
+      displayName:
+        current.isAgent && !candidate.isAgent
+          ? current.displayName
+          : candidate.isAgent && !current.isAgent
+            ? (candidate.displayName ?? current.displayName)
+            : (current.displayName ?? candidate.displayName),
+      isAgent: current.isAgent || candidate.isAgent,
+      isActiveAgent: current.isActiveAgent || candidate.isActiveAgent,
+      isMember: current.isMember || candidate.isMember,
+      personaId: current.personaId ?? candidate.personaId,
+      personaName: current.personaName ?? candidate.personaName ?? null,
+      role: current.role ?? candidate.role ?? null,
+      secondaryLabel:
+        current.secondaryLabel ?? candidate.secondaryLabel ?? null,
+      ownerPubkey:
+        current.ownerPubkey ??
+        candidate.ownerPubkey ??
+        (candidate.isAgent && candidate.pubkey
+          ? profiles?.[pubkey]?.ownerPubkey
+          : null) ??
+        null,
+      isManagedAgent: current.isManagedAgent || candidate.isManagedAgent,
+    });
+  };
+  for (const member of members ?? []) {
+    const pubkey = normalizePubkey(member.pubkey);
+    const linkedPersonaId = activePersonaById.has(pubkey) ? pubkey : undefined;
+    const agentName =
+      managedAgentNamesByPubkey.get(pubkey) ??
+      relayAgentNamesByPubkey.get(pubkey) ??
+      null;
+    const profile = profiles?.[pubkey] ?? null;
+    addCandidate({
+      kind: "identity",
+      pubkey,
+      displayName:
+        member.displayName?.trim() ||
+        agentName ||
+        profile?.displayName?.trim() ||
+        profile?.nip05Handle?.trim() ||
+        null,
+      avatarUrl: profile?.avatarUrl ?? null,
+      isMember: true,
+      personaId: managedAgentPersonaIdsByPubkey.get(pubkey) ?? linkedPersonaId,
+      isAgent:
+        member.isAgent === true ||
+        profile?.isAgent === true ||
+        member.role === "bot" ||
+        managedAgentNamesByPubkey.has(pubkey) ||
+        relayAgentNamesByPubkey.has(pubkey),
+      isActiveAgent: activeAgentPubkeys.has(pubkey),
+      ownerPubkey: profile?.ownerPubkey ?? null,
+      personaName: personaNameByPubkey.get(pubkey) ?? null,
+      role: member.role,
+      secondaryLabel:
+        profile?.displayName?.trim() && profile?.nip05Handle?.trim()
+          ? profile.nip05Handle
+          : null,
+    });
+  }
+  for (const agent of relayAgents ?? []) {
+    const pubkey = normalizePubkey(agent.pubkey);
+    addCandidate({
+      kind: "identity",
+      pubkey,
+      displayName: agent.name,
+      isMember: false,
+      personaId:
+        managedAgentPersonaIdsByPubkey.get(pubkey) ??
+        (activePersonaById.has(pubkey) ? pubkey : undefined),
+      ownerPubkey: agent.ownerPubkey,
+      isAgent: true,
+      isActiveAgent: agent.status !== "offline",
+    });
+  }
+  for (const agent of managedAgents ?? []) {
+    addCandidate({
+      kind: "identity",
+      pubkey: agent.pubkey,
+      displayName: agent.name,
+      isMember: false,
+      isAgent: true,
+      isActiveAgent: agent.status === "running" || agent.status === "deployed",
+      isManagedAgent: true,
+      personaId: agent.personaId ?? undefined,
+      personaName:
+        personaNameByPubkey.get(normalizePubkey(agent.pubkey)) ?? null,
+      ownerPubkey: currentPubkey,
+    });
+  }
+  if (canSearchGlobalUsers) {
+    for (const user of userSearchResults) {
+      const pubkey = normalizePubkey(user.pubkey);
+      addCandidate({
+        kind: "identity",
+        pubkey,
+        displayName: formatSearchUserDisplayName(user),
+        avatarUrl: user.avatarUrl ?? null,
+        personaId:
+          managedAgentPersonaIdsByPubkey.get(pubkey) ??
+          (activePersonaById.has(pubkey) ? pubkey : undefined),
+        isMember: false,
+        isAgent:
+          user.isAgent ||
+          managedAgentNamesByPubkey.has(pubkey) ||
+          relayAgentNamesByPubkey.has(pubkey),
+        personaName: personaNameByPubkey.get(pubkey) ?? null,
+        secondaryLabel: formatSearchUserSecondaryLabel(user),
+        ownerPubkey: user.ownerPubkey ?? null,
+        isGlobalSearchResult: true,
+        isManagedAgent: managedAgentNamesByPubkey.has(pubkey),
+      });
+    }
+  }
+  const personaCandidates: MentionCandidate[] = activePersonas
+    .filter((persona) => !managedAgentPersonaIds.has(persona.id))
+    .map((persona) => ({
+      kind: "persona" as const,
+      personaId: persona.id,
+      displayName: persona.displayName,
+      avatarUrl: persona.avatarUrl,
+      isMember: false,
+      isAgent: true,
+    }))
+    .filter((candidate) => candidate.displayName.trim().length > 0);
+  return coalesceAgentAutocompleteCandidates(
+    coalesceAutocompleteCandidatesByKey(
+      [...candidatesByPubkey.values(), ...personaCandidates],
+      globalSearchIdentityKey,
+    ),
+    {
+      currentPubkey,
+      getLabel: mentionCandidateLabel,
+      preferredPubkeys: memberPubkeys,
+    },
+  );
+}

--- a/desktop/src/features/messages/lib/flushMentionDebounce.test.mjs
+++ b/desktop/src/features/messages/lib/flushMentionDebounce.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { flushMentionDebounce } from "./flushMentionDebounce.ts";
+import { flushMentionDebounce, isPlainSpace } from "./flushMentionDebounce.ts";
 
 function ref(current) {
   return { current };
@@ -17,6 +17,20 @@ function candidate(overrides = {}) {
     ...overrides,
   };
 }
+
+test("isPlainSpace accepts only an unmodified Space outside composition", () => {
+  const event = {
+    altKey: false,
+    ctrlKey: false,
+    isComposing: false,
+    key: " ",
+    metaKey: false,
+  };
+  assert.equal(isPlainSpace(event), true);
+  assert.equal(isPlainSpace({ ...event, ctrlKey: true }), false);
+  assert.equal(isPlainSpace({ ...event, isComposing: true }), false);
+  assert.equal(isPlainSpace({ ...event, key: "Enter" }), false);
+});
 
 test("flushMentionDebounce returns the fresh suggestion with its fresh start index", () => {
   const debounceTimerRef = ref(setTimeout(() => {}, 1000));
@@ -69,6 +83,106 @@ test("flushMentionDebounce returns null for an empty fresh query", () => {
   });
 
   assert.equal(flushed, null);
+});
+
+test("flushMentionDebounce resolves an exact typed mention for Space", () => {
+  const flushed = flushMentionDebounce({
+    debounceTimerRef: ref(null),
+    latestValueRef: ref("Ask @Beta"),
+    latestCursorRef: ref("Ask @Beta".length),
+    searchableNamesLowerRef: ref(["beta"]),
+    candidates: [candidate()],
+    activePersonaIds: new Set(),
+    agentProvenanceReady: true,
+    channelType: "group",
+    requireExact: true,
+  });
+
+  assert.equal(flushed?.type, "match");
+  assert.equal(flushed?.suggestion.displayName, "Beta");
+  assert.equal(flushed?.startIndex, 4);
+});
+
+test("flushMentionDebounce does not complete a partial name for Space", () => {
+  const flushed = flushMentionDebounce({
+    debounceTimerRef: ref(null),
+    latestValueRef: ref("Ask @Bet"),
+    latestCursorRef: ref("Ask @Bet".length),
+    searchableNamesLowerRef: ref(["beta"]),
+    candidates: [candidate()],
+    activePersonaIds: new Set(),
+    agentProvenanceReady: true,
+    channelType: "group",
+    requireExact: true,
+  });
+
+  assert.equal(flushed, null);
+});
+
+test("flushMentionDebounce leaves an exact prefix open for a longer name", () => {
+  const flushed = flushMentionDebounce({
+    debounceTimerRef: ref(null),
+    latestValueRef: ref("Ask @Beta"),
+    latestCursorRef: ref("Ask @Beta".length),
+    searchableNamesLowerRef: ref(["beta", "beta tester"]),
+    candidates: [
+      candidate(),
+      candidate({
+        displayName: "Beta Tester",
+        pubkey: "c".repeat(64),
+      }),
+    ],
+    activePersonaIds: new Set(),
+    agentProvenanceReady: true,
+    channelType: "group",
+    requireExact: true,
+  });
+
+  assert.equal(flushed, null);
+});
+
+test("flushMentionDebounce resolves the complete longer name", () => {
+  const flushed = flushMentionDebounce({
+    debounceTimerRef: ref(null),
+    latestValueRef: ref("Ask @Beta Tester"),
+    latestCursorRef: ref("Ask @Beta Tester".length),
+    searchableNamesLowerRef: ref(["beta", "beta tester"]),
+    candidates: [
+      candidate(),
+      candidate({
+        displayName: "Beta Tester",
+        pubkey: "c".repeat(64),
+      }),
+    ],
+    activePersonaIds: new Set(),
+    agentProvenanceReady: true,
+    channelType: "group",
+    requireExact: true,
+  });
+
+  assert.equal(flushed?.type, "match");
+  assert.equal(flushed?.suggestion.displayName, "Beta Tester");
+});
+
+test("flushMentionDebounce prefers an exact channel member with a duplicate name", () => {
+  const memberPubkey = "a".repeat(64);
+  const flushed = flushMentionDebounce({
+    debounceTimerRef: ref(null),
+    latestValueRef: ref("@Beta"),
+    latestCursorRef: ref("@Beta".length),
+    searchableNamesLowerRef: ref(["beta"]),
+    candidates: [
+      candidate({ isMember: false }),
+      candidate({ pubkey: memberPubkey }),
+    ],
+    activePersonaIds: new Set(),
+    agentProvenanceReady: true,
+    channelType: "group",
+    requireExact: true,
+  });
+
+  assert.equal(flushed?.type, "match");
+  assert.equal(flushed?.suggestion.pubkey, memberPubkey);
 });
 
 test("flushMentionDebounce preserves a team expansion selected with Enter", () => {

--- a/desktop/src/features/messages/lib/flushMentionDebounce.test.mjs
+++ b/desktop/src/features/messages/lib/flushMentionDebounce.test.mjs
@@ -25,9 +25,11 @@ test("isPlainSpace accepts only an unmodified Space outside composition", () => 
     isComposing: false,
     key: " ",
     metaKey: false,
+    shiftKey: false,
   };
   assert.equal(isPlainSpace(event), true);
   assert.equal(isPlainSpace({ ...event, ctrlKey: true }), false);
+  assert.equal(isPlainSpace({ ...event, shiftKey: true }), false);
   assert.equal(isPlainSpace({ ...event, isComposing: true }), false);
   assert.equal(isPlainSpace({ ...event, key: "Enter" }), false);
 });

--- a/desktop/src/features/messages/lib/flushMentionDebounce.test.mjs
+++ b/desktop/src/features/messages/lib/flushMentionDebounce.test.mjs
@@ -105,6 +105,25 @@ test("flushMentionDebounce resolves an exact typed mention for Space", () => {
   assert.equal(flushed?.startIndex, 4);
 });
 
+test("flushMentionDebounce resolves an exact typed mention in any case", () => {
+  const flushed = flushMentionDebounce({
+    debounceTimerRef: ref(null),
+    latestValueRef: ref("Ask @BETA"),
+    latestCursorRef: ref("Ask @BETA".length),
+    searchableNamesLowerRef: ref(["beta"]),
+    candidates: [candidate()],
+    activePersonaIds: new Set(),
+    agentProvenanceReady: true,
+    channelType: "group",
+    requireExact: true,
+  });
+
+  // Casing is what tells a committed mention apart from literal text: the
+  // commit rewrites the draft to the candidate's canonical display name.
+  assert.equal(flushed?.type, "match");
+  assert.equal(flushed?.suggestion.displayName, "Beta");
+});
+
 test("flushMentionDebounce does not complete a partial name for Space", () => {
   const flushed = flushMentionDebounce({
     debounceTimerRef: ref(null),

--- a/desktop/src/features/messages/lib/flushMentionDebounce.ts
+++ b/desktop/src/features/messages/lib/flushMentionDebounce.ts
@@ -26,12 +26,12 @@ export type FlushMentionDebounceResult =
 export function isPlainSpace(
   event: Pick<
     KeyboardEvent,
-    "altKey" | "ctrlKey" | "isComposing" | "key" | "metaKey"
+    "altKey" | "ctrlKey" | "isComposing" | "key" | "metaKey" | "shiftKey"
   >,
 ): boolean {
   return (
     event.key === " " &&
-    !(event.metaKey || event.ctrlKey || event.altKey) &&
+    !(event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) &&
     !event.isComposing
   );
 }

--- a/desktop/src/features/messages/lib/flushMentionDebounce.ts
+++ b/desktop/src/features/messages/lib/flushMentionDebounce.ts
@@ -23,6 +23,19 @@ export type FlushMentionDebounceResult =
   | { type: "match"; suggestion: MentionSuggestion; startIndex: number }
   | { type: "no-match" };
 
+export function isPlainSpace(
+  event: Pick<
+    KeyboardEvent,
+    "altKey" | "ctrlKey" | "isComposing" | "key" | "metaKey"
+  >,
+): boolean {
+  return (
+    event.key === " " &&
+    !(event.metaKey || event.ctrlKey || event.altKey) &&
+    !event.isComposing
+  );
+}
+
 /**
  * Cancel the pending debounce timer, re-detect the prefix query from the
  * latest editor state, rank candidates, and return the top suggestion — or
@@ -42,6 +55,7 @@ export function flushMentionDebounce<T extends MentionCandidateWithUI>(opts: {
   currentPubkey?: string | null;
   ownerProfiles?: UserProfileLookup;
   profiles?: UserProfileLookup;
+  requireExact?: boolean;
 }): FlushMentionDebounceResult | null {
   if (opts.debounceTimerRef.current !== null) {
     clearTimeout(opts.debounceTimerRef.current);
@@ -66,10 +80,21 @@ export function flushMentionDebounce<T extends MentionCandidateWithUI>(opts: {
   );
 
   if (ranked.length === 0) {
-    return { type: "no-match" };
+    return opts.requireExact ? null : { type: "no-match" };
   }
 
-  const { candidate, label } = ranked[0];
+  const normalizedQuery = mention.query.trim().toLowerCase();
+  const exactMatch = opts.requireExact
+    ? ranked.find(({ label }) => label.trim().toLowerCase() === normalizedQuery)
+    : ranked[0];
+  const couldBeLongerName = opts.searchableNamesLowerRef.current.some((name) =>
+    name.trim().toLowerCase().startsWith(`${normalizedQuery} `),
+  );
+  if (!exactMatch || (opts.requireExact && couldBeLongerName)) {
+    return null;
+  }
+
+  const { candidate, label } = exactMatch;
   return {
     type: "match",
     suggestion: mapMentionCandidateToSuggestion({

--- a/desktop/src/features/messages/lib/mentionCodeContext.test.mjs
+++ b/desktop/src/features/messages/lib/mentionCodeContext.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isMentionCodeContext } from "./mentionCodeContext.ts";
+
+function textNode(...markNames) {
+  return { marks: markNames.map((name) => ({ type: { name } })) };
+}
+
+function editor({ active = [], nodeBefore = null, empty = true } = {}) {
+  return {
+    isActive: (name) => active.includes(name),
+    state: { selection: { $from: { nodeBefore }, empty } },
+  };
+}
+
+test("isMentionCodeContext is false for prose", () => {
+  assert.equal(isMentionCodeContext(editor({ nodeBefore: textNode() })), false);
+});
+
+test("isMentionCodeContext is false without an editor", () => {
+  assert.equal(isMentionCodeContext(null), false);
+  assert.equal(isMentionCodeContext(undefined), false);
+});
+
+test("isMentionCodeContext detects a fenced code block", () => {
+  assert.equal(isMentionCodeContext(editor({ active: ["codeBlock"] })), true);
+});
+
+test("isMentionCodeContext detects an inline code span", () => {
+  assert.equal(isMentionCodeContext(editor({ active: ["code"] })), true);
+});
+
+test("isMentionCodeContext detects a just-closed inline code span", () => {
+  // The closing backtick clears the stored mark, so only the text before the
+  // caret still reports the code mark.
+  assert.equal(
+    isMentionCodeContext(editor({ nodeBefore: textNode("code") })),
+    true,
+  );
+});
+
+test("isMentionCodeContext ignores a code span left behind earlier", () => {
+  assert.equal(
+    isMentionCodeContext(editor({ nodeBefore: textNode("italic") })),
+    false,
+  );
+});
+
+test("isMentionCodeContext ignores the text before a non-empty selection", () => {
+  assert.equal(
+    isMentionCodeContext(
+      editor({ nodeBefore: textNode("code"), empty: false }),
+    ),
+    false,
+  );
+});

--- a/desktop/src/features/messages/lib/mentionCodeContext.ts
+++ b/desktop/src/features/messages/lib/mentionCodeContext.ts
@@ -1,0 +1,33 @@
+/**
+ * Guard that keeps mention resolution out of code.
+ *
+ * Mention detection reads a plain-text projection of the document, where
+ * fences and backticks are already gone — so `@Name` inside code looks
+ * exactly like `@Name` in prose. Committing a mention there would swallow
+ * the keystroke and rewrite the code text to the canonical display name,
+ * so the composer asks this guard before treating Space as a commit.
+ */
+import type { Editor } from "@tiptap/react";
+
+/** The editor surface this guard reads — narrow so tests can stub it. */
+type CodeContextEditor = Pick<Editor, "isActive" | "state">;
+
+/**
+ * True when the mention being typed lives inside a fenced code block or an
+ * inline code span.
+ */
+export function isMentionCodeContext(
+  editor: CodeContextEditor | null | undefined,
+): boolean {
+  if (!editor) return false;
+  if (editor.isActive("codeBlock") || editor.isActive("code")) return true;
+  // A closing backtick converts the span to a code mark and clears the
+  // stored mark, so `isActive("code")` already reads false with the caret
+  // parked right after the span it just created. The typed mention is still
+  // inside that span, so inspect the text immediately before the caret.
+  const { $from, empty } = editor.state.selection;
+  if (!empty) return false;
+  return (
+    $from.nodeBefore?.marks.some((mark) => mark.type.name === "code") ?? false
+  );
+}

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -39,7 +39,7 @@ import { channelMemberPubkeySet } from "@/shared/lib/rosterDerivations";
 import { trimMapToSize } from "@/shared/lib/trimMapToSize";
 import { useActiveAgentPubkeys } from "./useActiveAgentPubkeys";
 import { useDefaultAgentSuggestion } from "./useDefaultAgentSuggestion";
-import { flushMentionDebounce } from "./flushMentionDebounce";
+import { flushMentionDebounce, isPlainSpace } from "./flushMentionDebounce";
 import { useAgentMentionRevalidation } from "./agentMentionRevalidation";
 import { extractMentionPubkeys } from "./extractMentionPubkeys";
 import {
@@ -507,9 +507,7 @@ export function useMentions(
   const latestCursorRef = React.useRef<number>(0);
   const flushedMentionStartIndexRef = React.useRef<number | null>(null);
   const searchableNamesLowerRef = React.useRef<string[]>(searchableNamesLower);
-  React.useEffect(() => {
-    searchableNamesLowerRef.current = searchableNamesLower;
-  }, [searchableNamesLower]);
+  searchableNamesLowerRef.current = searchableNamesLower;
   React.useEffect(
     () => () => {
       if (debounceTimerRef.current !== null) {
@@ -885,9 +883,8 @@ export function useMentions(
     (
       event: React.KeyboardEvent,
     ): { handled: boolean; suggestion?: MentionSuggestion } => {
-      if (!isMentionOpen) {
-        return { handled: false };
-      }
+      const exactMentionSpace = isPlainSpace(event.nativeEvent);
+      if (!isMentionOpen && !exactMentionSpace) return { handled: false };
       if (event.key === "ArrowDown") {
         event.preventDefault();
         setSelected((current) =>
@@ -903,6 +900,7 @@ export function useMentions(
         return { handled: true };
       }
       if (
+        exactMentionSpace ||
         event.key === "Tab" ||
         (event.key === "Enter" &&
           !event.ctrlKey &&
@@ -910,8 +908,7 @@ export function useMentions(
           !event.altKey &&
           !event.shiftKey)
       ) {
-        event.preventDefault();
-        if (debounceTimerRef.current !== null) {
+        if (debounceTimerRef.current !== null || exactMentionSpace) {
           const flushed = flushMentionDebounce({
             debounceTimerRef,
             latestValueRef,
@@ -924,7 +921,11 @@ export function useMentions(
             currentPubkey,
             ownerProfiles: ownerProfilesQuery.data?.profiles,
             profiles,
+            requireExact: exactMentionSpace,
           });
+          if (exactMentionSpace && flushed?.type !== "match")
+            return { handled: false };
+          event.preventDefault();
           if (flushed?.type === "match") {
             flushedMentionStartIndexRef.current = flushed.startIndex;
             mentionPickerOriginRef.current = "inline";
@@ -936,6 +937,7 @@ export function useMentions(
             return { handled: true };
           }
         }
+        event.preventDefault();
         return { handled: true, suggestion: suggestions[mentionSelectedIndex] };
       }
       if (event.key === "Escape") {

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -12,8 +12,6 @@ import {
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import type { MentionSuggestion } from "@/features/messages/ui/MentionAutocomplete";
 import {
-  coalesceAgentAutocompleteCandidates,
-  coalesceAutocompleteCandidatesByKey,
   filterAdmittedMentionPubkeys,
   filterCachedAgentSuggestions,
   getAdmittedAgentPubkeys,
@@ -22,7 +20,6 @@ import {
   getSharedChannelIds,
   isAgentMentionChannelType,
   rememberSelectedAgentPubkeys,
-  shouldHideAgentFromMentions,
   uniqueAutocompleteLabels,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -56,13 +53,10 @@ import { mapMentionCandidateToSuggestion } from "./mentionSuggestionMapping";
 import {
   appendUniqueName,
   buildTeamMentionCandidates,
-  formatSearchUserDisplayName,
-  formatSearchUserSecondaryLabel,
   formatTeamMention,
-  globalSearchIdentityKey,
   type MentionCandidate,
-  mentionCandidateLabel,
 } from "./mentionCandidates";
+import { buildMentionCandidates } from "./buildMentionCandidates";
 const MENTION_DEBOUNCE_MS = 120,
   MENTION_SUGGESTION_LIMIT = 50;
 type UseMentionsOptions = {
@@ -250,196 +244,53 @@ export function useMentions(
       }),
     [managedAgentPubkeys, members, profiles, relayAgentsQuery.data],
   );
-  const mentionCandidates = React.useMemo<MentionCandidate[]>(() => {
-    const candidatesByPubkey = new Map<string, MentionCandidate>();
-    const addCandidate = (candidate: MentionCandidate & { pubkey: string }) => {
-      const pubkey = normalizePubkey(candidate.pubkey);
-      if (isArchivedDiscovery(pubkey)) {
-        return;
-      }
-      if (
-        shouldHideAgentFromMentions({
-          isAgent: candidate.isAgent === true,
-          pubkey,
-          mentionableAgentPubkeys,
-          directoryReady:
-            candidate.isManagedAgent === true
-              ? managedAgentDirectoryReady
-              : relayAgentDirectoryReady,
-        })
-      ) {
-        return;
-      }
-      const current = candidatesByPubkey.get(pubkey);
-      if (!current) {
-        candidatesByPubkey.set(pubkey, { ...candidate, pubkey });
-        return;
-      }
-      candidatesByPubkey.set(pubkey, {
-        ...current,
-        avatarUrl: current.avatarUrl ?? candidate.avatarUrl ?? null,
-        displayName:
-          current.isAgent && !candidate.isAgent
-            ? current.displayName
-            : candidate.isAgent && !current.isAgent
-              ? (candidate.displayName ?? current.displayName)
-              : (current.displayName ?? candidate.displayName),
-        isAgent: current.isAgent || candidate.isAgent,
-        isActiveAgent: current.isActiveAgent || candidate.isActiveAgent,
-        isMember: current.isMember || candidate.isMember,
-        personaId: current.personaId ?? candidate.personaId,
-        personaName: current.personaName ?? candidate.personaName ?? null,
-        role: current.role ?? candidate.role ?? null,
-        secondaryLabel:
-          current.secondaryLabel ?? candidate.secondaryLabel ?? null,
-        ownerPubkey:
-          current.ownerPubkey ??
-          candidate.ownerPubkey ??
-          (candidate.isAgent && candidate.pubkey
-            ? profiles?.[pubkey]?.ownerPubkey
-            : null) ??
-          null,
-        isManagedAgent: current.isManagedAgent || candidate.isManagedAgent,
-      });
-    };
-    for (const member of members ?? []) {
-      const pubkey = normalizePubkey(member.pubkey);
-      const linkedPersonaId = activePersonaById.has(pubkey)
-        ? pubkey
-        : undefined;
-      const agentName =
-        managedAgentNamesByPubkey.get(pubkey) ??
-        relayAgentNamesByPubkey.get(pubkey) ??
-        null;
-      const profile = profiles?.[pubkey] ?? null;
-      addCandidate({
-        kind: "identity",
-        pubkey,
-        displayName:
-          member.displayName?.trim() ||
-          agentName ||
-          profile?.displayName?.trim() ||
-          profile?.nip05Handle?.trim() ||
-          null,
-        avatarUrl: profile?.avatarUrl ?? null,
-        isMember: true,
-        personaId:
-          managedAgentPersonaIdsByPubkey.get(pubkey) ?? linkedPersonaId,
-        isAgent:
-          member.isAgent === true ||
-          profile?.isAgent === true ||
-          member.role === "bot" ||
-          managedAgentNamesByPubkey.has(pubkey) ||
-          relayAgentNamesByPubkey.has(pubkey),
-        isActiveAgent: activeAgentPubkeys.has(pubkey),
-        ownerPubkey: profile?.ownerPubkey ?? null,
-        personaName: personaNameByPubkey.get(pubkey) ?? null,
-        role: member.role,
-        secondaryLabel:
-          profile?.displayName?.trim() && profile?.nip05Handle?.trim()
-            ? profile.nip05Handle
-            : null,
-      });
-    }
-    for (const agent of relayAgentsQuery.data ?? []) {
-      const pubkey = normalizePubkey(agent.pubkey);
-      addCandidate({
-        kind: "identity",
-        pubkey,
-        displayName: agent.name,
-        isMember: false,
-        personaId:
-          managedAgentPersonaIdsByPubkey.get(pubkey) ??
-          (activePersonaById.has(pubkey) ? pubkey : undefined),
-        ownerPubkey: agent.ownerPubkey,
-        isAgent: true,
-        isActiveAgent: agent.status !== "offline",
-      });
-    }
-    for (const agent of managedAgentsQuery.data ?? []) {
-      addCandidate({
-        kind: "identity",
-        pubkey: agent.pubkey,
-        displayName: agent.name,
-        isMember: false,
-        isAgent: true,
-        isActiveAgent:
-          agent.status === "running" || agent.status === "deployed",
-        isManagedAgent: true,
-        personaId: agent.personaId ?? undefined,
-        personaName:
-          personaNameByPubkey.get(normalizePubkey(agent.pubkey)) ?? null,
-        ownerPubkey: currentPubkey,
-      });
-    }
-    if (canSearchGlobalUsers) {
-      for (const user of userSearchResults) {
-        const pubkey = normalizePubkey(user.pubkey);
-        addCandidate({
-          kind: "identity",
-          pubkey,
-          displayName: formatSearchUserDisplayName(user),
-          avatarUrl: user.avatarUrl ?? null,
-          personaId:
-            managedAgentPersonaIdsByPubkey.get(pubkey) ??
-            (activePersonaById.has(pubkey) ? pubkey : undefined),
-          isMember: false,
-          isAgent:
-            user.isAgent ||
-            managedAgentNamesByPubkey.has(pubkey) ||
-            relayAgentNamesByPubkey.has(pubkey),
-          personaName: personaNameByPubkey.get(pubkey) ?? null,
-          secondaryLabel: formatSearchUserSecondaryLabel(user),
-          ownerPubkey: user.ownerPubkey ?? null,
-          isGlobalSearchResult: true,
-          isManagedAgent: managedAgentNamesByPubkey.has(pubkey),
-        });
-      }
-    }
-    const personaCandidates: MentionCandidate[] = activePersonas
-      .filter((persona) => !managedAgentPersonaIds.has(persona.id))
-      .map((persona) => ({
-        kind: "persona" as const,
-        personaId: persona.id,
-        displayName: persona.displayName,
-        avatarUrl: persona.avatarUrl,
-        isMember: false,
-        isAgent: true,
-      }))
-      .filter((candidate) => candidate.displayName.trim().length > 0);
-    return coalesceAgentAutocompleteCandidates(
-      coalesceAutocompleteCandidatesByKey(
-        [...candidatesByPubkey.values(), ...personaCandidates],
-        globalSearchIdentityKey,
-      ),
-      {
+  const mentionCandidates = React.useMemo<MentionCandidate[]>(
+    () =>
+      buildMentionCandidates({
+        activeAgentPubkeys,
+        activePersonaById,
+        activePersonas,
+        canSearchGlobalUsers,
         currentPubkey,
-        getLabel: mentionCandidateLabel,
-        preferredPubkeys: memberPubkeys,
-      },
-    );
-  }, [
-    activePersonaById,
-    activeAgentPubkeys,
-    activePersonas,
-    userSearchResults,
-    canSearchGlobalUsers,
-    currentPubkey,
-    isArchivedDiscovery,
-    managedAgentDirectoryReady,
-    managedAgentNamesByPubkey,
-    managedAgentPersonaIds,
-    managedAgentPersonaIdsByPubkey,
-    managedAgentsQuery.data,
-    memberPubkeys,
-    members,
-    mentionableAgentPubkeys,
-    personaNameByPubkey,
-    profiles,
-    relayAgentDirectoryReady,
-    relayAgentNamesByPubkey,
-    relayAgentsQuery.data,
-  ]);
+        isArchived: isArchivedDiscovery,
+        managedAgentDirectoryReady,
+        managedAgentNamesByPubkey,
+        managedAgentPersonaIds,
+        managedAgentPersonaIdsByPubkey,
+        managedAgents: managedAgentsQuery.data,
+        memberPubkeys,
+        members,
+        mentionableAgentPubkeys,
+        personaNameByPubkey,
+        profiles,
+        relayAgentDirectoryReady,
+        relayAgentNamesByPubkey,
+        relayAgents: relayAgentsQuery.data,
+        userSearchResults,
+      }),
+    [
+      activePersonaById,
+      activeAgentPubkeys,
+      activePersonas,
+      userSearchResults,
+      canSearchGlobalUsers,
+      currentPubkey,
+      isArchivedDiscovery,
+      managedAgentDirectoryReady,
+      managedAgentNamesByPubkey,
+      managedAgentPersonaIds,
+      managedAgentPersonaIdsByPubkey,
+      managedAgentsQuery.data,
+      memberPubkeys,
+      members,
+      mentionableAgentPubkeys,
+      personaNameByPubkey,
+      profiles,
+      relayAgentDirectoryReady,
+      relayAgentNamesByPubkey,
+      relayAgentsQuery.data,
+    ],
+  );
   const admittedAgentPubkeys = React.useMemo(
     () => getAdmittedAgentPubkeys(mentionCandidates),
     [mentionCandidates],

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -882,8 +882,12 @@ export function useMentions(
   const handleMentionKeyDown = React.useCallback(
     (
       event: React.KeyboardEvent,
+      // `isCodeContext` is only consulted for Space: inside code the typed
+      // text must stay literal, so Space is left to the editor.
+      opts?: { isCodeContext?: () => boolean },
     ): { handled: boolean; suggestion?: MentionSuggestion } => {
-      const exactMentionSpace = isPlainSpace(event.nativeEvent);
+      const exactMentionSpace =
+        isPlainSpace(event.nativeEvent) && !opts?.isCodeContext?.();
       if (!isMentionOpen && !exactMentionSpace) return { handled: false };
       if (event.key === "ArrowDown") {
         event.preventDefault();

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -18,7 +18,6 @@ import {
   restoreImetaMediaDisplayLabels,
   stripImetaMediaLines,
 } from "@/features/messages/lib/imetaMediaMarkdown";
-import { useAttachmentEditing } from "@/features/messages/lib/useAttachmentEditing";
 import { useMediaUpload } from "@/features/messages/lib/useMediaUpload";
 import {
   cancelBackgroundMediaUploads,
@@ -61,6 +60,7 @@ import { useAddressMentionPulse } from "./useAddressMentionPulse";
 import { useAlwaysAddressShortcut } from "./useAlwaysAddressShortcut";
 import { useComposerMentionPicker } from "./useComposerMentionPicker";
 import { useAutoPinMentionedAgents } from "./useAutoPinMentionedAgents";
+import { useComposerAttachmentSpoilers } from "./useComposerAttachmentSpoilers";
 import { useComposerContentState } from "./useComposerContentState";
 import { useComposerPasteHandler } from "./useComposerPasteHandler";
 import { useDraftPersistLifecycle } from "./useDraftPersistSnapshot";
@@ -118,11 +118,6 @@ function MessageComposerImpl({
   } = useComposerLinkPreviews(previewContent, editTarget == null);
   const [isEmojiPickerOpen, setIsEmojiPickerOpen] = React.useState(false);
   const [isFormattingOpen, setIsFormattingOpen] = React.useState(false);
-  const [spoileredAttachmentUrls, setSpoileredAttachmentUrls] = React.useState<
-    Set<string>
-  >(() => new Set());
-  const spoileredAttachmentUrlsRef = React.useRef(spoileredAttachmentUrls);
-  spoileredAttachmentUrlsRef.current = spoileredAttachmentUrls;
   const handleFormattingToggle = React.useCallback((pressed: boolean) => {
     if (pressed) setIsEmojiPickerOpen(false);
     setIsFormattingOpen(pressed);
@@ -160,6 +155,19 @@ function MessageComposerImpl({
   );
   const internalMedia = useMediaUpload({ deferUploadsUntilSend: true });
   const media = mediaController ?? internalMedia;
+  const {
+    handleAttachmentEditSave,
+    handleAttachmentRevert,
+    handleRemoveAttachment,
+    handleToggleAttachmentSpoiler,
+    setSpoileredAttachmentUrls,
+    spoileredAttachmentUrls,
+    spoileredAttachmentUrlsRef,
+  } = useComposerAttachmentSpoilers({
+    removeAttachment: media.removeAttachment,
+    revertAttachment: media.revertAttachment,
+    uploadEditedAttachment: media.uploadEditedAttachment,
+  });
   const [isDeferredEditPending, setDeferredEditPending] = React.useState(false);
   const composerDisabled = disabled || isDeferredEditPending;
   const isEditSubmissionLocked =
@@ -663,6 +671,7 @@ function MessageComposerImpl({
     richText.clearContent,
     richText.setContent,
     setComposerContent,
+    setSpoileredAttachmentUrls,
     spoileredAttachmentUrls,
     syncComposerContentFromEditor,
     onCaptureSendContext,
@@ -785,35 +794,6 @@ function MessageComposerImpl({
   const handlePaperclipClick = React.useCallback(() => {
     void media.handlePaperclip();
   }, [media.handlePaperclip]);
-  const handleRemoveAttachment = React.useCallback(
-    (url: string) => {
-      setSpoileredAttachmentUrls((current) => {
-        if (!current.has(url)) return current;
-        const next = new Set(current);
-        next.delete(url);
-        return next;
-      });
-      media.removeAttachment(url);
-    },
-    [media.removeAttachment],
-  );
-  const { handleAttachmentEditSave, handleAttachmentRevert } =
-    useAttachmentEditing({
-      revertAttachment: media.revertAttachment,
-      setSpoileredAttachmentUrls,
-      uploadEditedAttachment: media.uploadEditedAttachment,
-    });
-  const handleToggleAttachmentSpoiler = React.useCallback((url: string) => {
-    setSpoileredAttachmentUrls((current) => {
-      const next = new Set(current);
-      if (next.has(url)) {
-        next.delete(url);
-      } else {
-        next.add(url);
-      }
-      return next;
-    });
-  }, []);
   return (
     <>
       <footer

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -26,6 +26,7 @@ import {
   takeQueuedAttachmentsForDraft,
   useBackgroundMediaUpload,
 } from "@/features/messages/lib/backgroundMediaUploadStore";
+import { isMentionCodeContext } from "@/features/messages/lib/mentionCodeContext";
 import { useMentions } from "@/features/messages/lib/useMentions";
 import {
   getPersistentAgentAudienceScope,
@@ -723,7 +724,9 @@ function MessageComposerImpl({
         }
         return;
       }
-      const { handled, suggestion } = mentions.handleMentionKeyDown(event);
+      const { handled, suggestion } = mentions.handleMentionKeyDown(event, {
+        isCodeContext: () => isMentionCodeContext(richText.editor),
+      });
       if (handled) {
         if (suggestion) {
           selectMentionSuggestion(suggestion);
@@ -756,6 +759,7 @@ function MessageComposerImpl({
       channelLinks.handleChannelKeyDown,
       applyChannelInsert,
       mentions.handleMentionKeyDown,
+      richText.editor,
       selectMentionSuggestion,
       linkEditor.isCardOpen,
       linkEditor.focusCardFirstControl,

--- a/desktop/src/features/messages/ui/useComposerAttachmentSpoilers.ts
+++ b/desktop/src/features/messages/ui/useComposerAttachmentSpoilers.ts
@@ -1,0 +1,70 @@
+import * as React from "react";
+import { useAttachmentEditing } from "@/features/messages/lib/useAttachmentEditing";
+import type { MediaUploadController } from "@/features/messages/lib/useMediaUpload";
+
+type UseComposerAttachmentSpoilersArgs = {
+  removeAttachment: MediaUploadController["removeAttachment"];
+  revertAttachment: MediaUploadController["revertAttachment"];
+  uploadEditedAttachment: MediaUploadController["uploadEditedAttachment"];
+};
+
+/**
+ * Owns which composer attachments are marked as spoilers, and keeps that set
+ * consistent with the attachment lifecycle: removing an attachment drops its
+ * membership, and editing or reverting one carries membership over to the
+ * replacement URL. The mirrored ref lets draft persistence read the current
+ * set without re-subscribing to state.
+ */
+export function useComposerAttachmentSpoilers({
+  removeAttachment,
+  revertAttachment,
+  uploadEditedAttachment,
+}: UseComposerAttachmentSpoilersArgs) {
+  const [spoileredAttachmentUrls, setSpoileredAttachmentUrls] = React.useState<
+    Set<string>
+  >(() => new Set());
+  const spoileredAttachmentUrlsRef = React.useRef(spoileredAttachmentUrls);
+  spoileredAttachmentUrlsRef.current = spoileredAttachmentUrls;
+
+  const handleRemoveAttachment = React.useCallback(
+    (url: string) => {
+      setSpoileredAttachmentUrls((current) => {
+        if (!current.has(url)) return current;
+        const next = new Set(current);
+        next.delete(url);
+        return next;
+      });
+      removeAttachment(url);
+    },
+    [removeAttachment],
+  );
+
+  const handleToggleAttachmentSpoiler = React.useCallback((url: string) => {
+    setSpoileredAttachmentUrls((current) => {
+      const next = new Set(current);
+      if (next.has(url)) {
+        next.delete(url);
+      } else {
+        next.add(url);
+      }
+      return next;
+    });
+  }, []);
+
+  const { handleAttachmentEditSave, handleAttachmentRevert } =
+    useAttachmentEditing({
+      revertAttachment,
+      setSpoileredAttachmentUrls,
+      uploadEditedAttachment,
+    });
+
+  return {
+    handleAttachmentEditSave,
+    handleAttachmentRevert,
+    handleRemoveAttachment,
+    handleToggleAttachmentSpoiler,
+    setSpoileredAttachmentUrls,
+    spoileredAttachmentUrls,
+    spoileredAttachmentUrlsRef,
+  };
+}

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -567,6 +567,46 @@ test("typing an exact agent name and Space commits its chip and mention tag", as
     .toContain(TEST_IDENTITIES.alice.pubkey);
 });
 
+test("Shift+Space leaves an exact agent name plain and emits no mention tag", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: OUT_OF_CHANNEL_MANAGED_AGENT_PUBKEY,
+        name: "quinn",
+        status: "stopped",
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  // Plain in-channel member names are intentionally tagged at send time, so
+  // use an authorized non-member to isolate selection from text extraction.
+  const input = page.getByTestId("message-input");
+  await input.fill("@quinn");
+  await expect(
+    autocomplete(page).getByTestId(
+      `mention-suggestion-${OUT_OF_CHANNEL_MANAGED_AGENT_PUBKEY}`,
+    ),
+  ).toBeVisible();
+
+  await input.fill("Ask @quinn");
+  await input.press("Shift+Space");
+  await page.keyboard.type("please reply");
+
+  const content = "Ask @quinn please reply";
+  await expect(input).toHaveText(content);
+  await expect(input.locator(".agent-mention-highlight")).toHaveCount(0);
+
+  await page.getByTestId("send-message").click();
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, content))
+    .toEqual([]);
+});
+
 test("thread autocomplete keeps multiple long names readable in a narrow panel", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -536,6 +536,37 @@ test("relay-only shared agents emit an outbound mention tag when selected", asyn
     .toContain(TEST_IDENTITIES.alice.pubkey);
 });
 
+test("typing an exact agent name and Space commits its chip and mention tag", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("@alice");
+  await expect(
+    autocomplete(page).getByTestId(
+      `mention-suggestion-${TEST_IDENTITIES.alice.pubkey}`,
+    ),
+  ).toBeVisible();
+
+  await input.fill("Ask @alice");
+  await input.press(" ");
+  await page.keyboard.type("please reply");
+
+  const content = "Ask @alice please reply";
+  await expect(input).toHaveText(content);
+  await expect(
+    input.locator(".agent-mention-highlight", { hasText: "alice" }),
+  ).toBeVisible();
+
+  await page.getByTestId("send-message").click();
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, content))
+    .toContain(TEST_IDENTITIES.alice.pubkey);
+});
+
 test("thread autocomplete keeps multiple long names readable in a narrow panel", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -607,6 +607,84 @@ test("Shift+Space leaves an exact agent name plain and emits no mention tag", as
     .toEqual([]);
 });
 
+// The three tests below pin the code-context gate on the Space commit. They
+// key off casing, because a commit rewrites the draft to the candidate's
+// canonical display name: a surviving "@ALICE" means the typed text was left
+// alone. Chip decorations are deliberately not asserted — they already render
+// over known names inside code, which is a separate pre-existing gap.
+test("Space inside a code block leaves an exact agent name literal", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.click();
+  await page.keyboard.type("```");
+  await page.keyboard.press("Enter");
+  await expect(input.locator("pre")).toBeVisible();
+
+  await page.keyboard.type("deploy @ALICE");
+  await page.keyboard.press(" ");
+  await page.keyboard.type("now");
+
+  await expect(input.locator("pre")).toHaveText("deploy @ALICE now");
+
+  await page.getByTestId("send-message").click();
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, "```\ndeploy @ALICE now\n```"))
+    .toEqual([]);
+});
+
+test("Space inside an inline code span leaves an exact agent name literal", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.click();
+  // The closing backtick turns the span into a code mark, which drops the
+  // backticks from the text the mention pipeline reads.
+  await page.keyboard.type("run `@ALICE`");
+  await expect(input.locator("code")).toHaveText("@ALICE");
+
+  await page.keyboard.press(" ");
+  await page.keyboard.type("now");
+
+  await expect(input.locator("code")).toHaveText("@ALICE");
+  await expect(input).toHaveText("run @ALICE now");
+
+  await page.getByTestId("send-message").click();
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, "run `@ALICE` now"))
+    .toEqual([]);
+});
+
+test("Space still resolves an exact agent name typed after a code span", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.click();
+  await page.keyboard.type("run `deploy` @ALICE");
+  await page.keyboard.press(" ");
+  await page.keyboard.type("now");
+
+  const content = "run `deploy` @alice now";
+  await expect(input).toHaveText("run deploy @alice now");
+
+  await page.getByTestId("send-message").click();
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, content))
+    .toContain(TEST_IDENTITIES.alice.pubkey);
+});
+
 test("thread autocomplete keeps multiple long names readable in a narrow panel", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- Convert an exact, authorized manually typed `@Name` into the existing visual mention chip when plain Space is pressed.
- Reuse autocomplete selection so outbound mention pubkeys, agent styling, and address behavior remain identical.
- Preserve partial names, longer multi-word names, duplicate-name ranking, modifier keys, and IME composition.

Before:

https://github.com/user-attachments/assets/2bccc0eb-5c36-4554-8a2d-d67e41d85e64

After:

https://github.com/user-attachments/assets/12859538-031d-44b0-ab38-40e1fb25c256


### Related issue

None found. Originating Buzz conversation: channel `5efbefaf-f478-4574-927e-32f28df07f09`, thread `563cb6709454b924405caa07f120ba9b88f074242fc3ee168686da76038b303f`.

### Testing

Validated at `7f30db7b54e484cb510bd0a616db98a49ce1b6ae`:

- `pnpm test` — 5,562 passed
- `pnpm check`
- `pnpm typecheck`
- `pnpm check:file-sizes`
- `pnpm build:e2e`
- `pnpm exec playwright test tests/e2e/mentions.spec.ts --project=smoke --reporter=line` — 74 passed
