### PR TITLE
fix(desktop): resolve bundled sidecar on cheap path and bound login-shell spawns

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -63,7 +63,7 @@ user-idle = { version = "0.6", default-features = false }
 plist = "1"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Security", "Win32_Storage_FileSystem", "Win32_System_JobObjects", "Win32_System_Registry", "Win32_System_Threading", "Win32_Foundation"] }
+windows-sys = { version = "0.61", features = ["Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Registry", "Win32_System_Threading", "Win32_Foundation"] }
 keyring = { version = "3.6.3", default-features = false, features = ["windows-native", "vendored"], optional = true }
 user-idle = { version = "0.6", default-features = false }
 

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -1,8 +1,7 @@
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use crate::managed_agents::{
     buzz_managed_command_path, buzz_managed_node_bin_dir, buzz_managed_npm_bin_dir,
@@ -10,6 +9,7 @@ use crate::managed_agents::{
     HarnessSource,
 };
 mod auth_status_cache;
+mod bounded_command;
 mod login_shell;
 mod presets;
 mod runtime_metadata;
@@ -830,89 +830,11 @@ pub(crate) fn is_npm_global_install(cmd: &str) -> bool {
         || t.starts_with("npm uninstall -g ")
 }
 
-/// Run `command` to completion, bounded by `timeout`.
-///
-/// Returns `Some(output)` when the child exits within the deadline, `None` when
-/// it fails to spawn or is killed for exceeding it. Stdout and stderr are piped
-/// and drained on background threads so a chatty child can't dead-lock on a
-/// full pipe buffer. Mirrors the auth-probe timeout discipline so any spawn on
-/// the discovery path — including the login-shell PATH probes — is bounded.
-pub(crate) fn output_with_timeout(
-    mut command: Command,
-    timeout: Duration,
-) -> Option<std::process::Output> {
-    command
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped());
-
-    let mut child = command.spawn().ok()?;
-    let stdout_pipe = child.stdout.take();
-    let stderr_pipe = child.stderr.take();
-
-    let stdout_thread = std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Some(mut pipe) = stdout_pipe {
-            let _ = pipe.read_to_end(&mut buf);
-        }
-        buf
-    });
-    let stderr_thread = std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Some(mut pipe) = stderr_pipe {
-            let _ = pipe.read_to_end(&mut buf);
-        }
-        buf
-    });
-
-    let child_pid = child.id();
-    let (tx, rx) = std::sync::mpsc::channel();
-    let wait_thread = std::thread::spawn(move || {
-        let _ = tx.send(child.wait());
-    });
-
-    let deadline = Instant::now() + timeout;
-    let status = loop {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            #[cfg(unix)]
-            unsafe {
-                libc::kill(child_pid as i32, libc::SIGTERM);
-            }
-            #[cfg(not(unix))]
-            let _ = child_pid;
-            drop(rx);
-            let _ = wait_thread.join();
-            let _ = stdout_thread.join();
-            let _ = stderr_thread.join();
-            return None;
-        }
-        match rx.recv_timeout(Duration::from_millis(100).min(remaining)) {
-            Ok(Ok(status)) => break status,
-            Ok(Err(_)) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                let _ = wait_thread.join();
-                let _ = stdout_thread.join();
-                let _ = stderr_thread.join();
-                return None;
-            }
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
-        }
-    };
-
-    let _ = wait_thread.join();
-    let stdout = stdout_thread.join().unwrap_or_default();
-    let stderr = stderr_thread.join().unwrap_or_default();
-    Some(std::process::Output {
-        status,
-        stdout,
-        stderr,
-    })
-}
-
 /// Run a CLI auth probe with a 10-second process-level timeout.
 ///
 /// On timeout or spawn failure the child is killed and `Unknown` is returned;
-/// no orphaned threads or processes are left behind (see [`output_with_timeout`]).
+/// no orphaned threads or processes are left behind (see
+/// [`bounded_command::output_with_timeout`]).
 fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
     use crate::managed_agents::readiness::cli_probe;
 
@@ -925,7 +847,8 @@ fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
     }
     crate::util::configure_no_window(&mut command);
 
-    let Some(output) = output_with_timeout(command, Duration::from_secs(10)) else {
+    let Some(output) = bounded_command::output_with_timeout(command, Duration::from_secs(10))
+    else {
         return AuthStatus::Unknown;
     };
 

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -593,6 +593,16 @@ pub fn resolve_command_cached(command: &str) -> Option<PathBuf> {
     if let Some(managed) = resolve_buzz_managed_command(command) {
         return Some(managed);
     }
+    // Bundled sidecars (e.g. `buzz-agent`) ship next to the app executable, so
+    // `resolve_workspace_command` finds them with a filesystem stat and no
+    // login-shell spawn — the same class of work the managed-shim check above
+    // already performs. Without this the cheap path could never see the sidecar
+    // until a forced discovery warmed the resolve cache, so `buzz-agent` (which
+    // cannot legitimately be missing) reported "not installed" at every cold
+    // launch across the create/edit and agent-defaults surfaces.
+    if let Some(workspace) = resolve_workspace_command(command) {
+        return Some(workspace);
+    }
     resolve_cache()
         .lock()
         .ok()
@@ -820,34 +830,23 @@ pub(crate) fn is_npm_global_install(cmd: &str) -> bool {
         || t.starts_with("npm uninstall -g ")
 }
 
-/// Run a CLI auth probe with a 10-second process-level timeout.
+/// Run `command` to completion, bounded by `timeout`.
 ///
-/// Spawns the probe CLI as a child process. Stdout and stderr are drained on
-/// background threads to prevent pipe-buffer deadlock. On timeout the child is
-/// killed and `Unknown` is returned; no orphaned threads or processes are left
-/// behind. Returns `Unknown` on timeout.
-fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
-    use crate::managed_agents::readiness::cli_probe;
-
-    let augmented_path = cli_probe::augmented_path();
-
-    let mut command = std::process::Command::new(binary_path);
-    command.args(&probe_args[1..]);
-    if let Some(ref path) = augmented_path {
-        command.env("PATH", path);
-    }
+/// Returns `Some(output)` when the child exits within the deadline, `None` when
+/// it fails to spawn or is killed for exceeding it. Stdout and stderr are piped
+/// and drained on background threads so a chatty child can't dead-lock on a
+/// full pipe buffer. Mirrors the auth-probe timeout discipline so any spawn on
+/// the discovery path — including the login-shell PATH probes — is bounded.
+pub(crate) fn output_with_timeout(
+    mut command: Command,
+    timeout: Duration,
+) -> Option<std::process::Output> {
     command
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
-    crate::util::configure_no_window(&mut command);
 
-    let mut child = match command.spawn() {
-        Ok(c) => c,
-        Err(_) => return AuthStatus::Unknown,
-    };
-
-    // Drain stdout/stderr on background threads to prevent pipe-buffer deadlock.
+    let mut child = command.spawn().ok()?;
     let stdout_pipe = child.stdout.take();
     let stderr_pipe = child.stderr.take();
 
@@ -856,6 +855,7 @@ fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
         if let Some(mut pipe) = stdout_pipe {
             let _ = pipe.read_to_end(&mut buf);
         }
+        buf
     });
     let stderr_thread = std::thread::spawn(move || {
         let mut buf = Vec::new();
@@ -865,16 +865,14 @@ fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
         buf
     });
 
-    // Save PID for kill-on-timeout before moving child into the wait thread.
     let child_pid = child.id();
     let (tx, rx) = std::sync::mpsc::channel();
     let wait_thread = std::thread::spawn(move || {
         let _ = tx.send(child.wait());
     });
 
-    // 10-second timeout for auth probes.
-    let deadline = Instant::now() + Duration::from_secs(10);
-    let exit_status = loop {
+    let deadline = Instant::now() + timeout;
+    let status = loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
             #[cfg(unix)]
@@ -887,30 +885,51 @@ fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
             let _ = wait_thread.join();
             let _ = stdout_thread.join();
             let _ = stderr_thread.join();
-            return AuthStatus::Unknown;
+            return None;
         }
         match rx.recv_timeout(Duration::from_millis(100).min(remaining)) {
             Ok(Ok(status)) => break status,
-            Ok(Err(_)) => {
+            Ok(Err(_)) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                 let _ = wait_thread.join();
                 let _ = stdout_thread.join();
                 let _ = stderr_thread.join();
-                return AuthStatus::Unknown;
+                return None;
             }
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                let _ = stdout_thread.join();
-                let _ = stderr_thread.join();
-                return AuthStatus::Unknown;
-            }
         }
     };
 
     let _ = wait_thread.join();
