### PR TITLE
buzz-acp: add a TeamContextProvider registry seam for team_instructions

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,84 @@
+# buzz-acp: add a `TeamContextProvider` registry seam for `team_instructions`
+
+Implements #3351. Third and smallest of a coherent trio of "registry seam"
+proposals: #3167 (relay kind registry) and #3280 (desktop channel-feature
+registry) are being submitted separately.
+
+## Problem
+
+Every source that wants to contribute to an agent's standing `team_instructions`
+context (workspace house rules, per-team norms, channel-scoped policy, agent
+memory, future capability-carried context, …) has to be hand-wired into the
+same spot in `buzz-acp`'s startup path. That's a central chokepoint that gets
+harder to extend as the agent surface grows — the same pattern #3167 and #3280
+address on the relay and desktop client respectively.
+
+**Note on scope vs. the RFC text:** #3351 was written against a fork that had
+already added a workspace "Agent Guidelines" fetch-and-fold at this call site.
+That fetch does not exist in `block/buzz` upstream — at the current call site
+in `tokio_main`, `team_instructions` is just `config.team_instructions.clone()`,
+a straight pass-through with no fetch to generalize. So this PR ships the seam
+itself with an **empty** built-in provider list rather than porting a provider
+that has no upstream counterpart to port. The registry, trait, and fold
+function are exactly what the RFC proposes; only the "existing Agent
+Guidelines fetch becomes one registered provider" part is deferred — there's
+nothing upstream yet to convert. Wiring an actual first provider (e.g.
+workspace house rules) is natural follow-up work once this seam lands.
+
+## How
+
+- New `crates/buzz-acp/src/team_context.rs`:
+  - `TeamContextProvider` trait — `name()` plus `provide(ctx) -> Option<String>`,
+    object-safe via `Pin<Box<dyn Future<...> + Send>>` (the pattern already
+    used by `buzz_workflow::ActionSink`), so no `async-trait` dependency.
+  - `TeamContextCtx` — carries `relay_url` and `keys`, the inputs a
+    relay-backed provider needs.
+  - `builtin_team_context_providers()` — the ordered list run at startup.
+    Empty today (see note above).
+  - `build_team_instructions(providers, ctx, base)` — runs providers in
+    order, drops `None`/blank contributions, joins the rest ahead of `base`
+    with a blank line between sections. With an empty provider list this is
+    the identity on `base`.
+- `crates/buzz-acp/src/lib.rs`: the `tokio_main` startup call site now builds
+  `team_instructions` via `team_context::build_team_instructions(...)` instead
+  of `config.team_instructions.clone()`.
+
+**Behavior-preserving:** `config.team_instructions` is already trimmed and
+empty-filtered at config-parse time (`config.rs`), so `build_team_instructions`'s
+own trim/empty-filter on `base` is a no-op there — with the empty built-in
+provider list, the new call site produces byte-identical output to the old
+`config.team_instructions.clone()` for every input it can receive today.
+
+## Testing
+
+- `cargo test -p buzz-acp`: 805 passed, 0 failed (existing suite untouched).
+- New unit tests in `team_context.rs`:
+  - `empty_providers_is_identity_on_base` — with today's empty registry,
+    the fold reproduces `base` exactly (or `None` for blank/absent), the
+    property that makes this change behavior-preserving.
+  - `builtin_providers_start_empty`.
+  - `providers_fold_in_order_ahead_of_base` — ordering, blank-line joins,
+    `None`/whitespace-only contributions dropped, via a network-free stub
+    provider.
+  - `all_empty_yields_none`.
+- `cargo clippy -p buzz-acp --all-targets -- -D warnings`: clean.
+- `cargo fmt -p buzz-acp -- --check`: clean.
+- No new `unwrap()` or `unsafe` in production code.
+
+## Follow-ups (not in this PR)
+
+- Register a first real provider once one exists upstream (e.g. a workspace
+  house-rules/guidelines fetch) to exercise the non-empty-registry path in
+  production.
+- #3167 and #3280 (relay kind registry, desktop channel-feature registry) —
+  submitted separately.
+
+## Duplicate check (re-run for this PR)
+
+```
+gh search issues --repo block/buzz "agent context provider OR team_instructions"
+gh search prs --repo block/buzz "agent context provider OR team_instructions"
+gh search issues --repo block/buzz "TeamContextProvider"
+```
+
+Only hit: this PR's own RFC, #3351. No duplicate issues or PRs found.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -52,7 +52,22 @@ trim/empty-filter on `base` is a no-op there. With the empty provider list,
 the new call site produces the same output as the old
 `config.team_instructions.clone()` for every input it can receive today.
 
