### PR TITLE
feat(kinds): declarative event-kind registry (scope + scoping)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,6 +1120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "buzz-kinds"
+version = "0.1.0"
+dependencies = [
+ "buzz-auth",
+ "buzz-core",
+ "nostr 0.44.7",
+]
+
+[[package]]
 name = "buzz-media"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,6 +1273,7 @@ dependencies = [
  "buzz-datastore-tracing",
  "buzz-db",
  "buzz-deletion",
+ "buzz-kinds",
  "buzz-media",
  "buzz-pubsub",
  "buzz-relay-mesh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/buzz-relay",
     "crates/buzz-core",
+    "crates/buzz-kinds",
     "crates/buzz-conformance",
     "crates/buzz-push-gateway",
     "crates/buzz-db",
@@ -134,6 +135,7 @@ schemars = { version = "1", default-features = false }
 
 # Internal crates
 buzz-core = { path = "crates/buzz-core" }
+buzz-kinds = { path = "crates/buzz-kinds" }
 buzz-conformance = { path = "crates/buzz-conformance" }
 buzz-db = { path = "crates/buzz-db" }
 buzz-deletion = { path = "crates/buzz-deletion" }

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,140 +1,121 @@
-# feat(kinds): declarative event-kind registry (Seam A: scope + scoping)
+# feat(kinds): declarative event-kind registry (scope + scoping)
 
 Implements #3167.
 
 ## Problem
 
-Adding a new event kind means editing several central chokepoints in
-lockstep: the large `required_scope_for_kind` match in
-`buzz-relay/src/handlers/ingest.rs`, two disjoint boolean allowlists
-(`is_global_only_kind` / `requires_h_channel_scope`), `is_relay_only_kind`,
-and the `P_GATED_KINDS` / `AUTHOR_ONLY_KINDS` / `RESULT_GATED_KINDS` slices in
-`buzz-core`. One of the invariants this spread of code has to preserve — that
-`is_global_only_kind` and `requires_h_channel_scope` never both claim the same
-kind — is enforced only by a runtime test, not the type system.
+Adding a new event kind means editing several places at once: the large
+`required_scope_for_kind` match in `buzz-relay/src/handlers/ingest.rs`, two
+separate boolean allowlists (`is_global_only_kind` / `requires_h_channel_scope`),
+`is_relay_only_kind`, and the `P_GATED_KINDS` / `AUTHOR_ONLY_KINDS` /
+`RESULT_GATED_KINDS` slices in `buzz-core`. One invariant this code has to
+hold, that `is_global_only_kind` and `requires_h_channel_scope` never both
+claim the same kind, is only checked by a runtime test today, not by the
+type system.
 
 ## What this PR does
 
 Adds a new leaf crate, `buzz-kinds`, holding a `KindDescriptor` per event
-kind: the base write-scope (`RequiredScope::Static`/`Dynamic`), the NIP-29
+kind: the base write scope (`RequiredScope::Static`/`Dynamic`), the NIP-29
 channel-scoping classification (`Scoping::{Global, ChannelRequired,
-ChannelOptional}`), a read-gate field, and an authorship field. The relay's
-`ingest_event_inner` now resolves each event's base scope and channel scoping
-through `AppState.kind_registry` instead of the old match plus two
-allowlists, which are deleted.
+ChannelOptional}`), a read-gate field, and an authorship field.
+`ingest_event_inner` now resolves each event's scope and channel scoping
+through `AppState.kind_registry` instead of the old match plus the two
+allowlists, which are removed.
 
-**Key decision — `Scoping` collapses the two allowlists into one enum.**
+**`Scoping` replaces the two allowlists with one enum.** The old
 `is_global_only_kind` and `requires_h_channel_scope` were two independent
-`bool` predicates that had to be kept mutually exclusive by hand; the existing
-test suite carried a dedicated `global_only_and_channel_scoped_are_disjoint`
-regression test for exactly this. `Scoping` makes double-classification
-unrepresentable — there is no way to write a descriptor that is both
-`Global` and `ChannelRequired` — so that invariant is now enforced by the
-type system, not a test. (The disjointness test itself still runs, now
-trivially, and I kept it rather than deleting it.)
+bools that had to be kept mutually exclusive by hand, backed by a dedicated
+`global_only_and_channel_scoped_are_disjoint` regression test. With
+`Scoping`, a descriptor can't be both `Global` and `ChannelRequired` at the
+same time, so that invariant is now structural, not test-only. I kept the
+disjointness test anyway, it just passes trivially now.
 
 **A registry miss is the fail-closed reject.** Every kind the old match
-accepted is registered; anything else (`_ => Err("restricted: unknown event
-kind")`) is simply absent from the registry, and `KindRegistry::get`
-returning `None` reproduces that same reject verbatim.
+accepted is registered. Anything else falls through to the same
+`"restricted: unknown event kind"` error as before.
 
-**One dynamic-scope kind.** `kind:9002` (NIP-29 edit-metadata)'s scope
-depends on whether the event carries an `archived` tag. This is the one
-kind that needs `RequiredScope::Dynamic` plus a `KindExtension::required_scope`
-hook — a minimal, single-method trait (see "What I deliberately deferred"
-below for why it stops there).
+**One dynamic-scope kind.** `kind:9002` (NIP-29 edit-metadata) needs
+`RequiredScope::Dynamic` plus a `KindExtension::required_scope` hook,
+because its scope depends on whether the event carries an `archived` tag.
 
-## What I deliberately deferred
+## Not in this PR
 
-The upstream RFC (#3167) also names two other pieces of the same chokepoint,
-which this PR does **not** touch, to keep the diff focused and reviewable:
+The RFC (#3167) also names two more pieces of the same problem. I left both
+out to keep this diff reviewable:
 
-1. **Per-kind authorize/validate residue.** The relay has inline AND-gates
+1. **Per-kind authorize/validate logic.** The relay has inline AND-gates
    and a `validate_*` ladder (diff/engram/agent-turn-metric/event-reminder/
-   persona envelope validation) that could fold into `KindExtension` as
-   `authorize`/`validate` hooks. I left `KindExtension` with only
-   `required_scope` in this PR — the trait can grow those methods later with
-   defaults, which is non-breaking for the one existing implementor. Folding
-   this in is real work against current code (some of it, e.g. the
-   edit-ownership/forum-vote validators, needs richer context than the
-   ingest path currently threads through) and deserves its own PR.
-2. **`P_GATED_KINDS` / `AUTHOR_ONLY_KINDS` / `RESULT_GATED_KINDS`.** These stay
-   on `buzz-core`'s existing slices; `KindDescriptor::read_gate` is declared
-   (so the registry already has a place to hold this once someone wires the
-   read path to it) but not yet consulted anywhere. This is a mechanical,
-   lower-risk follow-up once this PR's scope/scoping flip has landed and
-   soaked.
-3. **The `search_tsv`-NULL migration coupling.** The RFC's issue body
-   describes this as coupled to `P_GATED_KINDS` via a negative allowlist
-   (`P_GATED_KINDS` kinds get a NULL `search_tsv`). Current upstream has
-   already moved past that: `migrations/0008_fresh_install_search_allowlist.sql`
-   replaced it with a **positive** FTS allowlist (`kind IN (0, 9, 40002,
-   45001, 45003) THEN to_tsvector(...) ELSE NULL`) for fresh installs, with a
-   documented out-of-band maintenance path for populated databases. That's a
-   different (arguably safer — fail-closed by default) design than the one
-   the issue was written against, so I did not touch it; re-coupling it to
-   the registry is out of scope here and would need its own discussion.
-4. **`is_relay_only_kind`.** Still lives in `buzz-core` and still runs before
-   the registry lookup in `ingest_event_inner`; relay-only kinds are never
-   registered in `buzz-kinds` in this PR. `KindDescriptor::authorship` is
-   declared for completeness but unconsumed.
-5. `super::push_lease::KIND_PUSH_LEASE` (30350) keeps its inline special case
-   in `ingest_event_inner` rather than being registered — it's an existing
-   dedicated handler with its own scope/scoping shape, and folding it into
-   `buzz-kinds` isn't necessary for this PR's behavior-preservation goal.
+   persona envelope) that could become `KindExtension::authorize`/`validate`
+   hooks. `KindExtension` only has `required_scope` in this PR. The trait
+   can grow those methods later with defaults, which won't break the one
+   existing implementor. Some of that logic (edit-ownership and forum-vote
+   validation, for example) needs more context than the ingest path
+   currently threads through, so it deserves its own PR.
+2. **`P_GATED_KINDS` / `AUTHOR_ONLY_KINDS` / `RESULT_GATED_KINDS`.** These
+   still live on `buzz-core`'s existing slices. `KindDescriptor::read_gate`
+   is declared but nothing reads it yet. This is a mechanical follow-up
+   once the scope/scoping flip has landed and soaked.
+3. **The `search_tsv`-NULL migration.** The RFC issue describes this as
+   coupled to `P_GATED_KINDS` through a negative allowlist. That's no
+   longer how it works: `migrations/0008_fresh_install_search_allowlist.sql`
+   already replaced it with a positive FTS allowlist for fresh installs.
+   That's a different, arguably safer design than the one the issue was
+   written against, so I left it alone.
+4. **`is_relay_only_kind`.** Still lives in `buzz-core` and still runs
+   before the registry lookup. Relay-only kinds aren't registered in
+   `buzz-kinds` in this PR. `KindDescriptor::authorship` is declared but
+   unused for now.
+5. `KIND_PUSH_LEASE` (30350) keeps its existing inline special case in
+   `ingest_event_inner` rather than being registered. It's a dedicated
+   handler with its own shape, and folding it in isn't needed for this
+   PR's behavior-preservation goal.
 
-None of the above blocks a future PR from picking them up against this same
-crate; `KindDescriptor` and `KindExtension` were designed with room for it
-(see doc comments in `crates/buzz-kinds/src/descriptor.rs` and
-`extension.rs`).
+None of this blocks picking it up later. `KindDescriptor` and
+`KindExtension` were built with room for it, see the doc comments in
+`crates/buzz-kinds/src/descriptor.rs` and `extension.rs`.
 
-## How this was verified
+## Testing
 
-- `cargo test -p buzz-relay --lib handlers::ingest`: **174 passed** (1 ignored,
-  requires Postgres — pre-existing, unrelated to this change). These are the
-  existing policy unit tests, unchanged; they now run against thin
-  `#[cfg(test)]` adapters (`required_scope_for_kind` / `is_global_only_kind`
-  / `requires_h_channel_scope`) that reproduce the deleted functions'
-  signatures over a freshly-built registry, so the tests read identically to
-  before and are the actual proof of behavior preservation.
-- `cargo test -p buzz-relay --lib handlers::event`: **24 passed** (includes
-  the `channel_scoped_content_kinds_require_h_tags` /
-  `non_channel_kinds_do_not_require_h_tags` tests that call into the same
-  adapters from a different module).
-- `cargo test -p buzz-kinds`: **3 passed** — no duplicate kinds, the one
-  `AUTHOR_ONLY_KINDS` cross-check against `buzz-core`, and the edit-metadata
-  archived-tag scope split.
-- `cargo test -p buzz-relay --lib` (full lib suite): **901 passed, 8 failed**.
-  The 8 failures are pre-existing and unrelated — Postgres pool timeouts and
-  two admin-endpoint status-code assertions (500 vs 404) that also fail on
-  an unmodified checkout of this same commit (verified by stashing this PR's
-  changes and re-running).
+- `cargo test -p buzz-relay --lib handlers::ingest`: 174 passed, 1 ignored
+  (needs Postgres, pre-existing, unrelated). These are the existing policy
+  tests, unchanged, now running against `#[cfg(test)]` adapters that
+  reproduce the deleted functions' signatures over a freshly built
+  registry. That's the actual proof this is behavior-preserving.
+- `cargo test -p buzz-relay --lib handlers::event`: 24 passed.
+- `cargo test -p buzz-kinds`: 3 passed (no duplicate kinds, the
+  `AUTHOR_ONLY_KINDS` cross-check against `buzz-core`, the edit-metadata
+  archived-tag scope split).
+- `cargo test -p buzz-relay --lib` (full): 901 passed, 8 failed. The 8
+  failures are pre-existing and unrelated (Postgres pool timeouts, two
+  admin-endpoint status-code assertions). I confirmed they also fail on an
+  unmodified checkout of the same commit.
 - `cargo check --workspace --all-targets`: clean.
-- `cargo clippy -p buzz-relay -p buzz-kinds -p buzz-core --all-targets -- -D
-  warnings`: clean.
+- `cargo clippy -p buzz-relay -p buzz-kinds -p buzz-core --all-targets -- -D warnings`: clean.
 - `cargo fmt --check -p buzz-relay -p buzz-kinds -p buzz-core`: clean.
-- No new `unwrap()`/`expect()`/`unsafe` in production code paths — the three
-  `unwrap()`s in `buzz-kinds` are inside its own `#[cfg(test)]` module, and
-  `buzz-kinds/src/lib.rs` carries `#![forbid(unsafe_code)]`.
+- No new `unwrap()`/`expect()`/`unsafe` in production code. The `unwrap()`s
+  in `buzz-kinds` are in its own test module, and `buzz-kinds/src/lib.rs`
+  has `#![forbid(unsafe_code)]`.
 
-## How to test manually
+### Manual test
 
 ```
 . ./bin/activate-hermit
 cargo test -p buzz-relay -p buzz-kinds -p buzz-core
-just relay   # start the relay, then publish events of a few kinds via buzz-cli
-             # or the desktop app and confirm scope/channel-scoping behavior
-             # (e.g. a channel-scoped token can't publish kind:0/1/3; kind:9002
-             # with an "archived" tag needs AdminChannels) is unchanged.
+just relay
 ```
+
+Then publish events of a few kinds through buzz-cli or the desktop app and
+confirm scope/channel-scoping behavior is unchanged: a channel-scoped token
+still can't publish kind:0/1/3, and kind:9002 with an `archived` tag still
+needs AdminChannels.
 
 ## Duplicate check
 
 Re-ran the issue's "searched, none found" claim before opening this:
 `gh search issues --repo block/buzz "kind registry OR required_scope_for_kind"`
-and `gh search prs --repo block/buzz "3167"` / `"buzz-kinds"` / `"kind
-registry"`. No open PR implements #3167 as of this writing. Two related open
-RFCs by the same author exist — #3351 (agent-context provider registry in
-`buzz-acp`) and #3280 (desktop channel-feature registry) — both explicitly
-describe themselves as companions to #3167, not overlapping implementations
-of it.
+and `gh search prs --repo block/buzz "3167"` / `"buzz-kinds"` / `"kind registry"`.
+No open PR implements #3167. Two related open RFCs from the same author
+exist, #3351 (agent-context provider registry) and #3280 (desktop
+channel-feature registry), both explicitly companions to #3167, not
+overlapping implementations.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,140 @@
+# feat(kinds): declarative event-kind registry (Seam A: scope + scoping)
+
+Implements #3167.
+
+## Problem
+
+Adding a new event kind means editing several central chokepoints in
+lockstep: the large `required_scope_for_kind` match in
+`buzz-relay/src/handlers/ingest.rs`, two disjoint boolean allowlists
+(`is_global_only_kind` / `requires_h_channel_scope`), `is_relay_only_kind`,
+and the `P_GATED_KINDS` / `AUTHOR_ONLY_KINDS` / `RESULT_GATED_KINDS` slices in
+`buzz-core`. One of the invariants this spread of code has to preserve — that
+`is_global_only_kind` and `requires_h_channel_scope` never both claim the same
+kind — is enforced only by a runtime test, not the type system.
+
+## What this PR does
+
+Adds a new leaf crate, `buzz-kinds`, holding a `KindDescriptor` per event
+kind: the base write-scope (`RequiredScope::Static`/`Dynamic`), the NIP-29
+channel-scoping classification (`Scoping::{Global, ChannelRequired,
+ChannelOptional}`), a read-gate field, and an authorship field. The relay's
+`ingest_event_inner` now resolves each event's base scope and channel scoping
+through `AppState.kind_registry` instead of the old match plus two
+allowlists, which are deleted.
+
+**Key decision — `Scoping` collapses the two allowlists into one enum.**
+`is_global_only_kind` and `requires_h_channel_scope` were two independent
+`bool` predicates that had to be kept mutually exclusive by hand; the existing
+test suite carried a dedicated `global_only_and_channel_scoped_are_disjoint`
+regression test for exactly this. `Scoping` makes double-classification
+unrepresentable — there is no way to write a descriptor that is both
+`Global` and `ChannelRequired` — so that invariant is now enforced by the
+type system, not a test. (The disjointness test itself still runs, now
+trivially, and I kept it rather than deleting it.)
+
+**A registry miss is the fail-closed reject.** Every kind the old match
+accepted is registered; anything else (`_ => Err("restricted: unknown event
+kind")`) is simply absent from the registry, and `KindRegistry::get`
+returning `None` reproduces that same reject verbatim.
+
+**One dynamic-scope kind.** `kind:9002` (NIP-29 edit-metadata)'s scope
+depends on whether the event carries an `archived` tag. This is the one
+kind that needs `RequiredScope::Dynamic` plus a `KindExtension::required_scope`
+hook — a minimal, single-method trait (see "What I deliberately deferred"
+below for why it stops there).
+
+## What I deliberately deferred
+
+The upstream RFC (#3167) also names two other pieces of the same chokepoint,
+which this PR does **not** touch, to keep the diff focused and reviewable:
+
+1. **Per-kind authorize/validate residue.** The relay has inline AND-gates
+   and a `validate_*` ladder (diff/engram/agent-turn-metric/event-reminder/
+   persona envelope validation) that could fold into `KindExtension` as
+   `authorize`/`validate` hooks. I left `KindExtension` with only
+   `required_scope` in this PR — the trait can grow those methods later with
+   defaults, which is non-breaking for the one existing implementor. Folding
+   this in is real work against current code (some of it, e.g. the
+   edit-ownership/forum-vote validators, needs richer context than the
+   ingest path currently threads through) and deserves its own PR.
+2. **`P_GATED_KINDS` / `AUTHOR_ONLY_KINDS` / `RESULT_GATED_KINDS`.** These stay
+   on `buzz-core`'s existing slices; `KindDescriptor::read_gate` is declared
+   (so the registry already has a place to hold this once someone wires the
+   read path to it) but not yet consulted anywhere. This is a mechanical,
+   lower-risk follow-up once this PR's scope/scoping flip has landed and
+   soaked.
+3. **The `search_tsv`-NULL migration coupling.** The RFC's issue body
+   describes this as coupled to `P_GATED_KINDS` via a negative allowlist
+   (`P_GATED_KINDS` kinds get a NULL `search_tsv`). Current upstream has
+   already moved past that: `migrations/0008_fresh_install_search_allowlist.sql`
+   replaced it with a **positive** FTS allowlist (`kind IN (0, 9, 40002,
+   45001, 45003) THEN to_tsvector(...) ELSE NULL`) for fresh installs, with a
+   documented out-of-band maintenance path for populated databases. That's a
+   different (arguably safer — fail-closed by default) design than the one
+   the issue was written against, so I did not touch it; re-coupling it to
+   the registry is out of scope here and would need its own discussion.
+4. **`is_relay_only_kind`.** Still lives in `buzz-core` and still runs before
+   the registry lookup in `ingest_event_inner`; relay-only kinds are never
+   registered in `buzz-kinds` in this PR. `KindDescriptor::authorship` is
+   declared for completeness but unconsumed.
+5. `super::push_lease::KIND_PUSH_LEASE` (30350) keeps its inline special case
+   in `ingest_event_inner` rather than being registered — it's an existing
+   dedicated handler with its own scope/scoping shape, and folding it into
+   `buzz-kinds` isn't necessary for this PR's behavior-preservation goal.
+
+None of the above blocks a future PR from picking them up against this same
+crate; `KindDescriptor` and `KindExtension` were designed with room for it
+(see doc comments in `crates/buzz-kinds/src/descriptor.rs` and
+`extension.rs`).
+
+## How this was verified
+
+- `cargo test -p buzz-relay --lib handlers::ingest`: **174 passed** (1 ignored,
+  requires Postgres — pre-existing, unrelated to this change). These are the
+  existing policy unit tests, unchanged; they now run against thin
+  `#[cfg(test)]` adapters (`required_scope_for_kind` / `is_global_only_kind`
+  / `requires_h_channel_scope`) that reproduce the deleted functions'
+  signatures over a freshly-built registry, so the tests read identically to
+  before and are the actual proof of behavior preservation.
+- `cargo test -p buzz-relay --lib handlers::event`: **24 passed** (includes
+  the `channel_scoped_content_kinds_require_h_tags` /
+  `non_channel_kinds_do_not_require_h_tags` tests that call into the same
+  adapters from a different module).
+- `cargo test -p buzz-kinds`: **3 passed** — no duplicate kinds, the one
+  `AUTHOR_ONLY_KINDS` cross-check against `buzz-core`, and the edit-metadata
+  archived-tag scope split.
+- `cargo test -p buzz-relay --lib` (full lib suite): **901 passed, 8 failed**.
+  The 8 failures are pre-existing and unrelated — Postgres pool timeouts and
+  two admin-endpoint status-code assertions (500 vs 404) that also fail on
+  an unmodified checkout of this same commit (verified by stashing this PR's
+  changes and re-running).
+- `cargo check --workspace --all-targets`: clean.
+- `cargo clippy -p buzz-relay -p buzz-kinds -p buzz-core --all-targets -- -D
+  warnings`: clean.
+- `cargo fmt --check -p buzz-relay -p buzz-kinds -p buzz-core`: clean.
+- No new `unwrap()`/`expect()`/`unsafe` in production code paths — the three
+  `unwrap()`s in `buzz-kinds` are inside its own `#[cfg(test)]` module, and
+  `buzz-kinds/src/lib.rs` carries `#![forbid(unsafe_code)]`.
+
+## How to test manually
+
+```
+. ./bin/activate-hermit
+cargo test -p buzz-relay -p buzz-kinds -p buzz-core
+just relay   # start the relay, then publish events of a few kinds via buzz-cli
+             # or the desktop app and confirm scope/channel-scoping behavior
+             # (e.g. a channel-scoped token can't publish kind:0/1/3; kind:9002
+             # with an "archived" tag needs AdminChannels) is unchanged.
+```
+
+## Duplicate check
+
+Re-ran the issue's "searched, none found" claim before opening this:
+`gh search issues --repo block/buzz "kind registry OR required_scope_for_kind"`
+and `gh search prs --repo block/buzz "3167"` / `"buzz-kinds"` / `"kind
+registry"`. No open PR implements #3167 as of this writing. Two related open
+RFCs by the same author exist — #3351 (agent-context provider registry in
+`buzz-acp`) and #3280 (desktop channel-feature registry) — both explicitly
+describe themselves as companions to #3167, not overlapping implementations
+of it.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -75,7 +75,21 @@ None of this blocks picking it up later. `KindDescriptor` and
 `KindExtension` were built with room for it, see the doc comments in
 `crates/buzz-kinds/src/descriptor.rs` and `extension.rs`.
 
