### PR TITLE
fix(desktop): add existing remote agents to channels

### DIFF
--- a/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import {
   useCreateChannelManagedAgentsMutation,
   usePersonasQuery,
+  useRelayAgentsQuery,
   useTeamsQuery,
   type CreateChannelManagedAgentResult,
 } from "@/features/agents/hooks";
@@ -12,8 +13,14 @@ import { resolvePersonaRuntime } from "@/features/agents/lib/resolvePersonaRunti
 import { getUsableTeams } from "@/features/agents/lib/teamPersonas";
 import { AddChannelBotPersonasSection } from "@/features/channels/ui/AddChannelBotPersonasSection";
 import { AddChannelBotTeamsSection } from "@/features/channels/ui/AddChannelBotTeamsSection";
+import { AddChannelExistingAgentsSection } from "@/features/channels/ui/AddChannelExistingAgentsSection";
 import { useInChannelPersonaIds } from "@/features/channels/ui/useInChannelPersonaIds";
+import {
+  useAddChannelMembersMutation,
+  useChannelMembersQuery,
+} from "@/features/channels/hooks";
 import type { AcpRuntime } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 import { Button } from "@/shared/ui/button";
 import { ChooserDialogContent } from "@/shared/ui/chooser-dialog-content";
 import { Dialog } from "@/shared/ui/dialog";
