### PR TITLE
fix(media): explain clock skew behind an opaque upload 401

### DIFF
--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine;
+use buzz_core::clock_skew::ClockOffsetBounds;
+use chrono::Utc;
 use nostr::{EventBuilder, JsonUtil, Keys, Kind, Tag};
 use sha2::{Digest, Sha256};
 
@@ -74,6 +76,25 @@ const MAX_IMAGE_BYTES: u64 = 50 * 1024 * 1024;
 
 /// Maximum file size for video uploads (500 MB).
 const MAX_VIDEO_BYTES: u64 = 500 * 1024 * 1024;
+
+/// Lifetime stamped on a Blossom upload token, in seconds.
+///
+/// Video uploads get an hour to survive a slow connection; everything else gets
+/// ten minutes. `sign_blossom_upload` stamps the `expiration` from this, and
+/// the clock diagnosis reads the same value to judge how far behind a clock
+/// would have to be for a token to arrive already expired — one definition, so
+/// the two cannot disagree.
+fn upload_token_lifetime_secs(mime: &str) -> u64 {
+    if mime.starts_with("video/") {
+        3600
+    } else {
+        600
+    }
+}
+
+/// Timeout for the clock-skew probe. Short on purpose: the probe only runs
+/// after an upload has already failed, and must not stretch out the failure.
+const CLOCK_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Sign a NIP-98 HTTP auth event (kind:27235) and return the Authorization header value.
 ///