+## Review focus
+
+1. The RFC issue (#3351) describes generalizing an existing Agent
+   Guidelines fetch that doesn't exist in this repo. Should the issue text
+   itself be corrected to match, so future readers aren't confused by a
+   motivation section describing code that isn't there?
+2. Is landing the seam with an empty provider list (proven by
+   `empty_providers_is_identity_on_base`) an acceptable way to merge this
+   ahead of any real provider, or would you rather see it land together
+   with a first provider so the non-empty path is exercised in production
+   immediately?
+
 ## Testing
+
+At commit `af6c2f0dc` (the last code commit on this branch; later commits
+only touch this description):
 
 - `cargo test -p buzz-acp`: 805 passed, 0 failed, existing suite untouched.
 - New unit tests in `team_context.rs`:

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,64 +1,67 @@
-# buzz-acp: add a `TeamContextProvider` registry seam for `team_instructions`
+# buzz-acp: add a TeamContextProvider registry seam for team_instructions
 
-Implements #3351. Third and smallest of a coherent trio of "registry seam"
-proposals: #3167 (relay kind registry) and #3280 (desktop channel-feature
-registry) are being submitted separately.
+Implements #3351. Third and smallest of a trio of registry-seam proposals.
+#3167 (relay kind registry) and #3280 (desktop channel-feature registry)
+are being submitted separately.
 
 ## Problem
 
-Every source that wants to contribute to an agent's standing `team_instructions`
-context (workspace house rules, per-team norms, channel-scoped policy, agent
-memory, future capability-carried context, …) has to be hand-wired into the
-same spot in `buzz-acp`'s startup path. That's a central chokepoint that gets
-harder to extend as the agent surface grows — the same pattern #3167 and #3280
-address on the relay and desktop client respectively.
+Every source that wants to contribute to an agent's standing
+`team_instructions` context (workspace house rules, per-team norms,
+channel-scoped policy, agent memory, future capability-carried context)
+has to be hand-wired into the same spot in `buzz-acp`'s startup path. That's
+a central chokepoint that gets harder to extend as the agent surface grows,
+the same pattern #3167 and #3280 address on the relay and desktop client.
 
-**Note on scope vs. the RFC text:** #3351 was written against a fork that had
-already added a workspace "Agent Guidelines" fetch-and-fold at this call site.
-That fetch does not exist in `block/buzz` upstream — at the current call site
-in `tokio_main`, `team_instructions` is just `config.team_instructions.clone()`,
-a straight pass-through with no fetch to generalize. So this PR ships the seam
-itself with an **empty** built-in provider list rather than porting a provider
-that has no upstream counterpart to port. The registry, trait, and fold
-function are exactly what the RFC proposes; only the "existing Agent
-Guidelines fetch becomes one registered provider" part is deferred — there's
-nothing upstream yet to convert. Wiring an actual first provider (e.g.
-workspace house rules) is natural follow-up work once this seam lands.
+**Note on scope versus the RFC text.** #3351 was written against a fork
+that had already added a workspace "Agent Guidelines" fetch at this call
+site. That fetch doesn't exist in `block/buzz` upstream. At the current
+call site in `tokio_main`, `team_instructions` is just
+`config.team_instructions.clone()`, a plain pass-through with nothing to
+generalize. So this PR ships the seam itself with an empty built-in
+provider list, rather than porting a provider that has no upstream
+counterpart. The registry, trait, and fold function are what the RFC
+proposes. Only "the existing Agent Guidelines fetch becomes one registered
+provider" is deferred, since there's nothing upstream yet to convert.
+Wiring a first real provider (workspace house rules, for example) is
+natural follow-up work once this seam lands.
 
 ## How
 
 - New `crates/buzz-acp/src/team_context.rs`:
-  - `TeamContextProvider` trait — `name()` plus `provide(ctx) -> Option<String>`,
-    object-safe via `Pin<Box<dyn Future<...> + Send>>` (the pattern already
-    used by `buzz_workflow::ActionSink`), so no `async-trait` dependency.
-  - `TeamContextCtx` — carries `relay_url` and `keys`, the inputs a
+  - `TeamContextProvider` trait: `name()` plus
+    `provide(ctx) -> Option<String>`, object-safe via
+    `Pin<Box<dyn Future<...> + Send>>`, the same pattern
+    `buzz_workflow::ActionSink` already uses, so no `async-trait` dependency.
+  - `TeamContextCtx`: carries `relay_url` and `keys`, the inputs a
     relay-backed provider needs.
