### PR TITLE
Add Nix flake for CLI, relay, and desktop installation

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -7,7 +7,12 @@ on:
     paths:
       - flake.nix
       - flake.lock
+      - nix/**
       - .github/workflows/nix.yml
+      - Cargo.lock
+      - desktop/src-tauri/Cargo.lock
+      - pnpm-lock.yaml
+      - package.json
   schedule:
     # Check for desktop release updates daily at 06:00 UTC
     - cron: "0 6 * * *"
@@ -54,10 +59,10 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v8
       - run: nix build .#buzz-relay --no-link --print-build-logs
 
-  build-desktop-linux:
-    name: build buzz-desktop (x86_64-linux)
+  build-desktop-source-linux:
+    name: build buzz-desktop from source (x86_64-linux)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     permissions:
       contents: read
     steps:
@@ -65,6 +70,18 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v16
       - uses: DeterminateSystems/magic-nix-cache-action@v8
       - run: nix build .#buzz-desktop --no-link --print-build-logs
+
+  build-desktop-prebuilt-linux:
+    name: build buzz-desktop-prebuilt (x86_64-linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - run: nix build .#buzz-desktop-prebuilt --no-link --print-build-logs
 
   build-cli-darwin:
     name: build buzz-cli (aarch64-darwin)
@@ -79,10 +96,10 @@ jobs:
       - run: nix build .#buzz-cli --no-link --print-build-logs
       - run: nix run .#buzz-cli -- --help
 
-  build-desktop-darwin:
-    name: build buzz-desktop (aarch64-darwin)
+  build-desktop-source-darwin:
+    name: build buzz-desktop from source (aarch64-darwin)
     runs-on: macos-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     permissions:
       contents: read
     steps:
@@ -90,6 +107,18 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v16
       - uses: DeterminateSystems/magic-nix-cache-action@v8
       - run: nix build .#buzz-desktop --no-link --print-build-logs
+
+  build-desktop-prebuilt-darwin:
+    name: build buzz-desktop-prebuilt (aarch64-darwin)
+    runs-on: macos-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - run: nix build .#buzz-desktop-prebuilt --no-link --print-build-logs
 
   update-desktop-hashes:
     name: Update desktop release hashes
@@ -139,13 +168,11 @@ jobs:
           AMD64_LINUX_SRI=$(nix hash to-sri --type sha256 "$AMD64_LINUX")
 
           # Update flake.nix
-          sed -i "s/desktopVersion = \".*\"/desktopVersion = \"${VERSION}\"/" flake.nix
-          sed -i "s|\"sha256-[^\"]*\";  # aarch64-darwin placeholder|\"${AARCH64_DARWIN_SRI}\";|" flake.nix || true
-          # Use more robust replacement
           python3 -c "
           import re
           with open('flake.nix', 'r') as f:
               content = f.read()
+          content = re.sub(r'desktopVersion = \"[^\"]*\"', 'desktopVersion = \"${VERSION}\"', content)
           content = re.sub(r'\"aarch64-darwin\" = \{[^}]*sha256 = \"[^\"]*\"', '\"aarch64-darwin\" = { file = \"Buzz_\${desktopVersion}_aarch64.app.tar.gz\"; sha256 = \"${AARCH64_DARWIN_SRI}\"', content)
           content = re.sub(r'\"x86_64-darwin\" = \{[^}]*sha256 = \"[^\"]*\"', '\"x86_64-darwin\" = { file = \"Buzz_\${desktopVersion}_x64.app.tar.gz\"; sha256 = \"${X64_DARWIN_SRI}\"', content)
           content = re.sub(r'\"x86_64-linux\" = \{[^}]*sha256 = \"[^\"]*\"', '\"x86_64-linux\" = { file = \"Buzz_\${desktopVersion}_amd64.AppImage\"; sha256 = \"${AMD64_LINUX_SRI}\"', content)

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,173 @@
+name: Nix
+
+on:
+  push:
+    branches: [main, release]
+  pull_request:
+    paths:
+      - flake.nix
+      - flake.lock
+      - .github/workflows/nix.yml
+  schedule:
+    # Check for desktop release updates daily at 06:00 UTC
+    - cron: "0 6 * * *"
+
+concurrency:
+  group: nix-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  flake-check:
+    name: flake check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - run: nix flake check --no-build
+
+  build-cli-linux:
+    name: build buzz-cli (x86_64-linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - run: nix build .#buzz-cli --no-link --print-build-logs
+      - run: nix run .#buzz-cli -- --help
+
+  build-relay-linux:
+    name: build buzz-relay (x86_64-linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - run: nix build .#buzz-relay --no-link --print-build-logs
+
+  build-desktop-linux:
+    name: build buzz-desktop (x86_64-linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - run: nix build .#buzz-desktop --no-link --print-build-logs
+
+  build-cli-darwin:
+    name: build buzz-cli (aarch64-darwin)
+    runs-on: macos-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - run: nix build .#buzz-cli --no-link --print-build-logs
+      - run: nix run .#buzz-cli -- --help
+
+  build-desktop-darwin:
+    name: build buzz-desktop (aarch64-darwin)
+    runs-on: macos-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - run: nix build .#buzz-desktop --no-link --print-build-logs
+
+  update-desktop-hashes:
+    name: Update desktop release hashes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    if: github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - name: Fetch latest desktop release tag
+        id: latest
+        run: |
+          TAG=$(curl -s https://api.github.com/repos/block/buzz/releases/latest | jq -r '.tag_name' | grep '^desktop-v')
+          if [ -z "$TAG" ]; then
+            echo "No desktop-v* release found"
+            exit 0
+          fi
+          VERSION="${TAG#desktop-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+      - name: Check if update needed
+        id: check
+        run: |
+          CURRENT=$(grep 'desktopVersion = "' flake.nix | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          if [ "$CURRENT" = "${{ steps.latest.outputs.version }}" ]; then
+            echo "Up to date ($CURRENT)"
+            echo "needs_update=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_update=true" >> "$GITHUB_OUTPUT"
+            echo "Updating from $CURRENT to ${{ steps.latest.outputs.version }}"
+          fi
+      - name: Prefetch hashes
+        if: steps.check.outputs.needs_update == 'true'
+        run: |
+          VERSION="${{ steps.latest.outputs.version }}"
+          # Prefetch all three desktop assets
+          AARCH64_DARWIN=$(nix-prefetch-url --type sha256 "https://github.com/block/buzz/releases/download/desktop-v${VERSION}/Buzz_${VERSION}_aarch64.app.tar.gz")
+          X64_DARWIN=$(nix-prefetch-url --type sha256 "https://github.com/block/buzz/releases/download/desktop-v${VERSION}/Buzz_${VERSION}_x64.app.tar.gz")
+          AMD64_LINUX=$(nix-prefetch-url --type sha256 "https://github.com/block/buzz/releases/download/desktop-v${VERSION}/Buzz_${VERSION}_amd64.AppImage")
+
+          # Convert to SRI
+          AARCH64_DARWIN_SRI=$(nix hash to-sri --type sha256 "$AARCH64_DARWIN")
+          X64_DARWIN_SRI=$(nix hash to-sri --type sha256 "$X64_DARWIN")
+          AMD64_LINUX_SRI=$(nix hash to-sri --type sha256 "$AMD64_LINUX")
+
+          # Update flake.nix
+          sed -i "s/desktopVersion = \".*\"/desktopVersion = \"${VERSION}\"/" flake.nix
+          sed -i "s|\"sha256-[^\"]*\";  # aarch64-darwin placeholder|\"${AARCH64_DARWIN_SRI}\";|" flake.nix || true
+          # Use more robust replacement
+          python3 -c "
+          import re
+          with open('flake.nix', 'r') as f:
+              content = f.read()
+          content = re.sub(r'\"aarch64-darwin\" = \{[^}]*sha256 = \"[^\"]*\"', '\"aarch64-darwin\" = { file = \"Buzz_\${desktopVersion}_aarch64.app.tar.gz\"; sha256 = \"${AARCH64_DARWIN_SRI}\"', content)
+          content = re.sub(r'\"x86_64-darwin\" = \{[^}]*sha256 = \"[^\"]*\"', '\"x86_64-darwin\" = { file = \"Buzz_\${desktopVersion}_x64.app.tar.gz\"; sha256 = \"${X64_DARWIN_SRI}\"', content)
+          content = re.sub(r'\"x86_64-linux\" = \{[^}]*sha256 = \"[^\"]*\"', '\"x86_64-linux\" = { file = \"Buzz_\${desktopVersion}_amd64.AppImage\"; sha256 = \"${AMD64_LINUX_SRI}\"', content)
+          with open('flake.nix', 'w') as f:
+              f.write(content)
+          "
+      - name: Update flake.lock
+        if: steps.check.outputs.needs_update == 'true'
+        run: nix flake lock --update-input nixpkgs
+      - name: Create pull request
+        if: steps.check.outputs.needs_update == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(nix): bump desktop release to ${{ steps.latest.outputs.version }}"
+          title: "chore(nix): bump desktop release to ${{ steps.latest.outputs.version }}"
+          body: |
+            Automated update of desktop release hashes.
+
+            Desktop version: ${{ steps.latest.outputs.version }}
+            Release tag: ${{ steps.latest.outputs.tag }}
+
+            Updated by the Nix workflow's scheduled hash automation.
+          branch: nix/update-desktop-hashes
+          delete-branch: true

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ identity.key
 
 # Helm dependency tarballs — regenerable from Chart.lock via `helm dependency build`
 deploy/charts/*/charts/*.tgz
+
+# Nix build results
+result
+result-

--- a/README.md
+++ b/README.md
@@ -132,6 +132,36 @@ The Windows build is not code-signed, so SmartScreen may show "Windows protected
 
 By default the app connects to `ws://localhost:3000`. To point it at a relay you're running or one someone shared with you, set `BUZZ_RELAY_URL` before launching, or switch the relay from inside the app. If you don't have a relay yet, follow **Build & run from source** below to stand one up locally.
 
+### Install via Nix (experimental)
+
+If you use the [Nix package manager](https://nixos.org/) (with flakes enabled), you can install the Buzz CLI, relay, and desktop app directly from this repo — no Rust toolchain or Node required.
+
+**CLI:**
+```bash
+nix run github:block/buzz#buzz-cli -- --help
+nix profile install github:block/buzz#buzz-cli   # install the `buzz` binary
+```
+
+**Relay/server:**
+```bash
+nix run github:block/buzz#buzz-relay -- --help
+nix profile install github:block/buzz#buzz-relay
+```
+
+**Desktop app** (prebuilt release binary, supported platforms only):
+```bash
+nix run github:block/buzz#buzz-desktop   # macOS Apple Silicon, macOS Intel, Linux x86_64
+```
+
+> **Note:** There is no prebuilt desktop binary for `aarch64-linux`. The CLI and relay are built from source on all four standard platforms (`x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`); the desktop package wraps the official release artifacts where they exist.
+>
+> **Intel macOS:** `x86_64-darwin` is supported via a pinned nixpkgs revision. Nixpkgs unstable has dropped `x86_64-darwin`; the flake uses a pre-drop pin for that system. Nixpkgs 26.05 will be the last release to support Intel Darwin.
+
+**Development shell** (Rust toolchain + PostgreSQL + Redis):
+```bash
+nix develop github:block/buzz
+```
+
 ### I want my own hosted relay
 
 To run a relay for your team without managing servers, you can deploy one to Railway in a click:

--- a/README.md
+++ b/README.md
@@ -148,12 +148,17 @@ nix run github:block/buzz#buzz-relay -- --help
 nix profile install github:block/buzz#buzz-relay
 ```
 
-**Desktop app** (prebuilt release binary, supported platforms only):
+**Desktop app** (built from source via cargo-tauri + pnpm):
 ```bash
-nix run github:block/buzz#buzz-desktop   # macOS Apple Silicon, macOS Intel, Linux x86_64
+nix run github:block/buzz#buzz-desktop
 ```
 
-> **Note:** There is no prebuilt desktop binary for `aarch64-linux`. The CLI and relay are built from source on all four standard platforms (`x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`); the desktop package wraps the official release artifacts where they exist.
+**Desktop app** (prebuilt release binary — faster, but not available on all platforms):
+```bash
+nix run github:block/buzz#buzz-desktop-prebuilt   # macOS Apple Silicon, macOS Intel, Linux x86_64
+```
+
+> **Note:** `buzz-desktop` (source build) is the default and works on all four standard platforms (`x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`). `buzz-desktop-prebuilt` wraps the official release artifacts where they exist; there is no prebuilt binary for `aarch64-linux`. The CLI and relay are always built from source.
 >
 > **Intel macOS:** `x86_64-darwin` is supported via a pinned nixpkgs revision. Nixpkgs unstable has dropped `x86_64-darwin`; the flake uses a pre-drop pin for that system. Nixpkgs 26.05 will be the last release to support Intel Darwin.
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-darwin": {
+      "locked": {
+        "lastModified": 1780271817,
+        "narHash": "sha256-LSTTcdkGRXfAxoshh6ljRedRjBGWRg9/J54ZGW7BwF8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5f85796ab70f9a6ac935b366065d4565288947ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5f85796ab70f9a6ac935b366065d4565288947ac",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-darwin": "nixpkgs-darwin"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,233 @@
+{
+  description = "Buzz — relay, desktop app, and CLI for the Buzz messaging platform";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # x86_64-darwin was dropped from nixos-unstable (26.11). Pin to a commit
+    # from 2026-05-31 (before the drop) that still supports Intel Darwin and
+    # has Rust 1.85+ (edition 2024). Nixpkgs 26.05 will be the last release
+    # to support x86_64-darwin.
+    nixpkgs-darwin.url = "github:NixOS/nixpkgs/5f85796ab70f9a6ac935b366065d4565288947ac";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { self, nixpkgs, nixpkgs-darwin, flake-utils, ... }:
+    let
+      # Desktop release version — bump on every desktop release.
+      # Keep in sync with the latest desktop-v* tag on block/buzz.
+      desktopVersion = "0.5.20";
+
+      # All standard Nix target systems. The relay and CLI are cross-platform
+      # Rust; the desktop prebuilt covers a subset (see desktopAssets below).
+      allSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      # Prebuilt desktop release assets. aarch64-linux has no prebuilt desktop
+      # binary — the project does not ship one. See PR body for details.
+      desktopAssets = {
+        "aarch64-darwin" = {
+          file = "Buzz_${desktopVersion}_aarch64.app.tar.gz";
+          sha256 = "sha256-WGViFkd1aiC4ur5mDDT3a0cNvaobCeA0jNLzD54fSx0=";
+        };
+        "x86_64-darwin" = {
+          file = "Buzz_${desktopVersion}_x64.app.tar.gz";
+          sha256 = "sha256-aF515sREKGWpiW01/IWy4KO1Wq6rQHj/GRm5X0UoC1U=";
+        };
+        "x86_64-linux" = {
+          file = "Buzz_${desktopVersion}_amd64.AppImage";
+          sha256 = "sha256-j6qvBOygHA5sFeadNzSCd1R3pub3d6nrmOof6d6Ut84=";
+        };
+      };
+
+      # Git dependency output hashes for Cargo.lock.
+      # Regenerate after Cargo.lock changes: remove one, nix build will error
+      # with the correct hash.
+      cargoOutputHashes = {
+        "aws-creds-0.39.1" = "sha256-QAAm1phmeLFtDRgfDCoHijN1ce/rYzh18KziOUbL+hw=";
+        "mesh-llm-api-client-0.75.1" = "sha256-RXjmM66u40cxnacbvTtCFJShMK4BM+MHOyJ2vQ7Gw60=";
+      };
+
+      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f system);
+
+      # Select the right nixpkgs for the system.
+      # x86_64-darwin uses the pinned pre-drop revision (unstable dropped it).
+      pkgsFor =
+        system:
+        if system == "x86_64-darwin" then
+          nixpkgs-darwin.legacyPackages.${system}
+        else
+          nixpkgs.legacyPackages.${system};
+
+      # Shared build configuration for Rust workspace members.
+      mkRustPackage =
+        {
+          pname,
+          cargoPackage,
+          pkgVersion,
+          metaDescription,
+          mainProgram,
+        }:
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        pkgs.rustPlatform.buildRustPackage {
+          inherit pname;
+          version = pkgVersion;
+          src = pkgs.lib.cleanSource ./.;
+          cargoBuildFlags = [ "-p" cargoPackage ];
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            outputHashes = cargoOutputHashes;
+          };
+          nativeBuildInputs = [ pkgs.pkg-config ];
+          buildInputs =
+            pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.openssl ];
+          doCheck = false;
+          meta = with pkgs.lib; {
+            description = metaDescription;
+            homepage = "https://github.com/block/buzz";
+            license = licenses.asl20;
+            inherit mainProgram;
+            platforms = allSystems;
+          };
+        };
+
+      # Prebuilt desktop app wrapper.
+      desktopFor =
+        system:
+        let
+          pkgs = pkgsFor system;
+          asset = desktopAssets.${system};
+        in
+        pkgs.stdenv.mkDerivation {
+          pname = "buzz-desktop";
+          version = desktopVersion;
+          src = pkgs.fetchurl {
+            url = "https://github.com/block/buzz/releases/download/desktop-v${desktopVersion}/${asset.file}";
+            sha256 = asset.sha256;
+          };
+          sourceRoot = ".";
+          nativeBuildInputs =
+            pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+          buildInputs =
+            pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
+          dontConfigure = true;
+          dontBuild = true;
+          installPhase =
+            if pkgs.stdenv.isDarwin then
+              ''
+                runHook preInstall
+                mkdir -p "$out/Applications"
+                tar xzf "$src" -C "$out/Applications"
+                runHook postInstall
+              ''
+            else
+              ''
+                runHook preInstall
+                mkdir -p "$out/bin"
+                cp "$src" "$out/bin/buzz-desktop"
+                chmod +x "$out/bin/buzz-desktop"
+                runHook postInstall
+              '';
+          meta = with pkgs.lib; {
+            description = "Buzz desktop app — Tauri 2 + React 19 desktop client";
+            homepage = "https://github.com/block/buzz";
+            downloadPage = "https://github.com/block/buzz/releases";
+            license = licenses.asl20;
+            mainProgram = "buzz-desktop";
+            platforms = builtins.attrNames desktopAssets;
+            sourceProvenance = [ sourceTypes.binaryNativeCode ];
+          };
+        };
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          buzz-cli = mkRustPackage {
+            pname = "buzz-cli";
+            cargoPackage = "buzz-cli";
+            pkgVersion = "0.1.0";
+            metaDescription = "Buzz CLI — agent-first command line interface";
+            mainProgram = "buzz";
+          } system;
+          buzz-relay = mkRustPackage {
+            pname = "buzz-relay";
+            cargoPackage = "buzz-relay";
+            pkgVersion = "0.2.1";
+            metaDescription = "Buzz relay — WebSocket relay server";
+            mainProgram = "buzz-relay";
+          } system;
+        in
+        rec {
+          inherit buzz-cli buzz-relay;
+          buzz = buzz-cli;
+          buzz-desktop =
+            if desktopAssets ? ${system} then
+              desktopFor system
+            else
+              throw "buzz-desktop: no prebuilt binary for ${system}";
+          default = buzz-cli;
+        }
+      );
+
+      apps = forAllSystems (
+        system:
+        {
+          buzz = {
+            type = "app";
+            program = "${self.packages.${system}.buzz-cli}/bin/buzz";
+          };
+          buzz-relay = {
+            type = "app";
+            program = "${self.packages.${system}.buzz-relay}/bin/buzz-relay";
+          };
+          default = self.apps.${system}.buzz;
+        }
+        // nixpkgs.lib.optionalAttrs (desktopAssets ? ${system}) {
+          buzz-desktop = {
+            type = "app";
+            program =
+              if system == "x86_64-linux" then
+                "${self.packages.${system}.buzz-desktop}/bin/buzz-desktop"
+              else
+                "${self.packages.${system}.buzz-desktop}/Applications/Buzz.app/Contents/MacOS/Buzz";
+          };
+        }
+      );
+
+      checks = forAllSystems (
+        system:
+        {
+          buzz-cli = self.packages.${system}.buzz-cli;
+          buzz-relay = self.packages.${system}.buzz-relay;
+        }
+        // nixpkgs.lib.optionalAttrs (desktopAssets ? ${system}) {
+          buzz-desktop = self.packages.${system}.buzz-desktop;
+        }
+      );
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          default = pkgs.mkShell {
+            nativeBuildInputs = [ pkgs.pkg-config ];
+            buildInputs =
+              [ pkgs.cargo pkgs.rustc ]
+              ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.openssl ]
+              # Runtime service deps for buzz-relay development
+              ++ [ pkgs.postgresql pkgs.redis ];
+          };
+        }
+      );
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,8 @@
       desktopVersion = "0.5.20";
 
       # All standard Nix target systems. The relay and CLI are cross-platform
-      # Rust; the desktop prebuilt covers a subset (see desktopAssets below).
+      # Rust; the desktop source build covers all four, the prebuilt covers a
+      # subset (see desktopAssets below).
       allSystems = [
         "x86_64-linux"
         "aarch64-linux"
@@ -28,7 +29,8 @@
       ];
 
       # Prebuilt desktop release assets. aarch64-linux has no prebuilt desktop
-      # binary — the project does not ship one. See PR body for details.
+      # binary — the project does not ship one. Use buzz-desktop (source build)
+      # for aarch64-linux instead.
       desktopAssets = {
         "aarch64-darwin" = {
           file = "Buzz_${desktopVersion}_aarch64.app.tar.gz";
@@ -98,15 +100,28 @@
           };
         };
 
-      # Prebuilt desktop app wrapper.
-      desktopFor =
+      # Source-built desktop app (cargo-tauri + pnpm + native deps).
+      # This is the default buzz-desktop package.
+      desktopFromSource =
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        pkgs.callPackage ./nix/buzz.nix {
+          src = pkgs.lib.cleanSource ./.;
+        };
+
+      # Prebuilt desktop app wrapper (release artifacts).
+      # Faster to install than the source build, but not available on all
+      # platforms and cannot be patched.
+      desktopPrebuilt =
         system:
         let
           pkgs = pkgsFor system;
           asset = desktopAssets.${system};
         in
         pkgs.stdenv.mkDerivation {
-          pname = "buzz-desktop";
+          pname = "buzz-desktop-prebuilt";
           version = desktopVersion;
           src = pkgs.fetchurl {
             url = "https://github.com/block/buzz/releases/download/desktop-v${desktopVersion}/${asset.file}";
@@ -136,7 +151,7 @@
                 runHook postInstall
               '';
           meta = with pkgs.lib; {
-            description = "Buzz desktop app — Tauri 2 + React 19 desktop client";
+            description = "Buzz desktop app (prebuilt release binary) — Tauri 2 + React 19 desktop client";
             homepage = "https://github.com/block/buzz";
             downloadPage = "https://github.com/block/buzz/releases";
             license = licenses.asl20;
@@ -168,11 +183,16 @@
         rec {
           inherit buzz-cli buzz-relay;
           buzz = buzz-cli;
-          buzz-desktop =
+          # Source-built desktop (default) — builds from the Tauri + React
+          # source with cargo-tauri, pnpm, and native dependencies.
+          buzz-desktop = desktopFromSource system;
+          # Prebuilt desktop (alternative) — wraps the release artifact for
+          # faster installation where a prebuilt binary exists.
+          buzz-desktop-prebuilt =
             if desktopAssets ? ${system} then
-              desktopFor system
+              desktopPrebuilt system
             else
-              throw "buzz-desktop: no prebuilt binary for ${system}";
+              throw "buzz-desktop-prebuilt: no release binary for ${system}";
           default = buzz-cli;
         }
       );
@@ -191,13 +211,13 @@
           default = self.apps.${system}.buzz;
         }
         // nixpkgs.lib.optionalAttrs (desktopAssets ? ${system}) {
-          buzz-desktop = {
+          buzz-desktop-prebuilt = {
             type = "app";
             program =
               if system == "x86_64-linux" then
-                "${self.packages.${system}.buzz-desktop}/bin/buzz-desktop"
+                "${self.packages.${system}.buzz-desktop-prebuilt}/bin/buzz-desktop"
               else
-                "${self.packages.${system}.buzz-desktop}/Applications/Buzz.app/Contents/MacOS/Buzz";
+                "${self.packages.${system}.buzz-desktop-prebuilt}/Applications/Buzz.app/Contents/MacOS/Buzz";
           };
         }
       );
@@ -209,7 +229,7 @@
           buzz-relay = self.packages.${system}.buzz-relay;
         }
         // nixpkgs.lib.optionalAttrs (desktopAssets ? ${system}) {
-          buzz-desktop = self.packages.${system}.buzz-desktop;
+          buzz-desktop-prebuilt = self.packages.${system}.buzz-desktop-prebuilt;
         }
       );
 

--- a/nix/buzz.nix
+++ b/nix/buzz.nix
@@ -1,0 +1,217 @@
+{
+  lib,
+  rustPlatform,
+  fetchPnpmDeps,
+  fetchurl,
+  linkFarm,
+  runCommand,
+  symlinkJoin,
+  perl,
+  cmake,
+  cargo-tauri,
+  git,
+  nodejs,
+  pnpm,
+  pnpmConfigHook,
+  pkg-config,
+  autoPatchelfHook,
+  wrapGAppsHook3,
+  gst_all_1,
+  glib-networking,
+  bzip2,
+  openssl,
+  webkitgtk_4_1,
+  alsa-lib,
+  libopus,
+  dbus,
+  glib,
+  gtk3,
+  libayatana-appindicator,
+  libsoup_3,
+  librsvg,
+  libiconv,
+  stdenv,
+  src,
+}:
+
+let
+  versions = import ./versions.nix;
+  desktopVersion =
+    (builtins.fromTOML (builtins.readFile (src + "/desktop/src-tauri/Cargo.toml"))).package.version;
+
+  sherpaOnnxSystemConfig =
+    versions.sherpaOnnx.systems.${stdenv.hostPlatform.system}
+      or (builtins.throw "Unsupported platform: ${stdenv.hostPlatform.system}. Supported platforms: ${builtins.toString (builtins.attrNames versions.sherpaOnnx.systems)}");
+
+  sherpaOnnxArchive = fetchurl {
+    name = "sherpa-onnx-v${versions.sherpaOnnx.version}-${sherpaOnnxSystemConfig.urlSuffix}.tar.bz2";
+    url = "https://github.com/k2-fsa/sherpa-onnx/releases/download/v${versions.sherpaOnnx.version}/sherpa-onnx-v${versions.sherpaOnnx.version}-${sherpaOnnxSystemConfig.urlSuffix}.tar.bz2";
+    hash = sherpaOnnxSystemConfig.hash;
+  };
+
+  sherpaOnnxArchiveDir = linkFarm "sherpa-onnx-archive" [
+    {
+      name = "sherpa-onnx-v${versions.sherpaOnnx.version}-${sherpaOnnxSystemConfig.urlSuffix}.tar.bz2";
+      path = sherpaOnnxArchive;
+    }
+  ];
+
+  workspaceCargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    name = "buzz-sidecars-${desktopVersion}";
+    hash = versions.workspaceCargoHash;
+  };
+
+  sidecarPackages = [
+    "buzz-acp"
+    "buzz-agent"
+    "buzz-dev-mcp"
+    "git-credential-nostr"
+    "buzz-cli"
+  ];
+  sidecarBinNames = [
+    "buzz-acp"
+    "buzz-agent"
+    "buzz-dev-mcp"
+    "git-credential-nostr"
+    "buzz"
+  ];
+  sidecars = rustPlatform.buildRustPackage {
+    pname = "buzz-sidecars";
+    version = desktopVersion;
+
+    inherit src;
+
+    cargoDeps = workspaceCargoDeps;
+
+    cargoBuildFlags = lib.concatLists (
+      map (p: [
+        "-p"
+        p
+      ]) sidecarPackages
+    );
+    doCheck = false;
+
+    nativeBuildInputs = [
+      cmake
+      pkg-config
+    ];
+
+    buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+      openssl
+    ];
+
+    meta = with lib; {
+      description = "Buzz sidecar binaries";
+      license = licenses.asl20;
+      platforms = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+    };
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "buzz-desktop";
+  version = desktopVersion;
+  inherit src;
+
+  cargoRoot = "desktop/src-tauri";
+  buildAndTestSubdir = "desktop/src-tauri";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    name = "buzz-desktop-${desktopVersion}";
+    srcSubdir = "desktop/src-tauri";
+    hash = versions.desktopCargoHash;
+  };
+
+  doCheck = false;
+
+  AWS_LC_SYS_CMAKE_BUILDER = 1;
+
+  pnpmDeps = fetchPnpmDeps {
+    pname = "buzz-workspace";
+    inherit (finalAttrs) version src;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = versions.pnpmHash;
+  };
+
+  pnpmWorkspaces = [ "buzz" ];
+
+  preBuild = ''
+    export SHERPA_ONNX_ARCHIVE_DIR=${sherpaOnnxArchiveDir}
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      export LD_LIBRARY_PATH=${lib.makeLibraryPath [ bzip2 ]}
+    ''}
+
+    mkdir -p desktop/src-tauri/binaries
+    for bin in ${builtins.concatStringsSep " " sidecarBinNames}; do
+      cp ${sidecars}/bin/$bin desktop/src-tauri/binaries/$bin-${stdenv.hostPlatform.config}
+    done
+  '';
+
+  # Project clone/fetch/push operations are performed by git itself. The
+  # Nostr credential helper is bundled as a Tauri sidecar, while this makes
+  # a compatible git client available to the launched desktop application.
+  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    gappsWrapperArgs+=(--prefix PATH : "${lib.makeBinPath [ git ]}")
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    cargo-tauri.hook
+    nodejs
+    perl
+    pnpmConfigHook
+    pnpm
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+    wrapGAppsHook3
+  ];
+
+  buildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [
+      alsa-lib
+      bzip2
+      libopus
+      dbus
+      glib
+      gtk3
+      libayatana-appindicator
+      libsoup_3
+      librsvg
+      glib-networking
+      openssl
+      webkitgtk_4_1
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-good
+      gst_all_1.gst-plugins-bad
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+
+  passthru = {
+    inherit sherpaOnnxArchiveDir sidecars;
+  };
+
+  meta = with lib; {
+    description = "Buzz desktop app — Tauri 2 + React 19 desktop client";
+    homepage = "https://github.com/block/buzz";
+    # sherpa-onnx statically links GPL-3.0-or-later eSpeak NG code.
+    license = licenses.gpl3Plus;
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    mainProgram = "buzz-desktop";
+  };
+})

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -1,0 +1,38 @@
+{
+  # sherpa-onnx static library archive for huddle audio.
+  # Per-platform archive URL and hash.
+  # Regenerate hashes after version bump: run
+  #   nix-prefetch-url <url>
+  # for each platform.
+  sherpaOnnx = {
+    version = "1.13.4";
+    systems = {
+      "x86_64-linux" = {
+        urlSuffix = "linux-x64-static-lib";
+        hash = "sha256-mLDjGZZCb254JE284ZVVSPLGTo8BxL51uFr3zaoujVw=";
+      };
+      "aarch64-linux" = {
+        urlSuffix = "linux-aarch64-static-lib";
+        hash = "sha256-I7M2Fnh8yUnVsUOOl5RVD4BeIIoBTFwiRUgyB8WLvA8=";
+      };
+      "x86_64-darwin" = {
+        urlSuffix = "osx-x64-static-lib";
+        hash = "sha256-K9osELMaHPxF2fnhS9SYN0PsN3nTCeQtmabI+haJBD8=";
+      };
+      "aarch64-darwin" = {
+        urlSuffix = "osx-arm64-static-lib";
+        hash = "sha256-V4Adsru3hqXTQ/UVo4/yELQBhCM4vcgE+gdTEtHNJAQ=";
+      };
+    };
+  };
+
+  # Vendored dependency hashes for the root and desktop Cargo.lock files.
+  # Regenerate after either lock file changes by replacing its hash with
+  # lib.fakeHash in nix/buzz.nix and building the affected package.
+  workspaceCargoHash = "sha256-WJj2FSdodTpyXBLY2avrgPShtIUDiewI18tn5+AYntM=";
+  desktopCargoHash = "sha256-WJj2FSdodTpyXBLY2avrgPShtIUDiewI18tn5+AYntM=";
+
+  # Hash for pnpm dependencies (desktop frontend).
+  # Regenerate after package.json / pnpm-lock.yaml changes: remove and let nix build fetch.
+  pnpmHash = "sha256-o59bopq5bDr51AOLOuVYOsy7/c+i1X7zeybz5teYFA4=";
+}


### PR DESCRIPTION
## Summary

Adds a Nix flake so Buzz can be installed through the Nix package manager without requiring a Rust toolchain or Node.

- **`buzz-cli`** and **`buzz-relay`**: built from source via `rustPlatform.buildRustPackage` from the repo's `Cargo.lock`. Available on `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, and `aarch64-darwin`.
- **`buzz-desktop`** (default): built from source via `cargo-tauri` + `pnpm` + native dependencies (WebKitGTK, GStreamer, sherpa-onnx, etc.). Works on all four standard platforms including `aarch64-linux`. This matches the approach used by PRs #3434 and #3734.
- **`buzz-desktop-prebuilt`** (alternative): wraps the prebuilt release artifacts (macOS `.app.tar.gz` and Linux `.AppImage`) where they exist. Faster to install, but not available on all platforms and cannot be patched.
- **`devShell`**: Rust toolchain + PostgreSQL + Redis for local development via `nix develop`.
- **CI workflow** (`.github/workflows/nix.yml`): build checks for CLI, relay, both desktop variants on Linux and Darwin, plus a scheduled daily job that tracks `desktop-v*` releases and opens PRs to bump hashes when a new desktop release ships.

### Platform support

| Package | x86_64-linux | aarch64-linux | x86_64-darwin | aarch64-darwin |
|---|---|---|---|---|
| buzz-cli | source | source | source | source |
| buzz-relay | source | source | source | source |
| buzz-desktop (default) | source | source | source | source |
| buzz-desktop-prebuilt | prebuilt AppImage | not available | prebuilt .app.tar.gz | prebuilt .app.tar.gz |

`x86_64-darwin` uses a pinned pre-drop nixpkgs revision (`5f85796ab70f9a6ac935b366065d4565288947ac`, 2026-05-31) because `nixos-unstable` (26.11) dropped Intel Darwin support. Nixpkgs 26.05 will be the last release to support `x86_64-darwin`.

### Usage

```bash
# CLI
nix run github:block/buzz#buzz-cli -- --help
nix profile install github:block/buzz#buzz-cli

# Relay
nix run github:block/buzz#buzz-relay -- --help
nix profile install github:block/buzz#buzz-relay

# Desktop (source build — default)
nix run github:block/buzz#buzz-desktop

# Desktop (prebuilt — faster, but not on all platforms)
nix run github:block/buzz#buzz-desktop-prebuilt

# Development shell
nix develop github:block/buzz
```

### Design decisions

- **Source build as default for desktop**: Matches the approach in PRs #3434 and #3734. Source builds are the idiomatic Nix approach — they allow patching, work on all platforms, and are reproducible. The prebuilt option is kept as an alternative for faster installation.
- **Prebuilt as alternative**: `buzz-desktop-prebuilt` wraps release artifacts for users who want fast installation on platforms with a prebuilt binary.
- **Source build for CLI/relay**: No standalone release artifacts exist for `buzz-cli` or `buzz-relay`, so they are built from source via Nix's `buildRustPackage`.
- **Sherpa-onnx static libraries**: Fetched per-platform from the k2-fsa/sherpa-onnx GitHub releases. Hashes pinned in `nix/versions.nix`.
- **Sidecar binaries**: The desktop source build compiles sidecar binaries (`buzz-acp`, `buzz-agent`, `buzz-dev-mcp`, `git-credential-nostr`, `buzz-cli`) and places them in the Tauri binaries directory.
- **Two Cargo vendor hashes**: The workspace root `Cargo.lock` and `desktop/src-tauri/Cargo.lock` are vendored separately via `rustPlatform.fetchCargoVendor`.
- **Pnpm hash**: The pnpm dependency hash is pinned in `nix/versions.nix`. It may need adjustment if the nixpkgs pnpm version differs from the one used to compute it.

### Files added

- `flake.nix` — flake outputs (packages, apps, checks, devShells)
- `flake.lock` — pinned inputs
- `nix/buzz.nix` — desktop source build expression (cargo-tauri + pnpm + sidecars + sherpa-onnx)
- `nix/versions.nix` — pinned versions and hashes (sherpa-onnx, cargo vendor, pnpm)
- `.github/workflows/nix.yml` — CI with build checks and scheduled hash automation
- `README.md` — Nix installation documentation

#### Test plan

- [x] `nix build .#buzz-cli` succeeds on `x86_64-darwin`
- [x] `nix run .#buzz-cli -- --help` prints help
- [x] `nix build .#buzz-relay` succeeds on `x86_64-darwin`
- [x] `nix run .#buzz-relay` starts (fails on DB connection as expected without Postgres)
- [x] `nix build .#buzz-desktop-prebuilt` succeeds on `x86_64-darwin`
- [x] `nix flake check --no-build` passes
- [x] Flake evaluates for both `buzz-desktop` and `buzz-desktop-prebuilt` on `x86_64-darwin`
- [ ] CI validates `buzz-desktop` source build on `x86_64-linux` and `aarch64-darwin`
- [ ] CI validates `buzz-desktop-prebuilt` on `x86_64-linux` and `aarch64-darwin`
- [ ] Pnpm hash matches nixpkgs pnpm version (may need adjustment on Linux CI)