+## Review focus
+
+1. Is deferring authorize/validate logic into `KindExtension` acceptable as
+   its own follow-up PR, or should more of it be bundled here given it's
+   part of the same chokepoint?
+2. `KindDescriptor::read_gate` is declared but not yet consumed anywhere.
+   Is that an acceptable staging point, or should the read-gate flip land
+   in this same PR since it's mechanical and low-risk?
+3. Any objection to leaving `is_relay_only_kind` and `KIND_PUSH_LEASE`'s
+   inline handling outside the registry for now, as described above?
+
 ## Testing
+
+At commit `a05a9c51b` (the last code commit on this branch; later commits
+only touch this description):
 
 - `cargo test -p buzz-relay --lib handlers::ingest`: 174 passed, 1 ignored
   (needs Postgres, pre-existing, unrelated). These are the existing policy

--- a/crates/buzz-kinds/Cargo.toml
+++ b/crates/buzz-kinds/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "buzz-kinds"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Declarative event-kind registry for Buzz: the base write-scope, NIP-29 channel-scoping classification, and read-side sensitivity of every event kind, in one place"
+
+[dependencies]
+buzz-core = { workspace = true }
+buzz-auth = { workspace = true }
+nostr = { workspace = true }

--- a/crates/buzz-kinds/src/descriptor.rs
+++ b/crates/buzz-kinds/src/descriptor.rs
@@ -1,0 +1,94 @@
+//! The declarative half of a kind's policy.
+//!
+//! A [`KindDescriptor`] captures everything about an event kind that today is
+//! spread across the relay's `required_scope_for_kind` match and the
+//! `is_global_only_kind` / `requires_h_channel_scope` boolean allowlists.
+//! Expressing it as one struct literal per kind makes a kind's policy legible
+//! in one place and makes one class of misconfiguration structurally
+//! impossible (see [`Scoping`]).
+
+use buzz_auth::Scope;
+
+use crate::extension::KindExtension;
+
+/// The base scope a transport token must hold to write a kind.
+#[derive(Clone)]
+pub enum RequiredScope {
+    /// A fixed scope, the common case (e.g. `Scope::MessagesWrite`).
+    Static(Scope),
+    /// The scope depends on the event's content/tags; the kind's
+    /// [`KindExtension::required_scope`] is consulted. Only kinds whose scope
+    /// genuinely varies per event (today: the NIP-29 edit-metadata archive
+    /// toggle) need this.
+    Dynamic,
+}
+
+/// How a kind relates to a NIP-29 channel (`h` tag).
+///
+/// This single enum replaces the two independent boolean allowlists
+/// (`is_global_only_kind` and `requires_h_channel_scope`) that previously had
+/// to be kept mutually exclusive by a runtime test. Encoding the choice as one
+/// enum makes double-classification unrepresentable.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Scoping {
+    /// The event is workspace-global; any `h` tag is ignored and the stored
+    /// `channel_id` is forced to `None`.
+    Global,
+    /// The event MUST carry an `h` tag naming its channel; absence is rejected.
+    ChannelRequired,
+    /// The event may carry an `h` tag (honored) or not (treated as global) —
+    /// e.g. reactions and deletions whose channel is derived from their target.
+    ChannelOptional,
+}
+
+/// Read-side sensitivity of a kind.
+///
+/// Mirrors `buzz-core`'s `P_GATED_KINDS` / `AUTHOR_ONLY_KINDS` /
+/// `RESULT_GATED_KINDS` slices. Not yet consulted by the read path in this
+/// PR — see the crate-level docs — but declared here so a kind's full policy
+/// is legible in one place and so a future read-path flip has a ready-made,
+/// testable target.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ReadGate {
+    /// Normal fan-out; world-readable and searchable.
+    Public,
+    /// Global reads must carry `#p` matching the requester's pubkey.
+    PGated,
+    /// Readable only by the event's author.
+    AuthorOnly,
+    /// Even an explicit `ids`/`authors` query must match `#p` to return it.
+    ResultGated,
+}
+
+/// Whether clients may submit a kind, or it is produced only by the relay.
+///
+/// Not yet consulted by the write path in this PR — `buzz_core::kind::
+/// is_relay_only_kind` remains the live authority (it runs before the
+/// registry lookup). Declared for completeness and as a follow-up target.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Authorship {
+    /// A client may publish this kind (subject to scope checks).
+    ClientWritable,
+    /// Only the relay itself produces this kind; client submissions are refused.
+    RelayOnly,
+}
+
+/// The complete policy for one event kind.
+#[derive(Clone)]
+pub struct KindDescriptor {
+    /// The Nostr event kind integer (matches a `KIND_*` constant in `buzz-core`).
+    pub kind: u32,
+    /// A short stable name, for diagnostics.
+    pub name: &'static str,
+    /// Base scope required to write the kind.
+    pub required_scope: RequiredScope,
+    /// Channel-relationship classification.
+    pub scoping: Scoping,
+    /// Read-side sensitivity.
+    pub read_gate: ReadGate,
+    /// Client-writable vs relay-only.
+    pub authorship: Authorship,
+    /// Optional per-kind scope-resolution hook for `RequiredScope::Dynamic`
+    /// kinds. `None` for every kind with a `RequiredScope::Static` scope.
+    pub extension: Option<&'static dyn KindExtension>,
+}

