### PR TITLE
fix(desktop): request Badge authorization so the macOS dock badge renders

### DIFF
--- a/desktop/src-tauri/src/macos_notifications.rs
+++ b/desktop/src-tauri/src/macos_notifications.rs
@@ -196,7 +196,13 @@ fn request_notification_access_sync() -> Result<NotificationPermissionState, Str
     });
     UNUserNotificationCenter::currentNotificationCenter()
         .requestAuthorizationWithOptions_completionHandler(
-            UNAuthorizationOptions::Alert | UNAuthorizationOptions::Sound,
+            // Badge must be requested here even though the dock badge is set via
+            // NSDockTile: once an app registers with UNUserNotificationCenter,
+            // macOS suppresses its dock badge (and hides the "Badge app icon"
+            // toggle in System Settings) unless Badge was part of the grant.
+            UNAuthorizationOptions::Alert
+                | UNAuthorizationOptions::Sound
+                | UNAuthorizationOptions::Badge,
             &handler,
         );
 


### PR DESCRIPTION
## Problem

On macOS, the desktop app's dock badge (unread count / dot) never renders, and the "Badge app icon" toggle is missing from the app's entry in System Settings → Notifications, so users can't enable it manually either.

The app *is* setting the badge — `setBadgeCount` / `setBadgeLabel` run and the value even registers in LaunchServices (visible via `lsappinfo info -only StatusLabel`) — but the Dock never paints it.

## Root cause

`macos_notifications.rs` requests notification authorization with only `Alert | Sound`:

Once an app registers with `UNUserNotificationCenter`, macOS scopes its notification capabilities to exactly the options granted. If `Badge` wasn't part of the request, the system suppresses the dock badge entirely — even badges set through the separate `NSDockTile` API — and hides the "Badge app icon" toggle in System Settings, so there's no user-side workaround.

## Fix

Add `UNAuthorizationOptions::Badge` to the authorization request. One line, plus a comment so it doesn't get dropped later (the connection between this request and the dock tile badge is non-obvious).

## Verification

- Built two identical minimal macOS apps that set `NSApp.dockTile.badgeLabel` and request UN authorization — one with `Alert | Sound` (matching Buzz today), one with `Alert | Sound | Badge`. The first never renders a badge and its granted-options bitmask in notification prefs is 6; the second renders the red badge and shows 7 (Badge+Sound+Alert), matching apps like Slack/Chrome/Zoom where badges work.
- With this change, existing installs pick up the wider grant on next launch without re-prompting the user (the request is a superset; macOS extends the grant silently).
- Full CI run on this change (fork): Desktop Build macOS, Desktop Core, Desktop E2E Relay, 4× Desktop Smoke E2E, 2× Desktop E2E Integration, Rust Lint, Windows Rust — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
