### PR TITLE
feat(acp): expose OBSERVER_PUBLISH_TICK as configuration

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -488,6 +488,12 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_RELAY_OBSERVER", default_value_t = false)]
     pub relay_observer: bool,
 
+    /// Seconds between observer frame publishes. Lower values use more of the
+    /// agent's message quota (shared with real chat); higher values leave more
+    /// headroom at the price of doubled viewer latency. Default: 1.
+    #[arg(long, env = "BUZZ_ACP_OBSERVER_PUBLISH_TICK_SECS", default_value_t = 1)]
+    pub observer_publish_tick_secs: u64,
+
     /// Exit after this many seconds with no dispatched events and no turn in flight.
     /// 0 disables inactivity self-termination.
     #[arg(long, env = "BUZZ_ACP_EXIT_AFTER_INACTIVITY", default_value_t = 0)]
@@ -582,6 +588,8 @@ pub struct Config {
     pub has_generated_codex_config: bool,
     /// Whether to publish encrypted observer frames through the relay.
     pub relay_observer: bool,
+    /// Seconds between observer frame publishes. Default: 1.
+    pub observer_publish_tick_secs: u64,
     /// Seconds without dispatched events before an idle harness exits. 0 = disabled.
     pub exit_after_inactivity_secs: u64,
     /// Whether ACP/LLM subprocess initialization is deferred until accepted work arrives.
@@ -1137,6 +1145,7 @@ impl Config {
             persona_env_vars,
             has_generated_codex_config,
             relay_observer: args.relay_observer,
+            observer_publish_tick_secs: args.observer_publish_tick_secs,
             exit_after_inactivity_secs: args.exit_after_inactivity,
             lazy_pool: args.lazy_pool,
             idle_pool_sleep_secs: args.idle_pool_sleep,
@@ -1510,6 +1519,7 @@ mod tests {
             persona_env_vars: vec![],
             has_generated_codex_config: false,
             relay_observer: false,
+            observer_publish_tick_secs: 1,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
             idle_pool_sleep_secs: 0,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -391,8 +391,6 @@ async fn check_sibling_via_profile(
 /// half that budget — regardless of how many channels are active. A slower
 /// tick (e.g. 2s → 30/min) would leave more quota headroom for chat at the
 /// price of doubled viewer latency; this constant is the knob.
-const OBSERVER_PUBLISH_TICK: Duration = Duration::from_secs(1);
-
 /// Byte budget for EVERYTHING retained while awaiting a publish slot: the
 /// event FIFO (serialized, post-`fit_observer_event_to_budget` bytes) PLUS
 /// the chunk coalescer's pending buffer (serialized event skeletons + raw
@@ -625,6 +623,7 @@ fn spawn_relay_observer_publisher(
     agent_pubkey_hex: String,
     owner_pubkey_hex: String,
     owner_pubkey: PublicKey,
+    observer_publish_tick_secs: u64,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         // Subscribe BEFORE snapshotting so an event emitted between the two
@@ -641,6 +640,7 @@ fn spawn_relay_observer_publisher(
             agent_pubkey_hex,
             owner_pubkey_hex,
             owner_pubkey,
+            observer_publish_tick_secs,
         )
         .await;
     })
@@ -654,6 +654,7 @@ async fn run_relay_observer_publisher(
     agent_pubkey_hex: String,
     owner_pubkey_hex: String,
     owner_pubkey: PublicKey,
+    observer_publish_tick_secs: u64,
 ) {
     let mut queue = ObserverPublishQueue::default();
     let max_snapshot_seq = snapshot.iter().map(|event| event.seq).max().unwrap_or(0);
@@ -666,9 +667,10 @@ async fn run_relay_observer_publisher(
     // the first tick a full period out, so a pre-loaded snapshot (up to the
     // 1,000-event replay buffer on reconnect) cannot burst at t=0 — the old
     // pacer's explicit "no initial burst" property, restored.
+    let tick = Duration::from_secs(observer_publish_tick_secs.max(1));
     let mut publish_tick = tokio::time::interval_at(
-        tokio::time::Instant::now() + OBSERVER_PUBLISH_TICK,
-        OBSERVER_PUBLISH_TICK,
+        tokio::time::Instant::now() + tick,
+        tick,
     );
     publish_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut closed = false;
@@ -2161,6 +2163,7 @@ async fn tokio_main() -> Result<()> {
             agent_pubkey,
             owner_pubkey,
             owner,
+            config.observer_publish_tick_secs,
         ));
     }
 
@@ -5786,6 +5789,7 @@ mod observer_snapshot_race_tests {
             agent_keys.public_key().to_hex(),
             owner_keys.public_key().to_hex(),
             owner_keys.public_key(),
+            1,
         )
         .await;
 
@@ -6510,6 +6514,7 @@ mod observer_publish_cadence_tests {
             agent_keys.public_key().to_hex(),
             owner_keys.public_key().to_hex(),
             owner_keys.public_key(),
+            1,
         ));
 
         // t=0: nothing may publish, no matter how full the snapshot was.
@@ -6589,6 +6594,7 @@ mod observer_publish_cadence_tests {
             agent_keys.public_key().to_hex(),
             owner_keys.public_key().to_hex(),
             owner_keys.public_key(),
+            1,
         ));
 
         settle().await;
@@ -6655,6 +6661,7 @@ mod observer_publish_cadence_tests {
             agent_keys.public_key().to_hex(),
             owner_keys.public_key().to_hex(),
             owner_keys.public_key(),
+            1,
         ));
         settle().await;
 


### PR DESCRIPTION

    Fixes #6830 
    
 ## Summary
    
    Expose the observer frame publish interval as
    --observer-publish-tick-secs / BUZZ_ACP_OBSERVER_PUBLISH_TICK_SECS,
    defaulting to 1 (preserving current behavior).
    
  ## At 1 frame/s, telemetry consumes up to ~60/min of the agent's 120/min
    message quota. Operators can now increase the tick to reclaim quota
    headroom for real chat messages:
    
    | tick | telemetry max/min | chat headroom (of 120) |
    |------|-------------------|------------------------|
    | 1s   | ~60               | ~60                    |
    | 2s   | ~30               | ~90                    |
    | 5s   | ~12               | ~108                   |
    
 ## Changes
    
    - config.rs: Add observer_publish_tick_secs to Args (clap) and
      ResolvedConfig, wired through from_cli() and test defaults.
    - lib.rs: Replace hardcoded OBSERVER_PUBLISH_TICK constant with
      Duration::from_secs(observer_publish_tick_secs.max(1)) in the
      publish pacer. Remove the now-unused constant. Thread the value
      through spawn_relay_observer_publisher → run_relay_observer_publisher.
   ## Validation
    
    - cargo check -p buzz-acp — compiles clean (no new warnings)
    - All existing observer tests pass (tick=1 preserves current behavior)
    - min(1) guard prevents zero/negative tick values
    
  ## Compatibility
    
    Additive config surface. Default value preserves existing behavior.
    No relay-side changes needed.