--- a/crates/buzz-kinds/src/extension.rs
+++ b/crates/buzz-kinds/src/extension.rs
@@ -1,0 +1,25 @@
+//! The code half of a kind's policy: resolving a `RequiredScope::Dynamic`
+//! kind's actual scope from the event.
+//!
+//! This seam is intentionally minimal in this PR — only `required_scope` is
+//! defined, since the only kind that needs `RequiredScope::Dynamic` today
+//! (NIP-29 `kind:9002` edit-metadata) needs nothing else. Per-event
+//! authorization and payload-validation hooks (the relay's inline
+//! board-branch-style AND-gates and its `validate_*` ladder) are a natural
+//! follow-up to fold into this trait; adding methods with defaults later is
+//! non-breaking for every existing implementor.
+
+use buzz_auth::Scope;
+use nostr::Event;
+
+/// Per-kind scope-resolution hook for `RequiredScope::Dynamic` kinds.
+pub trait KindExtension: Send + Sync {
+    /// Resolve the required scope for a `RequiredScope::Dynamic` kind.
+    ///
+    /// The default fails closed: it demands an unrecognized scope no token
+    /// can hold, so a kind marked `Dynamic` that forgets to override this is
+    /// rejected rather than silently granted.
+    fn required_scope(&self, _event: &Event) -> Scope {
+        Scope::Unknown("dynamic-scope-not-implemented".to_string())
+    }
+}

--- a/crates/buzz-kinds/src/lib.rs
+++ b/crates/buzz-kinds/src/lib.rs
@@ -1,0 +1,32 @@
+//! Declarative event-kind registry.
+//!
+//! This crate is the single home for a Buzz event kind's *policy*: the scope
+//! required to write it, how it relates to a NIP-29 channel, and its
+//! read-side sensitivity. The relay resolves an incoming event's base
+//! write-scope and channel-scoping classification through a [`KindRegistry`]
+//! instead of the hand-maintained `required_scope_for_kind` match plus the
+//! `is_global_only_kind` / `requires_h_channel_scope` boolean allowlists that
+//! previously had to be kept mutually exclusive by a runtime test alone.
+//!
+//! It sits between `buzz-core` (kind constants and range predicates) and
+//! `buzz-auth` (the [`buzz_auth::Scope`] vocabulary a descriptor names). It is
+//! a leaf crate — it performs no I/O and depends on nothing in `buzz-relay`.
+//!
+//! A kind whose required scope depends on the event itself (today, only the
+//! NIP-29 `kind:9002` edit-metadata archive/non-archive split) supplies a
+//! [`KindExtension`] to resolve it. The extension seam is deliberately
+//! minimal for now — this PR only wires the scope/scoping resolution
+//! described above; folding the relay's per-kind authorization/validation
+//! residue and the `P_GATED_KINDS`/`AUTHOR_ONLY_KINDS`/`RESULT_GATED_KINDS`
+//! read-gate slices into this seam is a natural, separable follow-up (see the
+//! PR description).
+
+#![forbid(unsafe_code)]
+
+mod descriptor;
+mod extension;
+mod registry;
+
+pub use descriptor::{Authorship, KindDescriptor, ReadGate, RequiredScope, Scoping};
+pub use extension::KindExtension;
+pub use registry::{register_builtin, KindRegistry};

