### PR TITLE
feat: add incoming huddle request ringtone

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -347,6 +347,7 @@ export function AppShell() {
   const {
     handleChannelNotification,
     handleDmNotification,
+    handleDmHuddleLifecycleEvent,
     handleThreadReplyDesktopNotification,
   } = useAppShellDesktopNotifications({
     channels,
@@ -356,6 +357,7 @@ export function AppShell() {
     notificationSettings: notificationSettings.settings,
     openSearchHit,
     pubkey: identityQuery.data?.pubkey,
+    mutedChannelIds,
     silentChannelIds: huddleBackingChannelIds,
   });
   const {
@@ -398,6 +400,7 @@ export function AppShell() {
       notifyForActiveChannel: notificationSettings.settings.notifyWhileViewing,
       onChannelMessage: handleChannelNotification,
       onDmMessage: handleDmNotification,
+      onDmHuddleLifecycleEvent: handleDmHuddleLifecycleEvent,
       onLiveMention: refetchHomeFeedFromLiveSignal,
       onThreadReplyDesktopNotification: handleThreadReplyDesktopNotification,
       followedRootIds,

--- a/desktop/src/app/useAppShellDesktopNotifications.ts
+++ b/desktop/src/app/useAppShellDesktopNotifications.ts
@@ -23,6 +23,12 @@ import {
 } from "@/features/notifications/lib/sound";
 import { useNotificationSenderName } from "@/features/notifications/useNotificationSenderName";
 import type { Channel, RelayEvent } from "@/shared/api/types";
+import { KIND_HUDDLE_STARTED } from "@/shared/constants/kinds";
+import {
+  huddleRequestRingtone,
+  huddleRingtoneCommand,
+  shouldRingForHuddleRequest,
+} from "@/features/huddle/lib/huddleRequestRingtone";
 
 export function useAppShellDesktopNotifications({
   channels,
@@ -32,6 +38,7 @@ export function useAppShellDesktopNotifications({
   notificationSettings,
   openSearchHit,
   pubkey,
+  mutedChannelIds,
   silentChannelIds,
 }: {
   channels: Channel[];
@@ -47,6 +54,7 @@ export function useAppShellDesktopNotifications({
     behavior?: { force?: boolean },
   ) => Promise<unknown>;
   pubkey?: string;
+  mutedChannelIds?: ReadonlySet<string>;
   silentChannelIds?: ReadonlySet<string>;
 }) {
   // Roster alerts are owner/admin-only and self-gating; mounted here because
@@ -70,9 +78,11 @@ export function useAppShellDesktopNotifications({
   const handleDmNotification = React.useEffectEvent(
     (event: RelayEvent, channel: Channel) => {
       if (!enabled) return;
+      const isHuddleRequest = event.kind === KIND_HUDDLE_STARTED;
+      const slot = isHuddleRequest ? "huddle_request" : "dm";
       if (
         !notificationSettings.desktopEnabled ||
-        !notificationSettings.slotAlertsEnabled.dm
+        !notificationSettings.slotAlertsEnabled[slot]
       ) {
         return;
       }
@@ -94,13 +104,56 @@ export function useAppShellDesktopNotifications({
         }),
       }).then((didSend) => {
         if (!didSend) return;
-        if (shouldPlayNotificationSound(channel.id, silentChannelIds)) {
+        if (
+          !isHuddleRequest &&
+          shouldPlayNotificationSound(channel.id, silentChannelIds)
+        ) {
           playNotificationSound(resolveSlotSound(notificationSettings, "dm"));
         }
         void requestDockBounce();
       });
     },
   );
+
+  const handleDmHuddleLifecycleEvent = React.useEffectEvent(
+    (event: RelayEvent, channel: Channel) => {
+      const command = huddleRingtoneCommand(event.kind, event.content);
+      if (
+        command?.action === "start" &&
+        enabled &&
+        notificationSettings.desktopEnabled &&
+        shouldRingForHuddleRequest({
+          currentPubkey: pubkey,
+          enabled: notificationSettings.slotAlertsEnabled.huddle_request,
+          initiatorPubkey: event.pubkey,
+          muted: mutedChannelIds?.has(channel.id) ?? false,
+        })
+      ) {
+        huddleRequestRingtone.start(
+          command.huddleId,
+          resolveSlotSound(notificationSettings, "huddle_request"),
+        );
+      }
+      if (command?.action === "stop") {
+        huddleRequestRingtone.stop(command.huddleId);
+      }
+    },
+  );
+
+  React.useEffect(() => {
+    if (
+      enabled &&
+      notificationSettings.desktopEnabled &&
+      notificationSettings.slotAlertsEnabled.huddle_request
+    ) {
+      return;
+    }
+    huddleRequestRingtone.stop();
+  }, [
+    enabled,
+    notificationSettings.desktopEnabled,
+    notificationSettings.slotAlertsEnabled.huddle_request,
+  ]);
 
   const handleThreadReplyDesktopNotification = React.useEffectEvent(
     (channelId: string, event: RelayEvent) => {
@@ -201,6 +254,7 @@ export function useAppShellDesktopNotifications({
   return {
     handleChannelNotification,
     handleDmNotification,
+    handleDmHuddleLifecycleEvent,
     handleThreadReplyDesktopNotification,
   };
 }

--- a/desktop/src/features/channels/isDmNotifiableKind.test.mjs
+++ b/desktop/src/features/channels/isDmNotifiableKind.test.mjs
@@ -28,6 +28,16 @@ test("human-visible message kinds fire DM notifications", () => {
   );
 });
 
+test("muted huddle requests do not fire DM notifications", () => {
+  assert.equal(isDmNotifiableKind(KIND_HUDDLE_STARTED, { muted: true }), false);
+  assert.equal(isDmNotifiableKind(KIND_HUDDLE_STARTED, { muted: false }), true);
+  assert.equal(
+    isDmNotifiableKind(9, { muted: true }),
+    true,
+    "the huddle feature must not change existing DM message mute behavior",
+  );
+});
+
 test("non-message kinds do NOT fire DM notifications", () => {
   assert.equal(isDmNotifiableKind(5), false, "kind:5 NIP-09 deletion");
   assert.equal(isDmNotifiableKind(7), false, "kind:7 reaction");

--- a/desktop/src/features/channels/isDmNotifiableKind.ts
+++ b/desktop/src/features/channels/isDmNotifiableKind.ts
@@ -14,6 +14,11 @@ const DM_NOTIFIABLE_KINDS = new Set<number>(DM_NOTIFIABLE_EVENT_KINDS);
 // event in the channel (kind:5/7/9005/edits/etc.), so we must filter to
 // human-visible message kinds before firing a toast. Huddle starts are included
 // only for DMs because the start card is the invite.
-export function isDmNotifiableKind(kind: number): boolean {
-  return DM_NOTIFIABLE_KINDS.has(kind);
+export function isDmNotifiableKind(
+  kind: number,
+  { muted = false }: { muted?: boolean } = {},
+): boolean {
+  return (
+    DM_NOTIFIABLE_KINDS.has(kind) && !(kind === KIND_HUDDLE_STARTED && muted)
+  );
 }

--- a/desktop/src/features/channels/unreadReadMarker.test.mjs
+++ b/desktop/src/features/channels/unreadReadMarker.test.mjs
@@ -19,6 +19,7 @@ import {
 } from "./useUnreadChannels.ts";
 import {
   isChannelUnreadTriggerKind,
+  shouldDispatchDmHuddleLifecycle,
   trackSeenEvent,
   withChannelTagFallback,
 } from "./useLiveChannelUpdates.ts";
@@ -117,6 +118,35 @@ test("dmHuddleStart_isDmOnlyUnreadTrigger", () => {
     isChannelUnreadTriggerKind(KIND_HUDDLE_ENDED, true),
     false,
     "huddle end lifecycle should stay quiet",
+  );
+});
+
+test("reconnect replay dispatches huddle ends but suppresses stale starts", () => {
+  const subscriptionStartedAt = 200;
+
+  assert.equal(
+    shouldDispatchDmHuddleLifecycle(
+      KIND_HUDDLE_ENDED,
+      100,
+      subscriptionStartedAt,
+    ),
+    true,
+  );
+  assert.equal(
+    shouldDispatchDmHuddleLifecycle(
+      KIND_HUDDLE_STARTED,
+      100,
+      subscriptionStartedAt,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldDispatchDmHuddleLifecycle(
+      KIND_HUDDLE_STARTED,
+      201,
+      subscriptionStartedAt,
+    ),
+    true,
   );
 });
 

--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -14,6 +14,8 @@ import { relayClient } from "@/shared/api/relayClient";
 import {
   CHANNEL_EVENT_KINDS,
   CHANNEL_MESSAGE_EVENT_KINDS,
+  KIND_HUDDLE_ENDED,
+  KIND_HUDDLE_STARTED,
 } from "@/shared/constants/kinds";
 import type { Channel, RelayEvent } from "@/shared/api/types";
 import {
@@ -32,6 +34,7 @@ export type UseLiveChannelUpdatesOptions = {
    */
   notifyForActiveChannel?: boolean;
   onDmMessage?: (event: RelayEvent, channel: Channel) => void;
+  onDmHuddleLifecycleEvent?: (event: RelayEvent, channel: Channel) => void;
   onLiveMention?: () => void;
   /**
    * Fired for live "new content" events in a member channel authored by
@@ -133,6 +136,17 @@ export function trackSeenEvent(
   return true;
 }
 
+export function shouldDispatchDmHuddleLifecycle(
+  kind: number,
+  createdAt: number,
+  subscriptionStartedAt: number,
+) {
+  return (
+    kind === KIND_HUDDLE_ENDED ||
+    (kind === KIND_HUDDLE_STARTED && createdAt >= subscriptionStartedAt)
+  );
+}
+
 export function useLiveChannelUpdates(
   channels: Channel[],
   activeChannelId: string | null,
@@ -194,14 +208,7 @@ export function useLiveChannelUpdates(
 
   const handleDmEvent = React.useEffectEvent(
     (event: RelayEvent, isFirstNotificationDelivery: boolean) => {
-      // Only human-visible message kinds should fire DM notifications.
-      if (!isDmNotifiableKind(event.kind) || !isFirstNotificationDelivery) {
-        return;
-      }
-
-      // Suppress backlog events that predate our subscription — these are
-      // historical replays, not live messages.
-      if (event.created_at < dmSubscriptionStartedAtRef.current) {
+      if (!isFirstNotificationDelivery) {
         return;
       }
 
@@ -216,6 +223,32 @@ export function useLiveChannelUpdates(
 
       const dmChannel = dmChannelMap.get(channelId);
       if (!dmChannel) {
+        return;
+      }
+
+      if (
+        shouldDispatchDmHuddleLifecycle(
+          event.kind,
+          event.created_at,
+          dmSubscriptionStartedAtRef.current,
+        )
+      ) {
+        options.onDmHuddleLifecycleEvent?.(event, dmChannel);
+      }
+
+      // Suppress backlog messages and Huddle starts that predate our
+      // subscription. Huddle ends are dispatched above because a reconnect
+      // replay may be the only signal available to stop an active ringtone.
+      if (event.created_at < dmSubscriptionStartedAtRef.current) {
+        return;
+      }
+
+      // Only human-visible message kinds should fire DM notifications.
+      if (
+        !isDmNotifiableKind(event.kind, {
+          muted: options.mutedChannelIds?.has(channelId) ?? false,
+        })
+      ) {
         return;
       }
 
@@ -273,8 +306,14 @@ export function useLiveChannelUpdates(
       isUnreadTriggerKind &&
       (normalizedCurrentPubkey.length === 0 ||
         event.pubkey.toLowerCase() !== normalizedCurrentPubkey);
+    const isExternalDmHuddleLifecycleEvent =
+      isDmChannel &&
+      (event.kind === KIND_HUDDLE_STARTED ||
+        event.kind === KIND_HUDDLE_ENDED) &&
+      (normalizedCurrentPubkey.length === 0 ||
+        event.pubkey.toLowerCase() !== normalizedCurrentPubkey);
     const isFirstNotificationDelivery =
-      !isExternalTriggerEvent ||
+      (!isExternalTriggerEvent && !isExternalDmHuddleLifecycleEvent) ||
       trackSeenEvent(
         seenNotificationEventIdsRef.current,
         event.id,

--- a/desktop/src/features/huddle/HuddleContext.tsx
+++ b/desktop/src/features/huddle/HuddleContext.tsx
@@ -13,6 +13,7 @@ import {
 import { useHuddleSpeakerActivity } from "./lib/useHuddleSpeakerActivity";
 import { useMicLevelAnalyser } from "./lib/useMicLevelAnalyser";
 import { useTtsSubscription } from "./lib/useTtsSubscription";
+import { huddleRequestRingtone } from "./lib/huddleRequestRingtone";
 import type {
   HuddleContextValue,
   HuddleLevelsValue,
@@ -708,6 +709,7 @@ export function HuddleProvider({
       ephemeralChannelId: string,
       huddleThreadEventId?: string,
     ) => {
+      huddleRequestRingtone.stop(ephemeralChannelId);
       if (busyRef.current) return;
       busyRef.current = true;
       tokenRef.current += 1;

--- a/desktop/src/features/huddle/lib/huddleRequestRingtone.test.mjs
+++ b/desktop/src/features/huddle/lib/huddleRequestRingtone.test.mjs
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  HUDDLE_REQUEST_RING_TIMEOUT_MS,
+  createHuddleRequestRingtoneController,
+  huddleIdFromLifecycleContent,
+  huddleRingtoneCommand,
+  shouldRingForHuddleRequest,
+} from "./huddleRequestRingtone.ts";
+
+function createHarness() {
+  const audioElements = [];
+  const timeouts = new Map();
+  let nextTimeoutId = 1;
+
+  const controller = createHuddleRequestRingtoneController({
+    createAudio: (source) => {
+      const audio = {
+        currentTime: -1,
+        loop: false,
+        pauseCount: 0,
+        playCount: 0,
+        source,
+        pause() {
+          this.pauseCount += 1;
+        },
+        async play() {
+          this.playCount += 1;
+        },
+      };
+      audioElements.push(audio);
+      return audio;
+    },
+    scheduleTimeout: (callback, delayMs) => {
+      const id = nextTimeoutId++;
+      timeouts.set(id, { callback, delayMs });
+      return id;
+    },
+    clearScheduledTimeout: (id) => timeouts.delete(id),
+  });
+
+  return { audioElements, controller, timeouts };
+}
+
+test("eligible huddle requests start one looping ringtone", () => {
+  const { audioElements, controller, timeouts } = createHarness();
+
+  assert.equal(controller.start("huddle-a", "unison"), true);
+  assert.equal(controller.start("huddle-a", "unison"), false);
+  assert.equal(audioElements.length, 1);
+  assert.equal(audioElements[0].source, "/sounds/unison.mp3");
+  assert.equal(audioElements[0].loop, true);
+  assert.equal(audioElements[0].currentTime, 0);
+  assert.equal(audioElements[0].playCount, 1);
+  assert.equal(timeouts.size, 1);
+  assert.equal(
+    [...timeouts.values()][0].delayMs,
+    HUDDLE_REQUEST_RING_TIMEOUT_MS,
+  );
+});
+
+test("a new huddle request replaces the ringtone already playing", () => {
+  const { audioElements, controller, timeouts } = createHarness();
+
+  controller.start("huddle-a", "unison");
+  controller.start("huddle-b", "ping");
+
+  assert.equal(audioElements.length, 2);
+  assert.equal(audioElements[0].pauseCount, 1);
+  assert.equal(audioElements[0].currentTime, 0);
+  assert.equal(audioElements[1].source, "/sounds/ping.mp3");
+  assert.equal(timeouts.size, 1);
+});
+
+test("only the matching huddle can stop an active ringtone", () => {
+  const { audioElements, controller, timeouts } = createHarness();
+
+  controller.start("huddle-a", "unison");
+  assert.equal(controller.stop("huddle-b"), false);
+  assert.equal(audioElements[0].pauseCount, 0);
+
+  assert.equal(controller.stop("huddle-a"), true);
+  assert.equal(audioElements[0].pauseCount, 1);
+  assert.equal(audioElements[0].currentTime, 0);
+  assert.equal(timeouts.size, 0);
+});
+
+test("the timeout stops a ringtone whose request received no response", () => {
+  const { audioElements, controller, timeouts } = createHarness();
+
+  controller.start("huddle-a", "unison");
+  [...timeouts.values()][0].callback();
+
+  assert.equal(audioElements[0].pauseCount, 1);
+  assert.equal(timeouts.size, 0);
+});
+
+test("huddle ringtone policy excludes initiators, disabled alerts, and muted channels", () => {
+  const base = {
+    currentPubkey: "recipient",
+    enabled: true,
+    initiatorPubkey: "initiator",
+    muted: false,
+  };
+
+  assert.equal(shouldRingForHuddleRequest(base), true);
+  assert.equal(
+    shouldRingForHuddleRequest({ ...base, currentPubkey: "INITIATOR" }),
+    false,
+  );
+  assert.equal(shouldRingForHuddleRequest({ ...base, enabled: false }), false);
+  assert.equal(shouldRingForHuddleRequest({ ...base, muted: true }), false);
+  assert.equal(
+    shouldRingForHuddleRequest({ ...base, currentPubkey: undefined }),
+    false,
+  );
+});
+
+test("huddle lifecycle content resolves the session that starts or stops ringing", () => {
+  assert.equal(
+    huddleIdFromLifecycleContent('{"ephemeral_channel_id":"huddle-a"}'),
+    "huddle-a",
+  );
+  assert.equal(huddleIdFromLifecycleContent("{}"), null);
+  assert.equal(huddleIdFromLifecycleContent("not-json"), null);
+});
+
+test("only huddle start and end events produce ringtone commands", () => {
+  const content = '{"ephemeral_channel_id":"huddle-a"}';
+
+  assert.deepEqual(huddleRingtoneCommand(48100, content), {
+    action: "start",
+    huddleId: "huddle-a",
+  });
+  assert.deepEqual(huddleRingtoneCommand(48103, content), {
+    action: "stop",
+    huddleId: "huddle-a",
+  });
+  assert.equal(huddleRingtoneCommand(48101, content), null);
+  assert.equal(huddleRingtoneCommand(48100, "{}"), null);
+});

--- a/desktop/src/features/huddle/lib/huddleRequestRingtone.ts
+++ b/desktop/src/features/huddle/lib/huddleRequestRingtone.ts
@@ -1,0 +1,117 @@
+import type { SoundName } from "@/features/notifications/lib/sound";
+import {
+  KIND_HUDDLE_ENDED,
+  KIND_HUDDLE_STARTED,
+} from "@/shared/constants/kinds";
+
+export const HUDDLE_REQUEST_RING_TIMEOUT_MS = 30_000;
+
+type RingtoneAudio = Pick<
+  HTMLAudioElement,
+  "currentTime" | "loop" | "pause" | "play"
+>;
+
+type RingtoneDependencies = {
+  createAudio: (source: string) => RingtoneAudio;
+  scheduleTimeout: (callback: () => void, delayMs: number) => number;
+  clearScheduledTimeout: (timeoutId: number) => void;
+};
+
+export type HuddleRequestRingtoneController = {
+  start: (huddleId: string, sound: SoundName) => boolean;
+  stop: (huddleId?: string) => boolean;
+};
+
+const browserDependencies: RingtoneDependencies = {
+  createAudio: (source) => new Audio(source),
+  scheduleTimeout: (callback, delayMs) => window.setTimeout(callback, delayMs),
+  clearScheduledTimeout: (timeoutId) => window.clearTimeout(timeoutId),
+};
+
+export function createHuddleRequestRingtoneController(
+  dependencies: RingtoneDependencies = browserDependencies,
+): HuddleRequestRingtoneController {
+  let active:
+    | { audio: RingtoneAudio; huddleId: string; timeoutId: number }
+    | undefined;
+
+  function stop(huddleId?: string) {
+    if (!active || (huddleId && active.huddleId !== huddleId)) {
+      return false;
+    }
+
+    const current = active;
+    active = undefined;
+    dependencies.clearScheduledTimeout(current.timeoutId);
+    current.audio.pause();
+    current.audio.currentTime = 0;
+    return true;
+  }
+
+  function start(huddleId: string, sound: SoundName) {
+    if (active?.huddleId === huddleId) {
+      return false;
+    }
+
+    stop();
+    const audio = dependencies.createAudio(`/sounds/${sound}.mp3`);
+    audio.loop = true;
+    audio.currentTime = 0;
+    const timeoutId = dependencies.scheduleTimeout(
+      () => stop(huddleId),
+      HUDDLE_REQUEST_RING_TIMEOUT_MS,
+    );
+    active = { audio, huddleId, timeoutId };
+    Promise.resolve(audio.play()).catch(() => {
+      // Best-effort — browser autoplay policy may block audio until interaction.
+    });
+    return true;
+  }
+
+  return { start, stop };
+}
+
+export function shouldRingForHuddleRequest({
+  currentPubkey,
+  enabled,
+  initiatorPubkey,
+  muted,
+}: {
+  currentPubkey?: string;
+  enabled: boolean;
+  initiatorPubkey: string;
+  muted: boolean;
+}) {
+  const normalizedCurrentPubkey = currentPubkey?.trim().toLowerCase();
+  return (
+    enabled &&
+    !muted &&
+    Boolean(normalizedCurrentPubkey) &&
+    normalizedCurrentPubkey !== initiatorPubkey.toLowerCase()
+  );
+}
+
+export function huddleIdFromLifecycleContent(content: string): string | null {
+  try {
+    const parsed = JSON.parse(content) as { ephemeral_channel_id?: unknown };
+    return typeof parsed.ephemeral_channel_id === "string" &&
+      parsed.ephemeral_channel_id.length > 0
+      ? parsed.ephemeral_channel_id
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function huddleRingtoneCommand(
+  kind: number,
+  content: string,
+): { action: "start" | "stop"; huddleId: string } | null {
+  const huddleId = huddleIdFromLifecycleContent(content);
+  if (!huddleId) return null;
+  if (kind === KIND_HUDDLE_STARTED) return { action: "start", huddleId };
+  if (kind === KIND_HUDDLE_ENDED) return { action: "stop", huddleId };
+  return null;
+}
+
+export const huddleRequestRingtone = createHuddleRequestRingtoneController();

--- a/desktop/src/features/notifications/hooks.test.mjs
+++ b/desktop/src/features/notifications/hooks.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { sanitizeSlotAlertsEnabled } from "./hooks.ts";
+
 import {
   buildHomeBadgeFeedItems,
   isHomeBadgeFeedItemUnread,
@@ -35,6 +37,28 @@ const homeFeed = (feed) => ({
     ...feed,
   },
   meta: { since: 0, total: 0, generatedAt: 0 },
+});
+
+test("adding a sound slot preserves an existing all-disabled master state", () => {
+  const migrated = sanitizeSlotAlertsEnabled({
+    dm: false,
+    mention: false,
+    thread_reply: false,
+    needs_action: false,
+  });
+
+  assert.equal(migrated.huddle_request, false);
+});
+
+test("adding a sound slot keeps its default when existing alerts are active", () => {
+  const migrated = sanitizeSlotAlertsEnabled({
+    dm: false,
+    mention: true,
+    thread_reply: false,
+    needs_action: false,
+  });
+
+  assert.equal(migrated.huddle_request, true);
 });
 
 test("home badge excludes thread activity already shown in a channel preview", () => {

--- a/desktop/src/features/notifications/hooks.ts
+++ b/desktop/src/features/notifications/hooks.ts
@@ -77,14 +77,26 @@ function sanitizeSoundsMap(value: unknown): SlotSounds {
   return result;
 }
 
-function sanitizeSlotAlertsEnabled(value: unknown): Record<SoundSlot, boolean> {
+export function sanitizeSlotAlertsEnabled(
+  value: unknown,
+): Record<SoundSlot, boolean> {
   const result = { ...DEFAULT_SLOT_ALERTS_ENABLED };
   if (!value || typeof value !== "object") return result;
   const candidate = value as Partial<Record<SoundSlot, unknown>>;
+  const storedLiveValues = SOUND_SLOTS.filter(
+    (slot) => !COMING_SOON_SLOTS.has(slot),
+  )
+    .map((slot) => candidate[slot])
+    .filter((picked): picked is boolean => typeof picked === "boolean");
+  const preserveAllDisabledState =
+    storedLiveValues.length > 0 && storedLiveValues.every((picked) => !picked);
+
   for (const slot of SOUND_SLOTS) {
     const picked = candidate[slot];
     if (typeof picked === "boolean") {
       result[slot] = picked;
+    } else if (preserveAllDisabledState && !COMING_SOON_SLOTS.has(slot)) {
+      result[slot] = false;
     }
   }
   return result;

--- a/desktop/src/features/notifications/lib/sound.test.mjs
+++ b/desktop/src/features/notifications/lib/sound.test.mjs
@@ -66,3 +66,11 @@ test("silences notifications from Huddle backing channels", () => {
   );
   assert.equal(shouldPlayNotificationSound(null, silentChannelIds), true);
 });
+
+test("huddle requests have their own enabled-by-default sound slot", async () => {
+  const sound = await import("./sound.ts");
+
+  assert.equal(sound.SOUND_SLOTS.includes("huddle_request"), true);
+  assert.equal(sound.DEFAULT_SLOT_ALERTS_ENABLED.huddle_request, true);
+  assert.equal(sound.DEFAULT_SLOT_SOUNDS.huddle_request, "unison");
+});

--- a/desktop/src/features/notifications/lib/sound.ts
+++ b/desktop/src/features/notifications/lib/sound.ts
@@ -24,6 +24,7 @@ export type SoundName = (typeof SOUND_NAMES)[number];
 
 export const SOUND_SLOTS = [
   "dm",
+  "huddle_request",
   "mention",
   "thread_reply",
   "needs_action",
@@ -36,6 +37,7 @@ export type SoundSlot = (typeof SOUND_SLOTS)[number];
 
 export const SLOT_LABELS: Record<SoundSlot, string> = {
   dm: "Direct messages",
+  huddle_request: "Huddle requests",
   mention: "@Mentions",
   thread_reply: "Thread replies",
   needs_action: "Needs action",
@@ -58,6 +60,7 @@ export const COMING_SOON_SLOTS: ReadonlySet<SoundSlot> = new Set([
 
 export const SLOT_DESCRIPTIONS: Record<SoundSlot, string> = {
   dm: "When someone messages you directly.",
+  huddle_request: "When someone invites you to a huddle.",
   mention: "When someone tags you in a channel.",
   thread_reply: "When someone replies in a thread you follow or posted in.",
   needs_action: "When an approval or reminder is waiting on you.",
@@ -69,6 +72,7 @@ export const SLOT_DESCRIPTIONS: Record<SoundSlot, string> = {
 
 export const RECOMMENDED_SOUND_BY_SLOT: Record<SoundSlot, SoundName> = {
   dm: "unison",
+  huddle_request: "unison",
   mention: "ping",
   thread_reply: "doop",
   needs_action: "doodone",
@@ -82,6 +86,7 @@ export type SlotSounds = Record<SoundSlot, SoundName>;
 
 export const DEFAULT_SLOT_SOUNDS: SlotSounds = {
   dm: "flutter",
+  huddle_request: "unison",
   mention: "flutter",
   thread_reply: "flutter",
   needs_action: "flutter",
@@ -94,6 +99,7 @@ export const DEFAULT_SLOT_SOUNDS: SlotSounds = {
 /** Per-event alerts (notification + sound) on/off. */
 export const DEFAULT_SLOT_ALERTS_ENABLED: Record<SoundSlot, boolean> = {
   dm: true,
+  huddle_request: true,
   mention: true,
   thread_reply: true,
   needs_action: true,


### PR DESCRIPTION
## Summary

- add a dedicated, configurable huddle-request notification sound
- loop the ringtone for incoming DM huddle requests until the huddle ends or 30 seconds elapse
- respect notification enablement and muted conversations, suppress self-initiated ringing, and avoid playing the normal DM sound on top
- preserve an explicitly all-disabled notification configuration when migrating stored settings to the new slot

### Related issue

None found.

### Testing

- `cd desktop && pnpm test` — 5,579 passed, 0 failed
- `cd desktop && pnpm typecheck`
- `cd desktop && pnpm check`
- `cd desktop && pnpm check:file-sizes`

The behavior is covered by unit tests for ringtone lifecycle, eligibility policy, huddle event routing, notification settings migration, and sound-slot defaults.
