### PR TITLE
fix(cli): preserve self-target member role updates

### DIFF
--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -586,7 +586,11 @@ pub fn build_add_member(
     if let Some(r) = role {
         tags.push(tag(&["role", r.as_str()])?);
     }
-    Ok(EventBuilder::new(Kind::Custom(9000), "").tags(tags))
+    // A role update may target the signer. nostr strips matching `p` tags by
+    // default, but kind:9000 requires that tag to identify the member.
+    Ok(EventBuilder::new(Kind::Custom(9000), "")
+        .tags(tags)
+        .allow_self_tagging())
 }
 
 /// Build a NIP-29 remove-member event (kind 9001).
@@ -2940,6 +2944,23 @@ mod tests {
         assert_eq!(ev.kind.as_u16(), 9000);
         assert!(has_tag(&ev, "p", pubkey));
         assert!(has_tag(&ev, "role", "admin"));
+    }
+
+    #[test]
+    fn add_member_preserves_self_target_p_tag_for_role_update() {
+        let cid = uuid();
+        let signer = keys();
+        let self_pubkey = signer.public_key().to_hex();
+        let ev = build_add_member(cid, &self_pubkey, Some(MemberRole::Bot))
+            .unwrap()
+            .sign_with_keys(&signer)
+            .expect("sign");
+
+        assert!(
+            has_tag(&ev, "p", &self_pubkey),
+            "self-target role update must retain its required p tag"
+        );
+        assert!(has_tag(&ev, "role", "bot"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve the required `p` tag when a kind:9000 member-role update targets the signer
- add a signed-event regression test for an owner changing its own channel role to `bot`
- leave relay and database authorization, including elevated-actor and last-owner guards, unchanged

## Root cause

`buzz channels add-member` correctly passed the requested target pubkey to `buzz_sdk::build_add_member`, which constructed `h`, `p`, and `role` tags. During signing, `nostr` 0.44 removed a `p` tag matching the signer unless the builder opted into self-tagging. The relay therefore received a self-targeted kind:9000 event without its target and rejected it as `invalid: missing p tag`. Non-self operations retained their `p` tag and continued to work.

The fix applies `.allow_self_tagging()` only to the shared kind:9000 builder, matching existing self-targeting builders elsewhere in the SDK.

## Security

No relay or database authorization code changes. The relay still requires an owner/admin to change an active member's role, and both relay and database layers still reject demotion of the last owner. The operational creator-agent flow therefore requires another owner to exist before self-demotion.

## Verification

Exact verified head: `9e63d6a54e0d9b225a5d64dfa9baa8cf49af6694`

- TDD red: the new signed-event regression failed on the old builder because the self-target `p` tag was absent
- TDD green: focused regression passed after the builder opt-in
- `cargo test -p buzz-sdk -p buzz-cli` — 302 SDK and 385 CLI tests passed; no failures
- `cargo fmt --all -- --check` — passed
- `cargo clippy -p buzz-sdk -p buzz-cli --all-targets -- -D warnings` — passed
- `git diff --check` — passed
- `cargo build --release -p buzz-cli` — passed

Originating Buzz channel UUID: `75cb549d-7927-4a21-a844-d4018bf6dfc3`

This PR does not merge or deploy anything.
