### PR TITLE
fix(cli): reject a project slug that cannot be typed back

### DIFF
--- a/crates/buzz-cli/src/commands/projects.rs
+++ b/crates/buzz-cli/src/commands/projects.rs
@@ -568,6 +568,29 @@ fn validate_project_slug(slug: &str) -> Result<(), CliError> {
             slug.len()
         )));
     }
+    // The slug is the `d` tag: it identifies the project, it is the value every
+    // later command filters `#d` on, and it is what a listing prints. Only
+    // length and emptiness were checked, so a slug could carry a newline, a NUL
+    // or a stray leading space — none of which survive a round trip through a
+    // human. A slug that differs from another only by an untypeable character
+    // creates a second project that is indistinguishable from the first in
+    // `projects list`, and every later `--slug` on the visible spelling reports
+    // "not found" for a project the caller can see.
+    //
+    // Deliberately narrower than `validate_repo_id`'s allowlist: project slugs
+    // are meant to be more permissive (`platform:v2` is a valid one), so this
+    // rejects only what cannot be typed back, not everything unusual.
+    if let Some(bad) = slug.chars().find(|c| c.is_control()) {
+        return Err(CliError::Usage(format!(
+            "project slug must not contain control characters (found {:?})",
+            bad
+        )));
+    }
+    if slug.trim() != slug {
+        return Err(CliError::Usage(
+            "project slug must not begin or end with whitespace".into(),
+        ));
+    }
     Ok(())
 }
 
@@ -693,6 +716,42 @@ mod tests {
     fn validate_project_slug_accepts_normal() {
         assert!(validate_project_slug("my-project").is_ok());
         assert!(validate_project_slug("platform:v2").is_ok()); // colons allowed — more permissive than repo-id
+    }
+
+    #[test]
+    fn validate_project_slug_rejects_control_characters() {
+        // Each of these is accepted on main and becomes a `d` tag nobody can
+        // type back, so `--slug` on the visible spelling reports "not found"
+        // for a project that is right there in the listing.
+        for slug in ["team\nx", "team\tx", "team\0x", "team\rx"] {
+            assert!(
+                validate_project_slug(slug).is_err(),
+                "{slug:?} was accepted as a project slug"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_project_slug_rejects_surrounding_whitespace() {
+        for slug in [" team-x", "team-x ", " team-x ", "\tteam-x"] {
+            assert!(
+                validate_project_slug(slug).is_err(),
+                "{slug:?} was accepted as a project slug"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_project_slug_keeps_permissive_interior_characters() {
+        // The point is untypeable characters, not unusual ones. Interior
+        // spaces, colons and unicode stay legal — projects are deliberately
+        // more permissive than repo ids.
+        for slug in ["platform:v2", "my project", "équipe", "team_x.2"] {
+            assert!(
+                validate_project_slug(slug).is_ok(),
+                "{slug:?} should still be a legal project slug"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Found by reading `validate_project_slug` against `validate_repo_id`; no issue filed.

`validate_project_slug` checks emptiness and length and nothing else:

```rust
fn validate_project_slug(slug: &str) -> Result<(), CliError> {
    if slug.is_empty() { ... }
    if slug.len() > PROJECT_D_MAX_LEN { ... }
    Ok(())
}
```

The slug is the `d` tag. It identifies the project (`fetch_project` filters `{"kinds":[KIND_PROJECT],"authors":[..],"#d":[slug]}`), it is the value every later `--slug` is matched on, and it is what `projects list` prints.

So a slug can carry a newline, a tab, a NUL, or a leading space, and nothing downstream ever recovers it:

```
$ buzz projects create --slug ' platform'   # leading space
$ buzz projects show --slug platform
project "platform" not found
```

The project is right there in the listing, rendered as `platform`, and every command that names it fails. Two projects that differ only by an untypeable character are indistinguishable in a listing and can only be told apart by reading the raw event. Because kind:30621 is addressable, the bad slug is also durable — it is the address, so there is no way to rename it, only to create the correct one alongside and delete the other.

## The change

Reject control characters and surrounding whitespace.

This is deliberately narrower than `validate_repo_id`'s `[a-zA-Z0-9._-]` allowlist. Project slugs are meant to be more permissive — the existing test asserts `platform:v2` is legal, with the comment "colons allowed — more permissive than repo-id" — so this rejects only what cannot be typed back, not everything unusual. `platform:v2`, `my project`, `équipe` and `team_x.2` all stay legal, and a test pins that so the rule can't quietly tighten into a repo-id clone later.

## Testing

- `cargo test -p buzz-cli --lib` — 366 passed, 0 failed (three new cases: control characters rejected, surrounding whitespace rejected, permissive interior characters still accepted)
- `cargo clippy -p buzz-cli --all-targets` — clean
- `cargo fmt --all -- --check` — clean

Not run against a live relay. I have not checked whether the relay independently rejects a `d` tag containing a control character — if it does, the effect today is a confusing relay-side error rather than a durable bad project, and this still moves the rejection to the argument where the message can name the actual problem.

## Related

Independent of #6877 and #6878 (UUID canonicalization in the same crate) — different function, different files, no shared symbols.