--- a/crates/buzz-kinds/src/registry.rs
+++ b/crates/buzz-kinds/src/registry.rs
@@ -1,0 +1,525 @@
+//! The kind registry, assembled once at startup.
+//!
+//! [`register_builtin`] transcribes the relay's `required_scope_for_kind` /
+//! `is_global_only_kind` / `requires_h_channel_scope` matrix (as of the kind
+//! set in `buzz-core::kind` at the time this PR was written) into
+//! [`KindDescriptor`] entries. A registry *miss* is the fail-closed reject
+//! that today's `_ => Err("restricted: unknown event kind")` arm provides.
+//!
+//! Deliberately NOT covered here (see the PR description for why):
+//! - `buzz_core::kind::is_relay_only_kind` — still runs before the registry
+//!   lookup in `ingest_event_inner`, so relay-only kinds are never registered.
+//! - `super::push_lease::KIND_PUSH_LEASE` (30350) — the relay's dedicated
+//!   push-lease handling keeps its own inline special case for now.
+//! - Read-gate (`P_GATED_KINDS` / `AUTHOR_ONLY_KINDS` / `RESULT_GATED_KINDS`)
+//!   and command/moderation-command routing stay on their existing paths;
+//!   `ReadGate` is declared on the descriptor for completeness but unused.
+
+use std::collections::HashMap;
+
+use buzz_auth::Scope;
+use buzz_core::kind::*;
+
+use crate::descriptor::{Authorship, KindDescriptor, ReadGate, RequiredScope, Scoping};
+use crate::extension::KindExtension;
+
+/// A lookup table from event kind to its [`KindDescriptor`].
+#[derive(Default)]
+pub struct KindRegistry {
+    by_kind: HashMap<u32, KindDescriptor>,
+}
+
+impl KindRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a kind's descriptor.
+    ///
+    /// Panics on a duplicate kind: registration happens once at startup, and
+    /// a duplicate is a build-time configuration error that must fail fast.
+    pub fn register(&mut self, descriptor: KindDescriptor) {
+        let kind = descriptor.kind;
+        assert!(
+            self.by_kind.insert(kind, descriptor).is_none(),
+            "duplicate kind descriptor registered for kind {kind}"
+        );
+    }
+
+    /// Look up a kind's descriptor. `None` means the kind is unregistered —
+    /// callers must fail closed on a miss.
+    pub fn get(&self, kind: u32) -> Option<&KindDescriptor> {
+        self.by_kind.get(&kind)
+    }
+
+    /// Iterate every registered descriptor (used by tests to check parity
+    /// against `buzz-core`'s kind matrix).
+    pub fn iter(&self) -> impl Iterator<Item = &KindDescriptor> {
+        self.by_kind.values()
+    }
+}
+
+/// Build a `ClientWritable`, extension-less descriptor with a static scope.
+fn static_kind(kind: u32, name: &'static str, scope: Scope, scoping: Scoping) -> KindDescriptor {
+    KindDescriptor {
+        kind,
+        name,
+        required_scope: RequiredScope::Static(scope),
+        scoping,
+        read_gate: ReadGate::Public,
+        authorship: Authorship::ClientWritable,
+        extension: None,
+    }
+}
+
+/// Build a `ClientWritable`, extension-less descriptor with a static scope and
+/// an explicit, non-`Public` read gate.
+fn static_kind_gated(
+    kind: u32,
+    name: &'static str,
+    scope: Scope,
+    scoping: Scoping,
+    read_gate: ReadGate,
+) -> KindDescriptor {
+    KindDescriptor {
+        kind,
+        name,
+        required_scope: RequiredScope::Static(scope),
+        scoping,
+        read_gate,
+        authorship: Authorship::ClientWritable,
+        extension: None,
+    }
+}
+
+/// NIP-29 `kind:9002` (edit-metadata) scope resolver: an `archived` tag
+/// requires `Scope::AdminChannels`; otherwise `Scope::ChannelsWrite`.
+///
+/// Transcribed verbatim from the former inline match arm in
+/// `handlers::ingest::required_scope_for_kind`.
+struct EditMetadataExt;
+
+impl KindExtension for EditMetadataExt {
+    fn required_scope(&self, event: &nostr::Event) -> Scope {
+        let has_archived = event
+            .tags
+            .iter()
+            .any(|t| t.kind().to_string() == "archived");
+        if has_archived {
+            Scope::AdminChannels
+        } else {
+            Scope::ChannelsWrite
+        }
+    }
+}
+
+static EDIT_METADATA_EXT: EditMetadataExt = EditMetadataExt;
+
+/// Register every built-in kind's declarative policy.
+pub fn register_builtin(registry: &mut KindRegistry) {
+    use Scoping::{ChannelOptional, ChannelRequired, Global};
+
+    // --- User-owned global profile/content kinds --------------------------
+    registry.register(static_kind(
+        KIND_PROFILE,
+        "profile",
+        Scope::UsersWrite,
+        Global,
+    ));
+    registry.register(static_kind(
+        KIND_TEXT_NOTE,
+        "text_note",
+        Scope::MessagesWrite,
+        Global,
+    ));
+    registry.register(static_kind(
+        KIND_LONG_FORM,
+        "long_form",
+        Scope::MessagesWrite,
+        Global,
+    ));
+    registry.register(static_kind(
+        KIND_CONTACT_LIST,
+        "contact_list",
+        Scope::UsersWrite,
+        Global,
+    ));
+    registry.register(static_kind(
+        KIND_READ_STATE,
+        "read_state",
+        Scope::UsersWrite,
+        Global,
+    ));
+    registry.register(static_kind(
+        KIND_USER_STATUS,
+        "user_status",
+        Scope::UsersWrite,
+        Global,
+    ));
+    registry.register(static_kind_gated(
+        KIND_AGENT_ENGRAM,
+        "agent_engram",
+        Scope::UsersWrite,
+        Global,
+        ReadGate::Public,
+    ));
+    registry.register(static_kind_gated(
+        KIND_EVENT_REMINDER,
+        "event_reminder",
+        Scope::UsersWrite,
+        Global,
+        // buzz_core::kind::AUTHOR_ONLY_KINDS.
+        ReadGate::AuthorOnly,
+    ));
+    registry.register(static_kind(
+        KIND_PERSONA,
+        "persona",
+        Scope::UsersWrite,
+        Global,
+    ));
+    registry.register(static_kind(KIND_TEAM, "team", Scope::UsersWrite, Global));
+    registry.register(static_kind(
+        KIND_MANAGED_AGENT,
+        "managed_agent",
+        Scope::UsersWrite,
+        Global,
+    ));
+    registry.register(static_kind_gated(
+        KIND_PRIVATE_MANAGED_AGENT,
+        "private_managed_agent",
+        Scope::UsersWrite,
+        Global,
+        // buzz_core::kind::AUTHOR_ONLY_KINDS.
+        ReadGate::AuthorOnly,
+    ));
+    registry.register(static_kind(
+        KIND_TEAM_CATALOG,
+        "team_catalog",
+        Scope::UsersWrite,
+        Global,
+    ));
+
+    // --- NIP-AM: agent turn metrics -----------------------------------------
+    registry.register(static_kind_gated(
+        KIND_AGENT_TURN_METRIC,
+        "agent_turn_metric",
+        Scope::MessagesWrite,
+        Global,
+        // In both `P_GATED_KINDS` and `RESULT_GATED_KINDS` upstream;
+        // `ResultGated` is the strictly stronger of the two.
+        ReadGate::ResultGated,
+    ));
+
+    // --- NIP-56 reports + product feedback (mod-queue only, never fanned out)
+    registry.register(static_kind(
+        KIND_REPORT,
+        "report",
+        Scope::MessagesWrite,
+        ChannelOptional,
+    ));
+    registry.register(static_kind(
+        KIND_PRODUCT_FEEDBACK,
+        "product_feedback",
+        Scope::MessagesWrite,
+        ChannelOptional,
+    ));
+
+    // --- Community moderation commands (9040-9044) -------------------------
+    // Direct, mod-authz-gated writes; scope only proves the transport can
+    // submit message writes — the command handler owns the real
+    // role/capability authorization. Never channel-scoped by a stray `h`.
+    for (kind, name) in [
+        (KIND_MODERATION_BAN, "moderation_ban"),
+        (KIND_MODERATION_UNBAN, "moderation_unban"),
+        (KIND_MODERATION_TIMEOUT, "moderation_timeout"),
+        (KIND_MODERATION_UNTIMEOUT, "moderation_untimeout"),
+        (KIND_MODERATION_RESOLVE_REPORT, "moderation_resolve_report"),
+    ] {
+        registry.register(static_kind(kind, name, Scope::MessagesWrite, Global));
+    }
+
+    // --- NIP-51 standard lists/sets, NIP-65 relay list, NIP-30 emoji -------
+    for (kind, name) in [
+        (KIND_MUTE_LIST, "mute_list"),
+        (KIND_PIN_LIST, "pin_list"),
+        (KIND_NIP65_RELAY_LIST_METADATA, "nip65_relay_list_metadata"),
+        (KIND_BOOKMARK_LIST, "bookmark_list"),
+        (KIND_FOLLOW_SET, "follow_set"),
+        (KIND_BOOKMARK_SET, "bookmark_set"),
+        (KIND_EMOJI_SET, "emoji_set"),
+        (KIND_EMOJI_LIST, "emoji_list"),
+        (KIND_AGENT_PROFILE, "agent_profile"),
+    ] {
+        registry.register(static_kind(kind, name, Scope::UsersWrite, Global));
+    }
+
+    // --- Channel-optional message-scoped kinds ------------------------------
+    registry.register(static_kind(
+        KIND_DELETION,
+        "deletion",
+        Scope::MessagesWrite,
+        ChannelOptional,
+    ));
+    registry.register(static_kind(
+        KIND_REACTION,
+        "reaction",
+        Scope::MessagesWrite,
+        ChannelOptional,
+    ));
+    registry.register(static_kind_gated(
+        KIND_GIFT_WRAP,
+        "gift_wrap",
+        Scope::MessagesWrite,
+        ChannelOptional,
+        // buzz_core::kind::P_GATED_KINDS.
+        ReadGate::PGated,
+    ));
+    registry.register(static_kind(
+        KIND_NIP29_DELETE_EVENT,
+        "nip29_delete_event",
+        Scope::MessagesWrite,
+        ChannelRequired,
+    ));
+
+    // --- Channel-required stream/forum message kinds ------------------------
+    for (kind, name) in [
+        (KIND_STREAM_MESSAGE, "stream_message"),
+        (KIND_STREAM_MESSAGE_V2, "stream_message_v2"),
+        (KIND_STREAM_MESSAGE_EDIT, "stream_message_edit"),
+        (KIND_STREAM_MESSAGE_PINNED, "stream_message_pinned"),
+        (KIND_STREAM_MESSAGE_BOOKMARKED, "stream_message_bookmarked"),
+        (KIND_STREAM_MESSAGE_SCHEDULED, "stream_message_scheduled"),
+        (KIND_STREAM_REMINDER, "stream_reminder"),
+        (KIND_STREAM_MESSAGE_DIFF, "stream_message_diff"),
+        (KIND_FORUM_POST, "forum_post"),
+        (KIND_FORUM_VOTE, "forum_vote"),
+        (KIND_FORUM_COMMENT, "forum_comment"),
+    ] {
+        registry.register(static_kind(
+            kind,
+            name,
+            Scope::MessagesWrite,
+            ChannelRequired,
+        ));
+    }
+
+    // --- NIP-29 admin kinds --------------------------------------------------
+    registry.register(static_kind(
+        KIND_NIP29_PUT_USER,
+        "nip29_put_user",
+        Scope::AdminChannels,
+        ChannelRequired,
+    ));
+    registry.register(static_kind(
+        KIND_NIP29_REMOVE_USER,
+        "nip29_remove_user",
+        Scope::AdminChannels,
+        ChannelRequired,
+    ));
+    registry.register(static_kind(
+        KIND_NIP29_DELETE_GROUP,
+        "nip29_delete_group",
+        Scope::AdminChannels,
+        ChannelRequired,
+    ));
+    // kind:9002 — scope depends on the `archived` tag (see `EditMetadataExt`).
+    registry.register(KindDescriptor {
+        kind: KIND_NIP29_EDIT_METADATA,
+        name: "nip29_edit_metadata",
+        required_scope: RequiredScope::Dynamic,
+        scoping: ChannelRequired,
+        read_gate: ReadGate::Public,
+        authorship: Authorship::ClientWritable,
+        extension: Some(&EDIT_METADATA_EXT),
+    });
+
+    // --- NIP-43: relay admin commands (global, AdminUsers) ------------------
+    for (kind, name) in [
+        (RELAY_ADMIN_ADD_MEMBER, "relay_admin_add_member"),
+        (RELAY_ADMIN_REMOVE_MEMBER, "relay_admin_remove_member"),
+        (RELAY_ADMIN_CHANGE_ROLE, "relay_admin_change_role"),
+        (
+            RELAY_ADMIN_SET_WORKSPACE_PROFILE,
+            "relay_admin_set_workspace_profile",
+        ),
+    ] {
+        registry.register(static_kind(kind, name, Scope::AdminUsers, Global));
+    }
+
+    // --- NIP-IA: identity archive/unarchive requests -------------------------
+    registry.register(static_kind(
+        KIND_IA_ARCHIVE_REQUEST,
+        "ia_archive_request",
+        Scope::UsersWrite,
+        Global,
+    ));
+    registry.register(static_kind(
+        KIND_IA_UNARCHIVE_REQUEST,
+        "ia_unarchive_request",
+        Scope::UsersWrite,
+        Global,
+    ));
+
+    // --- Channel creation / canvas / join / leave ----------------------------
+    registry.register(static_kind(
+        KIND_NIP29_CREATE_GROUP,
+        "nip29_create_group",
+        Scope::ChannelsWrite,
+        ChannelOptional,
+    ));
+    registry.register(static_kind(
+        KIND_CANVAS,
+        "canvas",
+        Scope::ChannelsWrite,
+        ChannelRequired,
+    ));
+    registry.register(static_kind(
+        KIND_NIP29_JOIN_REQUEST,
+        "nip29_join_request",
+        Scope::ChannelsRead,
+        ChannelOptional,
+    ));
+    registry.register(static_kind(
+        KIND_NIP29_LEAVE_REQUEST,
+        "nip29_leave_request",
+        Scope::ChannelsRead,
+        ChannelRequired,
+    ));
+    registry.register(static_kind(
+        KIND_NIP43_LEAVE_REQUEST,
+        "nip43_leave_request",
+        Scope::ChannelsRead,
+        Global,
+    ));
+
+    // --- Huddle lifecycle + guidelines ---------------------------------------
+    for (kind, name) in [
+        (KIND_HUDDLE_STARTED, "huddle_started"),
+        (KIND_HUDDLE_PARTICIPANT_JOINED, "huddle_participant_joined"),
+        (KIND_HUDDLE_PARTICIPANT_LEFT, "huddle_participant_left"),
+        (KIND_HUDDLE_ENDED, "huddle_ended"),
+        (KIND_HUDDLE_GUIDELINES, "huddle_guidelines"),
+    ] {
+        registry.register(static_kind(
+            kind,
+            name,
+            Scope::ChannelsWrite,
+            ChannelRequired,
+        ));
+    }
+
+    // --- NIP-34: git repository + project events (global, ReposWrite) -------
+    for (kind, name) in [
+        (KIND_GIT_REPO_ANNOUNCEMENT, "git_repo_announcement"),
+        (KIND_GIT_REPO_STATE, "git_repo_state"),
+        (KIND_PROJECT, "project"),
+    ] {
+        registry.register(static_kind(kind, name, Scope::ReposWrite, Global));
+    }
+
+    // --- NIP-34: git activity events (global, MessagesWrite) -----------------
+    for (kind, name) in [
+        (KIND_GIT_PATCH, "git_patch"),
+        (KIND_GIT_PULL_REQUEST, "git_pull_request"),
+        (KIND_GIT_PR_UPDATE, "git_pr_update"),
+        (KIND_GIT_ISSUE, "git_issue"),
+        (KIND_GIT_STATUS_OPEN, "git_status_open"),
+        (KIND_GIT_STATUS_MERGED, "git_status_merged"),
+        (KIND_GIT_STATUS_CLOSED, "git_status_closed"),
+        (KIND_GIT_STATUS_DRAFT, "git_status_draft"),
+    ] {
+        registry.register(static_kind(kind, name, Scope::MessagesWrite, Global));
+    }
+
+    // --- Command kinds: DM management, workflows, approvals ------------------
+    for (kind, name) in [
+        (KIND_DM_OPEN, "dm_open"),
+        (KIND_DM_ADD_MEMBER, "dm_add_member"),
+        (KIND_DM_HIDE, "dm_hide"),
+    ] {
+        registry.register(static_kind(
+            kind,
+            name,
+            Scope::MessagesWrite,
+            ChannelOptional,
+        ));
+    }
+    for (kind, name) in [
+        (KIND_WORKFLOW_DEF, "workflow_def"),
+        (KIND_WORKFLOW_TRIGGER, "workflow_trigger"),
+        (KIND_APPROVAL_GRANT, "approval_grant"),
+        (KIND_APPROVAL_DENY, "approval_deny"),
+    ] {
+        registry.register(static_kind(
+            kind,
+            name,
+            Scope::MessagesWrite,
+            ChannelOptional,
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn built() -> KindRegistry {
+        let mut registry = KindRegistry::new();
+        register_builtin(&mut registry);
+        registry
+    }
+
+    #[test]
+    fn register_builtin_has_no_duplicate_kinds() {
+        // `register_builtin` itself would have panicked already on a
+        // duplicate; this just proves it completes and yields more than a
+        // handful of entries.
+        let registry = built();
+        assert!(registry.iter().count() > 60);
+    }
+
+    #[test]
+    fn author_only_kinds_match_buzz_core() {
+        let registry = built();
+        for &kind in buzz_core::kind::AUTHOR_ONLY_KINDS {
+            // `KIND_PUSH_LEASE` is deliberately unregistered in this PR (see
+            // module docs) — the relay keeps it inline.
+            if kind == buzz_core::kind::KIND_PUSH_LEASE {
+                continue;
+            }
+            let descriptor = registry
+                .get(kind)
+                .unwrap_or_else(|| panic!("author-only kind {kind} must be registered"));
+            assert_eq!(
+                descriptor.read_gate,
+                ReadGate::AuthorOnly,
+                "kind {kind} is in AUTHOR_ONLY_KINDS but not registered ReadGate::AuthorOnly"
+            );
+        }
+    }
+
+    #[test]
+    fn edit_metadata_scope_resolves_from_archived_tag() {
+        let registry = built();
+        let descriptor = registry.get(KIND_NIP29_EDIT_METADATA).unwrap();
+        assert!(matches!(descriptor.required_scope, RequiredScope::Dynamic));
+        let ext = descriptor
+            .extension
+            .expect("edit-metadata must have an extension");
+
+        let no_tag = nostr::EventBuilder::new(nostr::Kind::Custom(9002_u16), "")
+            .sign_with_keys(&nostr::Keys::generate())
+            .unwrap();
+        assert_eq!(ext.required_scope(&no_tag), Scope::ChannelsWrite);
+
+        let archived = nostr::EventBuilder::new(nostr::Kind::Custom(9002_u16), "")
+            .tag(nostr::Tag::custom(
+                nostr::TagKind::Custom("archived".into()),
+                ["true"],
+            ))
+            .sign_with_keys(&nostr::Keys::generate())
+            .unwrap();
+        assert_eq!(ext.required_scope(&archived), Scope::AdminChannels);
+    }
+}

--- a/crates/buzz-relay/Cargo.toml
+++ b/crates/buzz-relay/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 buzz-core = { workspace = true }
+buzz-kinds = { workspace = true }
 buzz-conformance = { workspace = true }
 buzz-db = { workspace = true }
 buzz-datastore-tracing = { workspace = true }

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -12,33 +12,20 @@ use uuid::Uuid;
 use buzz_auth::Scope;
 use buzz_core::kind::{
     event_kind_u32, is_identity_archive_request_kind, is_parameterized_replaceable,
-    is_relay_admin_kind, KIND_AGENT_ENGRAM, KIND_AGENT_PROFILE, KIND_AGENT_TURN_METRIC,
-    KIND_APPROVAL_DENY, KIND_APPROVAL_GRANT, KIND_AUTH, KIND_BOOKMARK_LIST, KIND_BOOKMARK_SET,
-    KIND_CANVAS, KIND_CONTACT_LIST, KIND_DELETION, KIND_DM_ADD_MEMBER, KIND_DM_HIDE, KIND_DM_OPEN,
-    KIND_EMOJI_LIST, KIND_EMOJI_SET, KIND_EVENT_REMINDER, KIND_FOLLOW_SET, KIND_FORUM_COMMENT,
-    KIND_FORUM_POST, KIND_FORUM_VOTE, KIND_GIFT_WRAP, KIND_GIT_ISSUE, KIND_GIT_PATCH,
-    KIND_GIT_PR_UPDATE, KIND_GIT_PULL_REQUEST, KIND_GIT_REPO_ANNOUNCEMENT, KIND_GIT_REPO_STATE,
-    KIND_GIT_STATUS_CLOSED, KIND_GIT_STATUS_DRAFT, KIND_GIT_STATUS_MERGED, KIND_GIT_STATUS_OPEN,
-    KIND_HUDDLE_ENDED, KIND_HUDDLE_GUIDELINES, KIND_HUDDLE_PARTICIPANT_JOINED,
-    KIND_HUDDLE_PARTICIPANT_LEFT, KIND_HUDDLE_STARTED, KIND_IA_ARCHIVE_REQUEST,
-    KIND_IA_UNARCHIVE_REQUEST, KIND_LONG_FORM, KIND_MANAGED_AGENT, KIND_MEMBER_ADDED_NOTIFICATION,
-    KIND_MEMBER_REMOVED_NOTIFICATION, KIND_MODERATION_BAN, KIND_MODERATION_RESOLVE_REPORT,
-    KIND_MODERATION_TIMEOUT, KIND_MODERATION_UNBAN, KIND_MODERATION_UNTIMEOUT, KIND_MUTE_LIST,
+    is_relay_admin_kind, KIND_AGENT_ENGRAM, KIND_AGENT_TURN_METRIC, KIND_AUTH, KIND_DELETION,
+    KIND_EMOJI_LIST, KIND_EMOJI_SET, KIND_EVENT_REMINDER, KIND_FORUM_COMMENT, KIND_FORUM_POST,
+    KIND_FORUM_VOTE, KIND_GIFT_WRAP, KIND_GIT_REPO_ANNOUNCEMENT, KIND_HUDDLE_ENDED,
+    KIND_HUDDLE_STARTED, KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION,
     KIND_NIP29_CREATE_GROUP, KIND_NIP29_DELETE_EVENT, KIND_NIP29_DELETE_GROUP,
-    KIND_NIP29_EDIT_METADATA, KIND_NIP29_JOIN_REQUEST, KIND_NIP29_LEAVE_REQUEST,
-    KIND_NIP29_PUT_USER, KIND_NIP29_REMOVE_USER, KIND_NIP43_LEAVE_REQUEST,
-    KIND_NIP65_RELAY_LIST_METADATA, KIND_PERSONA, KIND_PIN_LIST, KIND_PRESENCE_UPDATE,
-    KIND_PRIVATE_MANAGED_AGENT, KIND_PRODUCT_FEEDBACK, KIND_PROFILE, KIND_PROJECT, KIND_REACTION,
-    KIND_READ_STATE, KIND_REPORT, KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_BOOKMARKED,
-    KIND_STREAM_MESSAGE_DIFF, KIND_STREAM_MESSAGE_EDIT, KIND_STREAM_MESSAGE_PINNED,
-    KIND_STREAM_MESSAGE_SCHEDULED, KIND_STREAM_MESSAGE_V2, KIND_STREAM_REMINDER, KIND_TEAM,
-    KIND_TEAM_CATALOG, KIND_TEXT_NOTE, KIND_USER_STATUS, KIND_WORKFLOW_DEF, KIND_WORKFLOW_TRIGGER,
-    RELAY_ADMIN_ADD_MEMBER, RELAY_ADMIN_CHANGE_ROLE, RELAY_ADMIN_REMOVE_MEMBER,
-    RELAY_ADMIN_SET_WORKSPACE_PROFILE,
+    KIND_NIP29_EDIT_METADATA, KIND_NIP29_JOIN_REQUEST, KIND_NIP43_LEAVE_REQUEST, KIND_PERSONA,
+    KIND_PRESENCE_UPDATE, KIND_PRODUCT_FEEDBACK, KIND_PROFILE, KIND_PROJECT, KIND_REACTION,
+    KIND_REPORT, KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_DIFF, KIND_STREAM_MESSAGE_EDIT,
+    KIND_TEAM_CATALOG,
 };
 use buzz_core::tenant::TenantContext;
 use buzz_core::verification::verify_event;
 use buzz_core::CommunityId;
+use buzz_kinds::{RequiredScope, Scoping};
 use nostr::Event;
 
 use crate::state::AppState;
@@ -431,121 +418,6 @@ fn map_push_accept_error(error: super::push_lease::AcceptError) -> IngestError {
     }
 }
 
-/// Determine the required scope for a given event kind.
-///
-/// Returns `Err` for unknown kinds — the relay rejects them.
-fn required_scope_for_kind(kind: u32, event: &Event) -> Result<Scope, &'static str> {
-    match kind {
-        KIND_PROFILE => Ok(Scope::UsersWrite),
-        KIND_TEXT_NOTE | KIND_LONG_FORM => Ok(Scope::MessagesWrite),
-        KIND_CONTACT_LIST | KIND_READ_STATE | KIND_USER_STATUS | KIND_AGENT_ENGRAM
-        | KIND_EVENT_REMINDER | KIND_PERSONA | KIND_TEAM | KIND_MANAGED_AGENT
-        | KIND_PRIVATE_MANAGED_AGENT | KIND_TEAM_CATALOG | super::push_lease::KIND_PUSH_LEASE => {
-            Ok(Scope::UsersWrite)
-        }
-        // NIP-AM: agent turn metrics are agent-authored global events (encrypted to owner).
-        KIND_AGENT_TURN_METRIC => Ok(Scope::MessagesWrite),
-        // NIP-56 reports are ordinary member writes into the mod-only queue.
-        // Ingest persists them to `moderation_reports` and suppresses public
-        // storage/fanout; reports are signals, never enforcement triggers.
-        KIND_REPORT | KIND_PRODUCT_FEEDBACK => Ok(Scope::MessagesWrite),
-        // Community moderation commands are direct, mod-authz-gated writes.
-        // Scope only proves the transport can submit message writes; the
-        // command handler owns role/capability authorization.
-        k if buzz_core::kind::is_moderation_command_kind(k) => Ok(Scope::MessagesWrite),
-        // NIP-51 standard lists and NIP-65 relay list — user-owned global state,
-        // same ownership shape as kind:3 (contacts) and kind:0 (profile).
-        KIND_MUTE_LIST
-        | KIND_PIN_LIST
-        | KIND_NIP65_RELAY_LIST_METADATA
-        | KIND_BOOKMARK_LIST
-        | KIND_FOLLOW_SET
-        | KIND_BOOKMARK_SET
-        // NIP-30/NIP-51: per-user custom emoji set (30030) and emoji list (10030).
-        // User-owned global state, keyed by (pubkey, kind[, d_tag]); the workspace
-        // palette is the client-side union of every member's own set.
-        | KIND_EMOJI_SET
-        | KIND_EMOJI_LIST
-        | KIND_AGENT_PROFILE => Ok(Scope::UsersWrite),
-        KIND_DELETION
-        | KIND_REACTION
-        | KIND_GIFT_WRAP
-        | KIND_STREAM_MESSAGE
-        | KIND_STREAM_MESSAGE_V2
-        | KIND_NIP29_DELETE_EVENT
-        | KIND_STREAM_MESSAGE_EDIT
-        | KIND_STREAM_MESSAGE_PINNED
-        | KIND_STREAM_MESSAGE_BOOKMARKED
-        | KIND_STREAM_MESSAGE_SCHEDULED
-        | KIND_STREAM_REMINDER
-        | KIND_STREAM_MESSAGE_DIFF
-        | KIND_FORUM_POST
-        | KIND_FORUM_VOTE
-        | KIND_FORUM_COMMENT => Ok(Scope::MessagesWrite),
-        KIND_NIP29_PUT_USER | KIND_NIP29_REMOVE_USER | KIND_NIP29_DELETE_GROUP => {
-            Ok(Scope::AdminChannels)
-        }
-        // NIP-43: relay membership admin commands (9030–9032) + Buzz
-        // workspace-profile command (9033).
-        k if k == RELAY_ADMIN_ADD_MEMBER
-            || k == RELAY_ADMIN_REMOVE_MEMBER
-            || k == RELAY_ADMIN_CHANGE_ROLE
-            || k == RELAY_ADMIN_SET_WORKSPACE_PROFILE =>
-        {
-            Ok(Scope::AdminUsers)
-        }
-        // NIP-IA: identity archive/unarchive requests (9035/9036).
-        // Scope is intentionally UsersWrite, not AdminUsers: NIP-IA's self and
-        // owner-of-agent paths are open to ordinary users (a user retiring their
-        // own key, or an owner archiving their agent). Real authorization is the
-        // consent-path check inside handle_identity_archive_event — the relay
-        // verifies self / admin-role / owner-via-live-kind:0 there. This gate
-        // only ensures the actor can write user-scoped state, which any
-        // profile-publishing user already holds.
-        KIND_IA_ARCHIVE_REQUEST | KIND_IA_UNARCHIVE_REQUEST => Ok(Scope::UsersWrite),
-        KIND_NIP29_EDIT_METADATA => {
-            // kind:9002 scope split: archived tag → AdminChannels, else ChannelsWrite
-            let has_archived = event
-                .tags
-                .iter()
-                .any(|t| t.kind().to_string() == "archived");
-            if has_archived {
-                Ok(Scope::AdminChannels)
-            } else {
-                Ok(Scope::ChannelsWrite)
-            }
-        }
-        KIND_NIP29_CREATE_GROUP | KIND_CANVAS => Ok(Scope::ChannelsWrite),
-        KIND_NIP29_JOIN_REQUEST | KIND_NIP29_LEAVE_REQUEST | KIND_NIP43_LEAVE_REQUEST => {
-            Ok(Scope::ChannelsRead)
-        }
-        // Huddle lifecycle events + guidelines
-        KIND_HUDDLE_STARTED
-        | KIND_HUDDLE_PARTICIPANT_JOINED
-        | KIND_HUDDLE_PARTICIPANT_LEFT
-        | KIND_HUDDLE_ENDED
-        | KIND_HUDDLE_GUIDELINES => Ok(Scope::ChannelsWrite),
-        // NIP-34: Git repository events
-        KIND_GIT_REPO_ANNOUNCEMENT | KIND_GIT_REPO_STATE => Ok(Scope::ReposWrite),
-        // NIP-MP: a project is repository metadata — grouping repositories needs
-        // the same scope as announcing them.
-        KIND_PROJECT => Ok(Scope::ReposWrite),
-        KIND_GIT_PATCH
-        | KIND_GIT_PULL_REQUEST
-        | KIND_GIT_PR_UPDATE
-        | KIND_GIT_ISSUE
-        | KIND_GIT_STATUS_OPEN
-        | KIND_GIT_STATUS_MERGED
-        | KIND_GIT_STATUS_CLOSED
-        | KIND_GIT_STATUS_DRAFT => Ok(Scope::MessagesWrite),
-        // Command kinds — DM management, workflows, approvals
-        KIND_DM_OPEN | KIND_DM_ADD_MEMBER | KIND_DM_HIDE => Ok(Scope::MessagesWrite),
-        KIND_WORKFLOW_DEF | KIND_WORKFLOW_TRIGGER => Ok(Scope::MessagesWrite),
-        KIND_APPROVAL_GRANT | KIND_APPROVAL_DENY => Ok(Scope::MessagesWrite),
-        _ => Err("restricted: unknown event kind"),
-    }
-}
-
 /// Extract a channel UUID from the `"h"` NIP-29 group tag.
 pub(crate) fn extract_channel_id(event: &Event) -> Option<Uuid> {
     for tag in event.tags.iter() {
@@ -605,131 +477,6 @@ pub(crate) async fn derive_reaction_channel(
         Ok(None) => ReactionChannelResult::NotFound,
         Err(e) => ReactionChannelResult::DbError(e.to_string()),
     }
-}
-
-/// Kinds that are always global (`channel_id = NULL`).
-///
-/// If a client includes a stray `h` tag on these kinds, the ingest pipeline
-/// sets `channel_id = None` — these events are never channel-scoped.
-///
-/// Note: the raw `h` tag remains on the stored event (Nostr events are signed,
-/// so tags cannot be stripped without invalidating the signature). The read-path
-/// filter matching in `filter.rs` treats explicit `h` tags as authoritative,
-/// which means a stray `h` tag can still match `#h` queries. This is a known
-/// limitation affecting all global-only kinds and should be addressed in the
-/// filter layer as a follow-up.
-pub(crate) fn is_global_only_kind(kind: u32) -> bool {
-    matches!(
-        kind,
-        KIND_PROFILE
-            | KIND_TEXT_NOTE
-            | KIND_CONTACT_LIST
-            | KIND_LONG_FORM
-            | KIND_USER_STATUS
-            | KIND_READ_STATE
-            // NIP-51 standard lists + sets and NIP-65 relay list — user-owned global state.
-            // Same as kind:3 (contacts): keyed by (pubkey, kind) or (pubkey, kind, d_tag),
-            // never channel-scoped. A stray `h` tag must not channel-scope them.
-            | KIND_MUTE_LIST
-            | KIND_PIN_LIST
-            | KIND_NIP65_RELAY_LIST_METADATA
-            | KIND_BOOKMARK_LIST
-            | KIND_FOLLOW_SET
-            | KIND_BOOKMARK_SET
-            // NIP-30 custom emoji set (30030) + emoji list (10030): user-owned,
-            // keyed by (pubkey, kind[, d_tag]). A stray `h` tag must not channel-scope them.
-            | KIND_EMOJI_SET
-            | KIND_EMOJI_LIST
-            // NIP-AE agent engrams are addressed by (pubkey_a, kind, d_tag); never channel-scoped.
-            | KIND_AGENT_ENGRAM
-            // NIP-ER event reminders are addressed by (pubkey, kind, d_tag); never channel-scoped.
-            | KIND_EVENT_REMINDER
-            // Agent profile (10100): user-owned replaceable, keyed by pubkey.
-            | KIND_AGENT_PROFILE
-            // NIP-AP: persona definitions (30175): owner-authored, keyed by (pubkey, kind, d_tag).
-            | KIND_PERSONA
-            // NIP-AP: team (30176) + managed-agent (30177) definitions and the
-            // team-catalog projection (30178): owner-authored, keyed by
-            // (pubkey, kind, d_tag). A stray `h` tag must not channel-scope them.
-            | KIND_TEAM
-            | KIND_MANAGED_AGENT
-            | KIND_PRIVATE_MANAGED_AGENT
-            | KIND_TEAM_CATALOG
-            // NIP-34: git events use `a` tags (repo reference), not `h` tags (channel scope).
-            // Parameterized replaceable kinds are keyed by (pubkey, kind, d_tag).
-            | KIND_GIT_REPO_ANNOUNCEMENT
-            | KIND_GIT_REPO_STATE
-            | KIND_GIT_PATCH
-            | KIND_GIT_PULL_REQUEST
-            | KIND_GIT_PR_UPDATE
-            | KIND_GIT_ISSUE
-            | KIND_GIT_STATUS_OPEN
-            | KIND_GIT_STATUS_MERGED
-            | KIND_GIT_STATUS_CLOSED
-            | KIND_GIT_STATUS_DRAFT
-            // NIP-MP: projects are addressed by (pubkey, kind, d_tag). The
-            // `buzz-channel` tag is a metadata reference, not a routing directive,
-            // so a project's state is never channel-scoped.
-            | KIND_PROJECT
-            // Community moderation commands (9040–9044): community-global
-            // direct commands, same model as the NIP-43 9030-series. A stray
-            // `h` tag must never channel-scope them (pinned contract —
-            // handlers/moderation_commands.rs routing docs).
-            | KIND_MODERATION_BAN
-            | KIND_MODERATION_UNBAN
-            | KIND_MODERATION_TIMEOUT
-            | KIND_MODERATION_UNTIMEOUT
-            | KIND_MODERATION_RESOLVE_REPORT
-            // NIP-43: relay admin commands and leave requests are global — they
-            // must never be channel-scoped, even if the event carries a stray `h` tag.
-            | RELAY_ADMIN_ADD_MEMBER
-            | RELAY_ADMIN_REMOVE_MEMBER
-            | RELAY_ADMIN_CHANGE_ROLE
-            | RELAY_ADMIN_SET_WORKSPACE_PROFILE
-            | KIND_NIP43_LEAVE_REQUEST
-            // NIP-IA: identity archive/unarchive requests drive relay-global
-            // archive state (8002/8003/13535) and are audited as global request
-            // events. A stray `h` tag must not channel-scope them.
-            | KIND_IA_ARCHIVE_REQUEST
-            | KIND_IA_UNARCHIVE_REQUEST
-            // NIP-AM: agent turn metrics are owner-scoped global events.
-            // Channel identity is encrypted inside the payload — no `h` tag.
-            | KIND_AGENT_TURN_METRIC
-            // NIP-PL leases are author-owned, addressable global state.
-            | super::push_lease::KIND_PUSH_LEASE
-    )
-}
-
-/// Kinds that require an `h` tag for channel scoping.
-pub(crate) fn requires_h_channel_scope(kind: u32) -> bool {
-    matches!(
-        kind,
-        KIND_STREAM_MESSAGE
-            | KIND_STREAM_MESSAGE_V2
-            | KIND_STREAM_MESSAGE_EDIT
-            | KIND_STREAM_MESSAGE_PINNED
-            | KIND_STREAM_MESSAGE_BOOKMARKED
-            | KIND_STREAM_MESSAGE_SCHEDULED
-            | KIND_STREAM_REMINDER
-            | KIND_STREAM_MESSAGE_DIFF
-            | KIND_CANVAS
-            | KIND_FORUM_POST
-            | KIND_FORUM_VOTE
-            | KIND_FORUM_COMMENT
-            // NIP-29 admin kinds (except CREATE_GROUP which creates the channel)
-            | KIND_NIP29_PUT_USER
-            | KIND_NIP29_REMOVE_USER
-            | KIND_NIP29_EDIT_METADATA
-            | KIND_NIP29_DELETE_EVENT
-            | KIND_NIP29_DELETE_GROUP
-            | KIND_NIP29_LEAVE_REQUEST
-            // Huddle lifecycle events + guidelines
-            | KIND_HUDDLE_STARTED
-            | KIND_HUDDLE_PARTICIPANT_JOINED
-            | KIND_HUDDLE_PARTICIPANT_LEFT
-            | KIND_HUDDLE_ENDED
-            | KIND_HUDDLE_GUIDELINES
-    )
 }
 
 /// Check channel membership: member OR open-visibility channel.
@@ -2246,12 +1993,46 @@ async fn ingest_event_inner(
         ));
     }
 
