### PR TITLE
fix(desktop): align agent message metadata

### DIFF
--- a/desktop/src/features/home/ui/InboxMessageRow.tsx
+++ b/desktop/src/features/home/ui/InboxMessageRow.tsx
@@ -236,7 +236,7 @@ export function InboxMessageRow({
                     start of a line on its own. Gap matches the container's, so
                     spacing reads the same either side of the divider.
                   */}
-                  <span className="inline-flex min-w-0 items-baseline gap-x-2">
+                  <span className="inline-flex min-w-0 items-center gap-x-2">
                     <MessageMetaSeparator />
                     {timestampNode}
                   </span>

--- a/desktop/src/features/home/ui/InboxMessageRow.tsx
+++ b/desktop/src/features/home/ui/InboxMessageRow.tsx
@@ -209,7 +209,7 @@ export function InboxMessageRow({
         <div className="min-w-0 flex-1">
           {isContinuation ? null : (
             <div
-              className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0"
+              className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0"
               data-testid="message-header"
             >
               <UserProfilePopover
@@ -236,7 +236,7 @@ export function InboxMessageRow({
                     start of a line on its own. Gap matches the container's, so
                     spacing reads the same either side of the divider.
                   */}
-                  <span className="inline-flex min-w-0 items-center gap-x-2">
+                  <span className="inline-flex min-w-0 items-baseline gap-x-2">
                     <MessageMetaSeparator />
                     {timestampNode}
                   </span>

--- a/desktop/src/features/messages/ui/MessageAgentOwner.tsx
+++ b/desktop/src/features/messages/ui/MessageAgentOwner.tsx
@@ -11,30 +11,13 @@ export function MessageAgentOwner({
 }) {
   return (
     <span
-      className="inline-flex min-w-0 max-w-56 items-baseline gap-1 text-xs leading-4 text-muted-foreground/65"
+      className="inline-flex min-w-0 max-w-56 items-baseline gap-1 text-message-timestamp text-muted-foreground/65"
       data-testid="message-agent-owner"
     >
       <span className="sr-only">
         {ownerLabel ? "Agent managed by" : "Agent; owner unavailable"}
       </span>
-      {/*
-       * Icon and label sit directly in this baseline row rather than in a nested
-       * flex wrapper, so the label's own baseline is what aligns with the author
-       * name beside it. Both branches share the icon for the same reason: two
-       * wrappers meant two alignment rules and the "owner unavailable" variant
-       * had drifted a pixel off the other one.
-       *
-       * `self-center` keeps the icon out of baseline alignment, so the label —
-       * not the icon's box — sets this chip's baseline. Centred on the line box
-       * the glyph's ink still rides ~1.6px above the text's cap band, reading as
-       * a couple of pixels too high; 0.125em drops its optical centre onto that
-       * band. In em so it holds under Cmd +/- zoom, and as a transform so it
-       * shifts nothing else in the row.
-       */}
-      <Bot
-        aria-hidden="true"
-        className="h-3.5 w-3.5 shrink-0 translate-y-[0.125em] self-center"
-      />
+      <Bot aria-hidden="true" className="h-3.5 w-3.5 shrink-0 self-center" />
       {ownerPubkey && ownerLabel ? (
         <>
           <span aria-hidden="true" className="shrink-0">

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -74,10 +74,8 @@ type MockInboxWindow = Window & {
   __BUZZ_E2E_PUSH_MOCK_FEED_ITEM__?: (item: MockInboxFeedItem) => unknown;
 };
 
-async function waitForStableAgentHeader(row: Locator, timestampTestId: string) {
+async function waitForLoadedAgentHeader(row: Locator, timestampTestId: string) {
   await row.evaluate(async (element, timestampId) => {
-    await document.fonts.ready;
-
     const targets = [
       element.querySelector<HTMLElement>('[data-testid="message-author"]'),
       element.querySelector<HTMLElement>('[data-testid="message-agent-owner"]'),
@@ -86,6 +84,38 @@ async function waitForStableAgentHeader(row: Locator, timestampTestId: string) {
     if (targets.some((target) => !target)) {
       throw new Error("Expected a complete agent message header.");
     }
+
+    const fontSample = "alice managed by bob 5:57 PM";
+    const fontRequests = new Set(
+      targets.map((target) => {
+        const style = getComputedStyle(target as HTMLElement);
+        const primaryFamily = style.fontFamily
+          .split(",")[0]
+          ?.replaceAll('"', "")
+          .trim();
+        if (primaryFamily !== "Inter Variable") {
+          throw new Error(
+            `Expected Inter Variable, received ${style.fontFamily}.`,
+          );
+        }
+        return `${style.fontStyle} ${style.fontWeight} ${style.fontSize} "Inter Variable"`;
+      }),
+    );
+
+    for (const fontRequest of fontRequests) {
+      const loadedFaces = await document.fonts.load(fontRequest, fontSample);
+      if (
+        loadedFaces.length === 0 ||
+        loadedFaces.some(
+          (face) =>
+            face.family !== "Inter Variable" || face.status !== "loaded",
+        ) ||
+        !document.fonts.check(fontRequest, fontSample)
+      ) {
+        throw new Error(`Expected loaded font face: ${fontRequest}.`);
+      }
+    }
+    await document.fonts.ready;
 
     await new Promise<void>((resolve, reject) => {
       let previousSignature: string | null = null;
@@ -213,7 +243,7 @@ async function expectAlignedAgentHeader(
     await page.evaluate((value) => {
       document.documentElement.dataset.fontSize = value;
     }, fontSize);
-    await waitForStableAgentHeader(row, timestampTestId);
+    await waitForLoadedAgentHeader(row, timestampTestId);
 
     const geometry = await measureAgentHeaderGeometry(row, timestampTestId);
     for (const [label, baseline] of Object.entries(geometry.baselines)) {
@@ -605,7 +635,7 @@ test.beforeEach(async ({ page }, testInfo) => {
   await installMockBridge(page, mock);
 });
 
-test("agent owner label aligns in the timeline and Inbox", async ({ page }) => {
+test("agent owner label aligns in the timeline", async ({ page }) => {
   await page.goto("/");
   await page.getByTestId("channel-general").click();
 
@@ -630,7 +660,9 @@ test("agent owner label aligns in the timeline and Inbox", async ({ page }) => {
     "message-timestamp",
     "timeline",
   );
+});
 
+test("agent owner label aligns in Inbox", async ({ page }) => {
   await page.goto("/");
   await expect(page.getByTestId("home-inbox-list")).toBeVisible();
   const inboxMessageId = await seedAgentInboxMessage(page);

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -49,6 +49,18 @@ async function expectThreadReplyUnobscured(row: Locator) {
     .toBe(true);
 }
 
+async function measureInlineBaseline(locator: Locator) {
+  return locator.evaluate((element) => {
+    const marker = document.createElement("span");
+    marker.style.cssText =
+      "display:inline-block;width:0;height:0;margin:0;padding:0;border:0";
+    element.append(marker);
+    const baseline = marker.getBoundingClientRect().top;
+    marker.remove();
+    return baseline;
+  });
+}
+
 async function measureThreadSummaryGeometry(summaryRow: Locator) {
   return summaryRow.evaluate((summaryButton) => {
     const summaryWrapper = summaryButton.parentElement;
@@ -396,6 +408,64 @@ test("agent owner label identifies the agent and owner", async ({ page }) => {
   await expect(ownerTreatment.locator(".sr-only")).toHaveText(
     "Agent managed by",
   );
+
+  const author = aliceMessage.getByTestId("message-author");
+  const managedBy = ownerTreatment.getByText("managed by", { exact: true });
+  const owner = ownerTreatment.locator(".font-semibold");
+  const timestamp = aliceMessage.getByTestId("message-timestamp");
+
+  for (const fontSize of ["smaller", "default", "larger"]) {
+    await page.evaluate((value) => {
+      document.documentElement.dataset.fontSize = value;
+    }, fontSize);
+
+    const [
+      authorBaseline,
+      managedByBaseline,
+      ownerBaseline,
+      timestampBaseline,
+    ] = await Promise.all([
+      measureInlineBaseline(author),
+      measureInlineBaseline(managedBy),
+      measureInlineBaseline(owner),
+      measureInlineBaseline(timestamp),
+    ]);
+    const [ownerTypography, timestampTypography] = await Promise.all([
+      ownerTreatment.evaluate((element) => {
+        const style = getComputedStyle(element);
+        return { fontSize: style.fontSize, lineHeight: style.lineHeight };
+      }),
+      timestamp.evaluate((element) => {
+        const style = getComputedStyle(element);
+        return { fontSize: style.fontSize, lineHeight: style.lineHeight };
+      }),
+    ]);
+    const iconCenterOffset = await ownerTreatment.evaluate((element) => {
+      const icon = element.querySelector("svg");
+      if (!icon) throw new Error("Expected the agent owner icon.");
+      const ownerRect = element.getBoundingClientRect();
+      const iconRect = icon.getBoundingClientRect();
+      return (
+        iconRect.top +
+        iconRect.height / 2 -
+        (ownerRect.top + ownerRect.height / 2)
+      );
+    });
+
+    expect(
+      { managedByBaseline, ownerBaseline, timestampBaseline },
+      `message header baselines at ${fontSize} font size`,
+    ).toEqual({
+      managedByBaseline: authorBaseline,
+      ownerBaseline: authorBaseline,
+      timestampBaseline: authorBaseline,
+    });
+    expect(ownerTypography).toEqual(timestampTypography);
+    expect(
+      Math.abs(iconCenterOffset),
+      `agent icon center at ${fontSize} font size`,
+    ).toBeLessThan(0.01);
+  }
 });
 
 test("send a message and see it in timeline", async ({ page }) => {

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
 
-import { expect, test, type Locator } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 
+import type { RelayEvent } from "../../src/shared/api/types";
 import { waitForAnimations } from "../helpers/animations";
 import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
 import { expectCornerRadiusPx, expectSmoothCorners } from "../helpers/css";
@@ -49,16 +50,230 @@ async function expectThreadReplyUnobscured(row: Locator) {
     .toBe(true);
 }
 
-async function measureInlineBaseline(locator: Locator) {
-  return locator.evaluate((element) => {
-    const marker = document.createElement("span");
-    marker.style.cssText =
-      "display:inline-block;width:0;height:0;margin:0;padding:0;border:0";
-    element.append(marker);
-    const baseline = marker.getBoundingClientRect().top;
-    marker.remove();
-    return baseline;
+const FONT_SIZES = ["smaller", "default", "larger"] as const;
+const GEOMETRY_TOLERANCE_PX = 0.25;
+const GENERAL_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+
+type MockInboxFeedItem = Pick<
+  RelayEvent,
+  "content" | "created_at" | "id" | "kind" | "pubkey" | "tags"
+> & {
+  category: "mention";
+  channel_id: string;
+  channel_name: string;
+};
+
+type MockInboxWindow = Window & {
+  __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
+    channelName: string;
+    content: string;
+    id?: string;
+    mentionPubkeys?: string[];
+    pubkey?: string;
+  }) => RelayEvent;
+  __BUZZ_E2E_PUSH_MOCK_FEED_ITEM__?: (item: MockInboxFeedItem) => unknown;
+};
+
+async function waitForStableAgentHeader(row: Locator, timestampTestId: string) {
+  await row.evaluate(async (element, timestampId) => {
+    await document.fonts.ready;
+
+    const targets = [
+      element.querySelector<HTMLElement>('[data-testid="message-author"]'),
+      element.querySelector<HTMLElement>('[data-testid="message-agent-owner"]'),
+      element.querySelector<HTMLElement>(`[data-testid="${timestampId}"]`),
+    ];
+    if (targets.some((target) => !target)) {
+      throw new Error("Expected a complete agent message header.");
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      let previousSignature: string | null = null;
+      let stableFrameCount = 0;
+      let sampledFrameCount = 0;
+
+      const sample = () => {
+        const signature = targets
+          .map((target) => {
+            const rect = target?.getBoundingClientRect();
+            return rect
+              ? [rect.x, rect.y, rect.width, rect.height]
+                  .map((value) => value.toFixed(3))
+                  .join(",")
+              : "missing";
+          })
+          .join("|");
+
+        stableFrameCount =
+          signature === previousSignature ? stableFrameCount + 1 : 0;
+        sampledFrameCount += 1;
+        previousSignature = signature;
+
+        if (stableFrameCount >= 2) {
+          resolve();
+        } else if (sampledFrameCount >= 120) {
+          reject(new Error("Agent message header layout did not stabilize."));
+        } else {
+          requestAnimationFrame(sample);
+        }
+      };
+
+      requestAnimationFrame(sample);
+    });
+  }, timestampTestId);
+}
+
+async function measureAgentHeaderGeometry(
+  row: Locator,
+  timestampTestId: string,
+) {
+  return row.evaluate((element, timestampId) => {
+    const author = element.querySelector<HTMLElement>(
+      '[data-testid="message-author"]',
+    );
+    const ownerTreatment = element.querySelector<HTMLElement>(
+      '[data-testid="message-agent-owner"]',
+    );
+    const managedBy = Array.from(
+      ownerTreatment?.querySelectorAll<HTMLElement>('[aria-hidden="true"]') ??
+        [],
+    ).find((candidate) => candidate.textContent?.trim() === "managed by");
+    const owner = ownerTreatment?.querySelector<HTMLElement>(".font-semibold");
+    const icon = ownerTreatment?.querySelector<SVGElement>("svg");
+    const timestamp = element.querySelector<HTMLElement>(
+      `[data-testid="${timestampId}"]`,
+    );
+
+    if (
+      !author ||
+      !ownerTreatment ||
+      !managedBy ||
+      !owner ||
+      !icon ||
+      !timestamp
+    ) {
+      throw new Error("Expected measurable agent message header geometry.");
+    }
+
+    const ownerStyle = getComputedStyle(ownerTreatment);
+    const timestampStyle = getComputedStyle(timestamp);
+    const ownerRect = ownerTreatment.getBoundingClientRect();
+    const iconRect = icon.getBoundingClientRect();
+    const iconCenterOffset =
+      iconRect.top +
+      iconRect.height / 2 -
+      (ownerRect.top + ownerRect.height / 2);
+    const baselineElements = [author, managedBy, owner, timestamp];
+    const markers = baselineElements.map((baselineElement) => {
+      const marker = document.createElement("span");
+      marker.style.cssText =
+        "display:inline-block;width:0;height:0;margin:0;padding:0;border:0";
+      baselineElement.append(marker);
+      return marker;
+    });
+
+    try {
+      const [
+        authorBaseline,
+        managedByBaseline,
+        ownerBaseline,
+        timestampBaseline,
+      ] = markers.map((marker) => marker.getBoundingClientRect().top);
+
+      return {
+        baselines: {
+          author: authorBaseline,
+          managedBy: managedByBaseline,
+          owner: ownerBaseline,
+          timestamp: timestampBaseline,
+        },
+        iconCenterOffset,
+        ownerTypography: {
+          fontSize: ownerStyle.fontSize,
+          lineHeight: ownerStyle.lineHeight,
+        },
+        timestampTypography: {
+          fontSize: timestampStyle.fontSize,
+          lineHeight: timestampStyle.lineHeight,
+        },
+      };
+    } finally {
+      for (const marker of markers) marker.remove();
+    }
+  }, timestampTestId);
+}
+
+async function expectAlignedAgentHeader(
+  page: Page,
+  row: Locator,
+  timestampTestId: string,
+  surface: string,
+) {
+  for (const fontSize of FONT_SIZES) {
+    await page.evaluate((value) => {
+      document.documentElement.dataset.fontSize = value;
+    }, fontSize);
+    await waitForStableAgentHeader(row, timestampTestId);
+
+    const geometry = await measureAgentHeaderGeometry(row, timestampTestId);
+    for (const [label, baseline] of Object.entries(geometry.baselines)) {
+      expect(
+        Math.abs(baseline - geometry.baselines.author),
+        `${surface} ${label} baseline at ${fontSize} font size`,
+      ).toBeLessThanOrEqual(GEOMETRY_TOLERANCE_PX);
+    }
+    expect(geometry.ownerTypography).toEqual(geometry.timestampTypography);
+    expect(
+      Math.abs(geometry.iconCenterOffset),
+      `${surface} agent icon center at ${fontSize} font size`,
+    ).toBeLessThanOrEqual(GEOMETRY_TOLERANCE_PX);
+  }
+}
+
+async function seedAgentInboxMessage(page: Page) {
+  await page.waitForFunction(() => {
+    const win = window as MockInboxWindow;
+    return (
+      typeof win.__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function" &&
+      typeof win.__BUZZ_E2E_PUSH_MOCK_FEED_ITEM__ === "function"
+    );
   });
+
+  return page.evaluate(
+    ({ channelId, currentPubkey, senderPubkey }) => {
+      const win = window as MockInboxWindow;
+      const emitMessage = win.__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
+      const pushFeedItem = win.__BUZZ_E2E_PUSH_MOCK_FEED_ITEM__;
+      if (!emitMessage || !pushFeedItem) {
+        throw new Error("Mock Inbox helpers are unavailable.");
+      }
+
+      const message = emitMessage({
+        channelName: "general",
+        content: "Agent Inbox alignment check.",
+        id: "a9".repeat(32),
+        mentionPubkeys: [currentPubkey],
+        pubkey: senderPubkey,
+      });
+      pushFeedItem({
+        category: "mention",
+        channel_id: channelId,
+        channel_name: "general",
+        content: message.content,
+        created_at: message.created_at,
+        id: message.id,
+        kind: message.kind,
+        pubkey: message.pubkey,
+        tags: message.tags,
+      });
+      return message.id;
+    },
+    {
+      channelId: GENERAL_CHANNEL_ID,
+      currentPubkey: TEST_IDENTITIES.tyler.pubkey,
+      senderPubkey: TEST_IDENTITIES.alice.pubkey,
+    },
+  );
 }
 
 async function measureThreadSummaryGeometry(summaryRow: Locator) {
@@ -390,7 +605,7 @@ test.beforeEach(async ({ page }, testInfo) => {
   await installMockBridge(page, mock);
 });
 
-test("agent owner label identifies the agent and owner", async ({ page }) => {
+test("agent owner label aligns in the timeline and Inbox", async ({ page }) => {
   await page.goto("/");
   await page.getByTestId("channel-general").click();
 
@@ -409,63 +624,31 @@ test("agent owner label identifies the agent and owner", async ({ page }) => {
     "Agent managed by",
   );
 
-  const author = aliceMessage.getByTestId("message-author");
-  const managedBy = ownerTreatment.getByText("managed by", { exact: true });
-  const owner = ownerTreatment.locator(".font-semibold");
-  const timestamp = aliceMessage.getByTestId("message-timestamp");
+  await expectAlignedAgentHeader(
+    page,
+    aliceMessage,
+    "message-timestamp",
+    "timeline",
+  );
 
-  for (const fontSize of ["smaller", "default", "larger"]) {
-    await page.evaluate((value) => {
-      document.documentElement.dataset.fontSize = value;
-    }, fontSize);
+  await page.goto("/");
+  await expect(page.getByTestId("home-inbox-list")).toBeVisible();
+  const inboxMessageId = await seedAgentInboxMessage(page);
 
-    const [
-      authorBaseline,
-      managedByBaseline,
-      ownerBaseline,
-      timestampBaseline,
-    ] = await Promise.all([
-      measureInlineBaseline(author),
-      measureInlineBaseline(managedBy),
-      measureInlineBaseline(owner),
-      measureInlineBaseline(timestamp),
-    ]);
-    const [ownerTypography, timestampTypography] = await Promise.all([
-      ownerTreatment.evaluate((element) => {
-        const style = getComputedStyle(element);
-        return { fontSize: style.fontSize, lineHeight: style.lineHeight };
-      }),
-      timestamp.evaluate((element) => {
-        const style = getComputedStyle(element);
-        return { fontSize: style.fontSize, lineHeight: style.lineHeight };
-      }),
-    ]);
-    const iconCenterOffset = await ownerTreatment.evaluate((element) => {
-      const icon = element.querySelector("svg");
-      if (!icon) throw new Error("Expected the agent owner icon.");
-      const ownerRect = element.getBoundingClientRect();
-      const iconRect = icon.getBoundingClientRect();
-      return (
-        iconRect.top +
-        iconRect.height / 2 -
-        (ownerRect.top + ownerRect.height / 2)
-      );
-    });
-
-    expect(
-      { managedByBaseline, ownerBaseline, timestampBaseline },
-      `message header baselines at ${fontSize} font size`,
-    ).toEqual({
-      managedByBaseline: authorBaseline,
-      ownerBaseline: authorBaseline,
-      timestampBaseline: authorBaseline,
-    });
-    expect(ownerTypography).toEqual(timestampTypography);
-    expect(
-      Math.abs(iconCenterOffset),
-      `agent icon center at ${fontSize} font size`,
-    ).toBeLessThan(0.01);
-  }
+  await page.getByTestId(`home-inbox-item-${inboxMessageId}`).click();
+  const inboxMessage = page.getByTestId("home-inbox-selected-message");
+  await expect(inboxMessage).toContainText("Agent Inbox alignment check.");
+  const inboxOwnerTreatment = inboxMessage.getByTestId("message-agent-owner");
+  await expect(
+    inboxOwnerTreatment.getByText("managed by", { exact: true }),
+  ).toBeVisible();
+  await expect(inboxOwnerTreatment.locator(".font-semibold")).toHaveText("bob");
+  await expectAlignedAgentHeader(
+    page,
+    inboxMessage,
+    "inbox-message-timestamp",
+    "Inbox",
+  );
 });
 
 test("send a message and see it in timeline", async ({ page }) => {


### PR DESCRIPTION
## Summary

- use the responsive timestamp typography for agent-owner attribution so the author, `managed by`, owner, and timestamp share a baseline at every message font size
- remove the icon's downward transform and baseline-align the Inbox message-header variant
- cover Timeline and Inbox independently at Smaller, Default, and Larger after explicitly loading and verifying the rendered `Inter Variable` font

## Testing

- `pnpm --dir desktop test` (5,556 passed)
- `pnpm --dir desktop check`
- `pnpm --dir desktop build:e2e`
- exact-build Playwright geometry tests repeated across 40 clean browser launches (20/20 Timeline and 20/20 Inbox)
- mutation check: reverting only the Inbox header's outer baseline rule fails specifically at `Inbox managedBy baseline at smaller font size` by 1px

## Before / After

Agent message header (`alice` · managed by `bob` · timestamp) captured from the mock-bridge E2E build at 3× so per-pixel baseline drift is legible. BEFORE is `origin/main` (`e8172b5`, the PR's merge base); AFTER is the production state introduced at `235bae0cc`. Current head `348cf68cc` changes only the regression test, so the rendered production state below is unchanged. Each pair covers both surfaces the change touches — the timeline row and the Inbox detail header — at all three message font sizes. The thin 50%-alpha cyan guide follows the `alice` text baseline in each panel.

### Timeline

| Font size | Before → After |
| --- | --- |
| Smaller | ![Timeline — smaller](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6863/compare-timeline-smaller-baseline.png) |
| Default | ![Timeline — default](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6863/compare-timeline-default-baseline.png) |
| Larger | ![Timeline — larger](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6863/compare-timeline-larger-baseline.png) |

### Inbox

| Font size | Before → After |
| --- | --- |
| Smaller | ![Inbox — smaller](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6863/compare-inbox-smaller-baseline.png) |
| Default | ![Inbox — default](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6863/compare-inbox-default-baseline.png) |
| Larger | ![Inbox — larger](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/6863/compare-inbox-larger-baseline.png) |

In each BEFORE frame the bot glyph rides above the name's baseline and the `managed by`/timestamp run sits slightly high; AFTER, the icon is centered on the metadata line box and the author, `managed by`, owner, and timestamp share one baseline.