-  - `builtin_team_context_providers()` — the ordered list run at startup.
-    Empty today (see note above).
-  - `build_team_instructions(providers, ctx, base)` — runs providers in
+  - `builtin_team_context_providers()`: the ordered list run at startup.
+    Empty today, see the note above.
+  - `build_team_instructions(providers, ctx, base)`: runs providers in
     order, drops `None`/blank contributions, joins the rest ahead of `base`
     with a blank line between sections. With an empty provider list this is
     the identity on `base`.
-- `crates/buzz-acp/src/lib.rs`: the `tokio_main` startup call site now builds
-  `team_instructions` via `team_context::build_team_instructions(...)` instead
-  of `config.team_instructions.clone()`.
+- `crates/buzz-acp/src/lib.rs`: the `tokio_main` startup call site now
+  builds `team_instructions` via
+  `team_context::build_team_instructions(...)` instead of
+  `config.team_instructions.clone()`.
 
-**Behavior-preserving:** `config.team_instructions` is already trimmed and
-empty-filtered at config-parse time (`config.rs`), so `build_team_instructions`'s
-own trim/empty-filter on `base` is a no-op there — with the empty built-in
-provider list, the new call site produces byte-identical output to the old
+**Behavior-preserving.** `config.team_instructions` is already trimmed and
+empty-filtered at config-parse time, so `build_team_instructions`'s own
+trim/empty-filter on `base` is a no-op there. With the empty provider list,
+the new call site produces the same output as the old
 `config.team_instructions.clone()` for every input it can receive today.
 
 ## Testing
 
-- `cargo test -p buzz-acp`: 805 passed, 0 failed (existing suite untouched).
+- `cargo test -p buzz-acp`: 805 passed, 0 failed, existing suite untouched.
 - New unit tests in `team_context.rs`:
-  - `empty_providers_is_identity_on_base` — with today's empty registry,
-    the fold reproduces `base` exactly (or `None` for blank/absent), the
-    property that makes this change behavior-preserving.
+  - `empty_providers_is_identity_on_base`: with today's empty registry, the
+    fold reproduces `base` exactly (or `None` for blank/absent input). This
+    is the property that makes the change behavior-preserving.
   - `builtin_providers_start_empty`.
-  - `providers_fold_in_order_ahead_of_base` — ordering, blank-line joins,
-    `None`/whitespace-only contributions dropped, via a network-free stub
+  - `providers_fold_in_order_ahead_of_base`: ordering, blank-line joins,
+    `None`/whitespace-only contributions dropped, using a network-free stub
     provider.
   - `all_empty_yields_none`.
 - `cargo clippy -p buzz-acp --all-targets -- -D warnings`: clean.
@@ -67,13 +70,13 @@ provider list, the new call site produces byte-identical output to the old
 
 ## Follow-ups (not in this PR)
 
-- Register a first real provider once one exists upstream (e.g. a workspace
-  house-rules/guidelines fetch) to exercise the non-empty-registry path in
-  production.
-- #3167 and #3280 (relay kind registry, desktop channel-feature registry) —
+- Register a first real provider once one exists upstream, such as a
+  workspace house-rules or guidelines fetch, to exercise the non-empty
+  registry path in production.
+- #3167 and #3280 (relay kind registry, desktop channel-feature registry),
   submitted separately.
 