@@ -357,12 +378,7 @@ fn sign_blossom_upload(
     use nostr::Timestamp;
 
     let now = Timestamp::now().as_secs();
-    let expiry: u64 = if mime.starts_with("video/") {
-        3600
-    } else {
-        600
-    };
-    let exp_str = (now + expiry).to_string();
+    let exp_str = (now + upload_token_lifetime_secs(mime)).to_string();
 
     let mut tags = vec![
         Tag::parse(["t", "upload"]).map_err(|e| CliError::Other(e.to_string()))?,
@@ -1116,6 +1132,62 @@ impl BuzzClient {
         .to_string())
     }
 
+    /// Explain a refused upload when this machine's clock is provably why.
+    ///
+    /// Runs its own `HEAD` of the upload route rather than reading the `Date`
+    /// off the rejection: the relay verifies Blossom auth *before* it reads the
+    /// body, so on a large upload that header was stamped at the start of a
+    /// transfer that ran for minutes, and treating it as "the relay's clock
+    /// now" would pin every slow-upload 401 on a healthy clock. A dedicated
+    /// round trip is the only one short enough to bound.
+    ///
+    /// The local clock is read either side of that round trip so the offset is
+    /// bracketed rather than estimated. `None` whenever the observation does
+    /// not prove drift — no `Date`, probe failed, or a clock the relay would
+    /// have accepted.
+    async fn diagnose_upload_clock(&self, token_lifetime_secs: u64) -> Option<String> {
+        let before = Utc::now().timestamp_millis();
+        let resp = self
+            .http
+            .head(format!("{}/upload", self.relay_url))
+            .header(reqwest::header::CACHE_CONTROL, "no-cache")
+            .timeout(CLOCK_PROBE_TIMEOUT)
+            .send()
+            .await
+            .ok()?;
+        let after = Utc::now().timestamp_millis();
+        // Only a cache sends `Age`, and a cached reply carries the origin's
+        // original `Date` — a clock reading as stale as the cache entry. Refuse
+        // to measure rather than try to correct for it.
+        if resp.headers().contains_key(reqwest::header::AGE) {
+            return None;
+        }
+        let date = resp.headers().get(reqwest::header::DATE)?.to_str().ok()?;
+        ClockOffsetBounds::measure(before, after, date)?.media_auth_advice(token_lifetime_secs)
+    }
+
+    /// Append a clock-skew explanation to a refused upload's error body, when
+    /// this machine's clock is provably the cause.
+    ///
+    /// The relay's own message is kept: a 401 has many possible causes and only
+    /// one of them is the clock, so replacing the body would throw away the
+    /// evidence whenever the diagnosis is wrong.
+    async fn explain_upload_rejection(&self, status: u16, body: String, mime: &str) -> CliError {
+        if status != 401 {
+            return CliError::Relay { status, body };
+        }
+        match self
+            .diagnose_upload_clock(upload_token_lifetime_secs(mime))
+            .await
+        {
+            Some(advice) => CliError::Relay {
+                status,
+                body: format!("{body}\n\n{advice}"),
+            },
+            None => CliError::Relay { status, body },
+        }
+    }
+
     /// Upload a file to the relay's Blossom endpoint.
     /// Returns a BlobDescriptor on success.
     pub async fn upload_file(&self, file_path: &str) -> Result<BlobDescriptor, CliError> {
@@ -1193,7 +1265,7 @@ impl BuzzClient {
                     if !status.is_success() {
                         let s = status.as_u16();
                         let body = resp.text().await.unwrap_or_default();
-                        return Err(CliError::Relay { status: s, body });
+                        return Err(self.explain_upload_rejection(s, body, &mime).await);
                     }
                     resp.json::<BlobDescriptor>().await.map_err(CliError::from)
                 }
@@ -1238,7 +1310,7 @@ impl BuzzClient {
                 if !resp.status().is_success() {
                     let status = resp.status().as_u16();
                     let body = resp.text().await.unwrap_or_default();
-                    return Err(CliError::Relay { status, body });
+                    return Err(self.explain_upload_rejection(status, body, &mime).await);
                 }
                 resp.json::<BlobDescriptor>().await.map_err(CliError::from)
             }
@@ -2551,6 +2623,236 @@ mod tests {
         assert!(
             built.headers().get("x-auth-tag").is_none(),
             "x-auth-tag header must not be present when no auth tag is configured"
+        );
+    }
+}
+
+/// Upload clock-skew diagnosis: a drifted system clock makes the relay refuse
+/// Blossom auth with an opaque 401. These tests pin the behaviour that names
+/// the clock when it is provably at fault, keeps quiet when it is not, and
+/// never withholds what the relay actually said.
+#[cfg(test)]
+mod upload_clock_skew_tests {
+    use std::io::Write;
+    use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::extract::State;
+    use axum::http::{Response, StatusCode};
+    use axum::routing::head;
+    use axum::Router;
+    use nostr::Keys;
+    use tokio::net::TcpListener;
+
+    use super::super::error::CliError;
+    use super::BuzzClient;
+
+    /// Smallest byte sequence `infer` reports as `image/png`.
+    const PNG_MAGIC: &[u8] = b"\x89PNG\r\n\x1a\n";
+    /// What the stand-in relay says when it refuses an upload — the opaque
+    /// message the real relay sends for every auth failure.
+    const RELAY_401_BODY: &str = "{\"error\":\"authentication failed\"}";
+
+    /// The `Date` a server whose clock sits `delta` seconds from ours would send.
+    ///
+    /// A *negative* delta is a server behind us, which is what a local clock
+    /// running fast looks like from the client's side.
+    fn date_header(delta_secs: i64) -> String {
+        (chrono::Utc::now() + chrono::Duration::seconds(delta_secs))
+            .format("%a, %d %b %Y %H:%M:%S GMT")
+            .to_string()
+    }
+
+    struct SkewServer {
+        base_url: String,
+        /// `PUT /upload` attempts — the upload itself.
+        put_attempts: Arc<AtomicU32>,
+        /// `HEAD /upload` attempts — the clock probe, which must only ever fire
+        /// after an upload has already been refused.
+        probe_attempts: Arc<AtomicU32>,
+    }
+
+    /// A `Date` value no parser can read, standing in for the proxy that mangles
+    /// the header. Overwriting is the only way to test this: hyper stamps a
+    /// valid `Date` on any response that omits one, so a handler cannot produce
+    /// a header-less reply.
+    const UNREADABLE_DATE: &str = "whenever o'clock";
+
+    /// Spawn a relay stand-in that dates its responses as if its clock sat
+    /// `delta` seconds from ours. `None` replaces the header with
+    /// [`UNREADABLE_DATE`], leaving nothing to measure against.
+    ///
+    /// The probe (`HEAD`) and the rejection (`PUT` → 401) are dated separately,
+    /// so a test can prove which of the two the diagnosis actually trusts.
+    async fn skew_server(probe_delta: Option<i64>, reject_delta: Option<i64>) -> SkewServer {
+        let put_attempts = Arc::new(AtomicU32::new(0));
+        let probe_attempts = Arc::new(AtomicU32::new(0));
+        let state = (
+            probe_delta,
+            reject_delta,
+            put_attempts.clone(),
+            probe_attempts.clone(),
+        );
+        type S = (Option<i64>, Option<i64>, Arc<AtomicU32>, Arc<AtomicU32>);
+
+        fn dated(status: StatusCode, delta: Option<i64>, body: &'static str) -> Response<Body> {
+            let date = delta.map_or_else(|| UNREADABLE_DATE.to_string(), date_header);
+            Response::builder()
+                .status(status)
+                .header("date", date)
+                .body(Body::from(body))
+                .expect("valid response")
+        }
+
+        let app = Router::new()
+            .route(
+                "/upload",
+                head(|State((probe, _, _, probes)): State<S>| async move {
+                    probes.fetch_add(1, Ordering::SeqCst);
+                    dated(StatusCode::METHOD_NOT_ALLOWED, probe, "")
+                })
+                .put(
+                    |State((_, reject, puts, _)): State<S>, _body: Body| async move {
+                        puts.fetch_add(1, Ordering::SeqCst);
+                        dated(StatusCode::UNAUTHORIZED, reject, RELAY_401_BODY)
+                    },
+                ),
+            )
+            .with_state(state);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr: SocketAddr = listener.local_addr().expect("addr");
+        tokio::spawn(async move { axum::serve(listener, app).await.expect("serve") });
+        SkewServer {
+            base_url: format!("http://{addr}"),
+            put_attempts,
+            probe_attempts,
+        }
+    }
+
+    /// Upload a tiny PNG to the given server and return the resulting error.
+    async fn upload_png_err(server: &SkewServer) -> CliError {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        file.write_all(PNG_MAGIC).expect("write png magic");
+        file.flush().expect("flush");
+
+        let client =
+            BuzzClient::new(server.base_url.clone(), Keys::generate(), None, None).expect("client");
+        client
+            .upload_file(file.path().to_str().expect("utf-8 path"))
+            .await
+            .expect_err("upload must fail against this stand-in relay")
+    }
+
+    /// The reported bug: a clock running fast earns a named cause. The relay's
+    /// own message survives alongside it, and the error stays a `Relay` 401 so
+    /// exit codes and the JSON error category are unchanged.
+    #[tokio::test]
+    async fn a_fast_clock_is_named_on_the_rejection() {
+        let server = skew_server(Some(-30), Some(-30)).await;
+        let err = upload_png_err(&server).await;
+
+        let CliError::Relay { status, ref body } = err else {
+            panic!("expected a relay error, got {err}");
+        };
+        assert_eq!(status, 401);
+        assert!(body.contains("authentication failed"), "{body}");
+        assert!(body.contains("ahead of"), "{body}");
+        assert!(body.contains("w32tm"), "{body}");
+        assert_eq!(server.probe_attempts.load(Ordering::SeqCst), 1);
+    }
+
+    /// The asymmetric half: the backward bound is the token's own lifetime, so
+    /// it takes a much larger drift to trip, and the message says "behind".
+    #[tokio::test]
+    async fn a_slow_clock_is_named_too() {
+        let server = skew_server(Some(1200), Some(1200)).await;
+        let err = upload_png_err(&server).await;
+
+        assert!(err.to_string().contains("behind"), "{err}");
+    }
+
+    /// Regression test for the misdiagnosis this design was rebuilt to avoid.
+    ///
+    /// The relay verifies Blossom auth *before* it reads the body, so a large
+    /// upload that is refused at the start observes a `Date` stamped minutes
+    /// earlier. Reading the clock off that rejection would blame a perfectly
+    /// healthy clock for someone else's auth failure. The diagnosis must ignore
+    /// the rejection's own `Date` and trust only its own bounded probe.
+    #[tokio::test]
+    async fn a_stale_date_on_the_rejection_is_not_mistaken_for_drift() {
+        let server = skew_server(Some(0), Some(-600)).await;
+        let err = upload_png_err(&server).await;
+
+        let message = err.to_string();
+        assert!(
+            !message.contains("clock"),
+            "a healthy clock must not be blamed for a stale rejection date: {message}"
+        );
+        assert!(message.contains("authentication failed"), "{message}");
+    }
+
+    /// A synced clock is never blamed, so a genuine auth problem keeps the
+    /// relay's message and nothing else.
+    #[tokio::test]
+    async fn a_synced_clock_leaves_the_relays_401_alone() {
+        let server = skew_server(Some(0), Some(0)).await;
+        let err = upload_png_err(&server).await;
+
+        let CliError::Relay { status, ref body } = err else {
+            panic!("expected a relay error, got {err}");
+        };
+        assert_eq!(status, 401);
+        assert_eq!(body.trim(), RELAY_401_BODY);
+    }
+
+    /// With no readable `Date` to measure against there is nothing to say, and
+    /// the failure is reported exactly as it was before. This covers the
+    /// unparseable-header branch, which a synced-clock test cannot reach.
+    #[tokio::test]
+    async fn an_unreadable_date_header_changes_nothing() {
+        let server = skew_server(None, None).await;
+        let err = upload_png_err(&server).await;
+
+        let CliError::Relay { status, ref body } = err else {
+            panic!("expected a relay error, got {err}");
+        };
+        assert_eq!(status, 401);
+        assert_eq!(body.trim(), RELAY_401_BODY);
+        assert_eq!(server.probe_attempts.load(Ordering::SeqCst), 1);
+        assert!(server.put_attempts.load(Ordering::SeqCst) >= 1);
+    }
+
+    /// A failure that is not a 401 is none of this code's business: no probe
+    /// fires and the relay's error is returned untouched.
+    #[tokio::test]
+    async fn a_non_401_failure_is_not_probed_at_all() {
+        let server = skew_server(Some(-30), Some(-30)).await;
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        file.write_all(PNG_MAGIC).expect("write png magic");
+        file.flush().expect("flush");
+
+        // `/media/upload` is the legacy alias; this stand-in never routes it,
+        // so axum answers 405 and the upload fails without a 401 anywhere.
+        let client = BuzzClient::new(
+            format!("{}/nowhere", server.base_url),
+            Keys::generate(),
+            None,
+            None,
+        )
+        .expect("client");
+        let err = client
+            .upload_file(file.path().to_str().expect("utf-8 path"))
+            .await
+            .expect_err("no upload route exists at this base URL");
+
+        assert!(!err.to_string().contains("clock"), "{err}");
+        assert_eq!(
+            server.probe_attempts.load(Ordering::SeqCst),
+            0,
+            "a non-401 failure must not trigger a clock probe"
         );
     }
 }

--- a/crates/buzz-core/src/clock_skew.rs
+++ b/crates/buzz-core/src/clock_skew.rs
@@ -1,0 +1,372 @@
+//! Deciding whether a local clock is why Blossom media auth was refused.
+//!
+//! A Blossom upload token (`kind:24242`) is stamped with the client's clock and
+//! checked against the relay's. A client whose system clock has drifted mints
+//! tokens the relay reads as out of window and rejects — with a deliberately
+//! opaque `401 authentication failed`, because the media auth errors are
+//! collapsed to defeat enumeration. The failure is therefore indistinguishable
+//! from a signing, scope, or authorization problem, even though it is neither a
+//! Buzz bug nor anything the relay can fix.
+//!
+//! A relay response's `Date` header is a reference clock the client can compare
+//! against. The comparison is not exact: `Date` is truncated to whole seconds,
+//! and the client can only observe it before and after a round trip it does not
+//! control. So this module never computes a point estimate. It brackets the
+//! offset into the interval the observation actually proves, and speaks up only
+//! when that whole interval lies outside what the relay accepts. Anything less
+//! certain stays silent.
+//!
+//! Every function here is pure — the caller supplies the timestamps.
+//!
+//! ```
+//! use buzz_core::clock_skew::ClockOffsetBounds;
+//!
+//! // The relay's `Date` says 09:14:38. The client read its own clock at
+//! // 09:14:44.75 before sending and 09:14:44.95 after the reply arrived, so
+//! // even the most charitable reading has it more than 5s fast.
+//! let bounds = ClockOffsetBounds::measure(
+//!     1_787_822_084_750,
+//!     1_787_822_084_950,
+//!     "Thu, 27 Aug 2026 09:14:38 GMT",
+//! )
+//! .expect("IMF-fixdate parses");
+//!
+//! assert_eq!(bounds.min_millis(), 5_750);
+//! assert!(bounds.media_auth_advice(600).is_some());
+//! ```
+
+use chrono::{DateTime, NaiveDateTime};
+
+/// Seconds a Blossom auth event's `created_at` may lead the verifier's clock
+/// before it is rejected as `TimestampOutOfWindow`.
+///
+/// Mirrors the tolerance enforced by `buzz_media::auth`; a client that widened
+/// this would only make itself quieter, never the relay more permissive.
+pub const BLOSSOM_FUTURE_TOLERANCE_SECS: u64 = 5;
+
+/// Resolution of an HTTP `Date` header, in milliseconds. The header names a
+/// whole second, so the server's true clock at stamp time lies somewhere in the
+/// second that follows it.
+const DATE_RESOLUTION_MILLIS: i64 = 1_000;
+
+/// Parse an RFC 9110 `Date` header into a Unix timestamp in seconds.
+///
+/// Accepts IMF-fixdate (`Thu, 27 Aug 2026 09:14:38 GMT`), which RFC 9110
+/// requires senders to emit, and falls back to RFC 2822 for senders that use a
+/// numeric offset. The obsolete RFC 850 and asctime forms are not accepted;
+/// they yield `None`, which costs a diagnosis and nothing else.
+pub fn parse_http_date(value: &str) -> Option<i64> {
+    let value = value.trim();
+    if let Ok(naive) = NaiveDateTime::parse_from_str(value, "%a, %d %b %Y %H:%M:%S GMT") {
+        return Some(naive.and_utc().timestamp());
+    }
+    DateTime::parse_from_rfc2822(value)
+        .ok()
+        .map(|dt| dt.timestamp())
+}
+
+/// The interval of local-clock offsets consistent with one observed exchange.
+///
+/// Positive means the local clock is ahead of the server's.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClockOffsetBounds {
+    min_millis: i64,
+    max_millis: i64,
+}
+
+impl ClockOffsetBounds {
+    /// Bracket the local clock's offset from one request/response pair.
+    ///
+    /// `before` and `after` are local Unix **milliseconds**, read immediately
+    /// before the request was sent and immediately after the response arrived;
+    /// the server stamped `Date` somewhere between them. Writing `Δ` for the
+    /// true offset, `D` for the parsed header and `S` for the server's real
+    /// clock at stamp time, `D ≤ S < D + 1s` and `before − Δ ≤ S ≤ after − Δ`,
+    /// which rearranges to
+    ///
+    /// ```text
+    /// before − D − 1s  ≤  Δ  ≤  after − D
+    /// ```
+    ///
+    /// Both bounds hold whatever the network latency was, so no fudge factor is
+    /// needed and none is applied. Milliseconds matter: only the *server's*
+    /// stamp is truncated, so reading the local clock at full resolution keeps
+    /// the interval a second narrower than whole-second readings would — enough
+    /// to place a drift of six-and-change seconds decisively outside a five
+    /// second tolerance.
+    ///
+    /// Returns `None` if the header is unparseable, or if the readings are out
+    /// of order and the interval would be nonsense.
+    pub fn measure(before: i64, after: i64, date_header: &str) -> Option<Self> {
+        if after < before {
+            return None;
+        }
+        let date_millis = parse_http_date(date_header)?.checked_mul(DATE_RESOLUTION_MILLIS)?;
+        Some(Self {
+            min_millis: before - date_millis - DATE_RESOLUTION_MILLIS,
+            max_millis: after - date_millis,
+        })
+    }
+
+    /// The least the local clock can be ahead by, in milliseconds.
+    pub fn min_millis(self) -> i64 {
+        self.min_millis
+    }
+
+    /// The most the local clock can be ahead by, in milliseconds.
+    pub fn max_millis(self) -> i64 {
+        self.max_millis
+    }
+
+    /// A message reporting the drift, or `None` when the observation does not
+    /// prove this clock is outside what media upload auth allows.
+    ///
+    /// # What a verdict does and does not claim
+    ///
+    /// It claims a *measurement*: the local clock is provably outside the
+    /// window, and a clock in that state will break media uploads. It does not
+    /// claim to have diagnosed the 401 in hand, and the wording is careful not
+    /// to. Certainty about *this* rejection is not available to a client: the
+    /// relay compares whole seconds (`created > now + 5`), both sides are
+    /// truncated, and the transit time that separates them is unknown — so a
+    /// drift of, say, 5.6s is rejected or accepted depending on where the two
+    /// clocks happen to fall inside their respective seconds. Asserting cause
+    /// would be wrong in exactly the band this feature exists to serve.
+    ///
+    /// Callers therefore append this to the relay's own message rather than
+    /// replacing it: the user gets a real lead without losing the evidence.
+    ///
+    /// # `token_lifetime_secs`
+    ///
+    /// The `expiration` the client stamps on its own upload tokens. A clock
+    /// behind by more than a token's whole lifetime mints one already expired
+    /// when it lands. This is one of the verifier's two backward bounds, and
+    /// the only one a client knows exactly — the other, `max_age_secs`, is 600s
+    /// or 3600s depending on a pipeline the relay picks by sniffing the body
+    /// bytes rather than trusting `Content-Type`. Where that bound bites first
+    /// this stays silent, which is the safe direction to be wrong in.
+    pub fn media_auth_advice(self, token_lifetime_secs: u64) -> Option<String> {
+        let tolerance_millis = BLOSSOM_FUTURE_TOLERANCE_SECS as i64 * DATE_RESOLUTION_MILLIS;
+        let lifetime_millis = i64::try_from(token_lifetime_secs)
+            .ok()?
+            .checked_mul(DATE_RESOLUTION_MILLIS)?;
+
+        if self.min_millis > tolerance_millis {
+            return Some(Self::advice(
+                self.min_millis,
+                "ahead of",
+                format!("the {BLOSSOM_FUTURE_TOLERANCE_SECS}s that media upload auth allows"),
+            ));
+        }
+        // A token minted this far behind is already expired when it lands. The
+        // extra second absorbs the truncation of the `created_at` the client
+        // stamps, so the expiry is genuinely in the past and not merely level
+        // with the relay's clock.
+        if self.max_millis < -(lifetime_millis + DATE_RESOLUTION_MILLIS) {
+            return Some(Self::advice(
+                -self.max_millis,
+                "behind",
+                format!("the {token_lifetime_secs}s an upload token is valid for"),
+            ));
+        }
+        None
+    }
+
+    fn advice(magnitude_millis: i64, direction: &str, limit: String) -> String {
+        let magnitude = magnitude_millis as f64 / DATE_RESOLUTION_MILLIS as f64;
+        format!(
+            "note: this machine's clock is at least {magnitude:.1}s {direction} the relay's, which \
+             is outside {limit}. A clock this far out makes media uploads fail exactly like this, \
+             so it is worth ruling out before anything else. Sync the system clock and retry \
+             (Windows: start the w32time service, then `w32tm /resync`; macOS and Linux: turn on \
+             automatic network time)."
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Thu, 27 Aug 2026 09:14:38 GMT`
+    const SERVER_UNIX_MILLIS: i64 = 1_787_822_078_000;
+    const SERVER_DATE: &str = "Thu, 27 Aug 2026 09:14:38 GMT";
+    /// The `expiration` the CLI stamps on an image upload token.
+    const IMAGE_TOKEN_LIFETIME: u64 = 600;
+
+    #[test]
+    fn parses_imf_fixdate() {
+        assert_eq!(
+            parse_http_date(SERVER_DATE),
+            Some(SERVER_UNIX_MILLIS / 1_000)
+        );
+    }
+
+    #[test]
+    fn parses_rfc2822_with_a_non_zero_offset() {
+        assert_eq!(
+            parse_http_date("Thu, 27 Aug 2026 09:14:38 +0000"),
+            Some(SERVER_UNIX_MILLIS / 1_000)
+        );
+        // 14:14:38 +0500 is the same instant.
+        assert_eq!(
+            parse_http_date("Thu, 27 Aug 2026 14:14:38 +0500"),
+            Some(SERVER_UNIX_MILLIS / 1_000)
+        );
+    }
+
+    #[test]
+    fn rejects_unparseable_dates() {
+        assert_eq!(parse_http_date(""), None);
+        assert_eq!(parse_http_date("not a date"), None);
+        assert_eq!(parse_http_date("2026-08-27T09:14:38Z"), None);
+    }
+
+    /// An exchange where the local clock is `before` ms fast relative to the
+    /// server's stamp, and the reply came back `after - before` ms later.
+    fn bounds(before_millis: i64, after_millis: i64) -> ClockOffsetBounds {
+        ClockOffsetBounds::measure(
+            SERVER_UNIX_MILLIS + before_millis,
+            SERVER_UNIX_MILLIS + after_millis,
+            SERVER_DATE,
+        )
+        .expect("fixture date parses")
+    }
+
+    #[test]
+    fn brackets_the_offset_around_the_date_header() {
+        let b = bounds(20_000, 21_000);
+        assert_eq!(b.min_millis(), 19_000);
+        assert_eq!(b.max_millis(), 21_000);
+    }
+
+    #[test]
+    fn refuses_to_measure_readings_taken_out_of_order() {
+        assert!(ClockOffsetBounds::measure(
+            SERVER_UNIX_MILLIS + 5,
+            SERVER_UNIX_MILLIS,
+            SERVER_DATE
+        )
+        .is_none());
+        assert!(
+            ClockOffsetBounds::measure(SERVER_UNIX_MILLIS, SERVER_UNIX_MILLIS, "nonsense")
+                .is_none()
+        );
+    }
+
+    /// The regression this exists for: the ~6.75s-fast Windows clock reported
+    /// on the issue. Whole-second local readings would leave this straddling
+    /// the tolerance and silent; millisecond readings prove it.
+    #[test]
+    fn catches_the_reported_fast_clock() {
+        let advice = bounds(6_750, 6_950)
+            .media_auth_advice(IMAGE_TOKEN_LIFETIME)
+            .expect("a 6.75s fast clock is outside the 5s tolerance");
+        assert!(advice.contains("5.8s ahead of"), "{advice}");
+        assert!(
+            advice.contains("5s that media upload auth allows"),
+            "{advice}"
+        );
+    }
+
+    /// The message reports a measurement and a lead. It must not claim to have
+    /// diagnosed the rejection in hand — the relay compares whole seconds
+    /// across an unknown transit delay, so causation is not the client's to
+    /// assert.
+    #[test]
+    fn the_message_does_not_claim_to_explain_the_rejection() {
+        let advice = bounds(30_000, 30_100)
+            .media_auth_advice(IMAGE_TOKEN_LIFETIME)
+            .expect("30s is well outside the tolerance");
+        assert!(
+            !advice.contains("That is why"),
+            "must not assert causation: {advice}"
+        );
+        assert!(advice.contains("worth ruling out"), "{advice}");
+    }
+
+    /// The bug both reviews caught in the first cut of this module: latency
+    /// used to inflate the measured offset, so a correct clock on a slow link
+    /// got blamed. The lower bound is taken *before* the request, so no amount
+    /// of latency can manufacture an "ahead" verdict.
+    #[test]
+    fn latency_alone_never_produces_a_verdict() {
+        for latency in [1_000, 5_000, 30_000, 600_000] {
+            assert!(
+                bounds(0, latency)
+                    .media_auth_advice(IMAGE_TOKEN_LIFETIME)
+                    .is_none(),
+                "{latency}ms of latency on a synced clock must not be blamed"
+            );
+        }
+    }
+
+    /// A verdict must never outrun the interval: a clock the relay's tolerance
+    /// covers must stay silent no matter where the server's stamp fell inside
+    /// its second.
+    ///
+    /// This is the property the message actually asserts — that the drift is
+    /// outside the window — and the truncation term in `measure` is what makes
+    /// it hold. Drop the `- DATE_RESOLUTION_MILLIS` and a synced clock observed
+    /// at a late stamp fraction starts getting reported.
+    #[test]
+    fn a_verdict_never_outruns_what_the_interval_proves() {
+        let tolerance = BLOSSOM_FUTURE_TOLERANCE_SECS as i64 * 1_000;
+        for true_drift in [0, 1_000, 4_999, tolerance] {
+            for stamp_fraction in [0, 1, 500, 999] {
+                // `before - date` reads as the drift plus however far into its
+                // second the server's stamp fell.
+                let observed = true_drift + stamp_fraction;
+                assert!(
+                    bounds(observed, observed + 50)
+                        .media_auth_advice(IMAGE_TOKEN_LIFETIME)
+                        .is_none(),
+                    "a {true_drift}ms drift observed at stamp fraction {stamp_fraction} is within \
+                     the {tolerance}ms tolerance and must stay silent"
+                );
+            }
+        }
+
+        // Just past the tolerance, at the least favourable stamp fraction, the
+        // lower bound clears it and the drift is reported.
+        assert!(bounds(tolerance + 1_001, tolerance + 1_051)
+            .media_auth_advice(IMAGE_TOKEN_LIFETIME)
+            .is_some());
+    }
+
+    /// Skew runs both ways. The backward bound is the token's own lifetime plus
+    /// the second the client's own `created_at` loses to truncation, so a token
+    /// minted this far behind is genuinely expired on arrival rather than level
+    /// with the relay's clock.
+    #[test]
+    fn catches_a_clock_behind_by_more_than_the_token_lives() {
+        let lifetime = IMAGE_TOKEN_LIFETIME as i64 * 1_000;
+        for not_yet in [lifetime, lifetime + 500, lifetime + 1_000] {
+            assert!(
+                bounds(-not_yet, -not_yet)
+                    .media_auth_advice(IMAGE_TOKEN_LIFETIME)
+                    .is_none(),
+                "{not_yet}ms behind is not yet proven to outlive a {lifetime}ms token"
+            );
+        }
+
+        let advice = bounds(-lifetime - 60_000, -lifetime - 60_000)
+            .media_auth_advice(IMAGE_TOKEN_LIFETIME)
+            .expect("beyond the token lifetime");
+        assert!(advice.contains("behind"), "{advice}");
+        assert!(advice.contains("660.0s"), "{advice}");
+        assert!(
+            advice.contains("600s an upload token is valid for"),
+            "{advice}"
+        );
+    }
+
+    /// The backward bound tracks the lifetime the caller actually stamped, so a
+    /// short-lived desktop image token is judged more tightly than a video one.
+    #[test]
+    fn the_backward_bound_follows_the_token_lifetime() {
+        let behind = bounds(-700_000, -700_000);
+        assert!(behind.media_auth_advice(3600).is_none());
+        assert!(behind.media_auth_advice(300).is_some());
+    }
+}

--- a/crates/buzz-core/src/lib.rs
+++ b/crates/buzz-core/src/lib.rs
@@ -9,6 +9,8 @@
 pub mod agent_turn_metric;
 /// Channel and membership enums shared across crates.
 pub mod channel;
+/// Client-side clock-skew detection for Blossom media auth.
+pub mod clock_skew;
 /// NIP-AE Agent Engrams — slug grammar, conversation key, d-tag derivation,
 /// body parse/serialize, envelope build/validate, head selection.
 pub mod engram;

--- a/desktop/src-tauri/src/commands/media.rs
+++ b/desktop/src-tauri/src/commands/media.rs
@@ -13,6 +13,7 @@ use super::media_transcode::{
     transcode_and_extract_poster_with_cancellation, transcode_heic_path_to_jpeg_bytes,
     transcode_heic_path_to_jpeg_bytes_with_cancellation,
 };
+use super::media_upload_auth::{diagnose_upload_rejection, mint_upload_auth_header};
 use super::media_upload_progress::{emit_media_upload_phase, send_upload_attempt, UploadAttempt};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -43,7 +44,7 @@ pub struct BlobDescriptor {
 /// Extract the server authority from a URL for BUD-11 server tag scoping.
 ///
 /// Returns `host` for default ports (80/443), `host:port` for non-default ports.
-fn extract_server_authority(url_str: &str) -> Option<String> {
+pub(super) fn extract_server_authority(url_str: &str) -> Option<String> {
     let parsed = url::Url::parse(url_str).ok()?;
     let host = parsed.host_str()?;
     match parsed.port() {
@@ -373,28 +374,6 @@ pub(crate) fn mint_media_get_auth(state: &AppState, base_url: &str) -> Option<St
     }
 }
 
-fn sign_blossom_upload_auth(
-    keys: &Keys,
-    sha256: &str,
-    expiry_secs: u64,
-    base_url: &str,
-) -> Result<nostr::Event, String> {
-    let now = Timestamp::now().as_secs();
-    let mut tags = vec![
-        Tag::parse(vec!["t", "upload"]).map_err(|e| e.to_string())?,
-        Tag::parse(vec!["x", sha256]).map_err(|e| e.to_string())?,
-        Tag::parse(vec!["expiration", &(now + expiry_secs).to_string()])
-            .map_err(|e| e.to_string())?,
-    ];
-    if let Some(domain) = extract_server_authority(base_url) {
-        tags.push(Tag::parse(vec!["server".to_string(), domain]).map_err(|e| e.to_string())?);
-    }
-    EventBuilder::new(Kind::from(24242), "Upload buzz-media")
-        .tags(tags)
-        .sign_with_keys(keys)
-        .map_err(|e| e.to_string())
-}
-
 /// Execute the upload HTTP request. Shared by all upload entry points.
 // TODO(v2): Stream large video files to the relay instead of buffering in RAM.
 // Current approach works for videos up to ~100MB but will OOM on 500MB files.
@@ -437,15 +416,8 @@ async fn do_upload(
         300
     };
     let base_url = relay_api_base_url_with_override(state);
-    let auth_event = {
-        let keys = state.signing_keys()?;
-        sign_blossom_upload_auth(&keys, &sha256, expiry_secs, &base_url)?
-    };
 
-    let auth_header = format!(
-        "Nostr {}",
-        URL_SAFE_NO_PAD.encode(auth_event.as_json().as_bytes())
-    );
+    let auth_header = mint_upload_auth_header(state, &base_url, &sha256, expiry_secs)?;
     let body = bytes::Bytes::from(body);
     if let Some((app, progress_id)) = progress.as_ref() {
         emit_media_upload_phase(app, Some(progress_id.as_str()), "uploading");
@@ -480,7 +452,19 @@ async fn do_upload(
     }
 
     if !resp.status().is_success() {
-        return Err(relay_error_message(resp).await);
+        let status = resp.status();
+        let message = relay_error_message(resp).await;
+        // Keep the relay's own message: a 401 has many possible causes and only
+        // one of them is the clock. Joined with a space, not a newline — these
+        // strings surface in toasts and badges that collapse whitespace.
+        return Err(
+            match diagnose_upload_rejection(state, &base_url, status, expiry_secs, cancellation)
+                .await
+            {
+                Some(advice) => format!("{message} {advice}"),
+                None => message,
+            },
+        );
     }
 
     parse_json_response::<BlobDescriptor>(resp).await

--- a/desktop/src-tauri/src/commands/media_upload_auth.rs
+++ b/desktop/src-tauri/src/commands/media_upload_auth.rs
@@ -1,0 +1,219 @@
+//! Minting Blossom auth for media uploads, and explaining a refused one.
+//!
+//! An upload token is stamped with this machine's clock and verified against
+//! the relay's. When the two disagree by more than media auth tolerates, the
+//! upload comes back as a bare `401` that cannot say so — a user-fixable,
+//! non-Buzz problem wearing the costume of an authentication failure.
+//!
+//! After a refusal, a short `HEAD` of the upload route reads the relay's `Date`
+//! header and brackets this machine's offset against it. Only that dedicated
+//! round trip is short enough to bound: the relay verifies Blossom auth
+//! *before* it reads the body, so the `Date` on a large upload's rejection was
+//! stamped at the start of a transfer that may have run for minutes. The
+//! decision logic lives in [`buzz_core_pkg::clock_skew`], shared with the CLI.
+
+use std::time::Duration;
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use buzz_core_pkg::clock_skew::ClockOffsetBounds;
+use chrono::Utc;
+use nostr::{EventBuilder, JsonUtil, Keys, Kind, Tag, Timestamp};
+use tokio_util::sync::CancellationToken;
+
+use super::media::extract_server_authority;
+use crate::app_state::AppState;
+
+/// Timeout for the clock probe. Short on purpose: it only runs after an upload
+/// has already failed, and must not stretch out the failure.
+const CLOCK_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Mint the `t=upload` Blossom auth event for a blob.
+fn sign_blossom_upload_auth(
+    keys: &Keys,
+    sha256: &str,
+    expiry_secs: u64,
+    base_url: &str,
+) -> Result<nostr::Event, String> {
+    let now = Timestamp::now().as_secs();
+    let mut tags = vec![
+        Tag::parse(vec!["t", "upload"]).map_err(|e| e.to_string())?,
+        Tag::parse(vec!["x", sha256]).map_err(|e| e.to_string())?,
+        Tag::parse(vec!["expiration", &(now + expiry_secs).to_string()])
+            .map_err(|e| e.to_string())?,
+    ];
+    if let Some(domain) = extract_server_authority(base_url) {
+        tags.push(Tag::parse(vec!["server".to_string(), domain]).map_err(|e| e.to_string())?);
+    }
+    EventBuilder::new(Kind::from(24242), "Upload buzz-media")
+        .tags(tags)
+        .sign_with_keys(keys)
+        .map_err(|e| e.to_string())
+}
+
+/// Mint the `Authorization` header value for an upload.
+pub(super) fn mint_upload_auth_header(
+    state: &AppState,
+    base_url: &str,
+    sha256: &str,
+    expiry_secs: u64,
+) -> Result<String, String> {
+    let keys = state.signing_keys()?;
+    let auth_event = sign_blossom_upload_auth(&keys, sha256, expiry_secs, base_url)?;
+    Ok(format!(
+        "Nostr {}",
+        URL_SAFE_NO_PAD.encode(auth_event.as_json().as_bytes())
+    ))
+}
+
+/// Bracket this machine's clock offset against the relay's, with a short probe.
+///
+/// The local clock is read either side of the round trip, so the result is an
+/// interval the observation actually proves rather than a point estimate that
+/// network latency would inflate. `None` whenever no trustworthy measurement is
+/// available — the probe failed, or the reply carried no parseable `Date`.
+async fn measure_clock_bounds(state: &AppState, base_url: &str) -> Option<ClockOffsetBounds> {
+    let before = Utc::now().timestamp_millis();
+    let resp = state
+        .http_client
+        .head(format!("{base_url}/upload"))
+        .header(reqwest::header::CACHE_CONTROL, "no-cache")
+        .timeout(CLOCK_PROBE_TIMEOUT)
+        .send()
+        .await
+        .ok()?;
+    let after = Utc::now().timestamp_millis();
+    // Only a cache sends `Age`, and a cached reply carries the origin's
+    // original `Date` — a clock reading as stale as the cache entry. Refuse to
+    // measure rather than try to correct for it.
+    if resp.headers().contains_key(reqwest::header::AGE) {
+        return None;
+    }
+    let date = resp.headers().get(reqwest::header::DATE)?.to_str().ok()?;
+    ClockOffsetBounds::measure(before, after, date)
+}
+
+/// Explain a refused upload when this machine's clock is provably why.
+///
+/// `token_lifetime_secs` is the `expiration` this client stamped on the token:
+/// a clock behind by more than that mints one already expired on arrival, which
+/// is the tightest of the verifier's backward bounds and the only one the
+/// client knows exactly.
+///
+/// Returns `None` for any other failure, and for a clock the relay would have
+/// accepted — the caller then reports the relay's own message unchanged. A
+/// cancelled upload is not probed: the user has stopped caring, and the probe
+/// would hold the failure open for up to [`CLOCK_PROBE_TIMEOUT`].
+pub(super) async fn diagnose_upload_rejection(
+    state: &AppState,
+    base_url: &str,
+    status: reqwest::StatusCode,
+    token_lifetime_secs: u64,
+    cancellation: Option<&CancellationToken>,
+) -> Option<String> {
+    if !should_probe(status, cancellation.map(|c| c.is_cancelled())) {
+        return None;
+    }
+    measure_clock_bounds(state, base_url)
+        .await?
+        .media_auth_advice(token_lifetime_secs)
+}
+
+/// Whether a failed upload is worth spending a clock probe on.
+///
+/// Split out from the async path so the guard is testable without a live
+/// `AppState` or relay.
+fn should_probe(status: reqwest::StatusCode, cancelled: Option<bool>) -> bool {
+    status == reqwest::StatusCode::UNAUTHORIZED && cancelled != Some(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Only a 401 is worth a probe, and only while the user still wants the
+    /// upload. Anything else must cost nothing.
+    #[test]
+    fn only_a_live_401_is_worth_probing() {
+        assert!(should_probe(reqwest::StatusCode::UNAUTHORIZED, None));
+        assert!(should_probe(
+            reqwest::StatusCode::UNAUTHORIZED,
+            Some(false)
+        ));
+
+        assert!(
+            !should_probe(reqwest::StatusCode::UNAUTHORIZED, Some(true)),
+            "a cancelled upload must not be held open for a diagnostic"
+        );
+        for other in [
+            reqwest::StatusCode::FORBIDDEN,
+            reqwest::StatusCode::PAYLOAD_TOO_LARGE,
+            reqwest::StatusCode::UNPROCESSABLE_ENTITY,
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
+            assert!(!should_probe(other, None), "{other} is not an auth failure");
+        }
+    }
+
+    /// A cancelled token is what `do_upload` actually holds, so pin the wiring
+    /// rather than just the boolean.
+    #[test]
+    fn a_cancelled_token_suppresses_the_probe() {
+        let token = CancellationToken::new();
+        assert!(should_probe(
+            reqwest::StatusCode::UNAUTHORIZED,
+            Some(token.is_cancelled())
+        ));
+        token.cancel();
+        assert!(!should_probe(
+            reqwest::StatusCode::UNAUTHORIZED,
+            Some(token.is_cancelled())
+        ));
+    }
+
+    /// The token this module mints must carry the tags the relay's verifier
+    /// requires, with an `expiration` derived from the lifetime it was given —
+    /// that lifetime is also what the clock diagnosis measures against, so a
+    /// drift between the two would silently misjudge every rejection.
+    #[test]
+    fn the_minted_token_carries_the_expiry_it_was_given() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let minted_at = Timestamp::now().as_secs();
+
+        let event = sign_blossom_upload_auth(&keys, &sha256, 600, "https://relay.example")
+            .expect("signing succeeds");
+
+        assert_eq!(event.kind, Kind::from(24242));
+        let tag = |name: &str| {
+            event
+                .tags
+                .iter()
+                .find(|t| t.as_slice().first().map(String::as_str) == Some(name))
+                .and_then(|t| t.as_slice().get(1).cloned())
+        };
+        assert_eq!(tag("t").as_deref(), Some("upload"));
+        assert_eq!(tag("x").as_deref(), Some(sha256.as_str()));
+        assert_eq!(tag("server").as_deref(), Some("relay.example"));
+
+        let expiration: u64 = tag("expiration")
+            .expect("expiration tag")
+            .parse()
+            .expect("numeric expiration");
+        assert!(
+            expiration >= minted_at + 600 && expiration <= minted_at + 601,
+            "expiration {expiration} must be the mint time plus the 600s lifetime"
+        );
+    }
+
+    /// The `server` tag is omitted rather than faked when the base URL has no
+    /// authority to derive one from.
+    #[test]
+    fn an_unusable_base_url_yields_no_server_tag() {
+        let event = sign_blossom_upload_auth(&Keys::generate(), &"b".repeat(64), 300, "not-a-url")
+            .expect("signing succeeds");
+        assert!(!event
+            .tags
+            .iter()
+            .any(|t| t.as_slice().first().map(String::as_str) == Some("server")));
+    }
+}

--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -34,6 +34,7 @@ mod media_gif;
 mod media_raw;
 mod media_snapshot_png;
 mod media_transcode;
+mod media_upload_auth;
 mod media_upload_progress;
 #[cfg(feature = "mesh-llm")]
 pub(crate) mod mesh_llm;


### PR DESCRIPTION
Closes #4075.

Media uploads fail with `401 authentication failed` when the client's system clock has drifted. The 401 is deliberately opaque — all thirteen media auth failures collapse into it (`buzz-media/src/error.rs`) — so a **user-fixable, non-Buzz problem is presented as an authentication failure**, and people go looking for auth bugs. On #4075 the drift was ~6.75s on a Windows box whose `w32time` service had never started; uploads had worked days earlier and then stopped, with no client change in between.

This is option (2) from that issue: **compare the local clock against the relay's `Date` header and say so, instead of leaving the user with a bare 401.** No relay change — `crates/buzz-media` is untouched.

## What it does

When an upload is refused with a 401, the client makes one short `HEAD` request to the upload route, reads the `Date` header, and appends an explanation if — and only if — the observation *proves* the clock is at fault:

> `{"error":"authentication failed"}`
>
> note: this machine's clock is at least 5.8s ahead of the relay's, which is outside the 5s that media upload auth allows. A clock this far out makes media uploads fail exactly like this, so it is worth ruling out before anything else. Sync the system clock and retry (Windows: start the w32time service, then `w32tm /resync`; macOS and Linux: turn on automatic network time).

The relay's own message is kept. Fifteen distinct auth failures collapse into that 401 and only one of them is the clock, so replacing the body would destroy the evidence every time the guess is wrong. The error also stays a `CliError::Relay { status: 401 }`, so exit codes and the JSON error category are unchanged.

## What the message claims, and what it does not

It reports a **measurement** — this clock is provably outside the window — and offers it as the first thing to rule out. It does not claim to have diagnosed the 401 in hand, because a client cannot: the relay compares whole seconds (`created > now + 5`), both sides are truncated, and the transit between them is unknown, so a drift of ~5.6s is accepted or rejected depending on where the two clocks fall inside their respective seconds. Asserting causation would be wrong in exactly the band this feature exists to serve. Appending rather than replacing means a wrong guess costs the user nothing.

## Why the diagnosis runs *after* the failure, not before it

The obvious design is a pre-flight check before minting the token. I built that first and it was wrong twice over.

**Reading the `Date` off the rejection does not work.** `crates/buzz-relay/src/api/media.rs:139` verifies Blossom auth in `FromRequestParts`, before the body is read — the code comments call this out as the "pre-body auth-rejection guarantee". So on a 200 MB upload the 401's `Date` was stamped at t≈0 while the client spent the next minute pushing bytes. Treating it as "the relay's clock now" would pin every slow-upload 401 on a perfectly healthy clock. Hence a dedicated round trip: it is the only one short enough to bound.

**A pre-flight that can refuse is a regression risk.** Any check that runs before the upload and returns an error can turn a diagnostic into a new failure mode. Running only after a refusal makes that structurally impossible: there is no path where this code is the reason an upload does not happen.

## The measurement is bracketed, not estimated

The local clock is read on both sides of the probe. Writing `Δ` for the true offset, `D` for the parsed header, and `S` for the server's real clock at stamp time, `D ≤ S < D + 1s` and `before − Δ ≤ S ≤ after − Δ`, which gives

```text
before − D − 1s  ≤  Δ  ≤  after − D
```

Both bounds hold whatever the latency was, so no fudge factor is needed and none is applied. Each direction uses only its proven side: the "ahead" verdict reads the lower bound, sampled *before* the request, so latency cannot inflate it. A test pins this — 600 seconds of simulated latency on a synced clock yields no verdict. The cost of that rigour is silence when the interval straddles a bound, which is the right way to be wrong.

The local readings are in **milliseconds**; only the server's stamp is truncated. That matters for the reported case: with whole-second readings a 6.75s drift straddles the 5s tolerance and stays silent, while millisecond readings prove ≥5.75s.

A probe response carrying an `Age` header is discarded rather than measured — only a cache sends `Age`, and a cached reply's `Date` is as stale as the cache entry.

## Both directions, and the backward bound is the token's own lifetime

Skew goes both ways, and the verifier's branches do not share a bound:

```rust
if created > now + 5              { return Err(MediaError::TimestampOutOfWindow); }
if now > created + max_age_secs   { return Err(MediaError::TimestampOutOfWindow); }
if exp_value <= now               { return Err(MediaError::TokenExpired); }
```

The check uses the `expiration` the client stamped on its own token. That is the tightest of the backward bounds — a clock behind by more than the token's whole lifetime mints one already expired on arrival — and, unlike `max_age_secs`, the client knows it exactly. It cannot know `max_age_secs`: the relay selects the image (600s) or video (3600s) pipeline by **sniffing the body bytes**, not from `Content-Type` (`upload_blob`: "`Content-Type` is advisory only; a bounded body prefix selects the streaming video path from actual bytes"), so any client-side guess keyed on MIME can disagree with what the relay actually applied.

## Not done deliberately

The client could read the relay's clock and backdate `created_at` so skewed uploads *succeed*. That is a worse fix: a drifted clock also corrupts event timestamps, so masking it at the media layer hides a problem that is broken elsewhere too. The only correct repair is to fix the clock, and this change says so.

`TimestampOutOfWindow` is still collapsed into the blind 401. That is option (1) from the issue and belongs in its own PR.

## Testing

- `buzz-core` — 11 unit tests: `Date` parsing (IMF-fixdate, RFC 2822 at zero and non-zero offsets, junk), the bracketing arithmetic, out-of-order readings, the reported ~6.75s drift, the backward bound tracking the token lifetime, and three that exist to fail if the design regresses — latency alone never produces a verdict; a drift inside the tolerance stays silent at every fractional alignment of the server's stamp; the message never asserts causation.
- `buzz-cli` — 6 integration tests against an axum stand-in relay that dates the probe and the rejection **independently**, so a test can prove which one the diagnosis trusts. Includes the regression test for the pre-body rejection (a rejection dated 600s stale with a clean probe must not be read as drift), an unreadable-`Date` case, and a non-401 failure that must not be probed at all.
- `desktop` — the auth event's tag shape and that its `expiration` derives from the lifetime the diagnosis measures against, the `server`-tag omission path, and the probe guard for non-401 and cancelled uploads.
- `cargo clippy --workspace --all-targets` and the Tauri clippy pass clean; `cargo fmt --all --check` clean; the desktop file-size ratchet passes (the new desktop code lives in its own module, and `commands/media.rs` is smaller than before).
- Verified live against a running relay: a valid PNG still uploads `200`, and a non-401 failure (`422 invalid image data`) still surfaces exactly as it did.

No UI screenshot: the desktop change alters the text of an existing upload-failure error string rather than any layout or interaction. Happy to add one if you would rather see it in situ.
