### PR TITLE
feat(relay): make NIP-11 name and description configurable

### DIFF
--- a/crates/buzz-relay/src/nip11.rs
+++ b/crates/buzz-relay/src/nip11.rs
@@ -134,6 +134,31 @@ fn relay_limitation(max_message_length: usize) -> RelayLimitation {
     }
 }
 
+/// Operator-facing relay name advertised in NIP-11, from `RELAY_NAME`.
+///
+/// Self-hosted deployments are a distinct workspace to the people in them, but
+/// every relay currently introduces itself as "Buzz Relay" — the product's
+/// name, not the operator's. Clients surface this string, so an operator has no
+/// way to make their own instance read as theirs. Blank or whitespace-only
+/// values fall back to the default rather than advertising an empty name.
+fn relay_display_name() -> String {
+    non_empty_env("RELAY_NAME").unwrap_or_else(|| "Buzz Relay".to_string())
+}
+
+/// Relay description advertised in NIP-11, from `RELAY_DESCRIPTION`.
+fn relay_description() -> String {
+    non_empty_env("RELAY_DESCRIPTION")
+        .unwrap_or_else(|| "Buzz — private team communication relay".to_string())
+}
+
+/// Reads an env var, treating unset and blank as equivalent.
+fn non_empty_env(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
 impl RelayInfo {
     /// Builds the relay's NIP-11 information document.
     ///
@@ -187,8 +212,8 @@ impl RelayInfo {
         });
 
         Self {
-            name: "Buzz Relay".to_string(),
-            description: "Buzz — private team communication relay".to_string(),
+            name: relay_display_name(),
+            description: relay_description(),
             icon: icon.filter(|s| !s.is_empty()).map(|s| s.to_string()),
             pubkey: None,
             contact: None,
@@ -377,6 +402,35 @@ const _RELAY_INFO_BUILD_STATIC_INPUT_FENCE: fn(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    static NAME_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn relay_name_and_description_come_from_env_and_ignore_blanks() {
+        let _guard = NAME_ENV_MUTEX.lock().unwrap();
+
+        // Unset: the historical defaults, so existing deployments do not move.
+        std::env::remove_var("RELAY_NAME");
+        std::env::remove_var("RELAY_DESCRIPTION");
+        assert_eq!(relay_display_name(), "Buzz Relay");
+        assert_eq!(
+            relay_description(),
+            "Buzz — private team communication relay"
+        );
+
+        // Set: the operator's own identity, trimmed.
+        std::env::set_var("RELAY_NAME", "  Cofoundy  ");
+        std::env::set_var("RELAY_DESCRIPTION", "Cofoundy team relay");
+        assert_eq!(relay_display_name(), "Cofoundy");
+        assert_eq!(relay_description(), "Cofoundy team relay");
+
+        // Blank is not a name — advertising "" would be worse than the default.
+        std::env::set_var("RELAY_NAME", "   ");
+        assert_eq!(relay_display_name(), "Buzz Relay");
+
+        std::env::remove_var("RELAY_NAME");
+        std::env::remove_var("RELAY_DESCRIPTION");
+    }
 
     #[test]
     fn push_descriptor_is_gated_by_gateway_configuration_and_tenant_binding() {


### PR DESCRIPTION
## Problem

A self-hosted relay is a distinct workspace to the people using it, but every instance introduces itself as `"Buzz Relay"` — the product's name, not the operator's:

```rust
// crates/buzz-relay/src/nip11.rs
name: "Buzz Relay".to_string(),
description: "Buzz — private team communication relay".to_string(),
```

Clients surface this string, so an operator running Buzz for their own team has no way to make the deployment read as theirs. The Desktop's **Edit Community → Name** field looks like the answer but only writes to `localStorage`, so the NIP-11 document — what every other client reads — still says "Buzz Relay".

We hit this running Buzz for our own company: the workspace icon propagates fine via the `kind:9033` command, so the deployment ends up showing our logo next to someone else's name.

## Change

Adds `RELAY_NAME` and `RELAY_DESCRIPTION`, read at NIP-11 build time.

- **Defaults to the current strings**, so no existing deployment changes behaviour.
- Blank or whitespace-only values fall back to the default rather than advertising an empty name.
- Values are trimmed.

Kept deliberately small: two env vars and one helper, no config-struct plumbing, matching how `pairing_relay_url` and `icon` already reach this function.

## Testing

`relay_name_and_description_come_from_env_and_ignore_blanks` covers unset (defaults), set-and-trimmed, and blank-falls-back.

The test was **verified to have teeth** by mutating the fix back to the hardcoded string and confirming it fails:

```
test nip11::tests::relay_name_and_description_come_from_env_and_ignore_blanks ... FAILED
assertion `left == right` failed
```

Restored, the full `nip11` module passes:

```
test result: ok. 17 passed; 0 failed
```

`cargo fmt --check` and `cargo clippy -p buzz-relay --lib` are clean.

## Notes

Happy to move this into `Config` instead if you'd prefer the values to travel with the rest of the relay configuration — this shape just mirrors what the surrounding code already does.