### PR TITLE
fix(desktop): stop pulsing addressed agents on send

### DIFF
--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -341,7 +341,6 @@ function MessageComposerImpl({
     drafts,
     emojiAutocomplete,
     mentions,
-    onAddressedAgentsSendStarted: addressPulse.pulseMany,
     onAddressedAgentsComposerCleared: (pubkeys) =>
       restoreAddressedAgentMentionsRef.current(pubkeys),
     onAddressedAgentsSendFailed: addressPulse.shakeMany,

--- a/desktop/src/features/messages/ui/useMentionSendFlow.ts
+++ b/desktop/src/features/messages/ui/useMentionSendFlow.ts
@@ -52,7 +52,6 @@ export function useMentionSendFlow({
   emojiAutocomplete,
   mentions,
   onPrepareSendChannel,
-  onAddressedAgentsSendStarted,
   onAddressedAgentsComposerCleared,
   onAddressedAgentsSendFailed,
   onAddressedAgentsSendSucceeded,
@@ -404,9 +403,6 @@ export function useMentionSendFlow({
         draft.capturedChannelId === channelIdRef.current ||
         channelIdRef.current === null
       ) {
-        if (draft.addressedAgentPubkeys.length > 0) {
-          onAddressedAgentsSendStarted?.(draft.addressedAgentPubkeys);
-        }
         clearComposer();
         if (draft.addressedAgentPubkeys.length > 0) {
           optimisticComposerContent =
@@ -640,7 +636,6 @@ export function useMentionSendFlow({
       getManagedAgentsByPubkey,
       mentions.isAgentPubkey,
       mentions.revalidateMentionPubkeys,
-      onAddressedAgentsSendStarted,
       onAddressedAgentsComposerCleared,
       onAddressedAgentsSendFailed,
       onAddressedAgentsSendSucceeded,

--- a/desktop/src/features/messages/ui/useMentionSendFlow.types.ts
+++ b/desktop/src/features/messages/ui/useMentionSendFlow.types.ts
@@ -19,7 +19,6 @@ export type UseMentionSendFlowOptions = {
   emojiAutocomplete: Pick<UseEmojiAutocompleteResult, "clearEmojis">;
   mentions: UseMentionsResult;
   onPrepareSendChannel?: (pubkeys?: string[]) => Promise<string | null>;
-  onAddressedAgentsSendStarted?: (pubkeys: readonly string[]) => void;
   onAddressedAgentsComposerCleared?: (pubkeys: readonly string[]) => string;
   onAddressedAgentsSendFailed?: (pubkeys: readonly string[]) => void;
   onAddressedAgentsSendSucceeded?: (

--- a/desktop/tests/e2e/persistent-agent-audience.spec.ts
+++ b/desktop/tests/e2e/persistent-agent-audience.spec.ts
@@ -500,7 +500,7 @@ test("the mention button opens settings and can undo an address", async ({
   ).toHaveCount(0);
 });
 
-test("always-mentioned agents remain in the mention button while Enter-send resolves", async ({
+test("always-mentioned agents remain selected without replaying their animation while Enter-send resolves", async ({
   page,
 }) => {
   await installAudienceFixtures(page, {
@@ -549,7 +549,7 @@ test("always-mentioned agents remain in the mention button while Enter-send reso
     .not.toContain("");
   await expect(avatar).toHaveAttribute(
     "data-pulse-version",
-    String(initialPulseVersion + 1),
+    String(initialPulseVersion),
     { timeout: 500 },
   );
   await expect(
@@ -587,7 +587,7 @@ test("always-mentioned agents remain in the mention button while Enter-send reso
   ).toHaveCount(1);
 });
 
-test("a failed always-mentioned send shakes the composer avatar", async ({
+test("a failed always-mentioned send shakes the composer avatar without replaying its selection animation", async ({
   page,
 }) => {
   await installAudienceFixtures(page, {
@@ -610,7 +610,7 @@ test("a failed always-mentioned send shakes the composer avatar", async ({
 
   await expect(avatar).toHaveAttribute(
     "data-pulse-version",
-    String(initialPulseVersion + 1),
+    String(initialPulseVersion),
     { timeout: 500 },
   );
   await expect(input).toHaveText("@Morgarita please retry");


### PR DESCRIPTION
## Summary

- Stop replaying the selected-agent pulse when a remembered agent remains addressed across a send.
- Preserve the existing pulse for genuine selections and shake feedback for failed sends.

### Related issue

Reported in Buzz: buzz://message?channel=2745947d-f905-4f31-8a3f-fc4485d3c36c&id=0cffab376186be9cc4e7f29027352cc1c7941aead48b3fed948f36181f4a59af

### Testing

- `cd desktop && pnpm test` (5,556 passed)
- `cd desktop && pnpm typecheck`
- `cd desktop && pnpm check`
- `cd desktop && pnpm build:e2e`
- `cd desktop && pnpm exec playwright test tests/e2e/persistent-agent-audience.spec.ts --grep 'always-mentioned agents remain selected|failed always-mentioned send'` (2 passed)

This changes animation timing only; the regression is covered by Playwright assertions on the pulse and shake versions, while a static screenshot is unchanged.