-## Duplicate check (re-run for this PR)
+## Duplicate check
 
 ```
 gh search issues --repo block/buzz "agent context provider OR team_instructions"

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -10,6 +10,7 @@ mod pool_lifecycle;
 mod queue;
 mod relay;
 mod setup_mode;
+mod team_context;
 mod usage;
 
 pub use usage::TurnUsage;
@@ -2190,6 +2191,21 @@ async fn tokio_main() -> Result<()> {
 
     let base_prompt_content = config.base_prompt_content.take();
     let cwd = current_working_directory()?;
+    // Run the ordered team-context providers once at startup (best-effort)
+    // and fold their output ahead of the persona/team-supplied base
+    // team_instructions, so every agent — modern (with_team) and legacy
+    // (format_prompt) — receives them without touching either prompt path.
+    let team_context_providers = team_context::builtin_team_context_providers();
+    let team_context_ctx = team_context::TeamContextCtx {
+        relay_url: &config.relay_url,
+        keys: &config.keys,
+    };
+    let team_instructions = team_context::build_team_instructions(
+        &team_context_providers,
+        &team_context_ctx,
+        config.team_instructions.as_deref(),
+    )
+    .await;
     let ctx = Arc::new(PromptContext {
         mcp_servers: build_mcp_servers(&config),
         initial_message: config.initial_message.clone(),
@@ -2199,7 +2215,7 @@ async fn tokio_main() -> Result<()> {
         dedup_mode: config.dedup_mode,
         system_prompt: config.system_prompt.clone(),
         session_title: config.session_title.clone(),
-        team_instructions: config.team_instructions.clone(),
+        team_instructions,
         base_prompt: if config.no_base_prompt {
             None
         } else if let Some(content) = base_prompt_content {

--- a/crates/buzz-acp/src/team_context.rs
+++ b/crates/buzz-acp/src/team_context.rs
@@ -1,0 +1,190 @@
+//! Registry seam for sources that contribute to an agent's `team_instructions`
+//! layer (rendered by both the modern `with_team` system-prompt path and the
+//! legacy `format_prompt` `[Team Instructions]` section — one value, both
+//! paths).
+//!
+//! As Buzz leans further into agents as first-class participants, more
+//! sources will legitimately want to contribute standing context: workspace
+//! house rules, per-team norms, channel-scoped policy, agent memory, and
+//! whatever future capabilities add. Rather than hardcoding another
+//! fetch-and-fold at the startup call site for each one, sources register as
+//! an ordered [`TeamContextProvider`] and [`build_team_instructions`] folds
+//! them together with the base (persona/team-supplied) `team_instructions`.
+//!
+//! No built-in provider is registered yet — [`builtin_team_context_providers`]
+//! starts empty, so today's fold is the identity: the base instructions pass
+//! through unchanged, exactly as `tokio_main` did before this seam existed.
+//! This is the extension point future context sources register through.
+
+use std::future::Future;
+use std::pin::Pin;
+
+/// Context handed to each [`TeamContextProvider`] so it can fetch its
+/// contribution. Fields are borrowed references — providers run once at
+/// startup, before any of these values are mutated or moved.
+///
+/// Unread today (`builtin_team_context_providers` is empty, so no provider
+/// exists yet to read them) — kept `pub` and unsuppressed via `dead_code`
+/// so the first real provider's use of them shows up as ordinary code, not
+/// a lint fix.
+#[allow(dead_code)]
+pub struct TeamContextCtx<'a> {
+    /// Relay URL to fetch from (for providers that talk to the relay).
+    pub relay_url: &'a str,
+    /// Agent's Nostr keys, used to authenticate relay connections.
+    pub keys: &'a nostr::Keys,
+}
+
+/// A source of team-level context folded into `team_instructions` at agent
+/// startup. Each provider returns its own already-framed contribution (or
+/// `None` if it has nothing to add); [`build_team_instructions`] runs the
+/// registered providers in order and joins their outputs ahead of the
+/// persona/team-supplied base instructions.
+///
+/// Object-safe via a boxed future (this workspace does not depend on
+/// `async-trait`) — mirrors the pattern used by `buzz_workflow::ActionSink`.
+pub trait TeamContextProvider: Send + Sync {
+    /// Stable identifier used for ordering/diagnostics (e.g. logging).
+    fn name(&self) -> &'static str;
+
+    /// Fetch and frame this provider's contribution to `team_instructions`.
+    /// Returns `None` when the provider has nothing to add.
+    fn provide<'a>(
+        &'a self,
+        ctx: &'a TeamContextCtx<'a>,
+    ) -> Pin<Box<dyn Future<Output = Option<String>> + Send + 'a>>;
+}
+
+/// The built-in, ordered list of [`TeamContextProvider`]s run at agent
+/// startup. Empty today — no context source has been wired through this
+/// seam yet. Persona/team base instructions are not a provider — they are
+/// the `base` argument to [`build_team_instructions`], since they come from
+/// config rather than a fetch.
+pub fn builtin_team_context_providers() -> Vec<Box<dyn TeamContextProvider>> {
+    Vec::new()
+}
+
+/// Run each provider in order, collect the framed contributions that
+/// returned `Some`, then join `[provider outputs…, base]` (each trimmed,
+/// empties dropped) with a blank line between sections. Returns `None` when
+/// there is nothing to inject.
+///
+/// With today's empty provider list, this is the identity: it reproduces
+/// `base` (trimmed, or `None` if blank) exactly.
+pub async fn build_team_instructions(
+    providers: &[Box<dyn TeamContextProvider>],
+    ctx: &TeamContextCtx<'_>,
+    base: Option<&str>,
+) -> Option<String> {
+    let mut sections: Vec<String> = Vec::with_capacity(providers.len() + 1);
+    for provider in providers {
+        match provider.provide(ctx).await {
+            Some(contribution) => {
+                let trimmed = contribution.trim();
+                if !trimmed.is_empty() {
+                    sections.push(trimmed.to_string());
+                }
+            }
+            None => tracing::debug!(
+                provider = provider.name(),
+                "team context provider yielded nothing"
+            ),
+        }
+    }
+    if let Some(base) = base.map(str::trim).filter(|b| !b.is_empty()) {
+        sections.push(base.to_string());
+    }
+    if sections.is_empty() {
+        None
+    } else {
+        Some(sections.join("\n\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(keys: &nostr::Keys) -> TeamContextCtx<'_> {
+        TeamContextCtx {
+            relay_url: "wss://example.invalid",
+            keys,
+        }
+    }
+
+    /// With no providers registered (today's built-in list), the fold must
+    /// be the identity on `base` — this is the property that makes adding
+    /// the seam behavior-preserving relative to the direct
+    /// `config.team_instructions.clone()` pass-through it replaces.
+    #[tokio::test]
+    async fn empty_providers_is_identity_on_base() {
+        let keys = nostr::Keys::generate();
+        let c = ctx(&keys);
+        let providers: Vec<Box<dyn TeamContextProvider>> = Vec::new();
+
+        assert_eq!(
+            build_team_instructions(&providers, &c, Some("Be terse.")).await,
+            Some("Be terse.".to_string())
+        );
+        assert_eq!(build_team_instructions(&providers, &c, None).await, None);
+        assert_eq!(
+            build_team_instructions(&providers, &c, Some("   ")).await,
+            None
+        );
+    }
+
+    /// `builtin_team_context_providers` starts empty — no context source is
+    /// wired through this seam yet.
+    #[test]
+    fn builtin_providers_start_empty() {
+        assert!(builtin_team_context_providers().is_empty());
+    }
+
+    struct StubProvider(&'static str, Option<&'static str>);
+
+    impl TeamContextProvider for StubProvider {
+        fn name(&self) -> &'static str {
+            self.0
+        }
+
+        fn provide<'a>(
+            &'a self,
+            _ctx: &'a TeamContextCtx<'a>,
+        ) -> Pin<Box<dyn Future<Output = Option<String>> + Send + 'a>> {
+            let out = self.1.map(str::to_string);
+            Box::pin(async move { out })
+        }
+    }
+
+    /// Providers run in order, ahead of `base`, joined with a blank line;
+    /// a provider returning `None` contributes nothing (but does not abort
+    /// the fold), and an all-whitespace contribution is trimmed to nothing.
+    #[tokio::test]
+    async fn providers_fold_in_order_ahead_of_base() {
+        let keys = nostr::Keys::generate();
+        let c = ctx(&keys);
+        let providers: Vec<Box<dyn TeamContextProvider>> = vec![
+            Box::new(StubProvider("first", Some("First section."))),
+            Box::new(StubProvider("silent", None)),
+            Box::new(StubProvider("blank", Some("   "))),
+            Box::new(StubProvider("second", Some("Second section."))),
+        ];
+
+        let out = build_team_instructions(&providers, &c, Some("Base.")).await;
+        assert_eq!(
+            out,
+            Some("First section.\n\nSecond section.\n\nBase.".to_string())
+        );
+    }
+
+    /// All providers silent and no base yields `None`, not an empty string.
+    #[tokio::test]
+    async fn all_empty_yields_none() {
+        let keys = nostr::Keys::generate();
+        let c = ctx(&keys);
+        let providers: Vec<Box<dyn TeamContextProvider>> =
+            vec![Box::new(StubProvider("silent", None))];
+
+        assert_eq!(build_team_instructions(&providers, &c, None).await, None);
+    }
+}


### PR DESCRIPTION
Implements #3351. Third and smallest of a trio of registry-seam proposals.
#3167 (relay kind registry) and #3280 (desktop channel-feature registry)
are being submitted separately.

## Problem

Every source that wants to contribute to an agent's standing
`team_instructions` context (workspace house rules, per-team norms,
channel-scoped policy, agent memory, future capability-carried context)
has to be hand-wired into the same spot in `buzz-acp`'s startup path. That's
a central chokepoint that gets harder to extend as the agent surface grows,
the same pattern #3167 and #3280 address on the relay and desktop client.

**Note on scope versus the RFC text.** #3351 was written against a fork
that had already added a workspace "Agent Guidelines" fetch at this call
site. That fetch doesn't exist in `block/buzz` upstream. At the current
call site in `tokio_main`, `team_instructions` is just
`config.team_instructions.clone()`, a plain pass-through with nothing to
generalize. So this PR ships the seam itself with an empty built-in
provider list, rather than porting a provider that has no upstream
counterpart. The registry, trait, and fold function are what the RFC
proposes. Only "the existing Agent Guidelines fetch becomes one registered
provider" is deferred, since there's nothing upstream yet to convert.
Wiring a first real provider (workspace house rules, for example) is
natural follow-up work once this seam lands.

## How

- New `crates/buzz-acp/src/team_context.rs`:
  - `TeamContextProvider` trait: `name()` plus
    `provide(ctx) -> Option<String>`, object-safe via
    `Pin<Box<dyn Future<...> + Send>>`, the same pattern
    `buzz_workflow::ActionSink` already uses, so no `async-trait` dependency.
  - `TeamContextCtx`: carries `relay_url` and `keys`, the inputs a
    relay-backed provider needs.
  - `builtin_team_context_providers()`: the ordered list run at startup.
    Empty today, see the note above.
  - `build_team_instructions(providers, ctx, base)`: runs providers in
    order, drops `None`/blank contributions, joins the rest ahead of `base`
    with a blank line between sections. With an empty provider list this is
    the identity on `base`.
- `crates/buzz-acp/src/lib.rs`: the `tokio_main` startup call site now
  builds `team_instructions` via
  `team_context::build_team_instructions(...)` instead of
  `config.team_instructions.clone()`.

**Behavior-preserving.** `config.team_instructions` is already trimmed and
empty-filtered at config-parse time, so `build_team_instructions`'s own
trim/empty-filter on `base` is a no-op there. With the empty provider list,
the new call site produces the same output as the old
`config.team_instructions.clone()` for every input it can receive today.

## Review focus

1. The RFC issue (#3351) describes generalizing an existing Agent
   Guidelines fetch that doesn't exist in this repo. Should the issue text
   itself be corrected to match, so future readers aren't confused by a
   motivation section describing code that isn't there?
2. Is landing the seam with an empty provider list (proven by
   `empty_providers_is_identity_on_base`) an acceptable way to merge this
   ahead of any real provider, or would you rather see it land together
   with a first provider so the non-empty path is exercised in production
   immediately?

## Testing

At commit `af6c2f0dc` (the last code commit on this branch; later commits
only touch this description):

- `cargo test -p buzz-acp`: 805 passed, 0 failed, existing suite untouched.
- New unit tests in `team_context.rs`:
  - `empty_providers_is_identity_on_base`: with today's empty registry, the
    fold reproduces `base` exactly (or `None` for blank/absent input). This
    is the property that makes the change behavior-preserving.
  - `builtin_providers_start_empty`.
  - `providers_fold_in_order_ahead_of_base`: ordering, blank-line joins,
    `None`/whitespace-only contributions dropped, using a network-free stub
    provider.
  - `all_empty_yields_none`.
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`: clean.
- `cargo fmt -p buzz-acp -- --check`: clean.
- No new `unwrap()` or `unsafe` in production code.

## Follow-ups (not in this PR)

- Register a first real provider once one exists upstream, such as a
  workspace house-rules or guidelines fetch, to exercise the non-empty
  registry path in production.
- #3167 and #3280 (relay kind registry, desktop channel-feature registry),
  submitted separately.

## Duplicate check

```
gh search issues --repo block/buzz "agent context provider OR team_instructions"
gh search prs --repo block/buzz "agent context provider OR team_instructions"
gh search issues --repo block/buzz "TeamContextProvider"
```

Only hit: this PR's own RFC, #3351. No duplicate issues or PRs found.