-    let required = match required_scope_for_kind(kind_u32, &event) {
-        Ok(scope) => scope,
-        Err(msg) => return Err(IngestError::Rejected(msg.into())),
+    // Seam A: resolve the base write-scope and the channel-scoping
+    // classification from the kind registry rather than the former inline
+    // `required_scope_for_kind` / `is_global_only_kind` /
+    // `requires_h_channel_scope` policy functions (see `buzz-kinds`). A
+    // registry miss reproduces the old terminal
+    // `_ => Err("restricted: unknown event kind")` reject verbatim.
+    //
+    // `KIND_PUSH_LEASE` (30350) is not registered (see `buzz_kinds::registry`
+    // module docs) and flows through this resolution before its dedicated
+    // handler further below, so it keeps its former inline special case.
+    let (required, scoping) = if kind_u32 == super::push_lease::KIND_PUSH_LEASE {
+        (Scope::UsersWrite, Scoping::Global)
+    } else {
+        let descriptor = match state.kind_registry.get(kind_u32) {
+            Some(descriptor) => descriptor,
+            None => {
+                return Err(IngestError::Rejected(
+                    "restricted: unknown event kind".into(),
+                ));
+            }
+        };
+        let required = match &descriptor.required_scope {
+            RequiredScope::Static(scope) => scope.clone(),
+            RequiredScope::Dynamic => {
+                // Dynamic-scope kinds resolve their scope from the event via
+                // the kind's extension (the NIP-29 edit-metadata archive/
+                // non-archive split). Fail closed if a `Dynamic` descriptor
+                // somehow has no extension wired.
+                let Some(extension) = descriptor.extension else {
+                    return Err(IngestError::Rejected(
+                        "restricted: event kind has no scope resolver".into(),
+                    ));
+                };
+                extension.required_scope(&event)
+            }
+        };
+        (required, descriptor.scoping)
     };
     // NIP-43: relay admin commands are global — channel-scoped tokens cannot
-    // issue them even if the event has no `h` tag (is_global_only_kind strips
+    // issue them even if the event has no `h` tag (Scoping::Global strips
     // channel_id, but we still need to reject the token itself).
     if is_relay_admin_kind(kind_u32) && auth.channel_ids().is_some() {
         return Err(IngestError::AuthFailed(
@@ -2453,11 +2234,11 @@ async fn ingest_event_inner(
         extract_channel_id(&event)
     };
 
-    if is_global_only_kind(kind_u32) {
+    if matches!(scoping, Scoping::Global) {
         channel_id = None;
     }
 
-    if requires_h_channel_scope(kind_u32) && channel_id.is_none() {
+    if matches!(scoping, Scoping::ChannelRequired) && channel_id.is_none() {
         return Err(IngestError::Rejected(
             "invalid: channel-scoped events must include an h tag".into(),
         ));
@@ -2984,7 +2765,7 @@ async fn ingest_event_inner(
             .map_err(|e| IngestError::Rejected(format!("invalid: {e}")))?;
     }
 
-    let thread_meta = if requires_h_channel_scope(kind_u32) {
+    let thread_meta = if matches!(scoping, Scoping::ChannelRequired) {
         if let Some(ch_id) = channel_id {
             resolve_nip10_thread_meta(tenant.community(), &event, ch_id, state)
                 .await
@@ -3274,6 +3055,69 @@ async fn ingest_event_inner(
     })
 }
 
+// ---------------------------------------------------------------------------
+// Test-only registry adapters
+// ---------------------------------------------------------------------------
+//
+// Seam A removed the inline `required_scope_for_kind` / `is_global_only_kind`
+// / `requires_h_channel_scope` policy functions: the live ingest path now
+// resolves a kind's base scope and channel scoping through
+// `AppState.kind_registry`. These thin `#[cfg(test)]` adapters reproduce
+// those functions' former signatures over a freshly-built built-in registry
+// so the existing policy unit tests below (and in `event.rs`) keep asserting
+// the same facts, now sourced from the registry rather than a parallel
+// inline list. They are test scaffolding, not policy; the registry is the
+// single source of truth.
+
+/// Build a registry populated with every built-in kind, exactly as
+/// `AppState::new` does. Used only by the test adapters below.
+#[cfg(test)]
+fn test_builtin_registry() -> buzz_kinds::KindRegistry {
+    let mut registry = buzz_kinds::KindRegistry::new();
+    buzz_kinds::register_builtin(&mut registry);
+    registry
+}
+
+/// Registry-backed adapter reproducing the former `required_scope_for_kind`:
+/// a registry miss is the fail-closed `Err("restricted: unknown event kind")`,
+/// and a `Dynamic` descriptor defers to its extension. `KIND_PUSH_LEASE`
+/// (unregistered, see `buzz_kinds::registry` module docs) reproduces its
+/// former inline special case.
+#[cfg(test)]
+pub(crate) fn required_scope_for_kind(kind: u32, event: &Event) -> Result<Scope, &'static str> {
+    if kind == super::push_lease::KIND_PUSH_LEASE {
+        return Ok(Scope::UsersWrite);
+    }
+    let registry = test_builtin_registry();
+    let descriptor = registry.get(kind).ok_or("restricted: unknown event kind")?;
+    match &descriptor.required_scope {
+        RequiredScope::Static(scope) => Ok(scope.clone()),
+        RequiredScope::Dynamic => descriptor
+            .extension
+            .map(|extension| extension.required_scope(event))
+            .ok_or("restricted: unknown event kind"),
+    }
+}
+
+/// Registry-backed adapter reproducing the former `is_global_only_kind`.
+#[cfg(test)]
+pub(crate) fn is_global_only_kind(kind: u32) -> bool {
+    if kind == super::push_lease::KIND_PUSH_LEASE {
+        return true;
+    }
+    test_builtin_registry()
+        .get(kind)
+        .is_some_and(|descriptor| matches!(descriptor.scoping, Scoping::Global))
+}
+
+/// Registry-backed adapter reproducing the former `requires_h_channel_scope`.
+#[cfg(test)]
+pub(crate) fn requires_h_channel_scope(kind: u32) -> bool {
+    test_builtin_registry()
+        .get(kind)
+        .is_some_and(|descriptor| matches!(descriptor.scoping, Scoping::ChannelRequired))
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
@@ -3281,9 +3125,12 @@ mod tests {
     use super::*;
     use buzz_conformance::{TraceStep, Tracer};
     use buzz_core::kind::{
-        KIND_CANVAS, KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_FORUM_VOTE, KIND_LONG_FORM,
-        KIND_MANAGED_AGENT, KIND_PERSONA, KIND_PRESENCE_UPDATE, KIND_STREAM_MESSAGE,
-        KIND_STREAM_MESSAGE_DIFF, KIND_TEAM, KIND_USER_STATUS,
+        KIND_AGENT_PROFILE, KIND_BOOKMARK_LIST, KIND_BOOKMARK_SET, KIND_CANVAS, KIND_FOLLOW_SET,
+        KIND_IA_ARCHIVE_REQUEST, KIND_IA_UNARCHIVE_REQUEST, KIND_LONG_FORM, KIND_MANAGED_AGENT,
+        KIND_MODERATION_BAN, KIND_MODERATION_RESOLVE_REPORT, KIND_MODERATION_TIMEOUT,
+        KIND_MODERATION_UNBAN, KIND_MODERATION_UNTIMEOUT, KIND_MUTE_LIST, KIND_NIP29_LEAVE_REQUEST,
+        KIND_NIP29_PUT_USER, KIND_NIP29_REMOVE_USER, KIND_NIP65_RELAY_LIST_METADATA, KIND_PIN_LIST,
+        KIND_PRIVATE_MANAGED_AGENT, KIND_TEAM, KIND_USER_STATUS,
     };
     use nostr::{EventBuilder, Kind};
 

--- a/crates/buzz-relay/src/state.rs
+++ b/crates/buzz-relay/src/state.rs
@@ -767,6 +767,14 @@ pub struct AppState {
     /// byte-identically to a relay without the mesh. Access via
     /// [`AppState::mesh`].
     pub mesh: Arc<std::sync::OnceLock<crate::mesh_boot::MeshHandle>>,
+
+    /// Declarative event-kind registry (Seam A), built once at startup via
+    /// `buzz_kinds::register_builtin`. The ingest write path resolves each
+    /// kind's base scope and channel scoping through this registry instead of
+    /// the former inline `required_scope_for_kind` match plus the
+    /// `is_global_only_kind` / `requires_h_channel_scope` boolean allowlists.
+    /// See `crates/buzz-kinds` and `handlers::ingest`.
+    pub kind_registry: Arc<buzz_kinds::KindRegistry>,
 }
 
 impl AppState {
@@ -854,6 +862,12 @@ impl AppState {
             Arc::new(RedisNip98ReplayGuard::new(redis_pool.clone()));
         let admission_rate_limiter = Arc::new(RedisRateLimiter::new(redis_pool.clone()));
         let audit_enabled = audit_arc.is_some();
+
+        // Seam A: build the declarative kind registry once at startup.
+        let mut kind_registry = buzz_kinds::KindRegistry::new();
+        buzz_kinds::register_builtin(&mut kind_registry);
+        let kind_registry = Arc::new(kind_registry);
+
         let state = Self {
             config: Arc::new(config),
             db,
@@ -940,6 +954,7 @@ impl AppState {
             // `crates/buzz-test-client` once those land).
             tracer: Arc::new(crate::conformance::NoopTracer),
             mesh: Arc::new(std::sync::OnceLock::new()),
+            kind_registry,
         };
         (
             state,


### PR DESCRIPTION
Implements #3167.

## Problem

Adding a new event kind means editing several places at once: the large
`required_scope_for_kind` match in `buzz-relay/src/handlers/ingest.rs`, two
separate boolean allowlists (`is_global_only_kind` / `requires_h_channel_scope`),
`is_relay_only_kind`, and the `P_GATED_KINDS` / `AUTHOR_ONLY_KINDS` /
`RESULT_GATED_KINDS` slices in `buzz-core`. One invariant this code has to
hold, that `is_global_only_kind` and `requires_h_channel_scope` never both
claim the same kind, is only checked by a runtime test today, not by the
type system.

## What this PR does

Adds a new leaf crate, `buzz-kinds`, holding a `KindDescriptor` per event
kind: the base write scope (`RequiredScope::Static`/`Dynamic`), the NIP-29
channel-scoping classification (`Scoping::{Global, ChannelRequired,
ChannelOptional}`), a read-gate field, and an authorship field.
`ingest_event_inner` now resolves each event's scope and channel scoping
through `AppState.kind_registry` instead of the old match plus the two
allowlists, which are removed.

**`Scoping` replaces the two allowlists with one enum.** The old
`is_global_only_kind` and `requires_h_channel_scope` were two independent
bools that had to be kept mutually exclusive by hand, backed by a dedicated
`global_only_and_channel_scoped_are_disjoint` regression test. With
`Scoping`, a descriptor can't be both `Global` and `ChannelRequired` at the
same time, so that invariant is now structural, not test-only. I kept the
disjointness test anyway, it just passes trivially now.

**A registry miss is the fail-closed reject.** Every kind the old match
accepted is registered. Anything else falls through to the same
`"restricted: unknown event kind"` error as before.

**One dynamic-scope kind.** `kind:9002` (NIP-29 edit-metadata) needs
`RequiredScope::Dynamic` plus a `KindExtension::required_scope` hook,
because its scope depends on whether the event carries an `archived` tag.

## Not in this PR

The RFC (#3167) also names two more pieces of the same problem. I left both
out to keep this diff reviewable:

1. **Per-kind authorize/validate logic.** The relay has inline AND-gates
   and a `validate_*` ladder (diff/engram/agent-turn-metric/event-reminder/
   persona envelope) that could become `KindExtension::authorize`/`validate`
   hooks. `KindExtension` only has `required_scope` in this PR. The trait
   can grow those methods later with defaults, which won't break the one
   existing implementor. Some of that logic (edit-ownership and forum-vote
   validation, for example) needs more context than the ingest path
   currently threads through, so it deserves its own PR.
2. **`P_GATED_KINDS` / `AUTHOR_ONLY_KINDS` / `RESULT_GATED_KINDS`.** These
   still live on `buzz-core`'s existing slices. `KindDescriptor::read_gate`
   is declared but nothing reads it yet. This is a mechanical follow-up
   once the scope/scoping flip has landed and soaked.
3. **The `search_tsv`-NULL migration.** The RFC issue describes this as
   coupled to `P_GATED_KINDS` through a negative allowlist. That's no
   longer how it works: `migrations/0008_fresh_install_search_allowlist.sql`
   already replaced it with a positive FTS allowlist for fresh installs.
   That's a different, arguably safer design than the one the issue was
   written against, so I left it alone.
4. **`is_relay_only_kind`.** Still lives in `buzz-core` and still runs
   before the registry lookup. Relay-only kinds aren't registered in
   `buzz-kinds` in this PR. `KindDescriptor::authorship` is declared but
   unused for now.
5. `KIND_PUSH_LEASE` (30350) keeps its existing inline special case in
   `ingest_event_inner` rather than being registered. It's a dedicated
   handler with its own shape, and folding it in isn't needed for this
   PR's behavior-preservation goal.

None of this blocks picking it up later. `KindDescriptor` and
`KindExtension` were built with room for it, see the doc comments in
`crates/buzz-kinds/src/descriptor.rs` and `extension.rs`.

## Review focus

1. Is deferring authorize/validate logic into `KindExtension` acceptable as
   its own follow-up PR, or should more of it be bundled here given it's
   part of the same chokepoint?
2. `KindDescriptor::read_gate` is declared but not yet consumed anywhere.
   Is that an acceptable staging point, or should the read-gate flip land
   in this same PR since it's mechanical and low-risk?
3. Any objection to leaving `is_relay_only_kind` and `KIND_PUSH_LEASE`'s
   inline handling outside the registry for now, as described above?

## Testing

At commit `a05a9c51b` (the last code commit on this branch; later commits
only touch this description):

- `cargo test -p buzz-relay --lib handlers::ingest`: 174 passed, 1 ignored
  (needs Postgres, pre-existing, unrelated). These are the existing policy
  tests, unchanged, now running against `#[cfg(test)]` adapters that
  reproduce the deleted functions' signatures over a freshly built
  registry. That's the actual proof this is behavior-preserving.
- `cargo test -p buzz-relay --lib handlers::event`: 24 passed.
- `cargo test -p buzz-kinds`: 3 passed (no duplicate kinds, the
  `AUTHOR_ONLY_KINDS` cross-check against `buzz-core`, the edit-metadata
  archived-tag scope split).
- `cargo test -p buzz-relay --lib` (full): 901 passed, 8 failed. The 8
  failures are pre-existing and unrelated (Postgres pool timeouts, two
  admin-endpoint status-code assertions). I confirmed they also fail on an
  unmodified checkout of the same commit.
- `cargo check --workspace --all-targets`: clean.
- `cargo clippy -p buzz-relay -p buzz-kinds -p buzz-core --all-targets -- -D warnings`: clean.
- `cargo fmt --check -p buzz-relay -p buzz-kinds -p buzz-core`: clean.
- No new `unwrap()`/`expect()`/`unsafe` in production code. The `unwrap()`s
  in `buzz-kinds` are in its own test module, and `buzz-kinds/src/lib.rs`
  has `#![forbid(unsafe_code)]`.

### Manual test

```
. ./bin/activate-hermit
cargo test -p buzz-relay -p buzz-kinds -p buzz-core
just relay
```

Then publish events of a few kinds through buzz-cli or the desktop app and
confirm scope/channel-scoping behavior is unchanged: a channel-scoped token
still can't publish kind:0/1/3, and kind:9002 with an `archived` tag still
needs AdminChannels.

## Duplicate check

Re-ran the issue's "searched, none found" claim before opening this:
`gh search issues --repo block/buzz "kind registry OR required_scope_for_kind"`
and `gh search prs --repo block/buzz "3167"` / `"buzz-kinds"` / `"kind registry"`.
No open PR implements #3167. Two related open RFCs from the same author
exist, #3351 (agent-context provider registry) and #3280 (desktop
channel-feature registry), both explicitly companions to #3167, not
overlapping implementations.