-    let _ = stdout_thread.join();
-    let stderr_bytes = stderr_thread.join().unwrap_or_default();
+    let stdout = stdout_thread.join().unwrap_or_default();
+    let stderr = stderr_thread.join().unwrap_or_default();
+    Some(std::process::Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
 
-    match cli_probe::classify_probe_output(&stderr_bytes, exit_status.success()) {
+/// Run a CLI auth probe with a 10-second process-level timeout.
+///
+/// On timeout or spawn failure the child is killed and `Unknown` is returned;
+/// no orphaned threads or processes are left behind (see [`output_with_timeout`]).
+fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
+    use crate::managed_agents::readiness::cli_probe;
+
+    let augmented_path = cli_probe::augmented_path();
+
+    let mut command = std::process::Command::new(binary_path);
+    command.args(&probe_args[1..]);
+    if let Some(ref path) = augmented_path {
+        command.env("PATH", path);
+    }
+    crate::util::configure_no_window(&mut command);
+
+    let Some(output) = output_with_timeout(command, Duration::from_secs(10)) else {
+        return AuthStatus::Unknown;
+    };
+
+    match cli_probe::classify_probe_output(&output.stderr, output.status.success()) {
         cli_probe::ProbeOutcome::LoggedIn => AuthStatus::LoggedIn,
         cli_probe::ProbeOutcome::LoggedOut => AuthStatus::LoggedOut,
         cli_probe::ProbeOutcome::ConfigInvalid { stderr_excerpt } => AuthStatus::ConfigInvalid {

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -845,7 +845,10 @@ fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
     if let Some(ref path) = augmented_path {
         command.env("PATH", path);
     }
-    crate::util::configure_no_window(&mut command);
+    // Window suppression is owned by `output_with_timeout`'s spawn
+    // (`BOUNDED_CREATION_FLAGS` carries `CREATE_NO_WINDOW`); a
+    // `configure_no_window` call here would be clobbered by that later
+    // `creation_flags` set, so it is deliberately omitted.
 
     let Some(output) = bounded_command::output_with_timeout(command, Duration::from_secs(10))
     else {

--- a/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
@@ -470,21 +470,25 @@ mod tests {
     use super::*;
     use std::sync::mpsc;
 
-    /// Run `output_with_timeout` under an independent wall-clock watchdog. The
-    /// helper is driven on its own thread; if it fails to return within `bound`
-    /// the test fails instead of hanging forever. This is the real outer bound —
-    /// an inline `elapsed() < bound` assertion is never reached if the helper
-    /// itself hangs.
+    /// Drive `output_with_timeout` on its own thread under an independent
+    /// wall-clock `bound` — the real outer bound, unreachable by an inline `elapsed()` assertion if the helper hangs.
+    /// The raw result lets the Windows sites fold transcripts into the expiry panic.
     #[cfg(any(unix, windows))]
-    fn run_watchdogged(cmd: Command, timeout: Duration, bound: Duration) -> Option<Output> {
+    fn run_watchdogged_raw(
+        cmd: Command,
+        timeout: Duration,
+        bound: Duration,
+    ) -> Result<Option<Output>, mpsc::RecvTimeoutError> {
         let (tx, rx) = mpsc::channel();
         std::thread::spawn(move || {
             let _ = tx.send(output_with_timeout(cmd, timeout));
         });
-        match rx.recv_timeout(bound) {
-            Ok(result) => result,
-            Err(_) => panic!("output_with_timeout did not return within {bound:?}"),
-        }
+        rx.recv_timeout(bound)
+    }
+    #[cfg(unix)]
+    fn run_watchdogged(cmd: Command, timeout: Duration, bound: Duration) -> Option<Output> {
+        run_watchdogged_raw(cmd, timeout, bound)
+            .unwrap_or_else(|_| panic!("output_with_timeout did not return within {bound:?}"))
     }
 
     /// True while a Unix process (or a reaped-but-not-waited zombie under this
@@ -890,7 +894,9 @@ mod tests {
                 "-File",
                 root_ps1.to_str().expect("utf-8 root path"),
             ]);
-            let out = run_watchdogged(cmd, Duration::from_secs(20), Duration::from_secs(40))
+            let out = run_watchdogged_raw(cmd, Duration::from_secs(20), Duration::from_secs(40))
+                .ok()
+                .flatten()
                 .unwrap_or_else(|| {
                     panic!(
                         "iteration {iteration}: root exits, so this must return output\n{}",
@@ -969,7 +975,13 @@ mod tests {
             "-File",
             root_ps1.to_str().expect("utf-8 root path"),
         ]);
-        let result = run_watchdogged(cmd, Duration::from_secs(20), Duration::from_secs(40));
+        let result = run_watchdogged_raw(cmd, Duration::from_secs(20), Duration::from_secs(40))
+            .unwrap_or_else(|_| {
+                panic!(
+                    "watchdog expired — output_with_timeout hung on the timeout path\n{}",
+                    dump_logs(&[root_log_s, child_log_s])
+                )
+            });
         assert!(
             result.is_none(),
             "a timed-out tree must yield None\n{}",

--- a/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
@@ -12,6 +12,16 @@ use std::time::{Duration, Instant};
 /// Poll interval while waiting for the child to exit.
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
+/// Maximum bytes captured across stdout + stderr for one bounded probe.
+///
+/// Discovery output is tiny — a version string, an auth-status word, a PATH
+/// lookup. A probe that emits more than this is noisy or hostile, so the
+/// capture is failed closed (kill the tree, return `None`) rather than allowed
+/// to fill the disk during the process window or allocate an unbounded buffer
+/// at read time. The ceiling is *aggregate*, not per-stream, so a probe cannot
+/// double it by splitting output across stdout and stderr.
+const CAPTURE_LIMIT: u64 = 1 << 20; // 1 MiB
+
 /// Grace period between the initial `SIGTERM` and the escalating `SIGKILL` for a
 /// timed-out process group. Long enough for a well-behaved child to flush and
 /// exit cleanly, short enough that a signal-ignoring one is reaped promptly.
@@ -228,6 +238,14 @@ pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Op
                     child.reap();
                     return None;
                 }
+                // Fail closed on a capture breach *while the child runs*, so a
+                // noisy or hostile probe cannot fill the disk over the process
+                // window — the process bound alone does not bound its output.
+                if captured_len(&stdout_file, &stderr_file) > CAPTURE_LIMIT {
+                    child.kill_tree();
+                    child.reap();
+                    return None;
+                }
                 std::thread::sleep(POLL_INTERVAL);
             }
             Err(_) => {
@@ -244,6 +262,13 @@ pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Op
     child.kill_tree();
     child.reap();
 
+    // A child that exits within the deadline can still have written past the
+    // ceiling in a burst between polls; fail closed rather than allocate the
+    // full payload at read time.
+    if captured_len(&stdout_file, &stderr_file) > CAPTURE_LIMIT {
+        return None;
+    }
+
     Some(Output {
         status,
         stdout: read_captured(&mut stdout_file),
@@ -251,15 +276,25 @@ pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Op
     })
 }
 
-/// Rewind a captured-output temp file and read it in full. Bounded because the
-/// file is regular: the read reaches EOF at the current write position.
+/// Total bytes written across both capture files so far. A failed `metadata`
+/// call counts as zero for that file — a stat error cannot manufacture a false
+/// breach, and the read-time [`read_captured`] bound is the backstop.
+fn captured_len(stdout_file: &std::fs::File, stderr_file: &std::fs::File) -> u64 {
+    let len = |f: &std::fs::File| f.metadata().map(|m| m.len()).unwrap_or(0);
+    len(stdout_file).saturating_add(len(stderr_file))
+}
+
+/// Rewind a captured-output temp file and read it, capped at [`CAPTURE_LIMIT`].
+/// Bounded twice over: the file is regular (the read reaches EOF at the current
+/// write position) *and* `take` refuses to allocate more than the ceiling even
+/// if the file grew, so `read_to_end` can never balloon the buffer.
 fn read_captured(file: &mut std::fs::File) -> Vec<u8> {
     use std::io::{Read as _, Seek as _, SeekFrom};
     if file.seek(SeekFrom::Start(0)).is_err() {
         return Vec::new();
     }
     let mut buf = Vec::new();
-    let _ = file.read_to_end(&mut buf);
+    let _ = file.take(CAPTURE_LIMIT).read_to_end(&mut buf);
     buf
 }
 
@@ -399,6 +434,40 @@ mod tests {
         );
     }
 
+    // Adversarial (capture bound): a child that emits far more than
+    // CAPTURE_LIMIT and then blocks, so it neither exits nor stops writing on
+    // its own. The in-flight ceiling check must fail the probe closed (None)
+    // and reap the tree — the process bound alone would let it keep filling the
+    // disk for the whole window. `head -c` writes a bounded 4 MiB (so the test
+    // never risks the disk) which already exceeds the 1 MiB ceiling; the trailing
+    // `sleep` keeps the child alive long enough for a poll to observe the breach.
+    #[cfg(unix)]
+    #[test]
+    fn fails_closed_when_capture_exceeds_limit() {
+        let over = CAPTURE_LIMIT * 4;
+        let mut cmd = Command::new("/bin/sh");
+        cmd.args(["-c", &format!("head -c {over} /dev/zero; sleep 30")]);
+        let result = run_watchdogged(cmd, Duration::from_secs(10), Duration::from_secs(15));
+        assert!(
+            result.is_none(),
+            "a probe exceeding the capture limit must fail closed"
+        );
+    }
+
+    // The complement of the bound: output at or under the ceiling still returns
+    // in full, so the limit rejects only genuine overruns.
+    #[cfg(unix)]
+    #[test]
+    fn returns_full_output_at_capture_limit() {
+        let mut cmd = Command::new("/bin/sh");
+        // Comfortably under 1 MiB, emitted in one burst then a clean exit.
+        cmd.args(["-c", "head -c 4096 /dev/zero"]);
+        let out = run_watchdogged(cmd, Duration::from_secs(5), Duration::from_secs(10))
+            .expect("output under the limit must be returned");
+        assert!(out.status.success());
+        assert_eq!(out.stdout.len(), 4096);
+    }
+
     // ---- Windows tree-ownership verification (Will's box) ----------------
     //
     // No CI lane executes Windows tests for this helper, so these are
@@ -448,10 +517,14 @@ mod tests {
 
     // Success path, run in a loop to hammer the spawn/assign race: a cmd.exe
     // root launches a detached PowerShell descendant that records its own PID
-    // and sleeps, then the root exits 0 immediately. Because the child is
-    // spawned CREATE_SUSPENDED and assigned to the job before it can run, the
-    // descendant is born inside the job; closing the job on success must reap
-    // it even though the root is already gone.
+    // and sleeps, then the root exits 0 — but only *after* a synchronous waiter
+    // confirms the PID file is non-empty. Without that wait the root exits in
+    // the same tick, the success path closes the kill-on-close job immediately,
+    // and the descendant is reaped mid-cold-start before it can record its PID
+    // — starving the test of the evidence the reaping actually worked. The wait
+    // (bounded by the timeout and the outer watchdog) closes that fixture race
+    // without weakening the guarantee under test: the descendant is still born
+    // inside the job and must be reaped by the job close after the root exits.
     #[cfg(windows)]
     #[test]
     #[ignore = "requires a Windows host; run manually with --ignored"]
@@ -463,15 +536,23 @@ mod tests {
                 .to_str()
                 .expect("utf-8 temp path")
                 .to_string();
-            // `start /b` backgrounds the PowerShell child; the root cmd exits at
-            // once. PowerShell records $PID then sleeps 30s.
-            let ps = format!(
+            // `start /b` backgrounds the PowerShell descendant (records $PID,
+            // sleeps 30s); the second, synchronous PowerShell blocks the root
+            // until that PID file is non-empty; then the root exits 0.
+            let child = format!(
                 "$PID | Out-File -Encoding ascii -FilePath '{pid_path}'; Start-Sleep -Seconds 30"
             );
-            let script = format!("start /b powershell -NoProfile -Command \"{ps}\" & exit 0");
+            let waiter = format!(
+                "while (-not (Test-Path '{pid_path}') -or (Get-Item '{pid_path}').Length -eq 0) {{ Start-Sleep -Milliseconds 50 }}"
+            );
+            let script = format!(
+                "start /b powershell -NoProfile -Command \"{child}\" & powershell -NoProfile -Command \"{waiter}\" & exit 0"
+            );
             let mut cmd = Command::new("cmd.exe");
             cmd.args(["/c", &script]);
-            let out = run_watchdogged(cmd, Duration::from_secs(5), Duration::from_secs(15))
+            // Timeout is generous: two cold-starting PowerShells must both run
+            // before the root exits, and none of that may hit the deadline.
+            let out = run_watchdogged(cmd, Duration::from_secs(20), Duration::from_secs(40))
                 .expect("the root exits, so this must return its output");
             assert!(
                 out.status.success(),
@@ -489,8 +570,11 @@ mod tests {
 
     // Timeout path: a cmd.exe root launches a detached PowerShell descendant
     // (records its PID, sleeps 300s) and then blocks forever itself. The helper
-    // must time out and close the job, reaping both. Asserts on the actual
-    // descendant PID reaching "gone".
+    // must time out and close the job, reaping both. The timeout is set well
+    // above a PowerShell cold start so the descendant records its PID before the
+    // deadline fires — otherwise the reap (working instantly) would kill the
+    // descendant mid-cold-start and the test could not read its PID. Asserts on
+    // the actual descendant PID reaching "gone".
     #[cfg(windows)]
     #[test]
     #[ignore = "requires a Windows host; run manually with --ignored"]
@@ -501,14 +585,15 @@ mod tests {
             .to_str()
             .expect("utf-8 temp path")
             .to_string();
-        let ps = format!(
+        let child = format!(
             "$PID | Out-File -Encoding ascii -FilePath '{pid_path}'; Start-Sleep -Seconds 300"
         );
-        let script =
-            format!("start /b powershell -NoProfile -Command \"{ps}\" & powershell -NoProfile -Command \"Start-Sleep -Seconds 300\"");
+        let script = format!(
+            "start /b powershell -NoProfile -Command \"{child}\" & powershell -NoProfile -Command \"Start-Sleep -Seconds 300\""
+        );
         let mut cmd = Command::new("cmd.exe");
         cmd.args(["/c", &script]);
-        let result = run_watchdogged(cmd, Duration::from_millis(500), Duration::from_secs(10));
+        let result = run_watchdogged(cmd, Duration::from_secs(8), Duration::from_secs(25));
         assert!(result.is_none(), "a timed-out tree must yield None");
 
         let descendant_pid = read_recorded_pid(&pid_path);

--- a/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
@@ -22,29 +22,36 @@ const KILL_GRACE: Duration = Duration::from_millis(500);
 /// can be torn down on *every* exit path — timeout, error, or successful exit.
 ///
 /// The two platforms establish ownership differently, but both own the tree for
-/// the guard's whole lifetime rather than looking it up after the fact:
+/// the guard's whole lifetime and — critically — before the child can run any
+/// code that forks a descendant:
 ///
 /// - **Unix:** the child leads its own process group (`process_group(0)`), so
 ///   `killpg` reaches every descendant that has not left the group.
-/// - **Windows:** the child is assigned to a kill-on-close Job Object at spawn.
-///   Closing that job reaps the whole tree *even after the root has exited* —
-///   the distinction that makes `taskkill /T <pid>` (a live-root lookup) unfit
-///   for the success path, where the root is already gone by the time we tear
-///   down. This mirrors the Job Object discipline the harness already uses to
-///   reap its 24 agent workers (`process_lifecycle.rs`).
+/// - **Windows:** the child is spawned `CREATE_SUSPENDED`, assigned to a
+///   kill-on-close Job Object while frozen, then resumed. No descendant can
+///   exist until the job owns the root, so a probe that backgrounds a child and
+///   exits in the same tick cannot escape. Closing that job reaps the whole
+///   tree *even after the root has exited* — the distinction that makes
+///   `taskkill /T <pid>` (a live-root lookup) unfit for the success path, where
+///   the root is already gone by the time we tear down. This mirrors the Job
+///   Object discipline the harness already uses to reap its 24 agent workers
+///   (`process_lifecycle.rs`).
 struct BoundedChild {
     child: std::process::Child,
-    /// `Some` while the job owns the tree; taken and dropped by `kill_tree` so
-    /// the reap happens exactly once. `None` means job assignment failed at
-    /// spawn — teardown then falls back to killing the direct child only.
+    /// The kill-on-close job that owns the whole tree. Taken and dropped by
+    /// `kill_tree` so the reap happens exactly once. Spawn is fail-closed: if
+    /// the job cannot be created, assigned, or the child resumed, the child is
+    /// terminated and `spawn` returns `None` rather than running unowned.
     #[cfg(windows)]
     job: Option<crate::managed_agents::JobHandle>,
 }
 
 impl BoundedChild {
-    /// Spawn `command`, establishing tree ownership before returning. Returns
-    /// `None` only if the spawn itself fails; a Windows job-assignment failure
-    /// is retained as degraded (`job: None`) rather than aborting the spawn.
+    /// Spawn `command`, establishing tree ownership before the child can run.
+    /// Returns `None` if the spawn fails or — on Windows — if the job cannot be
+    /// created, assigned, or the frozen child resumed; in every such case the
+    /// child is terminated and reaped before returning, so no unowned process
+    /// survives.
     fn spawn(mut command: Command) -> Option<Self> {
         // Run the child in its own process group so the whole tree can be torn
         // down as a unit, not just a direct child that may have forked workers.
@@ -54,16 +61,36 @@ impl BoundedChild {
             command.process_group(0);
         }
 
-        let child = command.spawn().ok()?;
+        // Spawn frozen so the Job Object can take ownership before any child
+        // code runs and forks a descendant that would escape the job.
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt as _;
+            const CREATE_SUSPENDED: u32 = 0x0000_0004;
+            command.creation_flags(CREATE_SUSPENDED);
+        }
+
+        // `mut` is used only on the Windows fail-closed path (kill/wait on the
+        // frozen child); Unix moves the child unmodified into `Self`.
+        #[cfg_attr(not(windows), allow(unused_mut))]
+        let mut child = command.spawn().ok()?;
 
         #[cfg(windows)]
         let job = {
-            let job = crate::managed_agents::create_job_for_child(child.id());
-            if job.is_none() {
-                eprintln!(
-                    "buzz-desktop: bounded command could not take a Job Object; \
-                     a backgrounded descendant may outlive teardown"
-                );
+            // Assign the frozen child to a kill-on-close job, then resume it.
+            // Any failure is fail-closed: terminate + reap the still-owned
+            // child and abort the spawn, never run it unowned to the deadline.
+            let Some(job) = crate::managed_agents::create_job_for_child(child.id()) else {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            };
+            if !crate::managed_agents::resume_process(child.id()) {
+                // Dropping the job kills the still-suspended child via
+                // kill-on-close; reap it so no zombie lingers.
+                drop(job);
+                let _ = child.wait();
+                return None;
             }
             job
         };
@@ -71,7 +98,7 @@ impl BoundedChild {
         Some(Self {
             child,
             #[cfg(windows)]
-            job,
+            job: Some(job),
         })
     }
 
@@ -107,16 +134,12 @@ impl BoundedChild {
             libc::killpg(self.child.id() as i32, libc::SIGKILL);
         }
         #[cfg(windows)]
-        match self.job.take() {
-            // Closing the kill-on-close job reaps every descendant, even once
-            // the root has exited — which `taskkill /T <root>` cannot.
-            Some(job) => drop(job),
-            // Job assignment failed at spawn (already logged): no tree
-            // guarantee. Fail closed by killing the direct child; a descendant
-            // it backgrounded may still leak.
-            None => {
-                let _ = self.child.kill();
-            }
+        // Closing the kill-on-close job reaps every descendant, even once the
+        // root has exited — which `taskkill /T <root>` cannot. `spawn` is
+        // fail-closed, so the job is always present until this first take;
+        // a later take is a no-op (the tree is already reaped).
+        if let Some(job) = self.job.take() {
+            drop(job);
         }
     }
 
@@ -215,7 +238,7 @@ mod tests {
     /// the test fails instead of hanging forever. This is the real outer bound —
     /// an inline `elapsed() < bound` assertion is never reached if the helper
     /// itself hangs.
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     fn run_watchdogged(cmd: Command, timeout: Duration, bound: Duration) -> Option<Output> {
         let (tx, rx) = mpsc::channel();
         std::thread::spawn(move || {
@@ -338,6 +361,126 @@ mod tests {
         assert!(
             !pid_alive(descendant_pid),
             "backgrounded descendant {descendant_pid} must be group-killed on timeout, but it survived"
+        );
+    }
+
+    // ---- Windows tree-ownership verification (Will's box) ----------------
+    //
+    // No CI lane executes Windows tests for this helper, so these are
+    // `#[ignore]`-gated for a sanctioned local run on a real Windows machine:
+    //
+    //   cargo test -p buzz-desktop --lib bounded_command -- --ignored --nocapture
+    //
+    // Both assert on the actual PowerShell-recorded descendant PID (not the
+    // already-exited root), so neutering the Job Object ownership leaves that
+    // PID alive and fails the test — the mutation is observable.
+
+    /// True while a Windows process still exists. Opens with the minimal
+    /// query right and reads its exit code: `STILL_ACTIVE` (259) means running,
+    /// any other code means exited. A failed open means the PID is gone.
+    #[cfg(windows)]
+    fn pid_alive(pid: u32) -> bool {
+        use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+        use windows_sys::Win32::System::Threading::{
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+        unsafe {
+            let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+            if handle.is_null() {
+                return false;
+            }
+            let mut code: u32 = 0;
+            let ok = GetExitCodeProcess(handle, &mut code);
+            CloseHandle(handle);
+            ok != 0 && code == STILL_ACTIVE as u32
+        }
+    }
+
+    /// Read a PID that a probe wrote to `path`, retrying briefly since the
+    /// descendant records it asynchronously.
+    #[cfg(windows)]
+    fn read_recorded_pid(path: &str) -> u32 {
+        for _ in 0..200 {
+            if let Ok(text) = std::fs::read_to_string(path) {
+                if let Ok(pid) = text.trim().parse::<u32>() {
+                    return pid;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("descendant never recorded its PID at {path}");
+    }
+
+    // Success path, run in a loop to hammer the spawn/assign race: a cmd.exe
+    // root launches a detached PowerShell descendant that records its own PID
+    // and sleeps, then the root exits 0 immediately. Because the child is
+    // spawned CREATE_SUSPENDED and assigned to the job before it can run, the
+    // descendant is born inside the job; closing the job on success must reap
+    // it even though the root is already gone.
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "requires a Windows host; run manually with --ignored"]
+    fn reaps_backgrounded_descendant_on_success_windows() {
+        for iteration in 0..25 {
+            let pid_file = tempfile::NamedTempFile::new().expect("temp file for descendant pid");
+            let pid_path = pid_file
+                .path()
+                .to_str()
+                .expect("utf-8 temp path")
+                .to_string();
+            // `start /b` backgrounds the PowerShell child; the root cmd exits at
+            // once. PowerShell records $PID then sleeps 30s.
+            let ps = format!(
+                "$PID | Out-File -Encoding ascii -FilePath '{pid_path}'; Start-Sleep -Seconds 30"
+            );
+            let script = format!("start /b powershell -NoProfile -Command \"{ps}\" & exit 0");
+            let mut cmd = Command::new("cmd.exe");
+            cmd.args(["/c", &script]);
+            let out = run_watchdogged(cmd, Duration::from_secs(5), Duration::from_secs(15))
+                .expect("the root exits, so this must return its output");
+            assert!(
+                out.status.success(),
+                "iteration {iteration}: root must exit 0"
+            );
+
+            let descendant_pid = read_recorded_pid(&pid_path);
+            std::thread::sleep(Duration::from_millis(300));
+            assert!(
+                !pid_alive(descendant_pid),
+                "iteration {iteration}: descendant {descendant_pid} must be reaped on success, but it survived"
+            );
+        }
+    }
+
+    // Timeout path: a cmd.exe root launches a detached PowerShell descendant
+    // (records its PID, sleeps 300s) and then blocks forever itself. The helper
+    // must time out and close the job, reaping both. Asserts on the actual
+    // descendant PID reaching "gone".
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "requires a Windows host; run manually with --ignored"]
+    fn reaps_descendant_on_timeout_windows() {
+        let pid_file = tempfile::NamedTempFile::new().expect("temp file for descendant pid");
+        let pid_path = pid_file
+            .path()
+            .to_str()
+            .expect("utf-8 temp path")
+            .to_string();
+        let ps = format!(
+            "$PID | Out-File -Encoding ascii -FilePath '{pid_path}'; Start-Sleep -Seconds 300"
+        );
+        let script =
+            format!("start /b powershell -NoProfile -Command \"{ps}\" & powershell -NoProfile -Command \"Start-Sleep -Seconds 300\"");
+        let mut cmd = Command::new("cmd.exe");
+        cmd.args(["/c", &script]);
+        let result = run_watchdogged(cmd, Duration::from_millis(500), Duration::from_secs(10));
+        assert!(result.is_none(), "a timed-out tree must yield None");
+
+        let descendant_pid = read_recorded_pid(&pid_path);
+        std::thread::sleep(Duration::from_millis(300));
+        assert!(
+            !pid_alive(descendant_pid),
+            "descendant {descendant_pid} must be job-killed on timeout, but it survived"
         );
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
@@ -73,24 +73,23 @@ const _: () = {
     assert!(BOUNDED_CREATION_FLAGS & CREATE_NO_WINDOW == CREATE_NO_WINDOW);
 };
 
-/// A spawned child plus ownership of its entire descendant tree, so the tree
-/// can be torn down on *every* exit path — timeout, error, or successful exit.
-///
-/// The two platforms establish ownership differently, but both own the tree for
-/// the guard's whole lifetime and — critically — before the child can run any
-/// code that forks a descendant:
+/// A spawned child plus ownership of its descendant tree, torn down on *every*
+/// exit path — timeout, error, or successful exit. The two platforms establish
+/// ownership differently, and the guarantee is deliberately asymmetric — the
+/// adjudicated design, not an oversight:
 ///
 /// - **Unix:** the child leads its own process group (`process_group(0)`), so
-///   `killpg` reaches every descendant that has not left the group.
+///   `killpg` reaches every descendant that has not left the group. A
+///   `setsid`/`setpgid` escapee holding a pipe is *not* owned and may survive
+///   one probe, yet never hangs the helper (see [`output_with_timeout`]).
 /// - **Windows:** the child is spawned `CREATE_SUSPENDED`, assigned to a
-///   kill-on-close Job Object while frozen, then resumed. No descendant can
-///   exist until the job owns the root, so a probe that backgrounds a child and
-///   exits in the same tick cannot escape. Closing that job reaps the whole
-///   tree *even after the root has exited* — the distinction that makes
-///   `taskkill /T <pid>` (a live-root lookup) unfit for the success path, where
-///   the root is already gone by the time we tear down. This mirrors the Job
-///   Object discipline the harness already uses to reap its 24 agent workers
-///   (`process_lifecycle.rs`).
+///   kill-on-close Job Object while frozen, then resumed. The job owns the root
+///   before any descendant can exist and is created without breakaway, so no
+///   writer can escape it — a hard whole-tree guarantee. Closing that job reaps
+///   the whole tree *even after the root has exited* — the distinction that
+///   makes `taskkill /T <pid>` (a live-root lookup) unfit for the success path.
+///   This mirrors the Job Object discipline the harness uses to reap its 24
+///   agent workers (`process_lifecycle.rs`).
 struct BoundedChild {
     child: std::process::Child,
     /// The kill-on-close job that owns the whole tree. Taken and dropped by
@@ -353,13 +352,14 @@ fn spawn_drain<R: Read + Send + 'static>(
 ///   join forever on a group-escaping writer.
 /// - **No wait hang.** The child is polled with [`Child::try_wait`] against the
 ///   deadline rather than blocked on with `wait()`.
-/// - **Hard tree termination on every exit path.** [`BoundedChild`] owns the
-///   child's whole descendant tree and tears it down whether the child times
-///   out, errors, breaches the cap, *or exits successfully*. Success is not an
-///   exemption: a login-shell rc file or an auth CLI can legitimately background
-///   a descendant (`worker &`) that would otherwise outlive discovery and keep
-///   consuming resources. The timeout path additionally sends a graceful
-///   `SIGTERM` and a bounded grace period before the final kill.
+/// - **Tree termination on every exit path.** [`BoundedChild`] tears the tree
+///   down whether the child times out, errors, breaches the cap, *or exits
+///   successfully* — a login-shell rc file or auth CLI can legitimately
+///   background a descendant (`worker &`) that would outlive discovery.
+///   Ownership is a hard whole-tree guarantee on Windows but only the child's
+///   process group on Unix (the group-escapee case bounded by the drain rule
+///   above) — the adjudicated asymmetry. The timeout path additionally sends a
+///   graceful `SIGTERM` and a grace period before the kill.
 pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Option<Output> {
     command
         .stdin(Stdio::null())

--- a/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
@@ -6,7 +6,7 @@
 //! `SIGTERM`, or a forked descendant that keeps a pipe open must not be able to
 //! stall discovery; that stall is what left "Check again" spinning forever.
 
-use std::process::{Command, Output};
+use std::process::{Command, ExitStatus, Output, Stdio};
 use std::time::{Duration, Instant};
 
 /// Poll interval while waiting for the child to exit.
@@ -17,6 +17,114 @@ const POLL_INTERVAL: Duration = Duration::from_millis(50);
 /// exit cleanly, short enough that a signal-ignoring one is reaped promptly.
 #[cfg(unix)]
 const KILL_GRACE: Duration = Duration::from_millis(500);
+
+/// A spawned child plus ownership of its entire descendant tree, so the tree
+/// can be torn down on *every* exit path — timeout, error, or successful exit.
+///
+/// The two platforms establish ownership differently, but both own the tree for
+/// the guard's whole lifetime rather than looking it up after the fact:
+///
+/// - **Unix:** the child leads its own process group (`process_group(0)`), so
+///   `killpg` reaches every descendant that has not left the group.
+/// - **Windows:** the child is assigned to a kill-on-close Job Object at spawn.
+///   Closing that job reaps the whole tree *even after the root has exited* —
+///   the distinction that makes `taskkill /T <pid>` (a live-root lookup) unfit
+///   for the success path, where the root is already gone by the time we tear
+///   down. This mirrors the Job Object discipline the harness already uses to
+///   reap its 24 agent workers (`process_lifecycle.rs`).
+struct BoundedChild {
+    child: std::process::Child,
+    /// `Some` while the job owns the tree; taken and dropped by `kill_tree` so
+    /// the reap happens exactly once. `None` means job assignment failed at
+    /// spawn — teardown then falls back to killing the direct child only.
+    #[cfg(windows)]
+    job: Option<crate::managed_agents::JobHandle>,
+}
+
+impl BoundedChild {
+    /// Spawn `command`, establishing tree ownership before returning. Returns
+    /// `None` only if the spawn itself fails; a Windows job-assignment failure
+    /// is retained as degraded (`job: None`) rather than aborting the spawn.
+    fn spawn(mut command: Command) -> Option<Self> {
+        // Run the child in its own process group so the whole tree can be torn
+        // down as a unit, not just a direct child that may have forked workers.
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt as _;
+            command.process_group(0);
+        }
+
+        let child = command.spawn().ok()?;
+
+        #[cfg(windows)]
+        let job = {
+            let job = crate::managed_agents::create_job_for_child(child.id());
+            if job.is_none() {
+                eprintln!(
+                    "buzz-desktop: bounded command could not take a Job Object; \
+                     a backgrounded descendant may outlive teardown"
+                );
+            }
+            job
+        };
+
+        Some(Self {
+            child,
+            #[cfg(windows)]
+            job,
+        })
+    }
+
+    fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>> {
+        self.child.try_wait()
+    }
+
+    /// Timeout teardown: a graceful `SIGTERM` to the group and a bounded grace
+    /// period for a clean flush on Unix, then the unconditional forced kill.
+    /// Windows has no group signal, so it goes straight to the forced kill.
+    fn terminate_timed_out(&mut self) {
+        #[cfg(unix)]
+        {
+            // SAFETY: `killpg` on the group led by the child; an ignored result
+            // is intentional — the group may already be gone (ESRCH).
+            unsafe {
+                libc::killpg(self.child.id() as i32, libc::SIGTERM);
+            }
+            std::thread::sleep(KILL_GRACE);
+        }
+        self.kill_tree();
+    }
+
+    /// Forcibly reap the whole tree. Idempotent and safe on an already-exited
+    /// tree. Runs on every exit path — including success, because a login shell
+    /// or auth CLI can background a descendant that outlives the leader while
+    /// still holding the captured-output descriptors.
+    fn kill_tree(&mut self) {
+        #[cfg(unix)]
+        // SAFETY: `killpg` on the group led by the child; ignored result is
+        // intentional — `ESRCH` on a dead group is the success case.
+        unsafe {
+            libc::killpg(self.child.id() as i32, libc::SIGKILL);
+        }
+        #[cfg(windows)]
+        match self.job.take() {
+            // Closing the kill-on-close job reaps every descendant, even once
+            // the root has exited — which `taskkill /T <root>` cannot.
+            Some(job) => drop(job),
+            // Job assignment failed at spawn (already logged): no tree
+            // guarantee. Fail closed by killing the direct child; a descendant
+            // it backgrounded may still leak.
+            None => {
+                let _ = self.child.kill();
+            }
+        }
+    }
+
+    /// Reap the direct child so no zombie lingers after the tree is killed.
+    fn reap(&mut self) {
+        let _ = self.child.wait();
+    }
+}
 
 /// Run `command` to completion, bounded by `timeout`.
 ///
@@ -33,36 +141,24 @@ const KILL_GRACE: Duration = Duration::from_millis(500);
 ///   no background drain threads to join, so no drain-thread hang exists.
 /// - **No wait hang.** The child is polled with [`Child::try_wait`] against the
 ///   deadline rather than blocked on with `wait()`.
-/// - **Hard termination on every exit path.** The child runs as its own process
-///   group leader (Unix) / tree root (Windows), and that group/tree is torn down
-///   whether the child times out, errors, *or exits successfully* — see
-///   [`kill_tree`]. Success is not an exemption: a login-shell rc file or an
-///   auth CLI can legitimately background a descendant (`worker &`), which would
-///   otherwise outlive discovery still holding the captured-output descriptors.
-///   The timeout path additionally sends a graceful `SIGTERM` and a bounded
-///   grace period before the final `SIGKILL` (see [`terminate_timed_out`]).
+/// - **Hard tree termination on every exit path.** [`BoundedChild`] owns the
+///   child's whole descendant tree (Unix process group / Windows Job Object)
+///   and tears it down whether the child times out, errors, *or exits
+///   successfully*, before the captured output is read. Success is not an
+///   exemption: a login-shell rc file or an auth CLI can legitimately background
+///   a descendant (`worker &`) that would otherwise outlive discovery. The
+///   timeout path additionally sends a graceful `SIGTERM` and a bounded grace
+///   period before the final kill.
 pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Option<Output> {
     let mut stdout_file = tempfile::tempfile().ok()?;
     let mut stderr_file = tempfile::tempfile().ok()?;
 
     command
-        .stdin(std::process::Stdio::null())
+        .stdin(Stdio::null())
         .stdout(stdout_file.try_clone().ok()?)
         .stderr(stderr_file.try_clone().ok()?);
 
-    // Run the child in its own process group so the whole tree can be torn
-    // down as a unit, not just a direct child that may have forked workers.
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt as _;
-        command.process_group(0);
-    }
-
-    let mut child = command.spawn().ok()?;
-    // Cache the id: `try_wait` reaps the leader, but the group/tree id stays
-    // valid as long as any descendant keeps it alive — which is exactly the
-    // survivor we must reap.
-    let pid = child.id();
+    let mut child = BoundedChild::spawn(command)?;
 
     let deadline = Instant::now() + timeout;
     let status = loop {
@@ -70,24 +166,25 @@ pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Op
             Ok(Some(status)) => break status,
             Ok(None) => {
                 if Instant::now() >= deadline {
-                    terminate_timed_out(pid);
-                    let _ = child.wait();
+                    child.terminate_timed_out();
+                    child.reap();
                     return None;
                 }
                 std::thread::sleep(POLL_INTERVAL);
             }
             Err(_) => {
-                kill_tree(pid);
-                let _ = child.wait();
+                child.kill_tree();
+                child.reap();
                 return None;
             }
         }
     };
 
-    // Leader exited within the deadline. Reap any descendant it backgrounded
-    // before reading — otherwise a survivor keeps the captured-output fds (and
-    // whatever it is writing) alive after discovery reports success.
-    kill_tree(pid);
+    // Leader exited within the deadline. Tear the tree down before reading, so
+    // no descendant it backgrounded keeps the captured-output descriptors (or a
+    // busy loop) alive after discovery reports success.
+    child.kill_tree();
+    child.reap();
 
     Some(Output {
         status,
@@ -106,51 +203,6 @@ fn read_captured(file: &mut std::fs::File) -> Vec<u8> {
     let mut buf = Vec::new();
     let _ = file.read_to_end(&mut buf);
     buf
-}
-
-/// Terminate a timed-out child's whole group/tree with a graceful-then-forced
-/// sequence. `SIGTERM` the group, wait the fixed [`KILL_GRACE`] for a clean
-/// shutdown, then hand off to [`kill_tree`] for the unconditional `SIGKILL`.
-/// Bounded by `KILL_GRACE` on Unix; on Windows there is no group signal, so it
-/// is a direct forced tree kill. Every step is time-bounded.
-fn terminate_timed_out(pid: u32) {
-    #[cfg(unix)]
-    {
-        // SAFETY: `killpg` on the group led by `pid`; the child was spawned
-        // with `process_group(0)`. An unused result is intentional — the group
-        // may already be gone (ESRCH), which is the success case.
-        unsafe {
-            libc::killpg(pid as i32, libc::SIGTERM);
-        }
-        std::thread::sleep(KILL_GRACE);
-    }
-    kill_tree(pid);
-}
-
-/// Unconditionally reap the process group/tree rooted at `pid`, forcibly and
-/// without grace. Runs on **every** exit path — timeout, spawn/wait error, and
-/// successful exit — because a login shell or auth CLI can background a
-/// descendant that outlives the leader while still holding the captured-output
-/// descriptors. A signal to an already-dead group is `ESRCH`, a harmless no-op.
-///
-/// On Unix this `SIGKILL`s the whole group (the child is its leader). On Windows
-/// it delegates to [`taskkill_tree`](crate::managed_agents::taskkill_tree)
-/// (`taskkill /T /F`), which kills the tree — a direct `Child::kill` would leave
-/// descendants alive, exactly the leak this guards against.
-fn kill_tree(pid: u32) {
-    #[cfg(unix)]
-    // SAFETY: `killpg` on the group led by `pid`; unused result is intentional.
-    unsafe {
-        libc::killpg(pid as i32, libc::SIGKILL);
-    }
-    #[cfg(windows)]
-    {
-        let _ = crate::managed_agents::taskkill_tree(pid);
-    }
-    #[cfg(not(any(unix, windows)))]
-    {
-        let _ = pid;
-    }
 }
 
 #[cfg(test)]
@@ -226,13 +278,13 @@ mod tests {
             .to_str()
             .expect("utf-8 temp path")
             .to_string();
-        // The descendant records its PID, then becomes `yes` (the unbounded
-        // writer from the pass-2 reproducer, holding the inherited fds). The
-        // leader waits until the PID is recorded before exiting 0, so the test
-        // can read it deterministically even though the success path kills the
-        // group immediately on return.
+        // Background a real child process (`sleep`), record ITS pid via `$!`
+        // (not `$$`, which in a subshell is the invoking shell), then exit 0.
+        // The leader waits until the pid is recorded so the test can read it
+        // deterministically even though the success path kills the group at
+        // once. `$!` is the pass-2 `(yes) & exit 0` survivor, made observable.
         let script = format!(
-            "(echo $$ > '{pid_path}'; exec yes) & \
+            "sleep 30 & echo $! > '{pid_path}'; \
              until [ -s '{pid_path}' ]; do :; done; printf done; exit 0"
         );
         let mut cmd = Command::new("/bin/sh");
@@ -256,8 +308,9 @@ mod tests {
 
     // Adversarial (timeout path): a SIGTERM-ignoring leader that backgrounds a
     // descendant, both looping forever. The leader's process group is killed on
-    // timeout, so the descendant (same group) must die too. The descendant
-    // writes its PID to a known file before looping, so the test can prove it.
+    // timeout, so the descendant (same group) must die too. The descendant is a
+    // real child process whose PID is recorded via `$!`, so the test proves the
+    // actual descendant — not the already-reaped leader — reaches ESRCH.
     #[cfg(unix)]
     #[test]
     fn reaps_descendant_on_timeout() {
@@ -267,10 +320,8 @@ mod tests {
             .to_str()
             .expect("utf-8 temp path")
             .to_string();
-        // Leader ignores TERM and loops; it backgrounds a descendant that
-        // records its own PID then loops. Both share the leader's process group.
         let script = format!(
-            "trap '' TERM; (echo $$ > '{pid_path}'; while :; do sleep 1; done) & \
+            "trap '' TERM; sleep 300 & echo $! > '{pid_path}'; \
              while :; do sleep 1; done"
         );
         let mut cmd = Command::new("/bin/sh");

--- a/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
@@ -16,6 +16,12 @@ use std::time::{Duration, Instant};
 /// Poll interval while waiting for the child to exit.
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
+/// Idle backoff for a nonblocking Unix drain that has no bytes available and
+/// has not yet been told to stop. Short so a running child's output is pulled
+/// promptly and the post-teardown join returns quickly.
+#[cfg(unix)]
+const DRAIN_IDLE_POLL: Duration = Duration::from_millis(5);
+
 /// Maximum bytes retained across stdout + stderr for one bounded probe.
 ///
 /// Discovery output is tiny — a version string, an auth-status word, a PATH
@@ -212,28 +218,61 @@ impl BoundedChild {
     }
 }
 
+/// Set a file descriptor nonblocking so a read on it returns `WouldBlock`
+/// instead of parking when no bytes are available. Returns `false` on any
+/// `fcntl` failure, which the caller treats as fail-closed.
+#[cfg(unix)]
+fn set_nonblocking<F: std::os::unix::io::AsRawFd>(f: &F) -> bool {
+    let fd = f.as_raw_fd();
+    // SAFETY: `fd` is owned by `f` for the duration of this call; `F_GETFL` /
+    // `F_SETFL` read and set the descriptor's flags without transferring
+    // ownership or touching any other resource.
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        if flags < 0 {
+            return false;
+        }
+        libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) == 0
+    }
+}
+
 /// Drain one child stream on its own thread into a buffer capped by the shared
 /// aggregate budget, so the sink itself — not a post-hoc size sample — enforces
 /// [`CAPTURE_LIMIT`].
 ///
-/// The thread reads to EOF, which is what makes the join in
-/// [`output_with_timeout`] safe: it is only ever joined *after* the tree has
-/// been killed, so every writer (the child and any descendant that inherited
-/// the pipe) is gone and the read returns EOF instead of blocking forever —
-/// the exact hang that made the round-2 code abandon pipes for temp files.
-/// Draining continuously also keeps the pipe buffer from filling, so the child
-/// can never block on a full pipe while we poll it.
+/// Continuous draining keeps the pipe buffer from filling, so the child can
+/// never block on a full pipe while we poll it. Retention is bounded: `total`
+/// reserves a disjoint byte range per chunk across both streams, so the sum of
+/// both buffers never exceeds the aggregate cap. Once the cap is crossed,
+/// `overflow` is set and further bytes are read but discarded. A read error
+/// other than `Interrupted`/`WouldBlock` returns `Err`, which the caller treats
+/// as fail-closed.
 ///
-/// Retention is bounded: `total` reserves a disjoint byte range per chunk
-/// across both streams, so the sum of both buffers never exceeds the aggregate
-/// cap. Once the cap is crossed, `overflow` is set and further bytes are read
-/// (to reach EOF) but discarded. A non-`Interrupted` read error returns `Err`,
-/// which the caller treats as fail-closed.
+/// **Bounded completion differs by platform, because tree ownership does.**
+/// - **Unix:** the read end is nonblocking (see [`set_nonblocking`]). A killed
+///   in-group writer's descriptors close, so the read reaches EOF (`Ok(0)`) and
+///   the thread returns normally. But `kill_tree` is a `killpg` on the child's
+///   group, which does *not* reach a descendant that left the group via
+///   `setsid`/`setpgid` while retaining the pipe; that writer keeps the write
+///   end open and EOF never comes. So once teardown has set `stop`, a
+///   `WouldBlock` (nothing more buffered) ends the drain rather than waiting on
+///   that escaped writer forever. This is what makes bounded return hold
+///   *without* depending on every inherited writer exiting — the correction to
+///   the round-8 blocking-EOF design.
+/// - **Windows:** the read blocks to EOF. That is sound because the whole tree
+///   is owned by a kill-on-close Job Object created without
+///   `JOB_OBJECT_LIMIT_BREAKAWAY_OK`, so no descendant can escape the job; job
+///   close reaps every writer and the read reaches EOF. `stop` is unused there.
 fn spawn_drain<R: Read + Send + 'static>(
     mut reader: R,
     total: Arc<AtomicU64>,
     overflow: Arc<AtomicBool>,
+    stop: Arc<AtomicBool>,
 ) -> JoinHandle<std::io::Result<Vec<u8>>> {
+    // `stop` gates only the nonblocking Unix drain; the Windows path blocks to
+    // the job-close EOF and never consults it.
+    #[cfg(windows)]
+    let _ = &stop;
     std::thread::spawn(move || {
         let mut buf = Vec::new();
         let mut chunk = [0u8; 8192];
@@ -249,12 +288,24 @@ fn spawn_drain<R: Read + Send + 'static>(
                         overflow.store(true, Ordering::Relaxed);
                         let keep = CAPTURE_LIMIT.saturating_sub(prev).min(n as u64) as usize;
                         buf.extend_from_slice(&chunk[..keep]);
-                        // Keep reading to EOF (post-kill) but retain nothing more.
+                        // Keep reading to drain the pipe but retain nothing more.
                     } else {
                         buf.extend_from_slice(&chunk[..n]);
                     }
                 }
                 Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+                // Nonblocking read (Unix only): no bytes available right now.
+                // After teardown, an escaped out-of-group writer is the only
+                // thing that could still hold the pipe open, so stop draining it
+                // rather than block the join forever; otherwise back off and
+                // retry so a running child's later output is still captured.
+                #[cfg(unix)]
+                Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                    if stop.load(Ordering::Relaxed) {
+                        return Ok(buf);
+                    }
+                    std::thread::sleep(DRAIN_IDLE_POLL);
+                }
                 Err(e) => return Err(e),
             }
         }
@@ -275,25 +326,29 @@ fn spawn_drain<R: Read + Send + 'static>(
 ///   rather than temp files, cannot fill the disk either). Continuous draining
 ///   also keeps the pipe buffer from filling, so the child can never block on a
 ///   full pipe while we poll.
-/// - **No pipe-drain hang — via a strict ordering invariant.** A pipe read
-///   blocks until every writer (the child *and* any descendant that inherited
-///   the write end) closes it. This code joins the drains *only after*
-///   [`BoundedChild::kill_tree`] has torn the whole tree down (Unix process
-///   group / Windows kill-on-close Job Object), so by the time we join, every
-///   writer is dead and each read has hit EOF. **Kill-before-join is the
-///   load-bearing invariant** — reversing it reintroduces the round-1 hang
-///   where a backgrounded worker held the pipe open forever. This is why the
-///   round-2 switch to temp files is no longer needed.
+/// - **Bounded drain completion without depending on writer death.** Tree
+///   teardown runs on *every* exit path before the drains are joined —
+///   [`BoundedChild::kill_tree`] on timeout, error, cap breach, *and* success.
+///   But teardown alone does not guarantee EOF on Unix: `kill_tree` is a
+///   `killpg` on the child's process group, and a descendant that left the
+///   group (`setsid`/`setpgid`) while retaining the pipe survives it and keeps
+///   the write end open. So the drains do not rely on EOF from every writer:
+///   the Unix reads are nonblocking, and after teardown sets the shared `stop`
+///   flag a `WouldBlock` (no more buffered bytes) ends each drain. An escaped
+///   writer is allowed to survive; the join still returns promptly. On Windows
+///   the reads block to EOF, which is sound because the kill-on-close Job Object
+///   is created without breakaway, so no writer can escape the job. This is the
+///   correction to the round-8 design, whose blocking Unix reads could hang the
+///   join forever on a group-escaping writer.
 /// - **No wait hang.** The child is polled with [`Child::try_wait`] against the
 ///   deadline rather than blocked on with `wait()`.
 /// - **Hard tree termination on every exit path.** [`BoundedChild`] owns the
 ///   child's whole descendant tree and tears it down whether the child times
-///   out, errors, breaches the cap, *or exits successfully*, before the drains
-///   are joined. Success is not an exemption: a login-shell rc file or an auth
-///   CLI can legitimately background a descendant (`worker &`) that would
-///   otherwise outlive discovery and hold the pipe open. The timeout path
-///   additionally sends a graceful `SIGTERM` and a bounded grace period before
-///   the final kill.
+///   out, errors, breaches the cap, *or exits successfully*. Success is not an
+///   exemption: a login-shell rc file or an auth CLI can legitimately background
+///   a descendant (`worker &`) that would otherwise outlive discovery and keep
+///   consuming resources. The timeout path additionally sends a graceful
+///   `SIGTERM` and a bounded grace period before the final kill.
 pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Option<Output> {
     command
         .stdin(Stdio::null())
@@ -302,17 +357,41 @@ pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Op
 
     let mut child = BoundedChild::spawn(command)?;
 
-    // Shared drain state: one aggregate byte budget across both streams and one
+    let stdout_pipe = child.take_stdout();
+    let stderr_pipe = child.take_stderr();
+
+    // Unix: make the parent read ends nonblocking so a drain can be told to stop
+    // (post-teardown) instead of parking forever on a group-escaping writer that
+    // still holds the pipe. Fail closed if the fd cannot be reconfigured — the
+    // child is still fully owned here, so cleanup is just kill + reap.
+    #[cfg(unix)]
+    {
+        let stdout_ok = match stdout_pipe.as_ref() {
+            Some(p) => set_nonblocking(p),
+            None => true,
+        };
+        let stderr_ok = match stderr_pipe.as_ref() {
+            Some(p) => set_nonblocking(p),
+            None => true,
+        };
+        if !(stdout_ok && stderr_ok) {
+            child.kill_tree();
+            child.reap();
+            return None;
+        }
+    }
+
+    // Shared drain state: one aggregate byte budget across both streams, an
     // overflow flag the poll loop watches so a streaming producer that never
-    // exits is failed closed the moment it crosses the cap.
+    // exits is failed closed the moment it crosses the cap, and a stop flag that
+    // teardown raises to end the nonblocking Unix drains.
     let total = Arc::new(AtomicU64::new(0));
     let overflow = Arc::new(AtomicBool::new(false));
-    let stdout_drain = child
-        .take_stdout()
-        .map(|s| spawn_drain(s, total.clone(), overflow.clone()));
-    let stderr_drain = child
-        .take_stderr()
-        .map(|s| spawn_drain(s, total.clone(), overflow.clone()));
+    let stop = Arc::new(AtomicBool::new(false));
+    let stdout_drain =
+        stdout_pipe.map(|s| spawn_drain(s, total.clone(), overflow.clone(), stop.clone()));
+    let stderr_drain =
+        stderr_pipe.map(|s| spawn_drain(s, total.clone(), overflow.clone(), stop.clone()));
 
     let deadline = Instant::now() + timeout;
     let status = loop {
@@ -324,8 +403,8 @@ pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Op
                     break None;
                 }
                 // Fail closed on a capture breach *while the child runs*: the
-                // drain kept nothing over the cap, and killing the tree lets the
-                // drains reach EOF so the join below cannot hang.
+                // drain kept nothing over the cap; teardown below ends the
+                // drains so the join cannot hang.
                 if overflow.load(Ordering::Relaxed) {
                     child.kill_tree();
                     break None;
@@ -339,14 +418,16 @@ pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Op
         }
     };
 
-    // Tree down (timeout/error/overflow already killed it above; a clean exit
-    // may still have backgrounded a descendant holding the pipe). Kill is
-    // idempotent, so calling it here on the success path is safe and is what
-    // guarantees the joins below hit EOF instead of blocking.
+    // Tree down on every path (timeout/error/overflow killed it above; a clean
+    // exit may still have backgrounded a descendant holding the pipe). Kill is
+    // idempotent, so calling it here on the success path is safe. Then raise
+    // `stop`: a killed in-group writer's pipe reaches EOF and ends its drain on
+    // its own, but a group-escaping writer never will — `stop` ends that drain
+    // on the next `WouldBlock` so the joins below return promptly.
     child.kill_tree();
     child.reap();
+    stop.store(true, Ordering::Relaxed);
 
-    // Kill-before-join: every writer is now gone, so these joins return EOF.
     let stdout = join_drain(stdout_drain);
     let stderr = join_drain(stderr_drain);
 
@@ -432,11 +513,10 @@ mod tests {
 
     // Adversarial (success path): the direct child exits 0 but backgrounds a
     // descendant that keeps writing to the inherited stdout/stderr forever.
-    // Two guarantees under test: (1) the temp-file capture returns at EOF
-    // rather than blocking on the descendant, and (2) `kill_tree` reaps that
-    // descendant before returning, so no survivor keeps consuming disk/CPU
-    // after discovery reports success. This is the pass-2 leak Thufir proved
-    // with `(yes) & exit 0`.
+    // Two guarantees under test: (1) the drain returns rather than blocking on
+    // the descendant, and (2) `kill_tree` reaps that descendant before
+    // returning, so no survivor keeps consuming CPU after discovery reports
+    // success. This is the pass-2 leak Thufir proved with `(yes) & exit 0`.
     #[cfg(unix)]
     #[test]
     fn reaps_backgrounded_descendant_on_success() {
@@ -507,6 +587,62 @@ mod tests {
             !pid_alive(descendant_pid),
             "backgrounded descendant {descendant_pid} must be group-killed on timeout, but it survived"
         );
+    }
+
+    // Adversarial (group escape): the leader backgrounds a descendant that
+    // calls `setsid()` — leaving the leader's process group while retaining the
+    // inherited stdout — then sleeps 300s; the leader itself loops forever, so
+    // the helper times out. `kill_tree` is a `killpg` on the leader's group and
+    // cannot reach the escaped descendant, so its pipe write end stays open and
+    // never reaches EOF. The helper must still return within the outer watchdog
+    // and fail closed: the nonblocking drains stop on `WouldBlock` after
+    // teardown rather than blocking on that surviving writer. This is the exact
+    // primitive Thufir reproduced against the round-8 blocking-read design; with
+    // blocking reads the drain join hangs forever and `run_watchdogged` panics.
+    //
+    // Non-vacuous: the descendant is asserted *alive* after the helper returns,
+    // proving it genuinely escaped the `killpg` (so it was still holding the
+    // pipe at join time) — the return therefore came from the stop path, not
+    // from an EOF the kill happened to produce. The test then reaps it.
+    #[cfg(unix)]
+    #[test]
+    fn returns_when_escaped_descendant_retains_pipe() {
+        let pid_file = tempfile::NamedTempFile::new().expect("temp file for descendant pid");
+        let pid_path = pid_file
+            .path()
+            .to_str()
+            .expect("utf-8 temp path")
+            .to_string();
+        // The perl descendant `setsid()`s out of the leader's group, records its
+        // PID, writes a few bytes to the retained stdout, then sleeps. The
+        // leader waits until the PID is recorded (so the test can read it) and
+        // then loops forever, forcing the timeout path.
+        let script = format!(
+            "perl -MPOSIX -e 'POSIX::setsid() or die; open(my $f,\">\",$ARGV[0]) or die; \
+             print $f $$; close $f; print \"x\" x 4096; sleep 300;' '{pid_path}' & \
+             until [ -s '{pid_path}' ]; do :; done; while :; do sleep 1; done"
+        );
+        let mut cmd = Command::new("/bin/sh");
+        cmd.args(["-c", &script]);
+        let result = run_watchdogged(cmd, Duration::from_millis(300), Duration::from_secs(5));
+        assert!(
+            result.is_none(),
+            "a timed-out probe must fail closed even when an escaped writer holds the pipe"
+        );
+
+        let descendant_pid: i32 = std::fs::read_to_string(&pid_path)
+            .expect("escaped descendant must have recorded its PID")
+            .trim()
+            .parse()
+            .expect("descendant PID must be numeric");
+        assert!(
+            pid_alive(descendant_pid),
+            "descendant {descendant_pid} was expected to survive the group kill (proving it escaped)"
+        );
+        // Reap the escaped writer so the test leaves nothing behind.
+        unsafe {
+            libc::kill(descendant_pid, libc::SIGKILL);
+        }
     }
 
     // Adversarial (capture bound): a producer that streams zero bytes

--- a/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
@@ -33,10 +33,14 @@ const KILL_GRACE: Duration = Duration::from_millis(500);
 ///   no background drain threads to join, so no drain-thread hang exists.
 /// - **No wait hang.** The child is polled with [`Child::try_wait`] against the
 ///   deadline rather than blocked on with `wait()`.
-/// - **Hard termination.** On timeout the child's whole process group is torn
-///   down (see [`terminate`]) — `SIGTERM` then an escalating `SIGKILL` on Unix,
-///   `Child::kill` on Windows — so a `SIGTERM`-trapping child or a forked
-///   descendant cannot outlive the deadline.
+/// - **Hard termination on every exit path.** The child runs as its own process
+///   group leader (Unix) / tree root (Windows), and that group/tree is torn down
+///   whether the child times out, errors, *or exits successfully* — see
+///   [`kill_tree`]. Success is not an exemption: a login-shell rc file or an
+///   auth CLI can legitimately background a descendant (`worker &`), which would
+///   otherwise outlive discovery still holding the captured-output descriptors.
+///   The timeout path additionally sends a graceful `SIGTERM` and a bounded
+///   grace period before the final `SIGKILL` (see [`terminate_timed_out`]).
 pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Option<Output> {
     let mut stdout_file = tempfile::tempfile().ok()?;
     let mut stderr_file = tempfile::tempfile().ok()?;
@@ -46,8 +50,8 @@ pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Op
         .stdout(stdout_file.try_clone().ok()?)
         .stderr(stderr_file.try_clone().ok()?);
 
-    // Run the child in its own process group so a timeout can terminate the
-    // whole tree, not just a direct child that may have forked workers.
+    // Run the child in its own process group so the whole tree can be torn
+    // down as a unit, not just a direct child that may have forked workers.
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt as _;
@@ -55,6 +59,10 @@ pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Op
     }
 
     let mut child = command.spawn().ok()?;
+    // Cache the id: `try_wait` reaps the leader, but the group/tree id stays
+    // valid as long as any descendant keeps it alive — which is exactly the
+    // survivor we must reap.
+    let pid = child.id();
 
     let deadline = Instant::now() + timeout;
     let status = loop {
@@ -62,17 +70,24 @@ pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Op
             Ok(Some(status)) => break status,
             Ok(None) => {
                 if Instant::now() >= deadline {
-                    terminate(&mut child);
+                    terminate_timed_out(pid);
+                    let _ = child.wait();
                     return None;
                 }
                 std::thread::sleep(POLL_INTERVAL);
             }
             Err(_) => {
-                terminate(&mut child);
+                kill_tree(pid);
+                let _ = child.wait();
                 return None;
             }
         }
     };
+
+    // Leader exited within the deadline. Reap any descendant it backgrounded
+    // before reading — otherwise a survivor keeps the captured-output fds (and
+    // whatever it is writing) alive after discovery reports success.
+    kill_tree(pid);
 
     Some(Output {
         status,
@@ -93,46 +108,88 @@ fn read_captured(file: &mut std::fs::File) -> Vec<u8> {
     buf
 }
 
-/// Tear down a timed-out child and its process group with a bounded return.
-///
-/// The child is a group leader (`process_group(0)`), so its PID is also the
-/// group ID. `SIGTERM` the whole group for a clean shutdown, wait the fixed
-/// [`KILL_GRACE`], then unconditionally `SIGKILL` the group so a signal-ignoring
-/// child or descendant cannot survive. `wait` then reaps the (now-killed) direct
-/// child. Every step is time-bounded, so this returns in at most `KILL_GRACE`.
-#[cfg(unix)]
-fn terminate(child: &mut std::process::Child) {
-    let pgid = child.id() as i32;
-    // SAFETY: `killpg` with a valid PID/PGID; unused result is intentional —
-    // the group may already be gone.
-    unsafe {
-        libc::killpg(pgid, libc::SIGTERM);
+/// Terminate a timed-out child's whole group/tree with a graceful-then-forced
+/// sequence. `SIGTERM` the group, wait the fixed [`KILL_GRACE`] for a clean
+/// shutdown, then hand off to [`kill_tree`] for the unconditional `SIGKILL`.
+/// Bounded by `KILL_GRACE` on Unix; on Windows there is no group signal, so it
+/// is a direct forced tree kill. Every step is time-bounded.
+fn terminate_timed_out(pid: u32) {
+    #[cfg(unix)]
+    {
+        // SAFETY: `killpg` on the group led by `pid`; the child was spawned
+        // with `process_group(0)`. An unused result is intentional — the group
+        // may already be gone (ESRCH), which is the success case.
+        unsafe {
+            libc::killpg(pid as i32, libc::SIGTERM);
+        }
+        std::thread::sleep(KILL_GRACE);
     }
-    std::thread::sleep(KILL_GRACE);
-    unsafe {
-        libc::killpg(pgid, libc::SIGKILL);
-    }
-    let _ = child.wait();
+    kill_tree(pid);
 }
 
-/// Windows teardown: `Child::kill` maps to `TerminateProcess`, a guaranteed kill
-/// of the child (not mere PID consumption). `wait` reaps it so no handle leaks.
-#[cfg(not(unix))]
-fn terminate(child: &mut std::process::Child) {
-    let _ = child.kill();
-    let _ = child.wait();
+/// Unconditionally reap the process group/tree rooted at `pid`, forcibly and
+/// without grace. Runs on **every** exit path — timeout, spawn/wait error, and
+/// successful exit — because a login shell or auth CLI can background a
+/// descendant that outlives the leader while still holding the captured-output
+/// descriptors. A signal to an already-dead group is `ESRCH`, a harmless no-op.
+///
+/// On Unix this `SIGKILL`s the whole group (the child is its leader). On Windows
+/// it delegates to [`taskkill_tree`](crate::managed_agents::taskkill_tree)
+/// (`taskkill /T /F`), which kills the tree — a direct `Child::kill` would leave
+/// descendants alive, exactly the leak this guards against.
+fn kill_tree(pid: u32) {
+    #[cfg(unix)]
+    // SAFETY: `killpg` on the group led by `pid`; unused result is intentional.
+    unsafe {
+        libc::killpg(pid as i32, libc::SIGKILL);
+    }
+    #[cfg(windows)]
+    {
+        let _ = crate::managed_agents::taskkill_tree(pid);
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = pid;
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::mpsc;
+
+    /// Run `output_with_timeout` under an independent wall-clock watchdog. The
+    /// helper is driven on its own thread; if it fails to return within `bound`
+    /// the test fails instead of hanging forever. This is the real outer bound —
+    /// an inline `elapsed() < bound` assertion is never reached if the helper
+    /// itself hangs.
+    #[cfg(unix)]
+    fn run_watchdogged(cmd: Command, timeout: Duration, bound: Duration) -> Option<Output> {
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(output_with_timeout(cmd, timeout));
+        });
+        match rx.recv_timeout(bound) {
+            Ok(result) => result,
+            Err(_) => panic!("output_with_timeout did not return within {bound:?}"),
+        }
+    }
+
+    /// True while a Unix process (or a reaped-but-not-waited zombie under this
+    /// test process) still exists. `kill(pid, 0)` probes existence without
+    /// signalling. Descendants reparent to init on exit, so a survivor stays
+    /// probeable; once `kill_tree` reaps it, the pid is gone (ESRCH).
+    #[cfg(unix)]
+    fn pid_alive(pid: i32) -> bool {
+        unsafe { libc::kill(pid, 0) == 0 }
+    }
 
     #[cfg(unix)]
     #[test]
     fn returns_output_for_fast_command() {
         let mut cmd = Command::new("/bin/sh");
         cmd.args(["-c", "printf hi; printf oops 1>&2"]);
-        let out = output_with_timeout(cmd, Duration::from_secs(5))
+        let out = run_watchdogged(cmd, Duration::from_secs(5), Duration::from_secs(10))
             .expect("a fast command must complete within the timeout");
         assert!(out.status.success());
         assert_eq!(out.stdout, b"hi");
@@ -142,41 +199,94 @@ mod tests {
     // Adversarial: a child that traps and ignores SIGTERM. The old
     // wait-thread + lone-SIGTERM helper never returned for this input; the
     // process-group SIGKILL escalation must reap it inside the grace period.
+    // The watchdog thread is the real bound — the helper hanging fails the
+    // test rather than hanging it.
     #[cfg(unix)]
     #[test]
     fn kills_sigterm_ignoring_child_within_bound() {
-        let start = Instant::now();
         let mut cmd = Command::new("/bin/sh");
         cmd.args(["-c", "trap '' TERM; while :; do sleep 1; done"]);
-        let result = output_with_timeout(cmd, Duration::from_millis(200));
+        let result = run_watchdogged(cmd, Duration::from_millis(200), Duration::from_secs(5));
         assert!(result.is_none(), "a timed-out child must yield None");
+    }
+
+    // Adversarial (success path): the direct child exits 0 but backgrounds a
+    // descendant that keeps writing to the inherited stdout/stderr forever.
+    // Two guarantees under test: (1) the temp-file capture returns at EOF
+    // rather than blocking on the descendant, and (2) `kill_tree` reaps that
+    // descendant before returning, so no survivor keeps consuming disk/CPU
+    // after discovery reports success. This is the pass-2 leak Thufir proved
+    // with `(yes) & exit 0`.
+    #[cfg(unix)]
+    #[test]
+    fn reaps_backgrounded_descendant_on_success() {
+        let pid_file = tempfile::NamedTempFile::new().expect("temp file for descendant pid");
+        let pid_path = pid_file
+            .path()
+            .to_str()
+            .expect("utf-8 temp path")
+            .to_string();
+        // The descendant records its PID, then becomes `yes` (the unbounded
+        // writer from the pass-2 reproducer, holding the inherited fds). The
+        // leader waits until the PID is recorded before exiting 0, so the test
+        // can read it deterministically even though the success path kills the
+        // group immediately on return.
+        let script = format!(
+            "(echo $$ > '{pid_path}'; exec yes) & \
+             until [ -s '{pid_path}' ]; do :; done; printf done; exit 0"
+        );
+        let mut cmd = Command::new("/bin/sh");
+        cmd.args(["-c", &script]);
+        let out = run_watchdogged(cmd, Duration::from_secs(5), Duration::from_secs(10))
+            .expect("the direct child exits, so this must return its output");
+        assert!(out.status.success());
+
+        let descendant_pid: i32 = std::fs::read_to_string(&pid_path)
+            .expect("descendant must have recorded its PID")
+            .trim()
+            .parse()
+            .expect("descendant PID must be numeric");
+        // Give the reaped group a moment to fully disappear, then assert dead.
+        std::thread::sleep(Duration::from_millis(200));
         assert!(
-            start.elapsed() < Duration::from_secs(5),
-            "must return promptly after the deadline even when SIGTERM is ignored, \
-             took {:?}",
-            start.elapsed()
+            !pid_alive(descendant_pid),
+            "backgrounded descendant {descendant_pid} must be reaped on success, but it survived"
         );
     }
 
-    // Adversarial: the direct child exits immediately but leaves a background
-    // descendant holding the inherited stdout/stderr descriptors open. A pipe
-    // read would block on that descendant; the temp-file capture must return at
-    // EOF regardless, so the call cannot hang.
+    // Adversarial (timeout path): a SIGTERM-ignoring leader that backgrounds a
+    // descendant, both looping forever. The leader's process group is killed on
+    // timeout, so the descendant (same group) must die too. The descendant
+    // writes its PID to a known file before looping, so the test can prove it.
     #[cfg(unix)]
     #[test]
-    fn returns_when_descendant_retains_pipes() {
-        let start = Instant::now();
+    fn reaps_descendant_on_timeout() {
+        let pid_file = tempfile::NamedTempFile::new().expect("temp file for descendant pid");
+        let pid_path = pid_file
+            .path()
+            .to_str()
+            .expect("utf-8 temp path")
+            .to_string();
+        // Leader ignores TERM and loops; it backgrounds a descendant that
+        // records its own PID then loops. Both share the leader's process group.
+        let script = format!(
+            "trap '' TERM; (echo $$ > '{pid_path}'; while :; do sleep 1; done) & \
+             while :; do sleep 1; done"
+        );
         let mut cmd = Command::new("/bin/sh");
-        // Fork a grandchild that survives the parent and keeps fd 1/2 open.
-        cmd.args(["-c", "printf done; (sleep 30) & exit 0"]);
-        let out = output_with_timeout(cmd, Duration::from_secs(5))
-            .expect("the direct child exits, so this must return its output");
-        assert!(out.status.success());
-        assert_eq!(out.stdout, b"done");
+        cmd.args(["-c", &script]);
+        let result = run_watchdogged(cmd, Duration::from_millis(300), Duration::from_secs(5));
+        assert!(result.is_none(), "a timed-out tree must yield None");
+
+        let descendant_pid: i32 = std::fs::read_to_string(&pid_path)
+            .expect("descendant must have written its PID")
+            .trim()
+            .parse()
+            .expect("descendant PID must be numeric");
+        std::thread::sleep(Duration::from_millis(200));
         assert!(
-            start.elapsed() < Duration::from_secs(5),
-            "must not block on a descendant holding the output descriptors, took {:?}",
-            start.elapsed()
+            !pid_alive(descendant_pid),
+            "backgrounded descendant {descendant_pid} must be group-killed on timeout, but it survived"
         );
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
@@ -1,0 +1,182 @@
+//! Run a child process to completion under a hard wall-clock deadline.
+//!
+//! Every spawn on the discovery path — the CLI auth probes and the login-shell
+//! PATH lookups — must return in bounded time no matter how the child behaves.
+//! A login shell that blocks on an interactive prompt, a child that traps
+//! `SIGTERM`, or a forked descendant that keeps a pipe open must not be able to
+//! stall discovery; that stall is what left "Check again" spinning forever.
+
+use std::process::{Command, Output};
+use std::time::{Duration, Instant};
+
+/// Poll interval while waiting for the child to exit.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Grace period between the initial `SIGTERM` and the escalating `SIGKILL` for a
+/// timed-out process group. Long enough for a well-behaved child to flush and
+/// exit cleanly, short enough that a signal-ignoring one is reaped promptly.
+#[cfg(unix)]
+const KILL_GRACE: Duration = Duration::from_millis(500);
+
+/// Run `command` to completion, bounded by `timeout`.
+///
+/// Returns `Some(output)` when the child exits within the deadline, `None` when
+/// it fails to spawn or is killed for exceeding it. Guarantees a bounded return
+/// regardless of child cooperation:
+///
+/// - **No pipe-drain hang.** Stdout and stderr are captured to regular temp
+///   files rather than pipes. A pipe's read blocks until every writer — the
+///   child *and* any descendant that inherited the write end — closes it; a
+///   forked worker outliving its parent could hold it open forever. A regular
+///   file returns EOF at its current write position no matter who inherits the
+///   descriptor, so the post-exit read is bounded on every platform. There are
+///   no background drain threads to join, so no drain-thread hang exists.
+/// - **No wait hang.** The child is polled with [`Child::try_wait`] against the
+///   deadline rather than blocked on with `wait()`.
+/// - **Hard termination.** On timeout the child's whole process group is torn
+///   down (see [`terminate`]) — `SIGTERM` then an escalating `SIGKILL` on Unix,
+///   `Child::kill` on Windows — so a `SIGTERM`-trapping child or a forked
+///   descendant cannot outlive the deadline.
+pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Option<Output> {
+    let mut stdout_file = tempfile::tempfile().ok()?;
+    let mut stderr_file = tempfile::tempfile().ok()?;
+
+    command
+        .stdin(std::process::Stdio::null())
+        .stdout(stdout_file.try_clone().ok()?)
+        .stderr(stderr_file.try_clone().ok()?);
+
+    // Run the child in its own process group so a timeout can terminate the
+    // whole tree, not just a direct child that may have forked workers.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt as _;
+        command.process_group(0);
+    }
+
+    let mut child = command.spawn().ok()?;
+
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    terminate(&mut child);
+                    return None;
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            Err(_) => {
+                terminate(&mut child);
+                return None;
+            }
+        }
+    };
+
+    Some(Output {
+        status,
+        stdout: read_captured(&mut stdout_file),
+        stderr: read_captured(&mut stderr_file),
+    })
+}
+
+/// Rewind a captured-output temp file and read it in full. Bounded because the
+/// file is regular: the read reaches EOF at the current write position.
+fn read_captured(file: &mut std::fs::File) -> Vec<u8> {
+    use std::io::{Read as _, Seek as _, SeekFrom};
+    if file.seek(SeekFrom::Start(0)).is_err() {
+        return Vec::new();
+    }
+    let mut buf = Vec::new();
+    let _ = file.read_to_end(&mut buf);
+    buf
+}
+
+/// Tear down a timed-out child and its process group with a bounded return.
+///
+/// The child is a group leader (`process_group(0)`), so its PID is also the
+/// group ID. `SIGTERM` the whole group for a clean shutdown, wait the fixed
+/// [`KILL_GRACE`], then unconditionally `SIGKILL` the group so a signal-ignoring
+/// child or descendant cannot survive. `wait` then reaps the (now-killed) direct
+/// child. Every step is time-bounded, so this returns in at most `KILL_GRACE`.
+#[cfg(unix)]
+fn terminate(child: &mut std::process::Child) {
+    let pgid = child.id() as i32;
+    // SAFETY: `killpg` with a valid PID/PGID; unused result is intentional —
+    // the group may already be gone.
+    unsafe {
+        libc::killpg(pgid, libc::SIGTERM);
+    }
+    std::thread::sleep(KILL_GRACE);
+    unsafe {
+        libc::killpg(pgid, libc::SIGKILL);
+    }
+    let _ = child.wait();
+}
+
+/// Windows teardown: `Child::kill` maps to `TerminateProcess`, a guaranteed kill
+/// of the child (not mere PID consumption). `wait` reaps it so no handle leaks.
+#[cfg(not(unix))]
+fn terminate(child: &mut std::process::Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn returns_output_for_fast_command() {
+        let mut cmd = Command::new("/bin/sh");
+        cmd.args(["-c", "printf hi; printf oops 1>&2"]);
+        let out = output_with_timeout(cmd, Duration::from_secs(5))
+            .expect("a fast command must complete within the timeout");
+        assert!(out.status.success());
+        assert_eq!(out.stdout, b"hi");
+        assert_eq!(out.stderr, b"oops");
+    }
+
+    // Adversarial: a child that traps and ignores SIGTERM. The old
+    // wait-thread + lone-SIGTERM helper never returned for this input; the
+    // process-group SIGKILL escalation must reap it inside the grace period.
+    #[cfg(unix)]
+    #[test]
+    fn kills_sigterm_ignoring_child_within_bound() {
+        let start = Instant::now();
+        let mut cmd = Command::new("/bin/sh");
+        cmd.args(["-c", "trap '' TERM; while :; do sleep 1; done"]);
+        let result = output_with_timeout(cmd, Duration::from_millis(200));
+        assert!(result.is_none(), "a timed-out child must yield None");
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "must return promptly after the deadline even when SIGTERM is ignored, \
+             took {:?}",
+            start.elapsed()
+        );
+    }
+
+    // Adversarial: the direct child exits immediately but leaves a background
+    // descendant holding the inherited stdout/stderr descriptors open. A pipe
+    // read would block on that descendant; the temp-file capture must return at
+    // EOF regardless, so the call cannot hang.
+    #[cfg(unix)]
+    #[test]
+    fn returns_when_descendant_retains_pipes() {
+        let start = Instant::now();
+        let mut cmd = Command::new("/bin/sh");
+        // Fork a grandchild that survives the parent and keeps fd 1/2 open.
+        cmd.args(["-c", "printf done; (sleep 30) & exit 0"]);
+        let out = output_with_timeout(cmd, Duration::from_secs(5))
+            .expect("the direct child exits, so this must return its output");
+        assert!(out.status.success());
+        assert_eq!(out.stdout, b"done");
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "must not block on a descendant holding the output descriptors, took {:?}",
+            start.elapsed()
+        );
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
@@ -243,10 +243,12 @@ fn set_nonblocking<F: std::os::unix::io::AsRawFd>(f: &F) -> bool {
 /// Continuous draining keeps the pipe buffer from filling, so the child can
 /// never block on a full pipe while we poll it. Retention is bounded: `total`
 /// reserves a disjoint byte range per chunk across both streams, so the sum of
-/// both buffers never exceeds the aggregate cap. Once the cap is crossed,
-/// `overflow` is set and further bytes are read but discarded. A read error
-/// other than `Interrupted`/`WouldBlock` returns `Err`, which the caller treats
-/// as fail-closed.
+/// both buffers never exceeds the aggregate cap. The moment a read crosses the
+/// cap, `overflow` is set and the drain returns immediately — it does not keep
+/// reading, so a writer that keeps the pipe continuously readable cannot spin
+/// this loop forever (it must cross the finite cap). A read error other than
+/// `Interrupted`/`WouldBlock` returns `Err`, which the caller treats as
+/// fail-closed.
 ///
 /// **Bounded completion differs by platform, because tree ownership does.**
 /// - **Unix:** the read end is nonblocking (see [`set_nonblocking`]). A killed
@@ -288,10 +290,19 @@ fn spawn_drain<R: Read + Send + 'static>(
                         overflow.store(true, Ordering::Relaxed);
                         let keep = CAPTURE_LIMIT.saturating_sub(prev).min(n as u64) as usize;
                         buf.extend_from_slice(&chunk[..keep]);
-                        // Keep reading to drain the pipe but retain nothing more.
-                    } else {
-                        buf.extend_from_slice(&chunk[..n]);
+                        // Overflow: the result is already fail-closed, so nothing
+                        // still in the pipe is worth preserving. Return NOW rather
+                        // than draining to EOF — this is what bounds the `Ok(n)`
+                        // path against a writer that keeps the pipe continuously
+                        // readable, which would otherwise never reach the
+                        // `WouldBlock`/`stop` check below and hang the join. It is
+                        // safe to stop draining: the poll loop sees `overflow` and
+                        // kills the tree, and a writer that then blocks on a full
+                        // pipe dies to `killpg`/job-close. Do NOT "fix" that
+                        // blocked-writer case by resuming an unbounded drain here.
+                        return Ok(buf);
                     }
+                    buf.extend_from_slice(&chunk[..n]);
                 }
                 Err(e) if e.kind() == ErrorKind::Interrupted => continue,
                 // Nonblocking read (Unix only): no bytes available right now.
@@ -589,6 +600,59 @@ mod tests {
         );
     }
 
+    // Deterministic seam regression (Thufir's finding): a drain fed a reader
+    // that stays continuously readable — every `read` returns `Ok(8192)`, never
+    // `WouldBlock` — must still complete, because the `stop`/`WouldBlock` check
+    // alone never fires on such a reader. The bound comes from the `Ok(n)` path
+    // returning the instant the aggregate cap is crossed. No real process and no
+    // scheduler timing: the reader is a pure in-test `Read` impl, so this pins
+    // the control flow rather than relying on a descendant eventually blocking.
+    // With the round-9-initial code (which kept reading after overflow) the
+    // drain never returns and the join below hangs past the watchdog.
+    #[test]
+    fn overflow_bounds_a_continuously_readable_drain() {
+        /// A reader that is always ready with a full 8192-byte chunk. It never
+        /// returns 0 (EOF) or `WouldBlock`, so only the overflow return can end
+        /// a drain reading it.
+        struct AlwaysReady;
+        impl Read for AlwaysReady {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                for b in buf.iter_mut() {
+                    *b = b'x';
+                }
+                Ok(buf.len())
+            }
+        }
+
+        let total = Arc::new(AtomicU64::new(0));
+        let overflow = Arc::new(AtomicBool::new(false));
+        // `stop` set from the start: a correct drain must NOT depend on it here,
+        // since a continuously-ready reader never hits the `WouldBlock` arm that
+        // consults it. The overflow return is the only thing that can bound it.
+        let stop = Arc::new(AtomicBool::new(true));
+        let drain = spawn_drain(AlwaysReady, total.clone(), overflow.clone(), stop);
+
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(drain.join());
+        });
+        let joined = rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("a continuously-readable drain must be bounded by the capture cap");
+        let buf = joined
+            .expect("drain thread must not panic")
+            .expect("drain read must not error");
+        assert!(
+            overflow.load(Ordering::Relaxed),
+            "the drain must have tripped overflow"
+        );
+        assert!(
+            buf.len() as u64 <= CAPTURE_LIMIT,
+            "retained bytes {} must not exceed the cap {CAPTURE_LIMIT}",
+            buf.len()
+        );
+    }
+
     // Adversarial (group escape): the leader backgrounds a descendant that
     // calls `setsid()` — leaving the leader's process group while retaining the
     // inherited stdout — then sleeps 300s; the leader itself loops forever, so
@@ -718,9 +782,10 @@ mod tests {
     }
 
     /// Read a PID that a probe wrote to `path`, retrying briefly since the
-    /// descendant records it asynchronously.
+    /// descendant records it asynchronously. Dumps `logs` on failure so a remote
+    /// run diagnoses itself instead of panicking blind.
     #[cfg(windows)]
-    fn read_recorded_pid(path: &str) -> u32 {
+    fn read_recorded_pid(path: &str, logs: &[&str]) -> u32 {
         for _ in 0..200 {
             if let Ok(text) = std::fs::read_to_string(path) {
                 if let Ok(pid) = text.trim().parse::<u32>() {
@@ -729,105 +794,194 @@ mod tests {
             }
             std::thread::sleep(Duration::from_millis(10));
         }
-        panic!("descendant never recorded its PID at {path}");
+        panic!(
+            "descendant never recorded its PID at {path}\n{}",
+            dump_logs(logs)
+        );
     }
 
-    // Success path, run in a loop to hammer the spawn/assign race: a cmd.exe
-    // root launches a detached PowerShell descendant that records its own PID
-    // and sleeps, then the root exits 0 — but only *after* a synchronous waiter
-    // confirms the PID file is non-empty. Without that wait the root exits in
-    // the same tick, the success path closes the kill-on-close job immediately,
-    // and the descendant is reaped mid-cold-start before it can record its PID
-    // — starving the test of the evidence the reaping actually worked. The wait
-    // (bounded by the timeout and the outer watchdog) closes that fixture race
-    // without weakening the guarantee under test: the descendant is still born
-    // inside the job and must be reaped by the job close after the root exits.
+    /// Write a PowerShell payload to `path` as a `.ps1` file. Invoking these via
+    /// `powershell -File` avoids the Rust-std → cmd.exe → powershell quoting
+    /// gauntlet that silently mangled the inline `-Command` fixtures (the root
+    /// exited without its payload ever running), so the payload reaches
+    /// PowerShell verbatim.
+    #[cfg(windows)]
+    fn write_ps1(path: &std::path::Path, body: &str) {
+        std::fs::write(path, body).expect("write .ps1 payload");
+    }
+
+    /// Collect the named transcript files (each written by the fixture's
+    /// PowerShell) into one string for a self-diagnosing assert message. Missing
+    /// files are reported as such rather than skipped.
+    #[cfg(windows)]
+    fn dump_logs(paths: &[&str]) -> String {
+        let mut out = String::from("---- fixture transcripts ----\n");
+        for p in paths {
+            out.push_str(&format!("[{p}]\n"));
+            match std::fs::read_to_string(p) {
+                Ok(text) if text.is_empty() => out.push_str("(empty)\n"),
+                Ok(text) => {
+                    out.push_str(&text);
+                    if !text.ends_with('\n') {
+                        out.push('\n');
+                    }
+                }
+                Err(e) => out.push_str(&format!("(unreadable: {e})\n")),
+            }
+        }
+        out
+    }
+
+    // Success path, run in a loop to hammer the spawn/assign race. A PowerShell
+    // root (no cmd.exe anywhere) launches a hidden, detached PowerShell
+    // descendant via `Start-Process -WindowStyle Hidden`; the descendant records
+    // its own PID and sleeps. The root then waits synchronously until the PID
+    // file is non-empty before exiting 0 — without that wait the root would exit
+    // in the same tick, the success path would close the kill-on-close job
+    // immediately, and the descendant would be reaped mid-cold-start before it
+    // could record its PID, starving the test of its evidence. The descendant is
+    // still born inside the job (suspend → assign → resume, no breakaway), so the
+    // reaping guarantee under test is unchanged; only the delivery mechanism (a
+    // `.ps1` via `-File`, not a mangled inline `-Command`) is fixed. Every assert
+    // dumps the PowerShell transcripts so a remote failure is self-diagnosing.
     #[cfg(windows)]
     #[test]
     #[ignore = "requires a Windows host; run manually with --ignored"]
     fn reaps_backgrounded_descendant_on_success_windows() {
         for iteration in 0..25 {
-            let pid_file = tempfile::NamedTempFile::new().expect("temp file for descendant pid");
-            let pid_path = pid_file
-                .path()
-                .to_str()
-                .expect("utf-8 temp path")
-                .to_string();
-            // `start /b` backgrounds the PowerShell descendant (records $PID,
-            // sleeps 30s); the second, synchronous PowerShell blocks the root
-            // until that PID file is non-empty; then the root exits 0.
-            let child = format!(
-                "$PID | Out-File -Encoding ascii -FilePath '{pid_path}'; Start-Sleep -Seconds 30"
+            let dir = tempfile::tempdir().expect("temp dir for fixture scripts");
+            let pid_path = dir.path().join("descendant.pid");
+            let child_ps1 = dir.path().join("child.ps1");
+            let root_ps1 = dir.path().join("root.ps1");
+            let root_log = dir.path().join("root.log");
+            let child_log = dir.path().join("child.log");
+            let pid_s = pid_path.to_str().expect("utf-8 pid path");
+            let root_log_s = root_log.to_str().expect("utf-8 root log");
+            let child_log_s = child_log.to_str().expect("utf-8 child log");
+
+            write_ps1(
+                &child_ps1,
+                &format!(
+                    "$PID | Set-Content -Encoding ascii -Path '{pid_s}'\n\
+                     Add-Content -Path '{child_log_s}' -Value \"descendant $PID started\"\n\
+                     Start-Sleep -Seconds 30\n"
+                ),
             );
-            let waiter = format!(
-                "while (-not (Test-Path '{pid_path}') -or (Get-Item '{pid_path}').Length -eq 0) {{ Start-Sleep -Milliseconds 50 }}"
-            );
-            let script = format!(
-                "start /b powershell -NoProfile -Command \"{child}\" & powershell -NoProfile -Command \"{waiter}\" & exit 0"
-            );
-            let mut cmd = Command::new("cmd.exe");
-            cmd.args(["/c", &script]);
-            // Timeout is generous: two cold-starting PowerShells must both run
-            // before the root exits, and none of that may hit the deadline.
-            let out = run_watchdogged(cmd, Duration::from_secs(20), Duration::from_secs(40))
-                .expect("the root exits, so this must return its output");
-            assert!(
-                out.status.success(),
-                "iteration {iteration}: root must exit 0"
+            write_ps1(
+                &root_ps1,
+                &format!(
+                    "Add-Content -Path '{root_log_s}' -Value \"root $PID launching descendant\"\n\
+                     Start-Process -FilePath 'powershell' -WindowStyle Hidden -ArgumentList \
+                     '-NoProfile','-ExecutionPolicy','Bypass','-File','{child}'\n\
+                     $deadline = (Get-Date).AddSeconds(15)\n\
+                     while (((-not (Test-Path '{pid_s}')) -or ((Get-Item '{pid_s}').Length -eq 0)) \
+                     -and (Get-Date) -lt $deadline) {{ Start-Sleep -Milliseconds 50 }}\n\
+                     Add-Content -Path '{root_log_s}' -Value \"root observed pid file, exiting\"\n\
+                     exit 0\n",
+                    child = child_ps1.to_str().expect("utf-8 child path"),
+                ),
             );
 
-            let descendant_pid = read_recorded_pid(&pid_path);
+            let mut cmd = Command::new("powershell");
+            cmd.args([
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                root_ps1.to_str().expect("utf-8 root path"),
+            ]);
+            let out = run_watchdogged(cmd, Duration::from_secs(20), Duration::from_secs(40))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "iteration {iteration}: root exits, so this must return output\n{}",
+                        dump_logs(&[root_log_s, child_log_s])
+                    )
+                });
+            assert!(
+                out.status.success(),
+                "iteration {iteration}: root must exit 0\nstdout={}\nstderr={}\n{}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr),
+                dump_logs(&[root_log_s, child_log_s])
+            );
+
+            let descendant_pid = read_recorded_pid(pid_s, &[root_log_s, child_log_s]);
             std::thread::sleep(Duration::from_millis(300));
             assert!(
                 !pid_alive(descendant_pid),
-                "iteration {iteration}: descendant {descendant_pid} must be reaped on success, but it survived"
+                "iteration {iteration}: descendant {descendant_pid} must be reaped on success, but it survived\n{}",
+                dump_logs(&[root_log_s, child_log_s])
             );
         }
     }
 
-    // Timeout path: a cmd.exe root launches a detached PowerShell descendant
-    // (records its PID, sleeps 300s), then — via a second, synchronous
-    // PowerShell — blocks until that PID file is non-empty before entering its
-    // own long block. The helper must time out and close the job, reaping both.
-    //
-    // The synchronous waiter is the evidence, not the timeout: the descendant's
-    // PID is recorded *before* the root can reach the block the deadline fires
-    // in, so the reap (working instantly) can never kill the descendant
-    // mid-cold-start and starve the test of the PID it reads. The old fixture
-    // relied on "8s exceeds a cold start" — tolerance that fails on a slow host,
-    // exactly Will's failure mode. The timeout is generous so the two cold
-    // PowerShells and the wait all complete well within it; the deadline then
-    // fires during the *long block*, and the outer watchdog stays the bound.
-    // Asserts on the actual descendant PID reaching "gone".
+    // Timeout path: a PowerShell root launches a hidden, detached PowerShell
+    // descendant (records its PID, sleeps 300s), waits synchronously until the
+    // PID file is non-empty, then enters its own 300s block so the helper's
+    // deadline fires inside it. The helper must time out and close the job,
+    // reaping both. The synchronous wait is the evidence — the descendant's PID
+    // is recorded before the root reaches the block the deadline fires in, so the
+    // reap cannot kill it mid-cold-start and starve the assert. Same `.ps1`
+    // delivery as the success fixture (no cmd tokenizer), and every assert dumps
+    // the transcripts.
     #[cfg(windows)]
     #[test]
     #[ignore = "requires a Windows host; run manually with --ignored"]
     fn reaps_descendant_on_timeout_windows() {
-        let pid_file = tempfile::NamedTempFile::new().expect("temp file for descendant pid");
-        let pid_path = pid_file
-            .path()
-            .to_str()
-            .expect("utf-8 temp path")
-            .to_string();
-        let child = format!(
-            "$PID | Out-File -Encoding ascii -FilePath '{pid_path}'; Start-Sleep -Seconds 300"
-        );
-        let waiter = format!(
-            "while (-not (Test-Path '{pid_path}') -or (Get-Item '{pid_path}').Length -eq 0) {{ Start-Sleep -Milliseconds 50 }}; Start-Sleep -Seconds 300"
-        );
-        let script = format!(
-            "start /b powershell -NoProfile -Command \"{child}\" & powershell -NoProfile -Command \"{waiter}\""
-        );
-        let mut cmd = Command::new("cmd.exe");
-        cmd.args(["/c", &script]);
-        let result = run_watchdogged(cmd, Duration::from_secs(20), Duration::from_secs(40));
-        assert!(result.is_none(), "a timed-out tree must yield None");
+        let dir = tempfile::tempdir().expect("temp dir for fixture scripts");
+        let pid_path = dir.path().join("descendant.pid");
+        let child_ps1 = dir.path().join("child.ps1");
+        let root_ps1 = dir.path().join("root.ps1");
+        let root_log = dir.path().join("root.log");
+        let child_log = dir.path().join("child.log");
+        let pid_s = pid_path.to_str().expect("utf-8 pid path");
+        let root_log_s = root_log.to_str().expect("utf-8 root log");
+        let child_log_s = child_log.to_str().expect("utf-8 child log");
 
-        let descendant_pid = read_recorded_pid(&pid_path);
+        write_ps1(
+            &child_ps1,
+            &format!(
+                "$PID | Set-Content -Encoding ascii -Path '{pid_s}'\n\
+                 Add-Content -Path '{child_log_s}' -Value \"descendant $PID started\"\n\
+                 Start-Sleep -Seconds 300\n"
+            ),
+        );
+        write_ps1(
+            &root_ps1,
+            &format!(
+                "Add-Content -Path '{root_log_s}' -Value \"root $PID launching descendant\"\n\
+                 Start-Process -FilePath 'powershell' -WindowStyle Hidden -ArgumentList \
+                 '-NoProfile','-ExecutionPolicy','Bypass','-File','{child}'\n\
+                 $deadline = (Get-Date).AddSeconds(15)\n\
+                 while (((-not (Test-Path '{pid_s}')) -or ((Get-Item '{pid_s}').Length -eq 0)) \
+                 -and (Get-Date) -lt $deadline) {{ Start-Sleep -Milliseconds 50 }}\n\
+                 Add-Content -Path '{root_log_s}' -Value \"root observed pid file, blocking\"\n\
+                 Start-Sleep -Seconds 300\n",
+                child = child_ps1.to_str().expect("utf-8 child path"),
+            ),
+        );
+
+        let mut cmd = Command::new("powershell");
+        cmd.args([
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            root_ps1.to_str().expect("utf-8 root path"),
+        ]);
+        let result = run_watchdogged(cmd, Duration::from_secs(20), Duration::from_secs(40));
+        assert!(
+            result.is_none(),
+            "a timed-out tree must yield None\n{}",
+            dump_logs(&[root_log_s, child_log_s])
+        );
+
+        let descendant_pid = read_recorded_pid(pid_s, &[root_log_s, child_log_s]);
         std::thread::sleep(Duration::from_millis(300));
         assert!(
             !pid_alive(descendant_pid),
-            "descendant {descendant_pid} must be job-killed on timeout, but it survived"
+            "descendant {descendant_pid} must be job-killed on timeout, but it survived\n{}",
+            dump_logs(&[root_log_s, child_log_s])
         );
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
@@ -18,6 +18,38 @@ const POLL_INTERVAL: Duration = Duration::from_millis(50);
 #[cfg(unix)]
 const KILL_GRACE: Duration = Duration::from_millis(500);
 
+/// Freeze the child so the Job Object can take ownership before any child code
+/// runs (see [`BoundedChild::spawn`]).
+#[cfg(windows)]
+const CREATE_SUSPENDED: u32 = 0x0000_0004;
+
+/// Suppress the console window a GUI-spawned console child would otherwise
+/// flash — the same suppression [`crate::util::configure_no_window`] applies to
+/// non-bounded spawns.
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// The exact creation flags every bounded child is spawned with.
+///
+/// `Command::creation_flags` *replaces* rather than accumulates (std ORs only
+/// `CREATE_UNICODE_ENVIRONMENT` afterward), and [`BoundedChild::spawn`] is the
+/// last writer before spawn, so a caller's earlier `configure_no_window` is
+/// wiped. This constant therefore has to carry every flag a bounded child
+/// needs, and owning both here keeps the window-suppression contract in one
+/// place instead of split between the caller and the helper.
+#[cfg(windows)]
+const BOUNDED_CREATION_FLAGS: u32 = CREATE_SUSPENDED | CREATE_NO_WINDOW;
+
+/// Compile-time guard: the bounded flags must always carry *both* bits. A
+/// future edit that drops `CREATE_NO_WINDOW` (reintroducing the console-flash
+/// regression) or `CREATE_SUSPENDED` (reopening the spawn-to-assign race) fails
+/// the build on Windows rather than shipping silently.
+#[cfg(windows)]
+const _: () = {
+    assert!(BOUNDED_CREATION_FLAGS & CREATE_SUSPENDED == CREATE_SUSPENDED);
+    assert!(BOUNDED_CREATION_FLAGS & CREATE_NO_WINDOW == CREATE_NO_WINDOW);
+};
+
 /// A spawned child plus ownership of its entire descendant tree, so the tree
 /// can be torn down on *every* exit path — timeout, error, or successful exit.
 ///
@@ -62,12 +94,15 @@ impl BoundedChild {
         }
 
         // Spawn frozen so the Job Object can take ownership before any child
-        // code runs and forks a descendant that would escape the job.
+        // code runs and forks a descendant that would escape the job. The flags
+        // are set here as the last writer before spawn; `Command::creation_flags`
+        // replaces rather than ORs, so `BOUNDED_CREATION_FLAGS` must itself carry
+        // `CREATE_NO_WINDOW` — a caller's earlier `configure_no_window` would be
+        // clobbered otherwise, flashing a console window on GUI discovery.
         #[cfg(windows)]
         {
             use std::os::windows::process::CommandExt as _;
-            const CREATE_SUSPENDED: u32 = 0x0000_0004;
-            command.creation_flags(CREATE_SUSPENDED);
+            command.creation_flags(BOUNDED_CREATION_FLAGS);
         }
 
         // `mut` is used only on the Windows fail-closed path (kill/wait on the

--- a/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/bounded_command.rs
@@ -6,20 +6,27 @@
 //! `SIGTERM`, or a forked descendant that keeps a pipe open must not be able to
 //! stall discovery; that stall is what left "Check again" spinning forever.
 
-use std::process::{Command, ExitStatus, Output, Stdio};
+use std::io::{ErrorKind, Read};
+use std::process::{ChildStderr, ChildStdout, Command, ExitStatus, Output, Stdio};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 /// Poll interval while waiting for the child to exit.
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
-/// Maximum bytes captured across stdout + stderr for one bounded probe.
+/// Maximum bytes retained across stdout + stderr for one bounded probe.
 ///
 /// Discovery output is tiny — a version string, an auth-status word, a PATH
-/// lookup. A probe that emits more than this is noisy or hostile, so the
-/// capture is failed closed (kill the tree, return `None`) rather than allowed
-/// to fill the disk during the process window or allocate an unbounded buffer
-/// at read time. The ceiling is *aggregate*, not per-stream, so a probe cannot
-/// double it by splitting output across stdout and stderr.
+/// lookup. A probe that emits more than this is noisy or hostile. The ceiling
+/// is enforced *in the drain sink* (see [`spawn_drain`]): each stream is pulled
+/// on its own thread into a capped buffer, the limit is checked the moment a
+/// bounded read crosses it, and the probe is failed closed — so an over-cap
+/// payload is never retained in memory (and, since output goes to pipes not
+/// temp files, never written to disk). The ceiling is *aggregate*, not
+/// per-stream, so a probe cannot double it by splitting output across stdout
+/// and stderr.
 const CAPTURE_LIMIT: u64 = 1 << 20; // 1 MiB
 
 /// Grace period between the initial `SIGTERM` and the escalating `SIGKILL` for a
@@ -192,110 +199,178 @@ impl BoundedChild {
     fn reap(&mut self) {
         let _ = self.child.wait();
     }
+
+    /// Take the captured stdout pipe. `Some` because [`output_with_timeout`]
+    /// configures `Stdio::piped()` before spawn.
+    fn take_stdout(&mut self) -> Option<ChildStdout> {
+        self.child.stdout.take()
+    }
+
+    /// Take the captured stderr pipe.
+    fn take_stderr(&mut self) -> Option<ChildStderr> {
+        self.child.stderr.take()
+    }
+}
+
+/// Drain one child stream on its own thread into a buffer capped by the shared
+/// aggregate budget, so the sink itself — not a post-hoc size sample — enforces
+/// [`CAPTURE_LIMIT`].
+///
+/// The thread reads to EOF, which is what makes the join in
+/// [`output_with_timeout`] safe: it is only ever joined *after* the tree has
+/// been killed, so every writer (the child and any descendant that inherited
+/// the pipe) is gone and the read returns EOF instead of blocking forever —
+/// the exact hang that made the round-2 code abandon pipes for temp files.
+/// Draining continuously also keeps the pipe buffer from filling, so the child
+/// can never block on a full pipe while we poll it.
+///
+/// Retention is bounded: `total` reserves a disjoint byte range per chunk
+/// across both streams, so the sum of both buffers never exceeds the aggregate
+/// cap. Once the cap is crossed, `overflow` is set and further bytes are read
+/// (to reach EOF) but discarded. A non-`Interrupted` read error returns `Err`,
+/// which the caller treats as fail-closed.
+fn spawn_drain<R: Read + Send + 'static>(
+    mut reader: R,
+    total: Arc<AtomicU64>,
+    overflow: Arc<AtomicBool>,
+) -> JoinHandle<std::io::Result<Vec<u8>>> {
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 8192];
+        loop {
+            match reader.read(&mut chunk) {
+                Ok(0) => return Ok(buf),
+                Ok(n) => {
+                    // Atomically reserve [prev, prev + n) of the shared budget;
+                    // `prev` is unique per call, so the two streams keep
+                    // disjoint ranges and their retained bytes sum to <= cap.
+                    let prev = total.fetch_add(n as u64, Ordering::Relaxed);
+                    if prev.saturating_add(n as u64) > CAPTURE_LIMIT {
+                        overflow.store(true, Ordering::Relaxed);
+                        let keep = CAPTURE_LIMIT.saturating_sub(prev).min(n as u64) as usize;
+                        buf.extend_from_slice(&chunk[..keep]);
+                        // Keep reading to EOF (post-kill) but retain nothing more.
+                    } else {
+                        buf.extend_from_slice(&chunk[..n]);
+                    }
+                }
+                Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e),
+            }
+        }
+    })
 }
 
 /// Run `command` to completion, bounded by `timeout`.
 ///
 /// Returns `Some(output)` when the child exits within the deadline, `None` when
-/// it fails to spawn or is killed for exceeding it. Guarantees a bounded return
-/// regardless of child cooperation:
+/// it fails to spawn, exceeds the deadline, or breaches the capture ceiling.
+/// Guarantees a bounded return regardless of child cooperation:
 ///
-/// - **No pipe-drain hang.** Stdout and stderr are captured to regular temp
-///   files rather than pipes. A pipe's read blocks until every writer — the
-///   child *and* any descendant that inherited the write end — closes it; a
-///   forked worker outliving its parent could hold it open forever. A regular
-///   file returns EOF at its current write position no matter who inherits the
-///   descriptor, so the post-exit read is bounded on every platform. There are
-///   no background drain threads to join, so no drain-thread hang exists.
+/// - **Sink-enforced capture bound.** Stdout and stderr are piped to two drain
+///   threads that read into buffers capped by a shared aggregate budget
+///   ([`spawn_drain`]); nothing over [`CAPTURE_LIMIT`] is ever retained. On a
+///   breach the poll loop fails closed — kill the tree, return `None` — so a
+///   noisy or hostile probe cannot force unbounded memory (and, with pipes
+///   rather than temp files, cannot fill the disk either). Continuous draining
+///   also keeps the pipe buffer from filling, so the child can never block on a
+///   full pipe while we poll.
+/// - **No pipe-drain hang — via a strict ordering invariant.** A pipe read
+///   blocks until every writer (the child *and* any descendant that inherited
+///   the write end) closes it. This code joins the drains *only after*
+///   [`BoundedChild::kill_tree`] has torn the whole tree down (Unix process
+///   group / Windows kill-on-close Job Object), so by the time we join, every
+///   writer is dead and each read has hit EOF. **Kill-before-join is the
+///   load-bearing invariant** — reversing it reintroduces the round-1 hang
+///   where a backgrounded worker held the pipe open forever. This is why the
+///   round-2 switch to temp files is no longer needed.
 /// - **No wait hang.** The child is polled with [`Child::try_wait`] against the
 ///   deadline rather than blocked on with `wait()`.
 /// - **Hard tree termination on every exit path.** [`BoundedChild`] owns the
-///   child's whole descendant tree (Unix process group / Windows Job Object)
-///   and tears it down whether the child times out, errors, *or exits
-///   successfully*, before the captured output is read. Success is not an
-///   exemption: a login-shell rc file or an auth CLI can legitimately background
-///   a descendant (`worker &`) that would otherwise outlive discovery. The
-///   timeout path additionally sends a graceful `SIGTERM` and a bounded grace
-///   period before the final kill.
+///   child's whole descendant tree and tears it down whether the child times
+///   out, errors, breaches the cap, *or exits successfully*, before the drains
+///   are joined. Success is not an exemption: a login-shell rc file or an auth
+///   CLI can legitimately background a descendant (`worker &`) that would
+///   otherwise outlive discovery and hold the pipe open. The timeout path
+///   additionally sends a graceful `SIGTERM` and a bounded grace period before
+///   the final kill.
 pub(crate) fn output_with_timeout(mut command: Command, timeout: Duration) -> Option<Output> {
-    let mut stdout_file = tempfile::tempfile().ok()?;
-    let mut stderr_file = tempfile::tempfile().ok()?;
-
     command
         .stdin(Stdio::null())
-        .stdout(stdout_file.try_clone().ok()?)
-        .stderr(stderr_file.try_clone().ok()?);
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
 
     let mut child = BoundedChild::spawn(command)?;
+
+    // Shared drain state: one aggregate byte budget across both streams and one
+    // overflow flag the poll loop watches so a streaming producer that never
+    // exits is failed closed the moment it crosses the cap.
+    let total = Arc::new(AtomicU64::new(0));
+    let overflow = Arc::new(AtomicBool::new(false));
+    let stdout_drain = child
+        .take_stdout()
+        .map(|s| spawn_drain(s, total.clone(), overflow.clone()));
+    let stderr_drain = child
+        .take_stderr()
+        .map(|s| spawn_drain(s, total.clone(), overflow.clone()));
 
     let deadline = Instant::now() + timeout;
     let status = loop {
         match child.try_wait() {
-            Ok(Some(status)) => break status,
+            Ok(Some(status)) => break Some(status),
             Ok(None) => {
                 if Instant::now() >= deadline {
                     child.terminate_timed_out();
-                    child.reap();
-                    return None;
+                    break None;
                 }
-                // Fail closed on a capture breach *while the child runs*, so a
-                // noisy or hostile probe cannot fill the disk over the process
-                // window — the process bound alone does not bound its output.
-                if captured_len(&stdout_file, &stderr_file) > CAPTURE_LIMIT {
+                // Fail closed on a capture breach *while the child runs*: the
+                // drain kept nothing over the cap, and killing the tree lets the
+                // drains reach EOF so the join below cannot hang.
+                if overflow.load(Ordering::Relaxed) {
                     child.kill_tree();
-                    child.reap();
-                    return None;
+                    break None;
                 }
                 std::thread::sleep(POLL_INTERVAL);
             }
             Err(_) => {
                 child.kill_tree();
-                child.reap();
-                return None;
+                break None;
             }
         }
     };
 
-    // Leader exited within the deadline. Tear the tree down before reading, so
-    // no descendant it backgrounded keeps the captured-output descriptors (or a
-    // busy loop) alive after discovery reports success.
+    // Tree down (timeout/error/overflow already killed it above; a clean exit
+    // may still have backgrounded a descendant holding the pipe). Kill is
+    // idempotent, so calling it here on the success path is safe and is what
+    // guarantees the joins below hit EOF instead of blocking.
     child.kill_tree();
     child.reap();
 
-    // A child that exits within the deadline can still have written past the
-    // ceiling in a burst between polls; fail closed rather than allocate the
-    // full payload at read time.
-    if captured_len(&stdout_file, &stderr_file) > CAPTURE_LIMIT {
+    // Kill-before-join: every writer is now gone, so these joins return EOF.
+    let stdout = join_drain(stdout_drain);
+    let stderr = join_drain(stderr_drain);
+
+    // Fail closed if the child exited within the deadline but overran the cap in
+    // a final burst, or if either drain hit a read error (join_drain -> None).
+    let (status, stdout, stderr) = (status?, stdout?, stderr?);
+    if overflow.load(Ordering::Relaxed) {
         return None;
     }
 
     Some(Output {
         status,
-        stdout: read_captured(&mut stdout_file),
-        stderr: read_captured(&mut stderr_file),
+        stdout,
+        stderr,
     })
 }
 
-/// Total bytes written across both capture files so far. A failed `metadata`
-/// call counts as zero for that file — a stat error cannot manufacture a false
-/// breach, and the read-time [`read_captured`] bound is the backstop.
-fn captured_len(stdout_file: &std::fs::File, stderr_file: &std::fs::File) -> u64 {
-    let len = |f: &std::fs::File| f.metadata().map(|m| m.len()).unwrap_or(0);
-    len(stdout_file).saturating_add(len(stderr_file))
-}
-
-/// Rewind a captured-output temp file and read it, capped at [`CAPTURE_LIMIT`].
-/// Bounded twice over: the file is regular (the read reaches EOF at the current
-/// write position) *and* `take` refuses to allocate more than the ceiling even
-/// if the file grew, so `read_to_end` can never balloon the buffer.
-fn read_captured(file: &mut std::fs::File) -> Vec<u8> {
-    use std::io::{Read as _, Seek as _, SeekFrom};
-    if file.seek(SeekFrom::Start(0)).is_err() {
-        return Vec::new();
+/// Join a drain thread, returning its captured bytes. `None` (fail closed) if
+/// the stream was absent, the thread panicked, or the read errored.
+fn join_drain(drain: Option<JoinHandle<std::io::Result<Vec<u8>>>>) -> Option<Vec<u8>> {
+    match drain {
+        Some(handle) => handle.join().ok()?.ok(),
+        None => Some(Vec::new()),
     }
-    let mut buf = Vec::new();
-    let _ = file.take(CAPTURE_LIMIT).read_to_end(&mut buf);
-    buf
 }
 
 #[cfg(test)]
@@ -434,23 +509,29 @@ mod tests {
         );
     }
 
-    // Adversarial (capture bound): a child that emits far more than
-    // CAPTURE_LIMIT and then blocks, so it neither exits nor stops writing on
-    // its own. The in-flight ceiling check must fail the probe closed (None)
-    // and reap the tree — the process bound alone would let it keep filling the
-    // disk for the whole window. `head -c` writes a bounded 4 MiB (so the test
-    // never risks the disk) which already exceeds the 1 MiB ceiling; the trailing
-    // `sleep` keeps the child alive long enough for a poll to observe the breach.
+    // Adversarial (capture bound): a producer that streams zero bytes
+    // *indefinitely* — it never exits and never stops writing on its own, so
+    // the only thing that can end the probe is the in-flight ceiling check
+    // tripping `overflow`, killing the tree, and failing closed (None).
+    //
+    // The discriminator is `timeout >> bound`: the deadline is 60s but the
+    // watchdog fails the test at 10s, so a return within the bound proves the
+    // *cap* ended the probe, not the timeout. Neuter the overflow check and the
+    // helper runs until the 60s deadline, blowing the 10s watchdog. Pipe
+    // backpressure cannot end it either: the drains pull continuously, so `cat`
+    // would keep writing forever. Retention stays bounded by construction —
+    // `spawn_drain` reserves a disjoint byte range per chunk against the shared
+    // budget and discards everything past `CAPTURE_LIMIT` — so no over-cap
+    // payload is ever materialized even though the producer is infinite.
     #[cfg(unix)]
     #[test]
     fn fails_closed_when_capture_exceeds_limit() {
-        let over = CAPTURE_LIMIT * 4;
         let mut cmd = Command::new("/bin/sh");
-        cmd.args(["-c", &format!("head -c {over} /dev/zero; sleep 30")]);
-        let result = run_watchdogged(cmd, Duration::from_secs(10), Duration::from_secs(15));
+        cmd.args(["-c", "exec cat /dev/zero"]);
+        let result = run_watchdogged(cmd, Duration::from_secs(60), Duration::from_secs(10));
         assert!(
             result.is_none(),
-            "a probe exceeding the capture limit must fail closed"
+            "an unbounded producer must fail closed on the capture cap, well before the deadline"
         );
     }
 
@@ -569,12 +650,19 @@ mod tests {
     }
 
     // Timeout path: a cmd.exe root launches a detached PowerShell descendant
-    // (records its PID, sleeps 300s) and then blocks forever itself. The helper
-    // must time out and close the job, reaping both. The timeout is set well
-    // above a PowerShell cold start so the descendant records its PID before the
-    // deadline fires — otherwise the reap (working instantly) would kill the
-    // descendant mid-cold-start and the test could not read its PID. Asserts on
-    // the actual descendant PID reaching "gone".
+    // (records its PID, sleeps 300s), then — via a second, synchronous
+    // PowerShell — blocks until that PID file is non-empty before entering its
+    // own long block. The helper must time out and close the job, reaping both.
+    //
+    // The synchronous waiter is the evidence, not the timeout: the descendant's
+    // PID is recorded *before* the root can reach the block the deadline fires
+    // in, so the reap (working instantly) can never kill the descendant
+    // mid-cold-start and starve the test of the PID it reads. The old fixture
+    // relied on "8s exceeds a cold start" — tolerance that fails on a slow host,
+    // exactly Will's failure mode. The timeout is generous so the two cold
+    // PowerShells and the wait all complete well within it; the deadline then
+    // fires during the *long block*, and the outer watchdog stays the bound.
+    // Asserts on the actual descendant PID reaching "gone".
     #[cfg(windows)]
     #[test]
     #[ignore = "requires a Windows host; run manually with --ignored"]
@@ -588,12 +676,15 @@ mod tests {
         let child = format!(
             "$PID | Out-File -Encoding ascii -FilePath '{pid_path}'; Start-Sleep -Seconds 300"
         );
+        let waiter = format!(
+            "while (-not (Test-Path '{pid_path}') -or (Get-Item '{pid_path}').Length -eq 0) {{ Start-Sleep -Milliseconds 50 }}; Start-Sleep -Seconds 300"
+        );
         let script = format!(
-            "start /b powershell -NoProfile -Command \"{child}\" & powershell -NoProfile -Command \"Start-Sleep -Seconds 300\""
+            "start /b powershell -NoProfile -Command \"{child}\" & powershell -NoProfile -Command \"{waiter}\""
         );
         let mut cmd = Command::new("cmd.exe");
         cmd.args(["/c", &script]);
-        let result = run_watchdogged(cmd, Duration::from_secs(8), Duration::from_secs(25));
+        let result = run_watchdogged(cmd, Duration::from_secs(20), Duration::from_secs(40));
         assert!(result.is_none(), "a timed-out tree must yield None");
 
         let descendant_pid = read_recorded_pid(&pid_path);

--- a/desktop/src-tauri/src/managed_agents/discovery/login_shell.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/login_shell.rs
@@ -313,8 +313,10 @@ mod path_cache_race_tests {
     /// A probe that started before a refresh must not recache its stale result.
     /// Models the P1 interleaving: probe A captures generation G; a forced
     /// refresh bumps to G+1 and (via probe B) commits a fresh PATH; then A
-    /// finishes late with a false-negative `None`. A's publish must be dropped
-    /// because its generation is stale, leaving B's fresh value intact.
+    /// finishes late and tries to publish. A publishes a non-empty *success*
+    /// (`/stale/bin`), which the same-generation `None`-over-`Some` rule would
+    /// accept — so only the generation guard can reject it. This keeps the test
+    /// non-vacuous: delete the generation comparison and stale overwrites fresh.
     #[test]
     fn stale_probe_cannot_commit_after_refresh() {
         let _guard = crate::managed_agents::lock_path_mutex();
@@ -330,9 +332,10 @@ mod path_cache_race_tests {
         assert_ne!(gen_a, gen_b, "refresh must bump the generation");
         publish_probe_result(gen_b, Some("/fresh/bin".to_string()));
 
-        // Probe A finishes late with a false-negative and tries to publish
-        // under its stale generation.
-        publish_probe_result(gen_a, None);
+        // Probe A finishes late and tries to publish a *stale success* under
+        // its old generation. Only the generation guard can reject this — the
+        // same-generation success-retention rule would let a `Some` through.
+        publish_probe_result(gen_a, Some("/stale/bin".to_string()));
 
         assert_eq!(
             cached_probe(),

--- a/desktop/src-tauri/src/managed_agents/discovery/login_shell.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/login_shell.rs
@@ -53,7 +53,10 @@ fn run_in_login_shell(args: &[&str]) -> Option<String> {
     for shell in login_shell_candidates() {
         let mut cmd = Command::new(&shell);
         cmd.args(args);
-        crate::util::configure_no_window(&mut cmd);
+        // Window suppression is owned by `output_with_timeout`'s spawn
+        // (`BOUNDED_CREATION_FLAGS` carries `CREATE_NO_WINDOW`); a
+        // `configure_no_window` call here would be clobbered by that later
+        // `creation_flags` set, so it is deliberately omitted.
         let Some(output) = super::bounded_command::output_with_timeout(cmd, LOGIN_SHELL_TIMEOUT)
         else {
             continue;

--- a/desktop/src-tauri/src/managed_agents/discovery/login_shell.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/login_shell.rs
@@ -143,42 +143,84 @@ fn fetch_login_shell_path_inner() -> Option<String> {
 /// Within one generation two callers may both probe; a failure/timeout result
 /// (`None`) never clobbers an already-committed success, so a slow timeout can't
 /// undo a peer's fresh PATH.
+///
+/// The caller never returns its own local probe result: after publishing it
+/// returns the value now in the cache. This closes two divergences where a
+/// caller's own result contradicted the authoritative cache:
+///   - same-generation timeout-vs-success — a peer committed a success while
+///     our probe timed out (`None`); we return the peer's success, not `None`;
+///   - a pre-refresh probe whose writeback was generation-rejected — its local
+///     value is stale, so we re-probe under the new generation instead.
 pub fn login_shell_path() -> Option<String> {
-    // Fast path: return the cached result and capture the generation the probe
-    // will run under, all under a single lock.
-    let generation = {
-        let guard = path_cache().lock().unwrap_or_else(|e| e.into_inner());
-        if let LoginShellPath::Probed(ref result) = guard.state {
-            return result.clone();
+    loop {
+        // Fast path: return the cached result and capture the generation the
+        // probe will run under, all under a single lock.
+        let generation = {
+            let guard = path_cache().lock().unwrap_or_else(|e| e.into_inner());
+            if let LoginShellPath::Probed(ref result) = guard.state {
+                return result.clone();
+            }
+            guard.generation
+        };
+
+        // Slow path: spawn shell outside any lock.
+        let result = probe_login_shell_path();
+
+        // Publish under our generation, then return whatever value is now
+        // authoritative. `None` means a refresh invalidated our generation
+        // mid-probe and no fresh value is cached yet, so our `result` is stale
+        // by definition — discard it and re-probe under the new generation.
+        //
+        // Termination: another lap requires another [`refresh_login_shell_path`]
+        // to land during a probe. Refreshes come only from discrete human
+        // actions (install/retry/Doctor re-run) and one-shot boot warm, so the
+        // loop cannot spin unbounded.
+        if let Some(committed) = publish_probe_result(generation, result) {
+            return committed;
         }
-        guard.generation
-    };
-
-    // Slow path: spawn shell outside any lock.
-    let result = fetch_login_shell_path_inner();
-
-    // Publish only if our generation is still current, and never let a failure
-    // overwrite a peer's committed success within the same generation.
-    publish_probe_result(generation, result.clone());
-
-    result
+    }
 }
 
-/// Commit a probe's `result` under the generation it started with.
+/// Real login-shell probe. A `cfg(test)` seam lets the race tests inject
+/// deterministic probe results (and side effects) without spawning shells.
+#[cfg(not(test))]
+fn probe_login_shell_path() -> Option<String> {
+    fetch_login_shell_path_inner()
+}
+
+#[cfg(test)]
+fn probe_login_shell_path() -> Option<String> {
+    match path_cache_race_tests::take_injected_probe() {
+        Some(injected) => injected(),
+        None => fetch_login_shell_path_inner(),
+    }
+}
+
+/// Commit a probe's `result` under the generation it started with, then report
+/// the value the caller should return.
 ///
 /// A probe whose generation is stale (a [`refresh_login_shell_path`] ran while
-/// it was probing) is dropped. Within a live generation a failure/timeout
+/// it was probing) does not commit. Within a live generation a failure/timeout
 /// (`None`) never overwrites an already-committed success. This is the sole
 /// writer of a probed value, so the two race outcomes are decided here.
-fn publish_probe_result(generation: u64, result: Option<String>) {
+///
+/// Returns `Some(v)` — the now-cached probed value the caller must return
+/// (its own commit, or a peer's success that superseded it) — or `None` when
+/// the cache is `Uninit` because a refresh landed mid-probe, signalling the
+/// caller to re-probe under the new generation. Commit and re-read happen under
+/// one lock so no refresh can slip between them.
+fn publish_probe_result(generation: u64, result: Option<String>) -> Option<Option<String>> {
     let mut guard = path_cache().lock().unwrap_or_else(|e| e.into_inner());
-    if guard.generation != generation {
-        return;
+    if guard.generation == generation {
+        let keep_committed_success =
+            result.is_none() && matches!(guard.state, LoginShellPath::Probed(Some(_)));
+        if !keep_committed_success {
+            guard.state = LoginShellPath::Probed(result);
+        }
     }
-    let keep_committed_success =
-        result.is_none() && matches!(guard.state, LoginShellPath::Probed(Some(_)));
-    if !keep_committed_success {
-        guard.state = LoginShellPath::Probed(result);
+    match guard.state {
+        LoginShellPath::Probed(ref v) => Some(v.clone()),
+        LoginShellPath::Uninit => None,
     }
 }
 
@@ -295,6 +337,35 @@ pub(crate) fn parse_semver_tag(s: &str) -> Option<(u64, u64, u64)> {
 #[cfg(test)]
 mod path_cache_race_tests {
     use super::*;
+    use std::collections::VecDeque;
+    use std::sync::{Mutex, OnceLock};
+
+    /// A deterministic stand-in for one login-shell spawn. Returning it lets a
+    /// test drive `login_shell_path`'s slow path without a real shell, and run
+    /// side effects (a peer commit, a mid-probe refresh) at the exact moment a
+    /// probe would be executing.
+    pub(super) type InjectedProbe = Box<dyn FnOnce() -> Option<String> + Send>;
+
+    fn probe_queue() -> &'static Mutex<VecDeque<InjectedProbe>> {
+        static Q: OnceLock<Mutex<VecDeque<InjectedProbe>>> = OnceLock::new();
+        Q.get_or_init(|| Mutex::new(VecDeque::new()))
+    }
+
+    /// Consumed by the `cfg(test)` `probe_login_shell_path` seam: each slow-path
+    /// probe pops the next injected result, falling back to the real shell when
+    /// the queue is empty (so unrelated cache tests still exercise real probing).
+    pub(super) fn take_injected_probe() -> Option<InjectedProbe> {
+        probe_queue()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .pop_front()
+    }
+
+    fn inject_probes(probes: Vec<InjectedProbe>) {
+        let mut q = probe_queue().lock().unwrap_or_else(|e| e.into_inner());
+        q.clear();
+        q.extend(probes);
+    }
 
     fn cached_probe() -> Option<Option<String>> {
         match path_cache().lock().unwrap_or_else(|e| e.into_inner()).state {
@@ -370,6 +441,70 @@ mod path_cache_race_tests {
 
         // Restore the shared cache so sibling tests re-probe a real PATH rather
         // than reading this fixture value.
+        refresh_login_shell_path();
+    }
+
+    /// P1 #2, divergence (a): same-generation timeout-vs-success. A caller
+    /// whose own probe times out (`None`) must still return the success a peer
+    /// committed under the same generation — never its own `None`, which would
+    /// let a forced discovery on this thread settle a PATH-missing UI while the
+    /// authoritative cache holds the peer's success.
+    ///
+    /// Injected probe: commit the peer's `/peer/bin` success, then return `None`
+    /// (this caller's timeout). Non-vacuous for the "return authoritative value"
+    /// rule: return the local result instead and this yields `None`.
+    #[test]
+    fn caller_returns_peer_success_not_own_timeout() {
+        let _guard = crate::managed_agents::lock_path_mutex();
+        refresh_login_shell_path();
+        let gen = generation();
+
+        inject_probes(vec![Box::new(move || {
+            // A peer probe finishes first and commits a success under gen.
+            publish_probe_result(gen, Some("/peer/bin".to_string()));
+            // Our probe then times out.
+            None
+        })]);
+
+        assert_eq!(
+            login_shell_path(),
+            Some("/peer/bin".to_string()),
+            "a timed-out caller must return the peer's committed success, not its own None"
+        );
+
+        refresh_login_shell_path();
+    }
+
+    /// P1 #2, divergence (b): a pre-refresh probe whose writeback is
+    /// generation-rejected must not return its stale local value; the caller
+    /// re-probes under the new generation and returns the fresh result.
+    ///
+    /// First injected probe refreshes mid-flight (bumping the generation) and
+    /// returns a stale `/stale/bin`; publication is rejected, so the caller
+    /// loops and the second probe returns the fresh `/fresh/bin`. Non-vacuous
+    /// for the re-probe rule: return the stale local value on a rejected commit
+    /// instead and this yields `/stale/bin`.
+    #[test]
+    fn caller_reprobes_after_midprobe_refresh() {
+        let _guard = crate::managed_agents::lock_path_mutex();
+        refresh_login_shell_path();
+
+        inject_probes(vec![
+            Box::new(|| {
+                // A forced refresh lands while this probe runs, invalidating the
+                // generation it started under; its result is stale by definition.
+                refresh_login_shell_path();
+                Some("/stale/bin".to_string())
+            }),
+            Box::new(|| Some("/fresh/bin".to_string())),
+        ]);
+
+        assert_eq!(
+            login_shell_path(),
+            Some("/fresh/bin".to_string()),
+            "a generation-rejected probe must re-probe, never return its stale local value"
+        );
+
         refresh_login_shell_path();
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/login_shell.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/login_shell.rs
@@ -54,7 +54,8 @@ fn run_in_login_shell(args: &[&str]) -> Option<String> {
         let mut cmd = Command::new(&shell);
         cmd.args(args);
         crate::util::configure_no_window(&mut cmd);
-        let Some(output) = super::output_with_timeout(cmd, LOGIN_SHELL_TIMEOUT) else {
+        let Some(output) = super::bounded_command::output_with_timeout(cmd, LOGIN_SHELL_TIMEOUT)
+        else {
             continue;
         };
         if !output.status.success() {

--- a/desktop/src-tauri/src/managed_agents/discovery/login_shell.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/login_shell.rs
@@ -89,10 +89,25 @@ enum LoginShellPath {
     Probed(Option<String>),
 }
 
-fn path_cache() -> &'static std::sync::Mutex<LoginShellPath> {
+/// Cache plus a monotonic generation counter. `refresh_login_shell_path` bumps
+/// the generation and resets the state together; a probe records the generation
+/// it started under and may only publish its result while that generation is
+/// still current. This stops a slow, pre-refresh probe from committing a stale
+/// (often false-negative) PATH over the fresh value a post-refresh probe wrote.
+struct PathCache {
+    generation: u64,
+    state: LoginShellPath,
+}
+
+fn path_cache() -> &'static std::sync::Mutex<PathCache> {
     use std::sync::{Mutex, OnceLock};
-    static CACHE: OnceLock<Mutex<LoginShellPath>> = OnceLock::new();
-    CACHE.get_or_init(|| Mutex::new(LoginShellPath::Uninit))
+    static CACHE: OnceLock<Mutex<PathCache>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        Mutex::new(PathCache {
+            generation: 0,
+            state: LoginShellPath::Uninit,
+        })
+    })
 }
 
 fn fetch_login_shell_path_inner() -> Option<String> {
@@ -120,45 +135,70 @@ fn fetch_login_shell_path_inner() -> Option<String> {
 /// to invalidate the cache so the next call re-fetches — e.g. after the user
 /// installs Node.js mid-session and clicks Retry.
 ///
-/// The lock is never held while the login shell spawns: we check for a cached
-/// value, release the lock, run the shell, then re-lock to write. Two concurrent
-/// callers may both run the shell (last-writer-wins is fine — both produce the
-/// same result), but neither blocks a concurrent agent spawn on the Mutex.
+/// The lock is never held while the login shell spawns: we read the cached
+/// value and the current generation, release the lock, run the shell, then
+/// re-lock to publish. Publication is generation-guarded so a probe that
+/// started before a [`refresh_login_shell_path`] can never overwrite the fresh
+/// value: if the generation moved while the probe ran, its result is discarded.
+/// Within one generation two callers may both probe; a failure/timeout result
+/// (`None`) never clobbers an already-committed success, so a slow timeout can't
+/// undo a peer's fresh PATH.
 pub fn login_shell_path() -> Option<String> {
-    // Fast path: return cached result without spawning a shell.
-    {
+    // Fast path: return the cached result and capture the generation the probe
+    // will run under, all under a single lock.
+    let generation = {
         let guard = path_cache().lock().unwrap_or_else(|e| e.into_inner());
-        if let LoginShellPath::Probed(ref result) = *guard {
+        if let LoginShellPath::Probed(ref result) = guard.state {
             return result.clone();
         }
-    }
+        guard.generation
+    };
 
     // Slow path: spawn shell outside any lock.
     let result = fetch_login_shell_path_inner();
 
-    // Write back; last-writer-wins is safe here.
-    {
-        let mut guard = path_cache().lock().unwrap_or_else(|e| e.into_inner());
-        *guard = LoginShellPath::Probed(result.clone());
-    }
+    // Publish only if our generation is still current, and never let a failure
+    // overwrite a peer's committed success within the same generation.
+    publish_probe_result(generation, result.clone());
 
     result
+}
+
+/// Commit a probe's `result` under the generation it started with.
+///
+/// A probe whose generation is stale (a [`refresh_login_shell_path`] ran while
+/// it was probing) is dropped. Within a live generation a failure/timeout
+/// (`None`) never overwrites an already-committed success. This is the sole
+/// writer of a probed value, so the two race outcomes are decided here.
+fn publish_probe_result(generation: u64, result: Option<String>) {
+    let mut guard = path_cache().lock().unwrap_or_else(|e| e.into_inner());
+    if guard.generation != generation {
+        return;
+    }
+    let keep_committed_success =
+        result.is_none() && matches!(guard.state, LoginShellPath::Probed(Some(_)));
+    if !keep_committed_success {
+        guard.state = LoginShellPath::Probed(result);
+    }
 }
 
 /// Invalidate the login-shell PATH cache so the next [`login_shell_path`] call
 /// re-fetches from a fresh login shell.
 ///
 /// Called before every install/retry operation and on Doctor Re-run so a
-/// newly-installed tool becomes visible without restarting the app.
+/// newly-installed tool becomes visible without restarting the app. Bumping the
+/// generation revokes any in-flight probe's writeback, so a shell that started
+/// before this refresh cannot recache its now-stale result.
 pub(crate) fn refresh_login_shell_path() {
     let mut guard = path_cache().lock().unwrap_or_else(|e| e.into_inner());
-    *guard = LoginShellPath::Uninit;
+    guard.generation = guard.generation.wrapping_add(1);
+    guard.state = LoginShellPath::Uninit;
 }
 
 #[cfg(test)]
 pub(crate) fn is_login_shell_path_uninit() -> bool {
     matches!(
-        *path_cache().lock().unwrap_or_else(|e| e.into_inner()),
+        path_cache().lock().unwrap_or_else(|e| e.into_inner()).state,
         LoginShellPath::Uninit
     )
 }
@@ -250,4 +290,75 @@ pub(crate) fn parse_semver_tag(s: &str) -> Option<(u64, u64, u64)> {
     let patch_str = parts.next()?;
     let patch = patch_str.split('-').next()?.parse::<u64>().ok()?;
     Some((major, minor, patch))
+}
+
+#[cfg(test)]
+mod path_cache_race_tests {
+    use super::*;
+
+    fn cached_probe() -> Option<Option<String>> {
+        match path_cache().lock().unwrap_or_else(|e| e.into_inner()).state {
+            LoginShellPath::Uninit => None,
+            LoginShellPath::Probed(ref v) => Some(v.clone()),
+        }
+    }
+
+    fn generation() -> u64 {
+        path_cache()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .generation
+    }
+
+    /// A probe that started before a refresh must not recache its stale result.
+    /// Models the P1 interleaving: probe A captures generation G; a forced
+    /// refresh bumps to G+1 and (via probe B) commits a fresh PATH; then A
+    /// finishes late with a false-negative `None`. A's publish must be dropped
+    /// because its generation is stale, leaving B's fresh value intact.
+    #[test]
+    fn stale_probe_cannot_commit_after_refresh() {
+        let _guard = crate::managed_agents::lock_path_mutex();
+        refresh_login_shell_path();
+
+        // Probe A starts here.
+        let gen_a = generation();
+
+        // A forced refresh invalidates the cache; probe B (new generation) then
+        // commits a fresh PATH.
+        refresh_login_shell_path();
+        let gen_b = generation();
+        assert_ne!(gen_a, gen_b, "refresh must bump the generation");
+        publish_probe_result(gen_b, Some("/fresh/bin".to_string()));
+
+        // Probe A finishes late with a false-negative and tries to publish
+        // under its stale generation.
+        publish_probe_result(gen_a, None);
+
+        assert_eq!(
+            cached_probe(),
+            Some(Some("/fresh/bin".to_string())),
+            "a pre-refresh probe must not overwrite the post-refresh fresh PATH"
+        );
+    }
+
+    /// Within one generation a slow failure/timeout must not clobber a peer's
+    /// already-committed success. Two cold callers race under generation G: the
+    /// success lands first, the timeout (`None`) lands second and is dropped.
+    #[test]
+    fn timeout_does_not_clobber_committed_success() {
+        let _guard = crate::managed_agents::lock_path_mutex();
+        refresh_login_shell_path();
+        let gen = generation();
+
+        // Caller 1 succeeds.
+        publish_probe_result(gen, Some("/usr/local/bin".to_string()));
+        // Caller 2 times out later in the same generation.
+        publish_probe_result(gen, None);
+
+        assert_eq!(
+            cached_probe(),
+            Some(Some("/usr/local/bin".to_string())),
+            "a same-generation timeout must not overwrite a committed success"
+        );
+    }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/login_shell.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/login_shell.rs
@@ -6,8 +6,14 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use super::is_executable_file;
+
+/// Per-candidate wall-clock bound for a login-shell spawn. Matches the auth
+/// probe's 10s discipline: long enough for a healthy interactive shell to
+/// source its rc files, short enough that a wedged shell can't stall discovery.
+const LOGIN_SHELL_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Test-only spawn counter lives beside `discovery.rs`; import it here so the
 /// spawn-record call site stays byte-identical to the pre-extraction source.
@@ -34,6 +40,13 @@ pub(crate) fn login_shell_candidates() -> Vec<PathBuf> {
 
 /// Run a command in a login shell (tries zsh then bash on Unix, Git Bash on Windows).
 /// Returns trimmed stdout if the command succeeds with non-empty output.
+///
+/// Each candidate shell is bounded by [`LOGIN_SHELL_TIMEOUT`]: a shell whose
+/// startup blocks (an interactive prompt in `.zshrc`, a stalled network mount,
+/// a credential helper waiting on input) is killed and treated as a miss so the
+/// loop falls through to the next candidate rather than hanging the whole
+/// discovery. Without this bound a single slow login shell froze the forced
+/// pipeline indefinitely, which is what left "Check again" spinning forever.
 fn run_in_login_shell(args: &[&str]) -> Option<String> {
     #[cfg(test)]
     login_shell_spawn_probe::record();
@@ -41,7 +54,7 @@ fn run_in_login_shell(args: &[&str]) -> Option<String> {
         let mut cmd = Command::new(&shell);
         cmd.args(args);
         crate::util::configure_no_window(&mut cmd);
-        let Ok(output) = cmd.output() else {
+        let Some(output) = super::output_with_timeout(cmd, LOGIN_SHELL_TIMEOUT) else {
             continue;
         };
         if !output.status.success() {

--- a/desktop/src-tauri/src/managed_agents/discovery/login_shell.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/login_shell.rs
@@ -339,6 +339,10 @@ mod path_cache_race_tests {
             Some(Some("/fresh/bin".to_string())),
             "a pre-refresh probe must not overwrite the post-refresh fresh PATH"
         );
+
+        // Restore the shared cache so sibling tests re-probe a real PATH rather
+        // than reading this fixture value.
+        refresh_login_shell_path();
     }
 
     /// Within one generation a slow failure/timeout must not clobber a peer's
@@ -360,5 +364,9 @@ mod path_cache_race_tests {
             Some(Some("/usr/local/bin".to_string())),
             "a same-generation timeout must not overwrite a committed success"
         );
+
+        // Restore the shared cache so sibling tests re-probe a real PATH rather
+        // than reading this fixture value.
+        refresh_login_shell_path();
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -120,6 +120,60 @@ fn explicit_path_resolution_ignores_non_executable_files() {
     let _ = std::fs::remove_dir_all(dir);
 }
 
+#[cfg(unix)]
+#[test]
+fn cheap_path_resolves_workspace_sidecar_without_cache() {
+    // Regression: `resolve_command_cached` (the cheap discovery path) must find
+    // a bundled sidecar sitting next to the executable via a filesystem stat,
+    // even with a cold resolve cache. Before the fix it consulted only the
+    // managed-shim dirs + cache, so `buzz-agent` reported "not installed" at
+    // every cold launch. We assert the workspace resolver — the seam the cheap
+    // path now shares — resolves an executable file by path.
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = std::env::temp_dir().join(format!("buzz-sidecar-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let bin = dir.join("buzz-agent");
+    std::fs::write(&bin, "#!/bin/sh\n").expect("write sidecar");
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+    assert_eq!(
+        super::resolve_command_cached(bin.to_str().expect("utf8 path")),
+        Some(bin.clone()),
+        "cheap path must resolve a bundled sidecar by path with a cold cache"
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn output_with_timeout_returns_output_for_fast_command() {
+    let mut cmd = std::process::Command::new("/bin/sh");
+    cmd.args(["-c", "printf hi"]);
+    let out = super::output_with_timeout(cmd, std::time::Duration::from_secs(5))
+        .expect("fast command must complete within the timeout");
+    assert!(out.status.success());
+    assert_eq!(out.stdout, b"hi");
+}
+
+#[cfg(unix)]
+#[test]
+fn output_with_timeout_kills_and_returns_none_on_timeout() {
+    let start = std::time::Instant::now();
+    let mut cmd = std::process::Command::new("/bin/sh");
+    cmd.args(["-c", "sleep 30"]);
+    let result = super::output_with_timeout(cmd, std::time::Duration::from_millis(200));
+    assert!(
+        result.is_none(),
+        "a command exceeding the timeout must return None"
+    );
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(5),
+        "the call must return promptly after the timeout, not block on the child"
+    );
+}
+
 #[test]
 fn classifies_available_when_adapter_found() {
     let (status, cmd, path) = classify_runtime(

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -120,60 +120,6 @@ fn explicit_path_resolution_ignores_non_executable_files() {
     let _ = std::fs::remove_dir_all(dir);
 }
 
-#[cfg(unix)]
-#[test]
-fn cheap_path_resolves_workspace_sidecar_without_cache() {
-    // Regression: `resolve_command_cached` (the cheap discovery path) must find
-    // a bundled sidecar sitting next to the executable via a filesystem stat,
-    // even with a cold resolve cache. Before the fix it consulted only the
-    // managed-shim dirs + cache, so `buzz-agent` reported "not installed" at
-    // every cold launch. We assert the workspace resolver — the seam the cheap
-    // path now shares — resolves an executable file by path.
-    use std::os::unix::fs::PermissionsExt;
-
-    let dir = std::env::temp_dir().join(format!("buzz-sidecar-{}", uuid::Uuid::new_v4()));
-    std::fs::create_dir_all(&dir).expect("create temp dir");
-    let bin = dir.join("buzz-agent");
-    std::fs::write(&bin, "#!/bin/sh\n").expect("write sidecar");
-    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
-
-    assert_eq!(
-        super::resolve_command_cached(bin.to_str().expect("utf8 path")),
-        Some(bin.clone()),
-        "cheap path must resolve a bundled sidecar by path with a cold cache"
-    );
-
-    let _ = std::fs::remove_dir_all(dir);
-}
-
-#[cfg(unix)]
-#[test]
-fn output_with_timeout_returns_output_for_fast_command() {
-    let mut cmd = std::process::Command::new("/bin/sh");
-    cmd.args(["-c", "printf hi"]);
-    let out = super::output_with_timeout(cmd, std::time::Duration::from_secs(5))
-        .expect("fast command must complete within the timeout");
-    assert!(out.status.success());
-    assert_eq!(out.stdout, b"hi");
-}
-
-#[cfg(unix)]
-#[test]
-fn output_with_timeout_kills_and_returns_none_on_timeout() {
-    let start = std::time::Instant::now();
-    let mut cmd = std::process::Command::new("/bin/sh");
-    cmd.args(["-c", "sleep 30"]);
-    let result = super::output_with_timeout(cmd, std::time::Duration::from_millis(200));
-    assert!(
-        result.is_none(),
-        "a command exceeding the timeout must return None"
-    );
-    assert!(
-        start.elapsed() < std::time::Duration::from_secs(5),
-        "the call must return promptly after the timeout, not block on the child"
-    );
-}
-
 #[test]
 fn classifies_available_when_adapter_found() {
     let (status, cmd, path) = classify_runtime(

--- a/desktop/src-tauri/src/managed_agents/discovery/tests/managed_path_resolution.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests/managed_path_resolution.rs
@@ -187,3 +187,30 @@ fn cheap_discovery_never_spawns_login_shell_even_when_cold() {
         "the forced path must probe the absent command via login shell at least once, got {forced}"
     );
 }
+
+/// Regression: `resolve_command_cached` (the cheap discovery path) must find a
+/// bundled sidecar sitting next to the executable via a filesystem stat, even
+/// with a cold resolve cache. Before the fix it consulted only the managed-shim
+/// dirs + cache, so `buzz-agent` reported "not installed" at every cold launch.
+/// Here the path form exercises the same `resolve_workspace_command` stat the
+/// cheap path now shares.
+#[cfg(unix)]
+#[test]
+fn cheap_path_resolves_workspace_sidecar_without_cache() {
+    use crate::managed_agents::discovery::resolve_command_cached;
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = std::env::temp_dir().join(format!("buzz-sidecar-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let bin = dir.join("buzz-agent");
+    std::fs::write(&bin, "#!/bin/sh\n").expect("write sidecar");
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+    assert_eq!(
+        resolve_command_cached(bin.to_str().expect("utf8 path")),
+        Some(bin.clone()),
+        "cheap path must resolve a bundled sidecar by path with a cold cache"
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/desktop/src-tauri/src/managed_agents/process_lifecycle.rs
+++ b/desktop/src-tauri/src/managed_agents/process_lifecycle.rs
@@ -58,7 +58,7 @@ impl Drop for JobHandle {
 /// regardless of child timing, but it requires raw `CreateProcessW`/`ResumeThread`
 /// (materially more unsafe Win32) to close a microsecond race, so it is
 /// deliberately not used here.
-fn create_job_for_child(pid: u32) -> Option<JobHandle> {
+pub(crate) fn create_job_for_child(pid: u32) -> Option<JobHandle> {
     use std::ptr::null;
     use windows_sys::Win32::Foundation::{CloseHandle, FALSE};
     use windows_sys::Win32::System::JobObjects::{

--- a/desktop/src-tauri/src/managed_agents/process_lifecycle.rs
+++ b/desktop/src-tauri/src/managed_agents/process_lifecycle.rs
@@ -45,19 +45,18 @@ impl Drop for JobHandle {
 /// the caller can fall back to `Child::kill()` — a degraded teardown beats a
 /// failed spawn.
 ///
-/// Assignment happens immediately after spawn, on the same parent thread. The
-/// child (buzz-acp) does spawn its 24 workers before it connects to the relay,
-/// so the window between our spawn and our assignment is NOT structurally empty.
-/// What closes it is assign-latency: `OpenProcess` + `AssignProcessToJobObject`
-/// are a few synchronous Win32 calls (microseconds), while buzz-acp must init
-/// tokio, parse its config, and spawn 24 children (tens-to-hundreds of ms), so
-/// the assign reliably wins before any worker exists. Once assigned, Windows
-/// places every subsequently-spawned descendant in the job automatically.
+/// For the harness spawn path ([`finish_spawn`]) assignment happens immediately
+/// after a normal spawn. The child (buzz-acp) must init tokio, parse its config,
+/// and spawn 24 children (tens-to-hundreds of ms) before any descendant exists,
+/// so the microsecond `OpenProcess` + `AssignProcessToJobObject` reliably wins
+/// that race. Once assigned, Windows places every subsequently-spawned
+/// descendant in the job automatically.
 ///
-/// `CREATE_SUSPENDED` -> assign -> `ResumeThread` would make the window airtight
-/// regardless of child timing, but it requires raw `CreateProcessW`/`ResumeThread`
-/// (materially more unsafe Win32) to close a microsecond race, so it is
-/// deliberately not used here.
+/// The discovery path (`bounded_command`) runs arbitrary probe commands that
+/// can background a descendant and exit in the same tick, so it cannot rely on
+/// assign-latency. It spawns with `CREATE_SUSPENDED`, assigns the frozen child
+/// here, then calls [`resume_process`] — no descendant can exist until the job
+/// owns the root, closing the race by construction.
 pub(crate) fn create_job_for_child(pid: u32) -> Option<JobHandle> {
     use std::ptr::null;
     use windows_sys::Win32::Foundation::{CloseHandle, FALSE};
@@ -102,6 +101,56 @@ pub(crate) fn create_job_for_child(pid: u32) -> Option<JobHandle> {
         }
 
         Some(JobHandle(job))
+    }
+}
+
+/// Resume a process spawned with `CREATE_SUSPENDED` by resuming every thread it
+/// owns. A fresh `CREATE_SUSPENDED` process has exactly one thread suspended at
+/// its entry point; resuming it lets the process run. We enumerate via a
+/// ToolHelp thread snapshot filtered to `pid` rather than tracking the initial
+/// thread id (`std::process::Command` does not expose it), and resume each so
+/// the walk is correct even in the pathological multi-thread case.
+///
+/// Returns `true` only if at least one owned thread was resumed. `false` means
+/// no thread could be resumed — the caller must treat the child as unusable and
+/// tear it down, since a still-suspended root would otherwise hang to the
+/// deadline.
+pub(crate) fn resume_process(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+    };
+    use windows_sys::Win32::System::Threading::{OpenThread, ResumeThread, THREAD_SUSPEND_RESUME};
+
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+        if snapshot == INVALID_HANDLE_VALUE {
+            return false;
+        }
+
+        let mut entry: THREADENTRY32 = std::mem::zeroed();
+        entry.dwSize = std::mem::size_of::<THREADENTRY32>() as u32;
+
+        let mut resumed_any = false;
+        let mut has_entry = Thread32First(snapshot, &mut entry);
+        while has_entry != 0 {
+            if entry.th32OwnerProcessID == pid {
+                let thread = OpenThread(THREAD_SUSPEND_RESUME, 0, entry.th32ThreadID);
+                if !thread.is_null() {
+                    // ResumeThread returns u32::MAX on failure; any other value
+                    // is the thread's previous suspend count.
+                    if ResumeThread(thread) != u32::MAX {
+                        resumed_any = true;
+                    }
+                    CloseHandle(thread);
+                }
+            }
+            entry.dwSize = std::mem::size_of::<THREADENTRY32>() as u32;
+            has_entry = Thread32Next(snapshot, &mut entry);
+        }
+
+        CloseHandle(snapshot);
+        resumed_any
     }
 }
 

--- a/desktop/src/app/useAppShellLifecycleEffects.ts
+++ b/desktop/src/app/useAppShellLifecycleEffects.ts
@@ -1,5 +1,7 @@
 import * as React from "react";
+import { useQueryClient } from "@tanstack/react-query";
 
+import { refreshAcpRuntimes } from "@/features/agents/acpRuntimesQuery";
 import { setDesktopAppBadge } from "@/features/notifications/lib/desktop";
 import { useForegroundQueryRefresh } from "@/features/workflows/hooks";
 import { relayClient } from "@/shared/api/relayClient";
@@ -22,6 +24,20 @@ export function useAppShellLifecycleEffects({
   // the backoff timer when the relay session is degraded (CMD+R gap G1).
   useRelayResumeTriggers();
   useForegroundQueryRefresh();
+
+  // Warm the ACP runtime catalog once at app launch. The shared runtime-catalog
+  // cache is in-memory only, so it starts cold every boot; the cheap discovery
+  // path reports every harness as "(not installed)" until a forced pass warms
+  // it. The create/edit picker and Agents > Agent defaults surfaces read that
+  // cheap path, so without this warm they render all-missing (and block agent
+  // save) until the user visits Settings > Agents — the accidental workaround.
+  // Fire-and-forget: `refreshAcpRuntimes` writes the fresh catalog into the
+  // shared cache and swallows its own errors, so a failed probe leaves the last
+  // good catalog in place without an unhandled rejection.
+  const queryClient = useQueryClient();
+  React.useEffect(() => {
+    void refreshAcpRuntimes(queryClient);
+  }, [queryClient]);
 
   // Prevent webview file:/// navigation on file drop outside the composer.
   // Scoped to file drags only (text drag-and-drop into inputs still works).

--- a/desktop/src/app/useAppShellLifecycleEffects.ts
+++ b/desktop/src/app/useAppShellLifecycleEffects.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
-import { refreshAcpRuntimes } from "@/features/agents/acpRuntimesQuery";
+import { startBootWarm } from "@/features/agents/acpRuntimesQuery";
 import { setDesktopAppBadge } from "@/features/notifications/lib/desktop";
 import { useForegroundQueryRefresh } from "@/features/workflows/hooks";
 import { relayClient } from "@/shared/api/relayClient";
@@ -31,12 +31,14 @@ export function useAppShellLifecycleEffects({
   // it. The create/edit picker and Agents > Agent defaults surfaces read that
   // cheap path, so without this warm they render all-missing (and block agent
   // save) until the user visits Settings > Agents — the accidental workaround.
-  // Fire-and-forget: `refreshAcpRuntimes` writes the fresh catalog into the
-  // shared cache and swallows its own errors, so a failed probe leaves the last
-  // good catalog in place without an unhandled rejection.
+  // `startBootWarm` drives the module-level boot-warm gate (once per launch, so
+  // this remounting effect never re-fires the probe) which makes those cheap
+  // surfaces show loading/retryable-error instead of blessing the cold catalog,
+  // and swallows the probe's own errors so a failure leaves the last good
+  // catalog in place without an unhandled rejection.
   const queryClient = useQueryClient();
   React.useEffect(() => {
-    void refreshAcpRuntimes(queryClient);
+    void startBootWarm(queryClient);
   }, [queryClient]);
 
   // Prevent webview file:/// navigation on file drop outside the composer.

--- a/desktop/src/features/agents/acpRuntimesQuery.test.mjs
+++ b/desktop/src/features/agents/acpRuntimesQuery.test.mjs
@@ -239,37 +239,76 @@ afterEach(() => {
 // failure state (a failed forced pass must surface a retryable error carrying
 // the real reason, not a silent empty catalog), plus recovery on retry.
 describe("boot-warm gate drives cheap consumers through the initial pass", () => {
-  it("applyBootWarmGate: pending reads as loading, catalog always wins", () => {
-    const cold = {
-      data: [],
+  it("applyBootWarmGate: a non-empty cold catalog is not authoritative while pending or failed", () => {
+    // The real cold cheap response is NEVER empty: discovery always emits the
+    // known runtimes as not_installed/cli_missing rows plus presets. Model that
+    // wire shape so the gate is exercised against the payload it exists to
+    // gate, not a `[]` that never occurs in production.
+    const coldCatalog = {
+      data: [
+        rawEntry("codex", "unknown"),
+        rawEntry("goose", "unknown"),
+        rawEntry("claude-code", "unknown"),
+      ],
       error: null,
       isLoading: false,
       isPending: false,
       isFetching: false,
       isError: false,
     };
-    // Race: cheap path already resolved cold, but the first forced pass is in
-    // flight — the cold catalog must present as loading, never authoritative.
-    const pending = applyBootWarmGate(cold, { status: "pending", error: null });
+    // A consumer maps `isLoading -> "loading"`, `isError -> "error"`, else
+    // `"ready"`. "Ready" is what blesses the cold rows as authoritative — the
+    // exact P2 defect. Assert neither pending nor failed reads as ready.
+    const readsAsReady = (q) => !q.isLoading && !q.isError;
+
+    const pending = applyBootWarmGate(coldCatalog, {
+      status: "pending",
+      error: null,
+    });
     assert.equal(pending.isLoading, true);
     assert.equal(pending.isPending, true);
+    assert.equal(
+      readsAsReady(pending),
+      false,
+      "pending must not read as ready",
+    );
+    // The catalog rows are preserved so a consumer reading `data ?? []` keeps
+    // them; only the lifecycle flags are overlaid.
+    assert.equal(pending.data.length, 3);
 
-    // A non-empty catalog wins over the gate, so a revalidation or a later
-    // failure can never blank an already-good list.
-    const warm = { ...cold, data: [rawEntry("codex", "logged_in")] };
-    const kept = applyBootWarmGate(warm, {
+    const reason = new Error("PATH probe timed out");
+    const failed = applyBootWarmGate(coldCatalog, {
       status: "failed",
-      error: new Error("late failure"),
+      error: reason,
     });
-    assert.equal(kept.isError, false);
-    assert.equal(kept.data.length, 1);
+    assert.equal(failed.isError, true);
+    assert.equal(failed.error, reason);
+    assert.equal(readsAsReady(failed), false, "failed must not read as ready");
+    assert.equal(failed.data.length, 3);
 
-    // idle/settled pass through untouched (protects onboarding, warmed hot path).
+    // idle/settled pass through untouched: onboarding renders before the warm
+    // starts (idle) and the warmed hot path (settled) must both read as ready.
     for (const status of ["idle", "settled"]) {
-      const passed = applyBootWarmGate(cold, { status, error: null });
+      const passed = applyBootWarmGate(coldCatalog, { status, error: null });
       assert.equal(passed.isLoading, false);
       assert.equal(passed.isError, false);
+      assert.equal(readsAsReady(passed), true, `${status} must read as ready`);
     }
+  });
+
+  it("applyBootWarmGate: a warmed non-empty catalog reads as ready once settled", () => {
+    const warm = {
+      data: [rawEntry("codex", "logged_in")],
+      error: null,
+      isLoading: false,
+      isPending: false,
+      isFetching: false,
+      isError: false,
+    };
+    const settled = applyBootWarmGate(warm, { status: "settled", error: null });
+    assert.equal(settled.isLoading, false);
+    assert.equal(settled.isError, false);
+    assert.equal(settled.data.length, 1);
   });
 
   it("applyBootWarmGate: failed reads as a retryable error with the real reason", () => {

--- a/desktop/src/features/agents/acpRuntimesQuery.test.mjs
+++ b/desktop/src/features/agents/acpRuntimesQuery.test.mjs
@@ -184,7 +184,10 @@ import { QueryClientProvider } from "@tanstack/react-query";
 
 import {
   acpRuntimesQueryKey,
+  applyBootWarmGate,
+  getBootWarmSnapshot,
   refreshAcpRuntimes,
+  startBootWarm,
   useAcpRuntimesQueryForced,
 } from "./acpRuntimesQuery.ts";
 import { discoverAcpRuntimes } from "@/shared/api/tauriAcpDiscovery.ts";
@@ -228,6 +231,105 @@ function deferred() {
 afterEach(() => {
   calls.length = 0;
   discoverHandler = () => Promise.resolve([]);
+});
+
+// Runs FIRST so the process-global boot-warm gate is observed from `idle`.
+// Covers Carl's ask: the cheap/forced race (a cold cheap catalog must read as
+// loading, not authoritative, while the first forced pass is in flight) and the
+// failure state (a failed forced pass must surface a retryable error carrying
+// the real reason, not a silent empty catalog), plus recovery on retry.
+describe("boot-warm gate drives cheap consumers through the initial pass", () => {
+  it("applyBootWarmGate: pending reads as loading, catalog always wins", () => {
+    const cold = {
+      data: [],
+      error: null,
+      isLoading: false,
+      isPending: false,
+      isFetching: false,
+      isError: false,
+    };
+    // Race: cheap path already resolved cold, but the first forced pass is in
+    // flight — the cold catalog must present as loading, never authoritative.
+    const pending = applyBootWarmGate(cold, { status: "pending", error: null });
+    assert.equal(pending.isLoading, true);
+    assert.equal(pending.isPending, true);
+
+    // A non-empty catalog wins over the gate, so a revalidation or a later
+    // failure can never blank an already-good list.
+    const warm = { ...cold, data: [rawEntry("codex", "logged_in")] };
+    const kept = applyBootWarmGate(warm, {
+      status: "failed",
+      error: new Error("late failure"),
+    });
+    assert.equal(kept.isError, false);
+    assert.equal(kept.data.length, 1);
+
+    // idle/settled pass through untouched (protects onboarding, warmed hot path).
+    for (const status of ["idle", "settled"]) {
+      const passed = applyBootWarmGate(cold, { status, error: null });
+      assert.equal(passed.isLoading, false);
+      assert.equal(passed.isError, false);
+    }
+  });
+
+  it("applyBootWarmGate: failed reads as a retryable error with the real reason", () => {
+    const cold = {
+      data: [],
+      error: null,
+      isLoading: true,
+      isPending: true,
+      isFetching: true,
+      isError: false,
+    };
+    const reason = new Error("PATH probe timed out");
+    const failed = applyBootWarmGate(cold, { status: "failed", error: reason });
+    assert.equal(failed.isError, true);
+    assert.equal(failed.error, reason);
+    assert.equal(failed.isLoading, false, "a failed warm is not still loading");
+  });
+
+  it("startBootWarm: failure marks the gate failed, a retry settles it", async () => {
+    assert.equal(
+      getBootWarmSnapshot().status,
+      "idle",
+      "gate must start idle before any warm",
+    );
+
+    const queryClient = makeQueryClient();
+    queryClient.mount();
+
+    // 1. First forced pass fails: the gate goes `failed` and captures the
+    //    reason, so cold cheap surfaces can show a retryable error.
+    let failForced = true;
+    discoverHandler = (args) =>
+      args?.force === true && failForced
+        ? Promise.reject(new Error("discovery boom"))
+        : Promise.resolve([]);
+    await startBootWarm(queryClient);
+    assert.equal(getBootWarmSnapshot().status, "failed");
+    assert.equal(getBootWarmSnapshot().error?.message, "discovery boom");
+
+    // 2. A retry that succeeds settles the gate and clears the error, so cheap
+    //    consumers stop overlaying and render the warmed catalog.
+    failForced = false;
+    discoverHandler = () => Promise.resolve([rawEntry("codex", "logged_in")]);
+    await startBootWarm(queryClient);
+    assert.equal(getBootWarmSnapshot().status, "settled");
+    assert.equal(getBootWarmSnapshot().error, null);
+
+    // 3. Once settled, further boot warms are no-ops (fixes the per-remount
+    //    re-fire): no additional forced probe fires.
+    const before = calls.filter(
+      (c) => c.command === "discover_acp_providers" && c.args?.force === true,
+    ).length;
+    await startBootWarm(queryClient);
+    const after = calls.filter(
+      (c) => c.command === "discover_acp_providers" && c.args?.force === true,
+    ).length;
+    assert.equal(after, before, "a settled gate must not re-fire the probe");
+
+    queryClient.unmount();
+  });
 });
 
 describe("refreshAcpRuntimes cannot dedup onto an in-flight cheap request", () => {

--- a/desktop/src/features/agents/acpRuntimesQuery.test.mjs
+++ b/desktop/src/features/agents/acpRuntimesQuery.test.mjs
@@ -179,7 +179,7 @@ globalThis.__TAURI_INTERNALS__ = {
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { act } from "react";
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import { QueryClientProvider } from "@tanstack/react-query";
 
 import {
@@ -414,6 +414,59 @@ describe("refreshAcpRuntimes cannot dedup onto an in-flight cheap request", () =
       "shared cache must hold the forced result, not the later cheap one",
     );
 
+    queryClient.unmount();
+  });
+
+  it("an in-flight cheap query cannot clobber the forced result after refresh", async () => {
+    // Carl's settle-order finding: a cheap query in flight on the shared key
+    // must not land its (older) result after the forced catalog is written.
+    // `refreshAcpRuntimes` cancels the shared-key query before settling; this
+    // proves the cancel is load-bearing by holding a real cheap observer
+    // fetching, running the forced refresh, then resolving the cheap request
+    // late — its result must not overwrite the forced catalog, and the gate
+    // must settle on the forced state. (Removing the `cancelQueries` call makes
+    // the late cheap result win and fails this test.)
+    const queryClient = makeQueryClient();
+    queryClient.mount();
+
+    // Seed a pre-existing cold catalog, then start a mounted cheap observer that
+    // refetches and is held pending — the real in-flight shape.
+    queryClient.setQueryData(acpRuntimesQueryKey, [
+      rawEntry("codex", "unknown"),
+    ]);
+    const cheap = deferred();
+    discoverHandler = (args) => {
+      if (args?.force === false) return cheap.promise;
+      return Promise.resolve([rawEntry("codex", "logged_in")]);
+    };
+    const observer = new QueryObserver(queryClient, {
+      queryKey: acpRuntimesQueryKey,
+      queryFn: () => discoverAcpRuntimes(),
+      staleTime: 0,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    await new Promise((r) => setImmediate(r));
+
+    // Forced refresh completes and settles while the cheap observer is fetching.
+    await refreshAcpRuntimes(queryClient);
+
+    // The cheap request resolves afterward; its result must be dropped.
+    cheap.resolve([rawEntry("codex", "unknown")]);
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    assert.equal(
+      queryClient.getQueryData(acpRuntimesQueryKey)?.[0]?.authStatus.status,
+      "logged_in",
+      "shared cache must remain the forced result after a late cheap resolution",
+    );
+    assert.equal(
+      getBootWarmSnapshot().status,
+      "settled",
+      "the gate must settle on the forced catalog, not the stale cheap state",
+    );
+
+    unsubscribe();
     queryClient.unmount();
   });
 });

--- a/desktop/src/features/agents/acpRuntimesQuery.ts
+++ b/desktop/src/features/agents/acpRuntimesQuery.ts
@@ -76,15 +76,25 @@ export function getBootWarmSnapshot() {
 /**
  * Overlay the launch boot-warm gate onto a cheap-path query result so cheap
  * consumers never present a cold catalog as authoritative. Pure so it can be
- * unit-tested without a mounted hook:
+ * unit-tested without a mounted hook.
  *
- * - A non-empty catalog always wins — a revalidation or a post-warm failure
- *   never blanks an already-good list.
- * - `pending` (first forced pass in flight) reads as loading.
- * - `failed` (forced pass rejected, still no catalog) reads as a retryable
- *   error carrying the probe's real reason.
+ * The cheap backend response is *never* empty on a cold cache — discovery
+ * always emits the full set of known runtimes (as `not_installed`/`cli_missing`
+ * rows) plus presets. Gating on `data.length` would therefore be a no-op for the
+ * exact payload this exists to gate, so the gate keys on the boot-warm state
+ * instead and always preserves `query.data`:
+ *
+ * - `pending` (first forced pass in flight) reads as loading, so a cold catalog
+ *   is presented as still-loading rather than a settled "everything
+ *   unavailable" list — even though those cold rows are non-empty.
+ * - `failed` (forced pass rejected) reads as a retryable error carrying the
+ *   probe's real reason.
  * - `idle`/`settled` pass the query through unchanged, so onboarding (which
- *   renders before the warm starts) is unaffected.
+ *   renders before the warm starts) and the warmed hot path are untouched.
+ *
+ * `query.data` is preserved on every branch: overlaying only the lifecycle
+ * flags means a consumer that reads `data ?? []` keeps its rows while a
+ * status-driven consumer correctly treats them as not-yet-authoritative.
  */
 export function applyBootWarmGate<
   Q extends {
@@ -96,7 +106,6 @@ export function applyBootWarmGate<
     isError: boolean;
   },
 >(query: Q, bootWarm: { status: AcpBootWarmStatus; error: Error | null }): Q {
-  if ((query.data?.length ?? 0) > 0) return query;
   if (bootWarm.status === "pending") {
     return { ...query, isLoading: true, isPending: true, isFetching: true };
   }
@@ -132,6 +141,22 @@ export async function startBootWarm(
   if (result === undefined && bootWarmSnapshot.status === "pending") {
     setBootWarm("failed", lastForcedError);
   }
+}
+
+/**
+ * A stable callback that re-runs the boot warm after it failed, for the retry
+ * affordance the cheap-path surfaces (create/edit picker, Agent defaults) show
+ * when the gate is in its `failed` state. `startBootWarm` is the retry
+ * primitive: from `failed` it transitions back through `pending` (so the
+ * surface shows loading again) to `settled` on success or `failed` with a fresh
+ * reason on another rejection. It no-ops while `pending`/`settled`, so a
+ * double-click cannot stack probes.
+ */
+export function useRetryBootWarm() {
+  const queryClient = useQueryClient();
+  return React.useCallback(() => {
+    void startBootWarm(queryClient);
+  }, [queryClient]);
 }
 
 /**

--- a/desktop/src/features/agents/acpRuntimesQuery.ts
+++ b/desktop/src/features/agents/acpRuntimesQuery.ts
@@ -195,11 +195,14 @@ export async function refreshAcpRuntimes(
       staleTime: 0,
       gcTime: 0,
     });
-    queryClient.setQueryData(acpRuntimesQueryKey, result);
-    // A hot-surface cheap fetch may already be in flight on the shared key; cancel
-    // it so its (older, cached) result cannot land after and clobber the fresh
-    // forced catalog we just wrote.
+    // Cancel and *await* the in-flight cheap query on the shared key BEFORE
+    // writing the forced result. `cancelQueries` defaults to `revert: true`, so
+    // cancellation restores the cheap query's pre-fetch state; doing it after
+    // `setQueryData` would let that revert land last and clobber the fresh
+    // forced catalog, and the gate would then settle on the stale state. With
+    // the cancel awaited first, our `setQueryData` is the final write.
     await queryClient.cancelQueries({ queryKey: acpRuntimesQueryKey });
+    queryClient.setQueryData(acpRuntimesQueryKey, result);
     // Any forced success proves the catalog is warm: settle the boot-warm gate
     // and clear the last error, so cheap consumers stop overlaying loading/error.
     lastForcedError = null;

--- a/desktop/src/features/agents/acpRuntimesQuery.ts
+++ b/desktop/src/features/agents/acpRuntimesQuery.ts
@@ -20,6 +20,128 @@ export const acpRuntimesQueryKey = ["acp-runtimes"] as const;
 export const acpRuntimesForcedQueryKey = ["acp-runtimes", "forced"] as const;
 
 /**
+ * Boot-warm gate for the *initial* forced discovery pass.
+ *
+ * The shared runtime catalog is in-memory only, so it starts cold every launch:
+ * the cheap discovery path reports every harness `(not installed)` until a
+ * forced pass warms it. Without a gate, the create/edit picker and Agents >
+ * Agent defaults surfaces read that cheap path and present the cold catalog as
+ * *authoritative* — blessing every harness as unavailable and blocking save —
+ * during the 20–65s boot probe, and forever if that probe fails.
+ *
+ * This module-level state lets cheap consumers (`useAcpRuntimesQuery`) treat the
+ * catalog as still-loading while the first forced pass is in flight and as a
+ * retryable error if it failed, instead of authoritative. It is process-global
+ * (one launch), so `startBootWarm` runs the warm exactly once no matter how many
+ * times `AppShell` mounts — that also fixes the per-remount re-fire.
+ *
+ * The seam that protects onboarding (which renders before `AppShell` fires the
+ * warm): the gate only overlays loading/error once the warm has *started*
+ * (`pending`/`failed`). While `idle` — no warm yet, e.g. the onboarding flow —
+ * cheap consumers behave exactly as before. A successful forced refresh from any
+ * surface settles the gate, so onboarding's own forced warm clears it too.
+ */
+export type AcpBootWarmStatus = "idle" | "pending" | "settled" | "failed";
+
+/**
+ * A stable snapshot object for `useSyncExternalStore`: `getSnapshot` must return
+ * a referentially-stable value between changes, so the object is rebuilt only in
+ * `setBootWarm`, never per read.
+ */
+let bootWarmSnapshot: { status: AcpBootWarmStatus; error: Error | null } = {
+  status: "idle",
+  error: null,
+};
+const bootWarmListeners = new Set<() => void>();
+
+function setBootWarm(status: AcpBootWarmStatus, error: Error | null) {
+  if (bootWarmSnapshot.status === status && bootWarmSnapshot.error === error) {
+    return;
+  }
+  bootWarmSnapshot = { status, error };
+  for (const listener of bootWarmListeners) listener();
+}
+
+export function subscribeBootWarm(listener: () => void) {
+  bootWarmListeners.add(listener);
+  return () => {
+    bootWarmListeners.delete(listener);
+  };
+}
+
+export function getBootWarmSnapshot() {
+  return bootWarmSnapshot;
+}
+
+/**
+ * Overlay the launch boot-warm gate onto a cheap-path query result so cheap
+ * consumers never present a cold catalog as authoritative. Pure so it can be
+ * unit-tested without a mounted hook:
+ *
+ * - A non-empty catalog always wins — a revalidation or a post-warm failure
+ *   never blanks an already-good list.
+ * - `pending` (first forced pass in flight) reads as loading.
+ * - `failed` (forced pass rejected, still no catalog) reads as a retryable
+ *   error carrying the probe's real reason.
+ * - `idle`/`settled` pass the query through unchanged, so onboarding (which
+ *   renders before the warm starts) is unaffected.
+ */
+export function applyBootWarmGate<
+  Q extends {
+    data?: unknown[];
+    error: Error | null;
+    isLoading: boolean;
+    isPending: boolean;
+    isFetching: boolean;
+    isError: boolean;
+  },
+>(query: Q, bootWarm: { status: AcpBootWarmStatus; error: Error | null }): Q {
+  if ((query.data?.length ?? 0) > 0) return query;
+  if (bootWarm.status === "pending") {
+    return { ...query, isLoading: true, isPending: true, isFetching: true };
+  }
+  if (bootWarm.status === "failed") {
+    return {
+      ...query,
+      isError: true,
+      error: bootWarm.error ?? query.error,
+      isLoading: false,
+    };
+  }
+  return query;
+}
+
+/**
+ * Run the initial forced discovery pass once per launch and drive the boot-warm
+ * gate. `AppShell` calls this on mount; the `pending`/`settled` short-circuit
+ * makes remounts no-ops (fixing the re-fire) while still retrying after a prior
+ * failure. Success is recorded by `refreshAcpRuntimes` itself (any forced
+ * success settles the gate); this only has to mark its own failure.
+ */
+export async function startBootWarm(
+  queryClient: ReturnType<typeof useQueryClient>,
+) {
+  const status: AcpBootWarmStatus = bootWarmSnapshot.status;
+  if (status === "pending" || status === "settled") {
+    return;
+  }
+  setBootWarm("pending", null);
+  const result = await refreshAcpRuntimes(queryClient);
+  // A concurrent forced success may have already settled the gate; only mark
+  // failed if this pass is still the pending one and it returned no catalog.
+  if (result === undefined && bootWarmSnapshot.status === "pending") {
+    setBootWarm("failed", lastForcedError);
+  }
+}
+
+/**
+ * The error from the most recent failed forced probe, surfaced through the
+ * boot-warm `failed` state so a cold catalog shows a real reason rather than a
+ * silent empty list. Cleared on the next forced success.
+ */
+let lastForcedError: Error | null = null;
+
+/**
  * Run a forced (full re-discovery) refresh and write the result into the shared
  * runtime-catalog cache.
  *
@@ -53,8 +175,12 @@ export async function refreshAcpRuntimes(
     // it so its (older, cached) result cannot land after and clobber the fresh
     // forced catalog we just wrote.
     await queryClient.cancelQueries({ queryKey: acpRuntimesQueryKey });
+    // Any forced success proves the catalog is warm: settle the boot-warm gate
+    // and clear the last error, so cheap consumers stop overlaying loading/error.
+    lastForcedError = null;
+    setBootWarm("settled", null);
     return result;
-  } catch {
+  } catch (error) {
     // The forced probe rejected. `fetchQuery` has already recorded the error in
     // the forced key's query state, where `useAcpRuntimesQueryForced` projects
     // it into the hook's returned `error`/`isError`. Swallow the rejection here
@@ -63,7 +189,9 @@ export async function refreshAcpRuntimes(
     // paths) can keep `void refreshAcpRuntimes(...)` without ever leaking an
     // unhandled rejection, and a new call site can never reintroduce one. The
     // shared cache is left untouched so consumers keep the last good catalog
-    // alongside the surfaced error.
+    // alongside the surfaced error. Record the error so a failed boot warm can
+    // surface a real reason on the cheap-path surfaces (via the boot-warm gate).
+    lastForcedError = error instanceof Error ? error : new Error(String(error));
     return undefined;
   }
 }

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -57,7 +57,10 @@ import {
   refreshAcpRuntimes,
   subscribeBootWarm,
 } from "@/features/agents/acpRuntimesQuery";
-export { useAcpRuntimesQueryForced } from "@/features/agents/acpRuntimesQuery";
+export {
+  useAcpRuntimesQueryForced,
+  useRetryBootWarm,
+} from "@/features/agents/acpRuntimesQuery";
 import {
   createPersona,
   deletePersona,

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -52,7 +52,10 @@ import {
 import { bootstrapManagedAgentRuntimePairs } from "@/features/agents/managedAgentRuntimeHooks";
 import {
   acpRuntimesQueryKey,
+  applyBootWarmGate,
+  getBootWarmSnapshot,
   refreshAcpRuntimes,
+  subscribeBootWarm,
 } from "@/features/agents/acpRuntimesQuery";
 export { useAcpRuntimesQueryForced } from "@/features/agents/acpRuntimesQuery";
 import {
@@ -218,12 +221,23 @@ function invalidateManagedAgentQueriesInBackground(
  * probe pipeline.
  */
 export function useAcpRuntimesQuery(options?: { enabled?: boolean }) {
-  return useQuery({
+  const query = useQuery({
     enabled: options?.enabled ?? true,
     queryKey: acpRuntimesQueryKey,
     queryFn: () => discoverAcpRuntimes(),
     staleTime: 30 * 60_000,
   });
+  // Overlay the launch boot-warm gate so cheap consumers never present a cold
+  // catalog as authoritative: until the first forced pass settles, an un-warmed
+  // catalog reads as loading (`pending`) or a retryable error (`failed`) rather
+  // than "every harness not installed". `applyBootWarmGate` preserves an
+  // already-good list and passes through untouched while idle/settled.
+  const bootWarm = React.useSyncExternalStore(
+    subscribeBootWarm,
+    getBootWarmSnapshot,
+    getBootWarmSnapshot,
+  );
+  return applyBootWarmGate(query, bootWarm);
 }
 
 export function useAvailableAcpRuntimes(options?: { enabled?: boolean }) {

--- a/desktop/src/features/agents/ui/AgentDefaultsEditor.tsx
+++ b/desktop/src/features/agents/ui/AgentDefaultsEditor.tsx
@@ -33,6 +33,7 @@ import {
   sortPersonaRuntimes,
 } from "@/features/agents/ui/agentConfigOptions";
 import { AgentDropdownSelect } from "@/features/agents/ui/agentConfigControls";
+import { HarnessCatalogRetryNotice } from "@/features/agents/ui/HarnessCatalogRetryNotice";
 import {
   AgentConfigFields,
   EMPTY_GLOBAL_CONFIG,
@@ -171,10 +172,12 @@ export function AgentDefaultsEditor({
     [sortedRuntimes],
   );
   const configSurfaceLoading = isLoading || runtimesQuery.isLoading;
-  const configSurfaceError =
-    loadError ||
+  // The runtime catalog failing to warm is retryable in-place (re-run the boot
+  // probe); a global-config load failure is not, so it keeps the restart copy.
+  const runtimeCatalogError =
     runtimesQuery.isError ||
-    (!configSurfaceLoading && sortedRuntimes.length === 0);
+    (!configSurfaceLoading && !loadError && sortedRuntimes.length === 0);
+  const configSurfaceError = loadError || runtimeCatalogError;
 
   function handleConfigChange(next: GlobalAgentConfig) {
     configRef.current = next;
@@ -268,10 +271,16 @@ export function AgentDefaultsEditor({
           Loading…
         </div>
       ) : configSurfaceError ? (
-        <div className="flex items-center gap-2 py-4 text-sm text-destructive">
-          <AlertCircle className="size-4" />
-          Couldn't load agent defaults. Restart the app to try again.
-        </div>
+        runtimeCatalogError && !loadError ? (
+          <div className="py-4">
+            <HarnessCatalogRetryNotice />
+          </div>
+        ) : (
+          <div className="flex items-center gap-2 py-4 text-sm text-destructive">
+            <AlertCircle className="size-4" />
+            Couldn't load agent defaults. Restart the app to try again.
+          </div>
+        )
       ) : (
         <>
           <div className="space-y-1.5">

--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -823,6 +823,7 @@ export function AgentDefinitionDialog({
         >
           {aiConfigurationMode === "custom" ? (
             <AgentHarnessField
+              catalogStatus={runtimeCatalogStatus}
               disabled={isPending || runtimesLoading}
               onValueChange={handleRuntimeDropdownChange}
               options={runtimeDropdownOptions}
@@ -831,7 +832,6 @@ export function AgentDefinitionDialog({
               warning={runtimeWarning}
             />
           ) : null}
-
           {llmProviderFieldVisible && aiConfigurationMode === "custom" ? (
             <div className="space-y-1.5">
               <RequiredFieldLabel

--- a/desktop/src/features/agents/ui/AgentHarnessField.tsx
+++ b/desktop/src/features/agents/ui/AgentHarnessField.tsx
@@ -2,8 +2,10 @@ import type { ReactNode } from "react";
 
 import type { PersonaDropdownOption } from "./agentConfigOptions";
 import { PersonaDropdownField } from "./PersonaDropdownField";
+import { HarnessCatalogRetryNotice } from "./HarnessCatalogRetryNotice";
 
 export function AgentHarnessField({
+  catalogStatus,
   disabled,
   onValueChange,
   options,
@@ -11,6 +13,7 @@ export function AgentHarnessField({
   value,
   warning,
 }: {
+  catalogStatus?: "loading" | "ready" | "error";
   disabled: boolean;
   onValueChange: (value: string) => void;
   options: PersonaDropdownOption[];
@@ -34,7 +37,7 @@ export function AgentHarnessField({
         placeholder={placeholder}
         value={value}
       />
-      {warning}
+      {catalogStatus === "error" ? <HarnessCatalogRetryNotice /> : warning}
     </div>
   );
 }

--- a/desktop/src/features/agents/ui/HarnessCatalogRetryNotice.tsx
+++ b/desktop/src/features/agents/ui/HarnessCatalogRetryNotice.tsx
@@ -1,0 +1,24 @@
+import { AlertCircle } from "lucide-react";
+
+import { useRetryBootWarm } from "@/features/agents/hooks";
+import { Button } from "@/shared/ui/button";
+
+/**
+ * Inline error affordance shown when the launch runtime-catalog warm failed
+ * (the boot-warm gate's `failed` state). Unlike a global-config load failure —
+ * which is not retryable and keeps the "restart the app" copy — a failed
+ * harness probe re-runs in place via `useRetryBootWarm`, so the create/edit
+ * picker and Agent defaults surfaces both render this instead of a dead end.
+ */
+export function HarnessCatalogRetryNotice() {
+  const retryBootWarm = useRetryBootWarm();
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-sm text-destructive">
+      <AlertCircle className="size-4 shrink-0" />
+      <span>Couldn't detect agent harnesses.</span>
+      <Button onClick={retryBootWarm} size="sm" variant="outline">
+        Try again
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

PR #6330 split agent harness/runtime detection into a cheap (cache-only) path and a forced (spawning) path. Two regressions followed, both surfacing as every harness showing "(not installed)" / "CLI missing" across the agent create/edit picker, Agents > Agent defaults, and Settings > Agents — blocking agent create/edit until the user clicked Install in Settings > Agents.

## Root cause

One underlying bug, two victims:

- **Boot false-negative.** The resolve cache is in-memory, so it starts cold on every launch. `resolve_command_cached` (the cheap path) consulted only the Buzz-managed shim dirs plus that cold cache, and `buzz_managed_command_path`'s allowlist structurally excludes `buzz-agent`. The bundled sidecar could therefore never resolve on the cheap path until a forced pass warmed the cache, so cheap-path surfaces rendered all-missing at boot. App setup never warms the cache.
- **"Check again" hang.** `run_in_login_shell` used an untimeouted `Command::output()`; a wedged login shell froze the whole forced pipeline, leaving "Check again" spinning forever.

## What

- `resolve_command_cached` now also calls `resolve_workspace_command`, resolving the bundled sidecar via a filesystem stat (no spawn) — the same class of work the managed-shim check already performs. `buzz-agent` can no longer report missing, even inside the boot warm window.
- New `discovery/bounded_command.rs` runs any discovery child under a hard wall-clock deadline, polling with `try_wait` rather than blocking on `wait()`. Stdout and stderr are piped to two drain threads whose buffers share an aggregate `CAPTURE_LIMIT`; a breach fails closed (kill the tree, return `None`), so a noisy or hostile probe can force neither unbounded memory nor disk fill. Tree teardown runs on every exit path — timeout, error, cap breach, *and* success — because a login-shell rc file or auth CLI can legitimately background a descendant that would otherwise outlive discovery. Ownership is deliberately asymmetric:
  - **Unix:** the child leads its own process group (`process_group(0)`); teardown is `SIGTERM` → bounded grace → `SIGKILL` on the group. A descendant that leaves the group (`setsid`/`setpgid`) while holding a pipe is not owned and may survive one probe, but can never hang or unbound the helper: the Unix drains read nonblocking and end on `WouldBlock` once teardown sets the stop flag, so the join returns promptly without waiting on an escaped writer's EOF.
  - **Windows:** the child is spawned `CREATE_SUSPENDED`, assigned to a kill-on-close Job Object while frozen, then resumed. The job owns the root before any descendant can exist and is created without breakaway, so no writer can escape — a hard whole-tree guarantee, and closing the job reaps the tree even after the root has exited. Any failure to create, assign, or resume is fail-closed: the child is terminated and reaped and the spawn returns `None` (discovery treats it as command-not-found) rather than running unowned.
- Each login-shell candidate is bounded by a 10s timeout via that helper, falling through to the next candidate on timeout instead of aborting the resolve. The login-shell path cache is generation-aware: a probe that loses to a concurrent refresh or lands mid-refresh returns the authoritative cached value (or re-probes under the new generation) rather than its own rejected local result, so a losing thread can never settle the UI with a PATH-missing catalog while the cache holds a fresh success.
- Warm the ACP runtime catalog once at `AppShell` mount and gate the cheap-path surfaces on that pass. A module-level boot-warm state (`idle` → `pending` → `settled`/`failed`, deduped per launch) lets `useAcpRuntimesQuery` present a cold catalog as *loading* while the first forced pass runs and as a *retryable error* (carrying the probe's real reason) if it fails, instead of blessing "every harness not installed" as authoritative. A non-empty catalog always wins, so a revalidation or later failure never blanks a good list; the gate only overlays once the warm has started, so onboarding (which renders before the warm) is unaffected. Deduping per launch also fixes the previous per-remount re-fire.

## Verification

Unix teardown and the drain contract are runtime-proven by `#[ignore]`-free tests that record a backgrounded descendant's real PID and assert the helper returns promptly on both the success and timeout paths without blocking on that writer. The generation-aware login-shell cache is covered by deterministic tests through a `cfg(test)` injectable probe seam that assert the function's return value under both concurrent-refresh interleavings — the losing caller returns the peer's committed success, and a mid-probe refresh forces a re-probe to the fresh value. The Windows ownership contract has no CI lane, so `bounded_command.rs` carries two `#[ignore]`-gated tests (spawn/assign race, looped; and the timeout path) for a sanctioned run on a Windows host. The boot-warm gate is covered by unit tests for the pure overlay and the `startBootWarm` failure → retry → settle lifecycle.

Origin: [Buzz thread](buzz://message?channel=5ef5d5bb-643f-4b87-bbf4-e8b64585ffeb&id=a4b1c4485de4d35cff0f914d4f4211c796f44f670e76de2ef9431f7e882c906e)

Fixes #6872
Related #6662