@@ -63,12 +70,18 @@ export function AddChannelBotDialog({
   onOpenChange,
 }: AddChannelBotDialogProps) {
   const personasQuery = usePersonasQuery();
+  const relayAgentsQuery = useRelayAgentsQuery({ enabled: open });
   const teamsQuery = useTeamsQuery();
+  const channelMembersQuery = useChannelMembersQuery(
+    channelId,
+    open && channelId !== null,
+  );
   const inChannelPersonaIds = useInChannelPersonaIds(
     channelId,
     open && channelId !== null,
   );
   const createBotsMutation = useCreateChannelManagedAgentsMutation(channelId);
+  const addMembersMutation = useAddChannelMembersMutation(channelId);
   const personas = React.useMemo(
     () => getActivePersonas(personasQuery.data ?? []),
     [personasQuery.data],
@@ -80,6 +93,8 @@ export function AddChannelBotDialog({
   const [selectedPersonaIds, setSelectedPersonaIds] = React.useState<string[]>(
     [],
   );
+  const [selectedExistingAgentPubkeys, setSelectedExistingAgentPubkeys] =
+    React.useState<string[]>([]);
   const [submissionNotice, setSubmissionNotice] = React.useState<string | null>(
     null,
   );
@@ -90,6 +105,22 @@ export function AddChannelBotDialog({
   const selectedPersonas = React.useMemo(
     () => personas.filter((persona) => selectedPersonaIds.includes(persona.id)),
     [personas, selectedPersonaIds],
+  );
+  const relayAgents = React.useMemo(
+    () =>
+      [...(relayAgentsQuery.data ?? [])].sort((left, right) =>
+        left.name.localeCompare(right.name),
+      ),
+    [relayAgentsQuery.data],
+  );
+  const inChannelPubkeys = React.useMemo(
+    () =>
+      new Set(
+        (channelMembersQuery.data ?? []).map((member) =>
+          normalizePubkey(member.pubkey),
+        ),
+      ),
+    [channelMembersQuery.data],
   );
 
   React.useEffect(() => {
@@ -102,11 +133,24 @@ export function AddChannelBotDialog({
     );
   }, [inChannelPersonaIds, personas]);
 
+  React.useEffect(() => {
+    const addablePubkeys = new Set(
+      relayAgents
+        .map((agent) => normalizePubkey(agent.pubkey))
+        .filter((pubkey) => !inChannelPubkeys.has(pubkey)),
+    );
+    setSelectedExistingAgentPubkeys((current) =>
+      current.filter((pubkey) => addablePubkeys.has(normalizePubkey(pubkey))),
+    );
+  }, [inChannelPubkeys, relayAgents]);
+
   function reset() {
     setSelectedPersonaIds([]);
+    setSelectedExistingAgentPubkeys([]);
     setSubmissionNotice(null);
     setSubmissionError(null);
     createBotsMutation.reset();
+    addMembersMutation.reset();
   }
 
   function handleOpenChange(next: boolean) {
@@ -135,7 +179,13 @@ export function AddChannelBotDialog({
   }
 
   async function handleSubmit() {
-    if (providers.length === 0 || selectedPersonas.length === 0) return;
+    if (
+      selectedExistingAgentPubkeys.length === 0 &&
+      selectedPersonas.length === 0
+    ) {
+      return;
+    }
+    if (selectedPersonas.length > 0 && providers.length === 0) return;
 
     const inputs = selectedPersonas.map((persona) => {
       const resolved = resolvePersonaRuntime(
@@ -160,46 +210,94 @@ export function AddChannelBotDialog({
     setSubmissionNotice(null);
     setSubmissionError(null);
 
-    try {
-      const result = await createBotsMutation.mutateAsync(inputs);
-      if (result.failures.length === 0) {
-        if (result.successes[0]) onAdded?.(result.successes[0]);
-        handleOpenChange(false);
-        return;
-      }
+    const failures: Array<{ name: string; error: string }> = [];
+    let addedCount = 0;
 
-      const failedPersonaIds = new Set(
-        result.failures
-          .map((failure) => failure.personaId)
-          .filter((personaId): personaId is string => Boolean(personaId)),
-      );
-      setSelectedPersonaIds((current) =>
-        current.filter((personaId) => failedPersonaIds.has(personaId)),
-      );
-      if (result.successes.length > 0) {
-        setSubmissionNotice(
-          `Added ${result.successes.length} ${formatAgentCountLabel(
-            result.successes.length,
-          )}.`,
+    if (selectedExistingAgentPubkeys.length > 0) {
+      try {
+        const result = await addMembersMutation.mutateAsync({
+          pubkeys: selectedExistingAgentPubkeys,
+          role: "bot",
+        });
+        addedCount += result.added.length;
+        const failedPubkeys = new Set(
+          result.errors.map((failure) => normalizePubkey(failure.pubkey)),
         );
+        setSelectedExistingAgentPubkeys((current) =>
+          current.filter((pubkey) =>
+            failedPubkeys.has(normalizePubkey(pubkey)),
+          ),
+        );
+        for (const failure of result.errors) {
+          failures.push({
+            name:
+              relayAgents.find(
+                (agent) =>
+                  normalizePubkey(agent.pubkey) ===
+                  normalizePubkey(failure.pubkey),
+              )?.name ?? "agent",
+            error: failure.error,
+          });
+        }
+      } catch (error) {
+        failures.push({
+          name: "existing agents",
+          error:
+            error instanceof Error ? error.message : "Could not add agents.",
+        });
       }
-      setSubmissionError(formatBatchFailureSummary(result.failures));
-    } catch {
-      // The mutation error is rendered inline.
     }
+
+    if (inputs.length > 0) {
+      try {
+        const result = await createBotsMutation.mutateAsync(inputs);
+        addedCount += result.successes.length;
+        if (result.successes[0]) onAdded?.(result.successes[0]);
+        const failedPersonaIds = new Set(
+          result.failures
+            .map((failure) => failure.personaId)
+            .filter((personaId): personaId is string => Boolean(personaId)),
+        );
+        setSelectedPersonaIds((current) =>
+          current.filter((personaId) => failedPersonaIds.has(personaId)),
+        );
+        failures.push(...result.failures);
+      } catch (error) {
+        failures.push({
+          name: "new agents",
+          error:
+            error instanceof Error ? error.message : "Could not create agents.",
+        });
+      }
+    }
+
+    if (failures.length === 0) {
+      handleOpenChange(false);
+      return;
+    }
+    if (addedCount > 0) {
+      setSubmissionNotice(
+        `Added ${addedCount} ${formatAgentCountLabel(addedCount)}.`,
+      );
+    }
+    setSubmissionError(formatBatchFailureSummary(failures));
   }
 
+  const totalSelected =
+    selectedExistingAgentPubkeys.length + selectedPersonas.length;
+  const isPending =
+    createBotsMutation.isPending || addMembersMutation.isPending;
   const canSubmit =
-    providers.length > 0 &&
-    selectedPersonas.length > 0 &&
-    !providersLoading &&
-    !createBotsMutation.isPending;
-  const addButtonLabel = createBotsMutation.isPending
-    ? selectedPersonas.length > 1
-      ? `Adding ${selectedPersonas.length}…`
+    totalSelected > 0 &&
+    (selectedPersonas.length === 0 ||
+      (providers.length > 0 && !providersLoading)) &&
+    !isPending;
+  const addButtonLabel = isPending
+    ? totalSelected > 1
+      ? `Adding ${totalSelected}…`
       : "Adding…"
-    : selectedPersonas.length > 1
-      ? `Add ${selectedPersonas.length} agents`
+    : totalSelected > 1
+      ? `Add ${totalSelected} agents`
       : "Add agent";
 
   return (
@@ -235,23 +333,45 @@ export function AddChannelBotDialog({
         scrollAreaTestId="add-channel-bot-dialog-scroll-area"
         title="Add agents"
       >
-        <AddChannelBotPersonasSection
-          canToggleSelections={!createBotsMutation.isPending}
-          inChannelPersonaIds={inChannelPersonaIds}
-          isLoading={personasQuery.isLoading}
-          onCreateAgent={handleCreateAgent}
-          onTogglePersona={(personaId) => {
-            setSelectedPersonaIds((current) => toggleValue(current, personaId));
+        <AddChannelExistingAgentsSection
+          agents={relayAgents}
+          canToggleSelections={!isPending}
+          inChannelPubkeys={inChannelPubkeys}
+          isLoading={
+            relayAgentsQuery.isLoading || channelMembersQuery.isLoading
+          }
+          onToggleAgent={(pubkey) => {
+            setSelectedExistingAgentPubkeys((current) =>
+              toggleValue(current, pubkey),
+            );
             setSubmissionNotice(null);
             setSubmissionError(null);
           }}
-          personas={personas}
-          selectedPersonaIds={selectedPersonaIds}
+          selectedPubkeys={selectedExistingAgentPubkeys}
         />
 
-        {teams.length > 0 ? (
+        {providers.length > 0 || providersLoading ? (
+          <AddChannelBotPersonasSection
+            availableLabel="Create another agent on this computer"
+            canToggleSelections={!isPending && providers.length > 0}
+            inChannelPersonaIds={inChannelPersonaIds}
+            isLoading={personasQuery.isLoading}
+            onCreateAgent={handleCreateAgent}
+            onTogglePersona={(personaId) => {
+              setSelectedPersonaIds((current) =>
+                toggleValue(current, personaId),
+              );
+              setSubmissionNotice(null);
+              setSubmissionError(null);
+            }}
+            personas={personas}
+            selectedPersonaIds={selectedPersonaIds}
+          />
+        ) : null}
+
+        {teams.length > 0 && providers.length > 0 ? (
           <AddChannelBotTeamsSection
-            canToggleSelections={!createBotsMutation.isPending}
+            canToggleSelections={!isPending}
             inChannelPersonaIds={inChannelPersonaIds}
             isLoading={teamsQuery.isLoading}
             onToggleTeam={handleToggleTeam}
@@ -265,7 +385,8 @@ export function AddChannelBotDialog({
           <div className="flex gap-3 rounded-lg border border-warning/30 bg-warning-bg px-4 py-3">
             <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
             <p className="text-sm text-warning">
-              Install an agent runtime before adding an agent to this channel.
+              This computer cannot create a new agent until an agent runtime is
+              installed. Existing agents can still be added.
             </p>
           </div>
         ) : null}
@@ -278,6 +399,11 @@ export function AddChannelBotDialog({
         {personasQuery.error instanceof Error ? (
           <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
             {personasQuery.error.message}
+          </p>
+        ) : null}
+        {relayAgentsQuery.error instanceof Error ? (
+          <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {relayAgentsQuery.error.message}
           </p>
         ) : null}
         {submissionNotice ? (

--- a/desktop/src/features/channels/ui/AddChannelBotPersonasSection.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotPersonasSection.tsx
@@ -88,6 +88,7 @@ function CreateAgentRow({ onCreateAgent }: { onCreateAgent: () => void }) {
 }
 
 type AddChannelBotPersonasSectionProps = {
+  availableLabel?: string;
   canToggleSelections: boolean;
   inChannelPersonaIds?: ReadonlySet<string>;
   isLoading: boolean;
@@ -103,6 +104,7 @@ type AddChannelBotPersonasSectionProps = {
 };
 
 export function AddChannelBotPersonasSection({
+  availableLabel = "Your agents",
   canToggleSelections,
   inChannelPersonaIds,
   isLoading,
@@ -133,7 +135,7 @@ export function AddChannelBotPersonasSection({
       {!isLoading && available.length > 0 ? (
         <div className="space-y-1">
           <div className="px-3 pb-1 text-xs font-medium text-muted-foreground">
-            Your agents
+            {availableLabel}
           </div>
           {available.map((persona) => (
             <AgentRow

--- a/desktop/src/features/channels/ui/AddChannelExistingAgentsSection.tsx
+++ b/desktop/src/features/channels/ui/AddChannelExistingAgentsSection.tsx
@@ -1,0 +1,155 @@
+import { Check } from "lucide-react";
+
+import type { RelayAgent } from "@/shared/api/types";
+import { cn } from "@/shared/lib/cn";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
+
+function statusLabel(status: RelayAgent["status"]) {
+  if (status === "online") return "Online";
+  if (status === "away") return "Away";
+  return "Offline";
+}
+
+function ExistingAgentRow({
+  agent,
+  disabled,
+  inChannel,
+  onToggle,
+  selected,
+}: {
+  agent: RelayAgent;
+  disabled: boolean;
+  inChannel: boolean;
+  onToggle: () => void;
+  selected: boolean;
+}) {
+  return (
+    <button
+      aria-pressed={inChannel ? undefined : selected}
+      className={cn(
+        "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+        inChannel
+          ? "cursor-default text-muted-foreground"
+          : selected
+            ? "bg-accent text-accent-foreground"
+            : "hover:bg-accent/60",
+        disabled && !inChannel && "cursor-not-allowed opacity-50",
+      )}
+      data-testid={`add-existing-agent-${agent.pubkey}`}
+      disabled={disabled || inChannel}
+      onClick={onToggle}
+      type="button"
+    >
+      <ProfileAvatar
+        avatarUrl={null}
+        className="h-9 w-9 shrink-0 text-xs"
+        iconClassName="h-5 w-5"
+        label={agent.name}
+      />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium text-foreground">
+          {agent.name}
+        </span>
+        <span className="block text-xs text-muted-foreground">
+          {inChannel ? "Already in this channel" : statusLabel(agent.status)}
+        </span>
+      </span>
+      {inChannel ? (
+        <span className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-muted-foreground">
+          <Check className="h-4 w-4" />
+          In channel
+        </span>
+      ) : (
+        <span
+          aria-hidden
+          className={cn(
+            "flex h-5 w-5 shrink-0 items-center justify-center rounded border",
+            selected
+              ? "border-primary bg-primary text-primary-foreground"
+              : "border-border bg-background",
+          )}
+        >
+          {selected ? <Check className="h-3.5 w-3.5" /> : null}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export function AddChannelExistingAgentsSection({
+  agents,
+  canToggleSelections,
+  inChannelPubkeys,
+  isLoading,
+  onToggleAgent,
+  selectedPubkeys,
+}: {
+  agents: RelayAgent[];
+  canToggleSelections: boolean;
+  inChannelPubkeys: ReadonlySet<string>;
+  isLoading: boolean;
+  onToggleAgent: (pubkey: string) => void;
+  selectedPubkeys: readonly string[];
+}) {
+  if (!isLoading && agents.length === 0) {
+    return null;
+  }
+
+  const available = agents.filter(
+    (agent) => !inChannelPubkeys.has(normalizePubkey(agent.pubkey)),
+  );
+  const inChannel = agents.filter((agent) =>
+    inChannelPubkeys.has(normalizePubkey(agent.pubkey)),
+  );
+
+  return (
+    <div className="space-y-3" data-testid="add-existing-agents-section">
+      <div className="px-3">
+        <p className="text-xs font-medium text-muted-foreground">
+          Existing agents
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Add an agent that is already running on another computer. No local
+          runtime is needed.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <p className="px-3 text-sm text-muted-foreground">
+          Loading existing agents…
+        </p>
+      ) : null}
+
+      {available.length > 0 ? (
+        <div className="space-y-1">
+          {available.map((agent) => (
+            <ExistingAgentRow
+              agent={agent}
+              disabled={!canToggleSelections}
+              inChannel={false}
+              key={agent.pubkey}
+              onToggle={() => onToggleAgent(agent.pubkey)}
+              selected={selectedPubkeys.includes(agent.pubkey)}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {inChannel.length > 0 ? (
+        <div className="space-y-1 border-t border-border pt-3">
+          {inChannel.map((agent) => (
+            <ExistingAgentRow
+              agent={agent}
+              disabled
+              inChannel
+              key={agent.pubkey}
+              onToggle={() => undefined}
+              selected={false}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1860,6 +1860,58 @@ test("empty channel shows intro actions", async ({ page }) => {
   );
 });
 
+test("a client without runtimes can add an existing remote agent", async ({
+  page,
+}) => {
+  const remoteAgentPubkey =
+    "1234123412341234123412341234123412341234123412341234123412341234";
+  await installMockBridge(page, {
+    acpRuntimesCatalog: [],
+    relayAgents: [
+      {
+        pubkey: remoteAgentPubkey,
+        name: "PM Bot",
+        channels: ["general"],
+        channelIds: ["00000000-0000-4000-8000-000000000001"],
+        status: "online",
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-random").click();
+  await page.getByTestId("channel-intro-action-create-agent").click();
+
+  const existingAgent = page.getByTestId(
+    `add-existing-agent-${remoteAgentPubkey}`,
+  );
+  await expect(existingAgent).toContainText("PM Bot");
+  await expect(existingAgent).toContainText("Online");
+  await existingAgent.click();
+
+  const submit = page
+    .getByTestId("add-channel-bot-dialog-footer")
+    .getByRole("button", { name: "Add agent" });
+  await expect(submit).toBeEnabled();
+  await submit.click();
+  await expect(page.getByTestId("add-channel-bot-dialog")).toHaveCount(0);
+
+  const commands = await readCommandPayloadLog(page);
+  expect(
+    commands.filter((entry) => entry.command === "create_managed_agent"),
+  ).toHaveLength(0);
+  expect(commands).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        command: "add_channel_members",
+        payload: expect.objectContaining({
+          pubkeys: [remoteAgentPubkey],
+          role: "bot",
+        }),
+      }),
+    ]),
+  );
+});
+
 test("short channel with messages shows intro actions on open", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- separate existing relay-agent identities from local persona deployment in Add agents
- let a client with no runtimes attach the canonical existing identity to a channel
- do not mint another keypair or require a local provider for that path
- add a focused Playwright regression

## Why

The current Add agents dialog is persona-first and disables its action when the client has no runtime provider. On a chat-only second device, that prevents adding an agent which already exists and is running elsewhere; enabling a provider would instead risk creating a duplicate identity.

Buzz already has the identity-level relay primitive. This change exposes that existing-agent path directly while leaving local persona deployment intact.

Related: #3639 and #6232.

## Verification

- desktop TypeScript typecheck
- Biome/check scripts for the affected client files
- all 5,556 desktop unit tests in the combined patch tree
- focused Playwright: a client without runtimes can add an existing remote agent
