### PR TITLE
feat(model-capabilities): humanize Databricks UC model families

### DIFF
--- a/crates/buzz-agent/src/model_capabilities.rs
+++ b/crates/buzz-agent/src/model_capabilities.rs
@@ -686,6 +686,27 @@ mod tests {
     Q::Vector { id: "boundary-claude-3-digit-run-anthropic-probe", provider: "anthropic", raw_model_id: "claude-35", note: Some("Probes whether the claude-3 prefix binds a longer digit run ('35').") },
     Q::Vector { id: "boundary-claude-opus-4-70-anthropic-probe", provider: "anthropic", raw_model_id: "claude-opus-4-70", note: Some("Probes whether the claude-opus-4-7 prefix binds a longer digit run ('70').") },
     Q::Vector { id: "boundary-gpt-5-1234-openai-probe", provider: "openai", raw_model_id: "gpt-5-1234", note: Some("Probes a 4-digit run after the gpt-5 stem.") },
+    Q::Section { group: "Databricks UC model-family humanization probes (#6918 follow-up)", note: Some("Exact-record and UC-FQN strip probes for the Gemini/DeepSeek/GLM/Grok/Llama/Qwen/Gemma/Inkling families surfaced by UC discovery.") },
+    Q::Vector { id: "dbv2-gemini-3-1-flash-image-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-gemini-3-1-flash-image", note: Some("Probes the Gemini 3.1 Flash Image endpoint record and label.") },
+    Q::Vector { id: "dbv2-gemini-3-5-flash-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-gemini-3-5-flash", note: Some("Probes the Gemini 3.5 Flash endpoint record and label.") },
+    Q::Vector { id: "dbv2-gemini-3-5-flash-lite-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-gemini-3-5-flash-lite", note: Some("Probes the Gemini 3.5 Flash Lite endpoint record and label.") },
+    Q::Vector { id: "dbv2-gemini-3-6-flash-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-gemini-3-6-flash", note: Some("Probes the Gemini 3.6 Flash endpoint record and label.") },
+    Q::Vector { id: "dbv2-gemini-3-pro-image-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-gemini-3-pro-image", note: Some("Probes the Gemini 3 Pro Image endpoint record and label.") },
+    Q::Vector { id: "dbv2-deepseek-v4-flash-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-deepseek-v4-flash-0731", note: Some("Probes the DeepSeek V4 Flash endpoint record and label.") },
+    Q::Vector { id: "dbv2-deepseek-v4-pro-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-deepseek-v4-pro-0813", note: Some("Probes the DeepSeek V4 Pro endpoint record and label.") },
+    Q::Vector { id: "dbv2-glm-5-3-flash-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-glm-5-3-flash", note: Some("Probes the GLM-5.3 Flash endpoint record and label.") },
+    Q::Vector { id: "dbv2-grok-4-6-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-grok-4-6", note: Some("Probes the Grok 4.6 endpoint record and label.") },
+    Q::Vector { id: "dbv2-llama-4-maverick-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-llama-4-maverick", note: Some("Probes the Llama 4 Maverick endpoint record and label.") },
+    Q::Vector { id: "dbv2-meta-llama-3-1-8b-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-meta-llama-3-1-8b-instruct", note: Some("Probes the meta-llama record; the llama- token strips the meta- prefix identically for record and query.") },
+    Q::Vector { id: "dbv2-meta-llama-3-3-70b-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-meta-llama-3-3-70b-instruct", note: Some("Probes the meta-llama 3.3 70B record and label.") },
+    Q::Vector { id: "dbv2-qwen3-next-80b-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-qwen3-next-80b-a3b-instruct", note: Some("Probes the Qwen3 Next 80B record; the bare qwen token strips on a hyphen boundary.") },
+    Q::Vector { id: "dbv2-qwen35-122b-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-qwen35-122b-a10b", note: Some("Probes the Qwen3.5 122B record; the bare qwen token strips a qwen35 stem with no separator.") },
+    Q::Vector { id: "dbv2-gemma-3-12b-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-gemma-3-12b", note: Some("Probes the Gemma 3 12B endpoint record and label.") },
+    Q::Vector { id: "dbv2-inkling-exact-record-probe", provider: "databricks_v2", raw_model_id: "databricks-inkling", note: Some("Probes the Inkling endpoint record and label.") },
+    Q::Vector { id: "dbv2-uc-fqn-gemini-3-5-flash-strip-probe", provider: "databricks_v2", raw_model_id: "system.ai.gemini-3-5-flash", note: Some("Probes strip parity on a system.ai. UC FQN carrying the gemini- token (resolve carries no label; the alias label path is unit-tested).") },
+    Q::Vector { id: "dbv2-uc-fqn-meta-llama-strip-probe", provider: "databricks_v2", raw_model_id: "system.ai.meta-llama-3-3-70b-instruct", note: Some("Probes strip parity on a UC FQN where the llama- token strips through meta-.") },
+    Q::Vector { id: "dbv2-uc-goose-deepseek-strip-probe", provider: "databricks_v2", raw_model_id: "data_workflow_tools.goose.goose-deepseek-v4-pro-0813", note: Some("Probes strip parity on a goose- prefixed UC FQN carrying the deepseek- token.") },
+    Q::Vector { id: "dbv2-uc-fqn-inkling-strip-probe", provider: "databricks_v2", raw_model_id: "system.ai.inkling", note: Some("Probes strip parity on a UC FQN carrying the bare inkling token.") },
     ];
 
     /// A section marker in the generated corpus (`_group` + optional `_note`).
@@ -781,7 +802,7 @@ mod tests {
     }
 
     #[test]
-    fn corpus_has_exactly_113_executable_vectors() {
+    fn corpus_has_exactly_133_executable_vectors() {
         // Locks the vector count so a silent INPUTS edit can't quietly drop
         // coverage; must equal the gate in the TS harness
         // (modelCapabilitiesCorpus.test.mjs).
@@ -790,7 +811,7 @@ mod tests {
             .filter(|q| matches!(q, Q::Vector { .. }))
             .count();
         assert_eq!(
-            vectors, 113,
+            vectors, 133,
             "corpus executable-vector count changed; update this gate deliberately"
         );
     }
@@ -955,6 +976,38 @@ mod tests {
                 Some(label),
                 "alias={alias}"
             );
+        }
+        // UC-family humanization (#6918 follow-up): the new family tokens let the
+        // shared UC-FQN and goose- alias forms resolve onto their base records.
+        for (fqn, label) in [
+            ("system.ai.gemini-3-5-flash", "Gemini 3.5 Flash"),
+            ("system.ai.gemini-3-pro-image", "Gemini 3 Pro Image"),
+            ("system.ai.deepseek-v4-pro-0813", "DeepSeek V4 Pro"),
+            ("system.ai.glm-5-3-flash", "GLM-5.3 Flash"),
+            ("system.ai.grok-4-6", "Grok 4.6"),
+            ("system.ai.llama-4-maverick", "Llama 4 Maverick"),
+            (
+                "system.ai.meta-llama-3-3-70b-instruct",
+                "Llama 3.3 70B Instruct",
+            ),
+            (
+                "system.ai.qwen3-next-80b-a3b-instruct",
+                "Qwen3 Next 80B A3B Instruct",
+            ),
+            ("system.ai.qwen35-122b-a10b", "Qwen3.5 122B A10B"),
+            ("system.ai.gemma-3-12b", "Gemma 3 12B"),
+            ("system.ai.inkling", "Inkling"),
+            (
+                "data_workflow_tools.goose.goose-deepseek-v4-flash-0731",
+                "DeepSeek V4 Flash",
+            ),
+            (
+                "data_workflow_tools.goose.goose-glm-5-3-flash",
+                "GLM-5.3 Flash",
+            ),
+            ("data_workflow_tools.goose.goose-grok-4-6", "Grok 4.6"),
+        ] {
+            assert_eq!(databricks_registry_label(fqn), Some(label), "fqn={fqn}");
         }
         // Unknown ids, bare family ids, and blanks remain uncurated.
         assert_eq!(databricks_registry_label("custom-unlisted-endpoint"), None);

--- a/crates/buzz-agent/src/model_capabilities.rs
+++ b/crates/buzz-agent/src/model_capabilities.rs
@@ -192,6 +192,7 @@ impl ProviderFallbacks {
 #[serde(deny_unknown_fields)]
 struct Manifest {
     family_tokens: Vec<String>,
+    label_family_tokens: Vec<String>,
     family_rules: Vec<FamilyRule>,
     databricks_v2_known_models: Vec<String>,
     exact_records: Vec<ExactRecord>,
@@ -200,6 +201,9 @@ struct Manifest {
     #[serde(rename = "_comment", default)]
     #[allow(dead_code)]
     comment: Option<String>,
+    #[serde(rename = "_comment_label_family_tokens", default)]
+    #[allow(dead_code)]
+    comment_label_family_tokens: Option<String>,
     #[serde(rename = "_comment_databricks_v2_known_models", default)]
     #[allow(dead_code)]
     comment_known_models: Option<String>,
@@ -383,7 +387,7 @@ pub fn databricks_v2_known_models() -> &'static [String] {
 /// record label contract.
 pub fn databricks_registry_label(raw_model_id: &str) -> Option<&'static str> {
     let m = manifest();
-    registry_label_for_databricks_records(raw_model_id, &m.exact_records, &m.family_tokens)
+    registry_label_for_databricks_records(raw_model_id, &m.exact_records, &m.label_family_tokens)
 }
 
 fn registry_label_for_databricks_records<'a>(
@@ -424,6 +428,9 @@ fn registry_label_for_databricks_records<'a>(
 fn validate_manifest(m: &Manifest) -> Result<(), String> {
     if m.family_tokens.is_empty() {
         return Err("family_tokens must be non-empty".to_string());
+    }
+    if m.label_family_tokens.is_empty() {
+        return Err("label_family_tokens must be non-empty".to_string());
     }
 
     let check_efforts = |ctx: &str,
@@ -707,6 +714,9 @@ mod tests {
     Q::Vector { id: "dbv2-uc-fqn-meta-llama-strip-probe", provider: "databricks_v2", raw_model_id: "system.ai.meta-llama-3-3-70b-instruct", note: Some("Probes strip parity on a UC FQN where the llama- token strips through meta-.") },
     Q::Vector { id: "dbv2-uc-goose-deepseek-strip-probe", provider: "databricks_v2", raw_model_id: "data_workflow_tools.goose.goose-deepseek-v4-pro-0813", note: Some("Probes strip parity on a goose- prefixed UC FQN carrying the deepseek- token.") },
     Q::Vector { id: "dbv2-uc-fqn-inkling-strip-probe", provider: "databricks_v2", raw_model_id: "system.ai.inkling", note: Some("Probes strip parity on a UC FQN carrying the bare inkling token.") },
+    Q::Section { group: "Label/capability token isolation probes (#6955 review pass 1)", note: Some("Pins that label_family_tokens (the UC-humanization superset) never leaks into capability resolve(): capability stripping still uses only claude-/gpt-/kimi-, so a label token appearing before a gpt- marker must NOT displace the gpt-5-pro exact profile.") },
+    Q::Vector { id: "isolation-openai-gemini-gpt-5-pro-probe", provider: "openai", raw_model_id: "tenant-gemini-gpt-5-pro", note: Some("The gemini- label token must not strip here; capability resolve keeps the gpt-5-pro high-only profile.") },
+    Q::Vector { id: "isolation-openai-qwenchanted-gpt-5-pro-probe", provider: "openai", raw_model_id: "tenant-qwenchanted-gpt-5-pro", note: Some("The bare qwen label token must not fire mid-segment; capability resolve keeps the gpt-5-pro high-only profile.") },
     ];
 
     /// A section marker in the generated corpus (`_group` + optional `_note`).
@@ -802,7 +812,7 @@ mod tests {
     }
 
     #[test]
-    fn corpus_has_exactly_133_executable_vectors() {
+    fn corpus_has_exactly_135_executable_vectors() {
         // Locks the vector count so a silent INPUTS edit can't quietly drop
         // coverage; must equal the gate in the TS harness
         // (modelCapabilitiesCorpus.test.mjs).
@@ -811,7 +821,7 @@ mod tests {
             .filter(|q| matches!(q, Q::Vector { .. }))
             .count();
         assert_eq!(
-            vectors, 133,
+            vectors, 135,
             "corpus executable-vector count changed; update this gate deliberately"
         );
     }

--- a/desktop/src/features/agents/ui/modelCapabilities.ts
+++ b/desktop/src/features/agents/ui/modelCapabilities.ts
@@ -174,6 +174,7 @@ const ProviderFallbacksSchema = z
 export const ManifestSchema = z
   .object({
     family_tokens: z.array(z.string()).min(1),
+    label_family_tokens: z.array(z.string()).min(1),
     family_rules: z.array(FamilyRuleSchema),
     databricks_v2_known_models: z.array(z.string()),
     exact_records: z.array(ExactRecordSchema),
@@ -181,6 +182,7 @@ export const ManifestSchema = z
     // Root documentation keys; modeled for strict parsing, not read at runtime.
     // Mirrors the Rust `Manifest` doc fields under `deny_unknown_fields`.
     _comment: z.string().optional(),
+    _comment_label_family_tokens: z.string().optional(),
     _comment_databricks_v2_known_models: z.string().optional(),
     _sources: z.record(z.string(), z.string()).optional(),
   })
@@ -400,6 +402,6 @@ export function databricksRegistryLabel(rawModelId: string): string | null {
   return databricksRegistryLabelForRecords(
     rawModelId,
     MANIFEST.exact_records,
-    MANIFEST.family_tokens,
+    MANIFEST.label_family_tokens,
   );
 }

--- a/desktop/src/features/agents/ui/modelCapabilitiesCorpus.test.mjs
+++ b/desktop/src/features/agents/ui/modelCapabilitiesCorpus.test.mjs
@@ -25,10 +25,10 @@ const corpus = JSON.parse(readFileSync(fileURLToPath(corpusUrl), "utf8"));
 // (`_group`) are skipped. Mirrors the Rust corpus filter.
 const executable = corpus.filter((entry) => entry.expect != null);
 
-test("corpus has exactly 133 executable vectors", () => {
+test("corpus has exactly 135 executable vectors", () => {
   // Locks the vector count so a silent corpus edit can't quietly drop coverage;
   // must equal the gate in the Rust suite (model_capabilities.rs).
-  assert.equal(executable.length, 133);
+  assert.equal(executable.length, 135);
 });
 
 test("registry label aliases refuse an unprefixed query", () => {

--- a/desktop/src/features/agents/ui/modelCapabilitiesCorpus.test.mjs
+++ b/desktop/src/features/agents/ui/modelCapabilitiesCorpus.test.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 import {
+  databricksRegistryLabel,
   databricksRegistryLabelForRecords,
   ManifestSchema,
   resolveModelCapabilities,
@@ -24,10 +25,10 @@ const corpus = JSON.parse(readFileSync(fileURLToPath(corpusUrl), "utf8"));
 // (`_group`) are skipped. Mirrors the Rust corpus filter.
 const executable = corpus.filter((entry) => entry.expect != null);
 
-test("corpus has exactly 113 executable vectors", () => {
+test("corpus has exactly 133 executable vectors", () => {
   // Locks the vector count so a silent corpus edit can't quietly drop coverage;
   // must equal the gate in the Rust suite (model_capabilities.rs).
-  assert.equal(executable.length, 113);
+  assert.equal(executable.length, 133);
 });
 
 test("registry label aliases refuse an unprefixed query", () => {
@@ -42,6 +43,34 @@ test("registry label aliases refuse an unprefixed query", () => {
     databricksRegistryLabelForRecords("gpt-5", records, ["gpt-"]),
     null,
   );
+});
+
+test("UC model-family FQNs and goose- aliases humanize onto their base records", () => {
+  // #6918 follow-up: the shared UC-FQN (`system.ai.…`) and goose- alias forms
+  // must resolve onto the same base databricks_v2 records via the new family
+  // tokens. Mirrors the Rust `test_databricks_registry_label_lookup` coverage.
+  const cases = [
+    ["system.ai.gemini-3-5-flash", "Gemini 3.5 Flash"],
+    ["system.ai.gemini-3-pro-image", "Gemini 3 Pro Image"],
+    ["system.ai.deepseek-v4-pro-0813", "DeepSeek V4 Pro"],
+    ["system.ai.glm-5-3-flash", "GLM-5.3 Flash"],
+    ["system.ai.grok-4-6", "Grok 4.6"],
+    ["system.ai.llama-4-maverick", "Llama 4 Maverick"],
+    ["system.ai.meta-llama-3-3-70b-instruct", "Llama 3.3 70B Instruct"],
+    ["system.ai.qwen3-next-80b-a3b-instruct", "Qwen3 Next 80B A3B Instruct"],
+    ["system.ai.qwen35-122b-a10b", "Qwen3.5 122B A10B"],
+    ["system.ai.gemma-3-12b", "Gemma 3 12B"],
+    ["system.ai.inkling", "Inkling"],
+    [
+      "data_workflow_tools.goose.goose-deepseek-v4-flash-0731",
+      "DeepSeek V4 Flash",
+    ],
+    ["data_workflow_tools.goose.goose-glm-5-3-flash", "GLM-5.3 Flash"],
+    ["data_workflow_tools.goose.goose-grok-4-6", "Grok 4.6"],
+  ];
+  for (const [fqn, label] of cases) {
+    assert.equal(databricksRegistryLabel(fqn), label, `fqn=${fqn}`);
+  }
 });
 
 test("registry label aliases refuse ambiguous stripped record keys", () => {

--- a/scripts/model-capabilities.json
+++ b/scripts/model-capabilities.json
@@ -9,6 +9,12 @@
   "family_tokens": [
     "claude-",
     "gpt-",
+    "kimi-"
+  ],
+  "_comment_label_family_tokens": "Prefix tokens used ONLY by databricks_registry_label (and its TS mirror) to strip catalog/endpoint prefixes off Unity Catalog FQN and goose- alias ids before matching a curated display label. Deliberately SEPARATE from family_tokens: label stripping is a discovery-only display concern, while family_tokens drives capability resolution in resolve() for every provider. Adding a family marker here humanizes its UC ids without altering any model's resolved capability profile.",
+  "label_family_tokens": [
+    "claude-",
+    "gpt-",
     "kimi-",
     "gemini-",
     "deepseek-",
@@ -905,7 +911,10 @@
       "databricks_v2_wire_route": "mlflow-chat",
       "normalization_policy": "openai-clamp-max-to-xhigh",
       "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "_source": "registry_labels",
+      "_reconciliation": "keep-fallback",
+      "_reconciliation_note": "No model-level entry for gemini-3-1-flash-image exists under any provider in the pinned models.dev payload; there is genuinely no upstream reasoning evidence to reconcile. Retain the databricks_v2 concrete_unknown fallback profile.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): no providers.*.models[*] key matches gemini-3-1-flash-image."
     },
     {
       "provider": "databricks_v2",
@@ -924,7 +933,10 @@
       "databricks_v2_wire_route": "mlflow-chat",
       "normalization_policy": "openai-clamp-max-to-xhigh",
       "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "_source": "registry_labels",
+      "_reconciliation": "keep-fallback",
+      "_reconciliation_note": "No first-party google model-level entry exists for gemini-3-5-flash in the pinned payload. The only records are resellers that conflict: neon advertises effort [minimal, low, medium, high] while venice advertises [low, medium, high]. With no first-party anchor and divergent reseller effort sets, retain the databricks_v2 concrete_unknown fallback profile rather than adopt an arbitrary reseller list.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.google.models has no gemini-3-5-flash; providers.neon.models[\"gemini-3-5-flash\"].reasoning_options=[{\"type\":\"effort\",\"values\":[\"minimal\",\"low\",\"medium\",\"high\"]}] vs providers.venice.models[\"gemini-3-5-flash\"].reasoning_options=[{\"type\":\"effort\",\"values\":[\"low\",\"medium\",\"high\"]}]."
     },
     {
       "provider": "databricks_v2",
@@ -943,7 +955,10 @@
       "databricks_v2_wire_route": "mlflow-chat",
       "normalization_policy": "openai-clamp-max-to-xhigh",
       "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "_source": "registry_labels",
+      "_reconciliation": "keep-fallback",
+      "_reconciliation_note": "No first-party google model-level entry exists for gemini-3-5-flash-lite in the pinned payload. Only reseller records exist and they conflict: neon advertises effort [minimal, low, medium, high] while venice advertises an empty reasoning_options set. With no first-party anchor, retain the databricks_v2 concrete_unknown fallback profile.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.google.models has no gemini-3-5-flash-lite; providers.neon.models[\"gemini-3-5-flash-lite\"].reasoning_options=[{\"type\":\"effort\",\"values\":[\"minimal\",\"low\",\"medium\",\"high\"]}] vs providers.venice.models[\"gemini-3-5-flash-lite\"].reasoning_options=[]."
     },
     {
       "provider": "databricks_v2",
@@ -962,7 +977,10 @@
       "databricks_v2_wire_route": "mlflow-chat",
       "normalization_policy": "openai-clamp-max-to-xhigh",
       "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "_source": "registry_labels",
+      "_reconciliation": "keep-fallback",
+      "_reconciliation_note": "No first-party google model-level entry exists for gemini-3-6-flash in the pinned payload. Only reseller records exist and they conflict: neon advertises effort [minimal, low, medium, high] while venice advertises an empty reasoning_options set. With no first-party anchor, retain the databricks_v2 concrete_unknown fallback profile.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.google.models has no gemini-3-6-flash; providers.neon.models[\"gemini-3-6-flash\"].reasoning_options=[{\"type\":\"effort\",\"values\":[\"minimal\",\"low\",\"medium\",\"high\"]}] vs providers.venice.models[\"gemini-3-6-flash\"].reasoning_options=[]."
     },
     {
       "provider": "databricks_v2",
@@ -970,18 +988,17 @@
       "registry_label": "Gemini 3 Pro Image",
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
-        "minimal",
         "low",
-        "medium",
-        "high",
-        "xhigh"
+        "high"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
-      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "normalization_policy": "openai-standard",
+      "_provenance": "supported_efforts+thinking_mode+default_effort+normalization_policy: adopted from models.dev first-party google model-level evidence (Kimi-K3 precedent); databricks_v2_wire_route+label: registry_labels",
+      "source": "models.dev google reasoning_options effort: low|high",
+      "_reconciliation": "adopt",
+      "_reconciliation_note": "The exact databricks endpoint is absent from the models.dev databricks catalog, but the first-party google entry advertises effort [low, high]. Per the Kimi-K3 precedent, adopt model-level effort evidence despite endpoint absence. Databricks serves via MLflow Chat (reasoning_effort only), so thinking_mode stays none and default_effort is null.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.google.models[\"gemini-3-pro-image\"].reasoning_options=[{\"type\":\"effort\",\"values\":[\"low\",\"high\"]}]"
     },
     {
       "provider": "databricks_v2",
@@ -989,18 +1006,18 @@
       "registry_label": "DeepSeek V4 Flash",
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
-        "minimal",
         "low",
-        "medium",
         "high",
-        "xhigh"
+        "max"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
-      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "normalization_policy": "openai-standard",
+      "_provenance": "supported_efforts+thinking_mode+default_effort+normalization_policy: adopted from models.dev first-party deepseek model-level evidence (Kimi-K3 precedent); databricks_v2_wire_route+label: registry_labels",
+      "source": "models.dev deepseek reasoning_options effort: low|high|max",
+      "_reconciliation": "adopt",
+      "_reconciliation_note": "The exact databricks endpoint is absent from the models.dev databricks catalog, but the first-party deepseek entry advertises a reasoning toggle plus effort [low, high, max]. Per the Kimi-K3 precedent, adopt the model-level effort list despite endpoint absence. The toggle is not representable on the MLflow Chat request schema (reasoning_effort only), so thinking_mode stays none and default_effort is null — mirroring the kimi-k3 record.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.deepseek.models[\"deepseek-v4-flash\"].reasoning_options=[{\"type\":\"toggle\"},{\"type\":\"effort\",\"values\":[\"low\",\"high\",\"max\"]}]"
     },
     {
       "provider": "databricks_v2",
@@ -1008,18 +1025,17 @@
       "registry_label": "DeepSeek V4 Pro",
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
-        "minimal",
-        "low",
-        "medium",
         "high",
-        "xhigh"
+        "max"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
-      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "normalization_policy": "openai-standard",
+      "_provenance": "supported_efforts+thinking_mode+default_effort+normalization_policy: adopted from models.dev first-party deepseek model-level evidence (Kimi-K3 precedent); databricks_v2_wire_route+label: registry_labels",
+      "source": "models.dev deepseek reasoning_options effort: high|max",
+      "_reconciliation": "adopt",
+      "_reconciliation_note": "The exact databricks endpoint is absent from the models.dev databricks catalog, but the first-party deepseek entry advertises a reasoning toggle plus effort [high, max]. Per the Kimi-K3 precedent, adopt the model-level effort list despite endpoint absence. The toggle is not representable on the MLflow Chat request schema (reasoning_effort only), so thinking_mode stays none and default_effort is null — mirroring the kimi-k3 record.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.deepseek.models[\"deepseek-v4-pro\"].reasoning_options=[{\"type\":\"toggle\"},{\"type\":\"effort\",\"values\":[\"high\",\"max\"]}]"
     },
     {
       "provider": "databricks_v2",
@@ -1027,18 +1043,18 @@
       "registry_label": "GLM-5.3 Flash",
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
-        "minimal",
         "low",
-        "medium",
         "high",
-        "xhigh"
+        "max"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
-      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "normalization_policy": "openai-standard",
+      "_provenance": "supported_efforts+thinking_mode+default_effort+normalization_policy: adopted from models.dev first-party Z.AI model-level evidence (Kimi-K3 precedent); databricks_v2_wire_route+label: registry_labels",
+      "source": "models.dev zai reasoning_options effort: low|high|max",
+      "_reconciliation": "adopt",
+      "_reconciliation_note": "The exact databricks endpoint is absent from the models.dev databricks catalog, but the first-party Z.AI entry glm-5.3-flash advertises effort [low, high, max]. Per the Kimi-K3 precedent, adopt the model-level effort list despite endpoint absence. Databricks serves via MLflow Chat (reasoning_effort only), so thinking_mode stays none and default_effort is null.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.zai.models[\"glm-5.3-flash\"].reasoning_options=[{\"type\":\"effort\",\"values\":[\"low\",\"high\",\"max\"]}]"
     },
     {
       "provider": "databricks_v2",
@@ -1046,18 +1062,19 @@
       "registry_label": "Grok 4.6",
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
-        "minimal",
         "low",
         "medium",
         "high",
         "xhigh"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
-      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "normalization_policy": "openai-standard",
+      "_provenance": "supported_efforts+thinking_mode+default_effort+normalization_policy: adopted from models.dev first-party xAI model-level evidence (Kimi-K3 precedent); databricks_v2_wire_route+label: registry_labels",
+      "source": "models.dev xai reasoning_options effort: low|medium|high|xhigh",
+      "_reconciliation": "adopt",
+      "_reconciliation_note": "The exact databricks endpoint is absent from the models.dev databricks catalog, but the first-party xAI entry grok-4.6 advertises effort [low, medium, high, xhigh]. Per the Kimi-K3 precedent, adopt the model-level effort list despite endpoint absence. Databricks serves via MLflow Chat (reasoning_effort only), so thinking_mode stays none and default_effort is null.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.xai.models[\"grok-4.6\"].reasoning_options=[{\"type\":\"effort\",\"values\":[\"low\",\"medium\",\"high\",\"xhigh\"]}]"
     },
     {
       "provider": "databricks_v2",
@@ -1076,7 +1093,10 @@
       "databricks_v2_wire_route": "mlflow-chat",
       "normalization_policy": "openai-clamp-max-to-xhigh",
       "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "_source": "registry_labels",
+      "_reconciliation": "keep-fallback",
+      "_reconciliation_note": "Llama 4 Maverick is a non-reasoning model: all 26 model-level records across providers in the pinned payload report reasoning=false with no reasoning_options. There is no effort evidence to adopt. Retain the databricks_v2 concrete_unknown fallback profile.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): every providers.*.models[*] whose id contains \"llama-4-maverick\" (e.g. meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8) has reasoning=false, reasoning_options=null."
     },
     {
       "provider": "databricks_v2",
@@ -1095,7 +1115,10 @@
       "databricks_v2_wire_route": "mlflow-chat",
       "normalization_policy": "openai-clamp-max-to-xhigh",
       "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "_source": "registry_labels",
+      "_reconciliation": "keep-fallback",
+      "_reconciliation_note": "Llama 3.1 8B Instruct is a non-reasoning model: the consensus across model-level records in the pinned payload is reasoning=false with no reasoning_options (a single reseller, pioneer, is an outlier advertising effort [low, medium, high]). There is no first-party or consensus effort evidence to adopt. Retain the databricks_v2 concrete_unknown fallback profile.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.*.models[*] ids containing \"llama-3.1-8b\" report reasoning=false with reasoning_options=null across essentially all providers (huggingface, nvidia, groq, openrouter, kilo, ...); only pioneer/meta-llama/Llama-3.1-8B-Instruct is reasoning=true."
     },
     {
       "provider": "databricks_v2",
@@ -1114,7 +1137,10 @@
       "databricks_v2_wire_route": "mlflow-chat",
       "normalization_policy": "openai-clamp-max-to-xhigh",
       "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "_source": "registry_labels",
+      "_reconciliation": "keep-fallback",
+      "_reconciliation_note": "Llama 3.3 70B Instruct is a non-reasoning model: every model-level record across ~50 providers in the pinned payload reports reasoning=false with no effort values (one reseller, berget, sets reasoning=true but with an empty reasoning_options set, i.e. no effort list). There is no effort evidence to adopt. Retain the databricks_v2 concrete_unknown fallback profile.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.*.models[*] ids containing \"llama-3.3-70b\" report reasoning=false, reasoning_options=null across all providers; providers.berget.models[\"meta-llama/Llama-3.3-70B-Instruct\"] is reasoning=true with reasoning_options=[]."
     },
     {
       "provider": "databricks_v2",
@@ -1133,7 +1159,10 @@
       "databricks_v2_wire_route": "mlflow-chat",
       "normalization_policy": "openai-clamp-max-to-xhigh",
       "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "_source": "registry_labels",
+      "_reconciliation": "keep-fallback",
+      "_reconciliation_note": "The first-party alibaba entry qwen3-next-80b-a3b-instruct reports reasoning=false with no reasoning_options — the -instruct variant is the non-reasoning sibling of qwen3-next-80b-a3b-thinking. There is no effort evidence to adopt for the instruct model. Retain the databricks_v2 concrete_unknown fallback profile.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.alibaba.models[\"qwen3-next-80b-a3b-instruct\"].reasoning=false, reasoning_options=null (contrast qwen3-next-80b-a3b-thinking which is reasoning=true with budget_tokens)."
     },
     {
       "provider": "databricks_v2",
@@ -1152,7 +1181,10 @@
       "databricks_v2_wire_route": "mlflow-chat",
       "normalization_policy": "openai-clamp-max-to-xhigh",
       "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "_source": "registry_labels",
+      "_reconciliation": "keep-fallback",
+      "_reconciliation_note": "The first-party alibaba entry qwen3.5-122b-a10b expresses reasoning only as a toggle plus budget_tokens — NOT an effort-level selector. Neither axis is representable on the Databricks MLflow Chat transport (reasoning_effort only), mirroring the claude-opus-4-7 budget_tokens precedent where no effort divergence is reconciled. Resellers that do advertise effort sets conflict sharply (kilo [none, high]; tensorx [none..max]; neon [none, low, medium, high]), so there is no consistent effort list to adopt. Retain the databricks_v2 concrete_unknown fallback profile.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.alibaba.models[\"qwen3.5-122b-a10b\"].reasoning_options=[{\"type\":\"toggle\"},{\"type\":\"budget_tokens\"}]; reseller effort sets diverge (kilo=[none,high], tensorx=[none,minimal,low,medium,high,xhigh,max], neon=[none,low,medium,high])."
     },
     {
       "provider": "databricks_v2",
@@ -1171,7 +1203,10 @@
       "databricks_v2_wire_route": "mlflow-chat",
       "normalization_policy": "openai-clamp-max-to-xhigh",
       "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "_source": "registry_labels",
+      "_reconciliation": "keep-fallback",
+      "_reconciliation_note": "Gemma 3 12B is a non-reasoning model: every model-level record across providers in the pinned payload reports reasoning=false with no reasoning_options. There is no effort evidence to adopt. Retain the databricks_v2 concrete_unknown fallback profile.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.*.models[*] ids containing \"gemma-3-12b\" (e.g. google/gemma-3-12b-it) all report reasoning=false, reasoning_options=null."
     },
     {
       "provider": "databricks_v2",
@@ -1179,18 +1214,20 @@
       "registry_label": "Inkling",
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
-        "minimal",
         "low",
         "medium",
         "high",
-        "xhigh"
+        "xhigh",
+        "max"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
-      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels"
+      "normalization_policy": "openai-standard",
+      "_provenance": "supported_efforts+thinking_mode+default_effort+normalization_policy: adopted from models.dev first-party Thinking Machines model-level evidence (Kimi-K3 precedent); databricks_v2_wire_route+label: registry_labels",
+      "source": "models.dev thinkingmachines reasoning_options effort: low|medium|high|xhigh|max",
+      "_reconciliation": "adopt",
+      "_reconciliation_note": "The exact databricks endpoint is absent from the models.dev databricks catalog, but the first-party Thinking Machines entry Inkling advertises a reasoning toggle plus effort [low, medium, high, xhigh, max]. Per the Kimi-K3 precedent, adopt the model-level effort list despite endpoint absence. The toggle is not representable on the MLflow Chat request schema (reasoning_effort only), so thinking_mode stays none and default_effort is null — mirroring the kimi-k3 record.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.thinkingmachines.models[\"thinkingmachines/Inkling\"].reasoning_options=[{\"type\":\"toggle\"},{\"type\":\"effort\",\"values\":[\"low\",\"medium\",\"high\",\"xhigh\",\"max\"]}]"
     },
     {
       "provider": "databricks_v2",

--- a/scripts/model-capabilities.json
+++ b/scripts/model-capabilities.json
@@ -922,21 +922,19 @@
       "registry_label": "Gemini 3.5 Flash",
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
         "minimal",
         "low",
         "medium",
-        "high",
-        "xhigh"
+        "high"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
-      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels",
-      "_reconciliation": "keep-fallback",
-      "_reconciliation_note": "No first-party google model-level entry exists for gemini-3-5-flash in the pinned payload. The only records are resellers that conflict: neon advertises effort [minimal, low, medium, high] while venice advertises [low, medium, high]. With no first-party anchor and divergent reseller effort sets, retain the databricks_v2 concrete_unknown fallback profile rather than adopt an arbitrary reseller list.",
-      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.google.models has no gemini-3-5-flash; providers.neon.models[\"gemini-3-5-flash\"].reasoning_options=[{\"type\":\"effort\",\"values\":[\"minimal\",\"low\",\"medium\",\"high\"]}] vs providers.venice.models[\"gemini-3-5-flash\"].reasoning_options=[{\"type\":\"effort\",\"values\":[\"low\",\"medium\",\"high\"]}]."
+      "normalization_policy": "openai-standard",
+      "_provenance": "supported_efforts+thinking_mode+default_effort+normalization_policy: adopted from models.dev first-party google model-level evidence (Kimi-K3 precedent); databricks_v2_wire_route+label: registry_labels",
+      "source": "models.dev google reasoning_options effort: minimal|low|medium|high",
+      "_reconciliation": "adopt",
+      "_reconciliation_note": "The Unity Catalog endpoint uses the hyphenated stem gemini-3-5-flash, while the pinned models.dev first-party google entry uses the dotted model id gemini-3.5-flash and advertises effort [minimal, low, medium, high]. Per the Kimi-K3 precedent, adopt this model-level effort evidence despite the spelling difference and the exact endpoint being absent from the models.dev databricks catalog. Databricks serves via MLflow Chat (reasoning_effort only), so thinking_mode stays none and default_effort is null.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.google.models[\"gemini-3.5-flash\"].reasoning_options=[{\"type\":\"effort\",\"values\":[\"minimal\",\"low\",\"medium\",\"high\"]}]"
     },
     {
       "provider": "databricks_v2",
@@ -944,21 +942,19 @@
       "registry_label": "Gemini 3.5 Flash Lite",
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
         "minimal",
         "low",
         "medium",
-        "high",
-        "xhigh"
+        "high"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
-      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels",
-      "_reconciliation": "keep-fallback",
-      "_reconciliation_note": "No first-party google model-level entry exists for gemini-3-5-flash-lite in the pinned payload. Only reseller records exist and they conflict: neon advertises effort [minimal, low, medium, high] while venice advertises an empty reasoning_options set. With no first-party anchor, retain the databricks_v2 concrete_unknown fallback profile.",
-      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.google.models has no gemini-3-5-flash-lite; providers.neon.models[\"gemini-3-5-flash-lite\"].reasoning_options=[{\"type\":\"effort\",\"values\":[\"minimal\",\"low\",\"medium\",\"high\"]}] vs providers.venice.models[\"gemini-3-5-flash-lite\"].reasoning_options=[]."
+      "normalization_policy": "openai-standard",
+      "_provenance": "supported_efforts+thinking_mode+default_effort+normalization_policy: adopted from models.dev first-party google model-level evidence (Kimi-K3 precedent); databricks_v2_wire_route+label: registry_labels",
+      "source": "models.dev google reasoning_options effort: minimal|low|medium|high",
+      "_reconciliation": "adopt",
+      "_reconciliation_note": "The Unity Catalog endpoint uses the hyphenated stem gemini-3-5-flash-lite, while the pinned models.dev first-party google entry uses the dotted model id gemini-3.5-flash-lite and advertises effort [minimal, low, medium, high]. Per the Kimi-K3 precedent, adopt this model-level effort evidence despite the spelling difference and the exact endpoint being absent from the models.dev databricks catalog. Databricks serves via MLflow Chat (reasoning_effort only), so thinking_mode stays none and default_effort is null.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.google.models[\"gemini-3.5-flash-lite\"].reasoning_options=[{\"type\":\"effort\",\"values\":[\"minimal\",\"low\",\"medium\",\"high\"]}]"
     },
     {
       "provider": "databricks_v2",
@@ -966,21 +962,19 @@
       "registry_label": "Gemini 3.6 Flash",
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
         "minimal",
         "low",
         "medium",
-        "high",
-        "xhigh"
+        "high"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
-      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
-      "_source": "registry_labels",
-      "_reconciliation": "keep-fallback",
-      "_reconciliation_note": "No first-party google model-level entry exists for gemini-3-6-flash in the pinned payload. Only reseller records exist and they conflict: neon advertises effort [minimal, low, medium, high] while venice advertises an empty reasoning_options set. With no first-party anchor, retain the databricks_v2 concrete_unknown fallback profile.",
-      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.google.models has no gemini-3-6-flash; providers.neon.models[\"gemini-3-6-flash\"].reasoning_options=[{\"type\":\"effort\",\"values\":[\"minimal\",\"low\",\"medium\",\"high\"]}] vs providers.venice.models[\"gemini-3-6-flash\"].reasoning_options=[]."
+      "normalization_policy": "openai-standard",
+      "_provenance": "supported_efforts+thinking_mode+default_effort+normalization_policy: adopted from models.dev first-party google model-level evidence (Kimi-K3 precedent); databricks_v2_wire_route+label: registry_labels",
+      "source": "models.dev google reasoning_options effort: minimal|low|medium|high",
+      "_reconciliation": "adopt",
+      "_reconciliation_note": "The Unity Catalog endpoint uses the hyphenated stem gemini-3-6-flash, while the pinned models.dev first-party google entry uses the dotted model id gemini-3.6-flash and advertises effort [minimal, low, medium, high]. Per the Kimi-K3 precedent, adopt this model-level effort evidence despite the spelling difference and the exact endpoint being absent from the models.dev databricks catalog. Databricks serves via MLflow Chat (reasoning_effort only), so thinking_mode stays none and default_effort is null.",
+      "_reconciliation_doc": "https://models.dev/api.json (pinned SHA-256 9266003029c4ea265e923637826211f597db08e8f0f40123aad8547411029238): providers.google.models[\"gemini-3.6-flash\"].reasoning_options=[{\"type\":\"effort\",\"values\":[\"minimal\",\"low\",\"medium\",\"high\"]}]"
     },
     {
       "provider": "databricks_v2",

--- a/scripts/model-capabilities.json
+++ b/scripts/model-capabilities.json
@@ -9,7 +9,15 @@
   "family_tokens": [
     "claude-",
     "gpt-",
-    "kimi-"
+    "kimi-",
+    "gemini-",
+    "deepseek-",
+    "glm-",
+    "grok-",
+    "llama-",
+    "qwen",
+    "gemma-",
+    "inkling"
   ],
   "family_rules": [
     {
@@ -865,6 +873,310 @@
       "provider": "databricks_v2",
       "raw_model_id": "databricks-glm-5-2",
       "registry_label": "GLM-5.2",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-gemini-3-1-flash-image",
+      "registry_label": "Gemini 3.1 Flash Image",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-gemini-3-5-flash",
+      "registry_label": "Gemini 3.5 Flash",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-gemini-3-5-flash-lite",
+      "registry_label": "Gemini 3.5 Flash Lite",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-gemini-3-6-flash",
+      "registry_label": "Gemini 3.6 Flash",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-gemini-3-pro-image",
+      "registry_label": "Gemini 3 Pro Image",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-deepseek-v4-flash-0731",
+      "registry_label": "DeepSeek V4 Flash",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-deepseek-v4-pro-0813",
+      "registry_label": "DeepSeek V4 Pro",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-glm-5-3-flash",
+      "registry_label": "GLM-5.3 Flash",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-grok-4-6",
+      "registry_label": "Grok 4.6",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-llama-4-maverick",
+      "registry_label": "Llama 4 Maverick",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-meta-llama-3-1-8b-instruct",
+      "registry_label": "Llama 3.1 8B Instruct",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-meta-llama-3-3-70b-instruct",
+      "registry_label": "Llama 3.3 70B Instruct",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-qwen3-next-80b-a3b-instruct",
+      "registry_label": "Qwen3 Next 80B A3B Instruct",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-qwen35-122b-a10b",
+      "registry_label": "Qwen3.5 122B A10B",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-gemma-3-12b",
+      "registry_label": "Gemma 3 12B",
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "_provenance": "all axes materialized from provider fallback (databricks_v2/concrete_unknown)",
+      "_source": "registry_labels"
+    },
+    {
+      "provider": "databricks_v2",
+      "raw_model_id": "databricks-inkling",
+      "registry_label": "Inkling",
       "thinking_mode": "none",
       "supported_efforts": [
         "none",

--- a/scripts/normative-corpus.json
+++ b/scripts/normative-corpus.json
@@ -2363,16 +2363,12 @@
     "expect": {
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
-        "minimal",
         "low",
-        "medium",
-        "high",
-        "xhigh"
+        "high"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "normalization_policy": "openai-standard",
       "registry_label": "Gemini 3 Pro Image"
     }
   },
@@ -2384,16 +2380,13 @@
     "expect": {
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
-        "minimal",
         "low",
-        "medium",
         "high",
-        "xhigh"
+        "max"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "normalization_policy": "openai-standard",
       "registry_label": "DeepSeek V4 Flash"
     }
   },
@@ -2405,16 +2398,12 @@
     "expect": {
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
-        "minimal",
-        "low",
-        "medium",
         "high",
-        "xhigh"
+        "max"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "normalization_policy": "openai-standard",
       "registry_label": "DeepSeek V4 Pro"
     }
   },
@@ -2426,16 +2415,13 @@
     "expect": {
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
-        "minimal",
         "low",
-        "medium",
         "high",
-        "xhigh"
+        "max"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "normalization_policy": "openai-standard",
       "registry_label": "GLM-5.3 Flash"
     }
   },
@@ -2447,16 +2433,14 @@
     "expect": {
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
-        "minimal",
         "low",
         "medium",
         "high",
         "xhigh"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "normalization_policy": "openai-standard",
       "registry_label": "Grok 4.6"
     }
   },
@@ -2594,16 +2578,15 @@
     "expect": {
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
-        "minimal",
         "low",
         "medium",
         "high",
-        "xhigh"
+        "xhigh",
+        "max"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "normalization_policy": "openai-standard",
       "registry_label": "Inkling"
     }
   },
@@ -2688,6 +2671,42 @@
       "default_effort": "medium",
       "databricks_v2_wire_route": "mlflow-chat",
       "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": null
+    }
+  },
+  {
+    "_group": "Label/capability token isolation probes (#6955 review pass 1)",
+    "_note": "Pins that label_family_tokens (the UC-humanization superset) never leaks into capability resolve(): capability stripping still uses only claude-/gpt-/kimi-, so a label token appearing before a gpt- marker must NOT displace the gpt-5-pro exact profile."
+  },
+  {
+    "id": "isolation-openai-gemini-gpt-5-pro-probe",
+    "provider": "openai",
+    "raw_model_id": "tenant-gemini-gpt-5-pro",
+    "_note": "The gemini- label token must not strip here; capability resolve keeps the gpt-5-pro high-only profile.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "high"
+      ],
+      "default_effort": "high",
+      "databricks_v2_wire_route": "not-applicable",
+      "normalization_policy": "openai-standard",
+      "registry_label": null
+    }
+  },
+  {
+    "id": "isolation-openai-qwenchanted-gpt-5-pro-probe",
+    "provider": "openai",
+    "raw_model_id": "tenant-qwenchanted-gpt-5-pro",
+    "_note": "The bare qwen label token must not fire mid-segment; capability resolve keeps the gpt-5-pro high-only profile.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "high"
+      ],
+      "default_effort": "high",
+      "databricks_v2_wire_route": "not-applicable",
+      "normalization_policy": "openai-standard",
       "registry_label": null
     }
   }

--- a/scripts/normative-corpus.json
+++ b/scripts/normative-corpus.json
@@ -2300,16 +2300,14 @@
     "expect": {
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
         "minimal",
         "low",
         "medium",
-        "high",
-        "xhigh"
+        "high"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "normalization_policy": "openai-standard",
       "registry_label": "Gemini 3.5 Flash"
     }
   },
@@ -2321,16 +2319,14 @@
     "expect": {
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
         "minimal",
         "low",
         "medium",
-        "high",
-        "xhigh"
+        "high"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "normalization_policy": "openai-standard",
       "registry_label": "Gemini 3.5 Flash Lite"
     }
   },
@@ -2342,16 +2338,14 @@
     "expect": {
       "thinking_mode": "none",
       "supported_efforts": [
-        "none",
         "minimal",
         "low",
         "medium",
-        "high",
-        "xhigh"
+        "high"
       ],
-      "default_effort": "medium",
+      "default_effort": null,
       "databricks_v2_wire_route": "mlflow-chat",
-      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "normalization_policy": "openai-standard",
       "registry_label": "Gemini 3.6 Flash"
     }
   },

--- a/scripts/normative-corpus.json
+++ b/scripts/normative-corpus.json
@@ -2266,5 +2266,429 @@
       "normalization_policy": "openai-standard",
       "registry_label": null
     }
+  },
+  {
+    "_group": "Databricks UC model-family humanization probes (#6918 follow-up)",
+    "_note": "Exact-record and UC-FQN strip probes for the Gemini/DeepSeek/GLM/Grok/Llama/Qwen/Gemma/Inkling families surfaced by UC discovery."
+  },
+  {
+    "id": "dbv2-gemini-3-1-flash-image-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-gemini-3-1-flash-image",
+    "_note": "Probes the Gemini 3.1 Flash Image endpoint record and label.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "Gemini 3.1 Flash Image"
+    }
+  },
+  {
+    "id": "dbv2-gemini-3-5-flash-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-gemini-3-5-flash",
+    "_note": "Probes the Gemini 3.5 Flash endpoint record and label.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "Gemini 3.5 Flash"
+    }
+  },
+  {
+    "id": "dbv2-gemini-3-5-flash-lite-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-gemini-3-5-flash-lite",
+    "_note": "Probes the Gemini 3.5 Flash Lite endpoint record and label.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "Gemini 3.5 Flash Lite"
+    }
+  },
+  {
+    "id": "dbv2-gemini-3-6-flash-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-gemini-3-6-flash",
+    "_note": "Probes the Gemini 3.6 Flash endpoint record and label.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "Gemini 3.6 Flash"
+    }
+  },
+  {
+    "id": "dbv2-gemini-3-pro-image-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-gemini-3-pro-image",
+    "_note": "Probes the Gemini 3 Pro Image endpoint record and label.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "Gemini 3 Pro Image"
+    }
+  },
+  {
+    "id": "dbv2-deepseek-v4-flash-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-deepseek-v4-flash-0731",
+    "_note": "Probes the DeepSeek V4 Flash endpoint record and label.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "DeepSeek V4 Flash"
+    }
+  },
+  {
+    "id": "dbv2-deepseek-v4-pro-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-deepseek-v4-pro-0813",
+    "_note": "Probes the DeepSeek V4 Pro endpoint record and label.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "DeepSeek V4 Pro"
+    }
+  },
+  {
+    "id": "dbv2-glm-5-3-flash-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-glm-5-3-flash",
+    "_note": "Probes the GLM-5.3 Flash endpoint record and label.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "GLM-5.3 Flash"
+    }
+  },
+  {
+    "id": "dbv2-grok-4-6-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-grok-4-6",
+    "_note": "Probes the Grok 4.6 endpoint record and label.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "Grok 4.6"
+    }
+  },
+  {
+    "id": "dbv2-llama-4-maverick-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-llama-4-maverick",
+    "_note": "Probes the Llama 4 Maverick endpoint record and label.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "Llama 4 Maverick"
+    }
+  },
+  {
+    "id": "dbv2-meta-llama-3-1-8b-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-meta-llama-3-1-8b-instruct",
+    "_note": "Probes the meta-llama record; the llama- token strips the meta- prefix identically for record and query.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "Llama 3.1 8B Instruct"
+    }
+  },
+  {
+    "id": "dbv2-meta-llama-3-3-70b-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-meta-llama-3-3-70b-instruct",
+    "_note": "Probes the meta-llama 3.3 70B record and label.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "Llama 3.3 70B Instruct"
+    }
+  },
+  {
+    "id": "dbv2-qwen3-next-80b-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-qwen3-next-80b-a3b-instruct",
+    "_note": "Probes the Qwen3 Next 80B record; the bare qwen token strips on a hyphen boundary.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "Qwen3 Next 80B A3B Instruct"
+    }
+  },
+  {
+    "id": "dbv2-qwen35-122b-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-qwen35-122b-a10b",
+    "_note": "Probes the Qwen3.5 122B record; the bare qwen token strips a qwen35 stem with no separator.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "Qwen3.5 122B A10B"
+    }
+  },
+  {
+    "id": "dbv2-gemma-3-12b-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-gemma-3-12b",
+    "_note": "Probes the Gemma 3 12B endpoint record and label.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "Gemma 3 12B"
+    }
+  },
+  {
+    "id": "dbv2-inkling-exact-record-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "databricks-inkling",
+    "_note": "Probes the Inkling endpoint record and label.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": "Inkling"
+    }
+  },
+  {
+    "id": "dbv2-uc-fqn-gemini-3-5-flash-strip-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "system.ai.gemini-3-5-flash",
+    "_note": "Probes strip parity on a system.ai. UC FQN carrying the gemini- token (resolve carries no label; the alias label path is unit-tested).",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": null
+    }
+  },
+  {
+    "id": "dbv2-uc-fqn-meta-llama-strip-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "system.ai.meta-llama-3-3-70b-instruct",
+    "_note": "Probes strip parity on a UC FQN where the llama- token strips through meta-.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": null
+    }
+  },
+  {
+    "id": "dbv2-uc-goose-deepseek-strip-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "data_workflow_tools.goose.goose-deepseek-v4-pro-0813",
+    "_note": "Probes strip parity on a goose- prefixed UC FQN carrying the deepseek- token.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": null
+    }
+  },
+  {
+    "id": "dbv2-uc-fqn-inkling-strip-probe",
+    "provider": "databricks_v2",
+    "raw_model_id": "system.ai.inkling",
+    "_note": "Probes strip parity on a UC FQN carrying the bare inkling token.",
+    "expect": {
+      "thinking_mode": "none",
+      "supported_efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_effort": "medium",
+      "databricks_v2_wire_route": "mlflow-chat",
+      "normalization_policy": "openai-clamp-max-to-xhigh",
+      "registry_label": null
+    }
   }
 ]


### PR DESCRIPTION
Chat-eligible Unity Catalog models from the Gemini, DeepSeek, GLM, Grok, Llama, Qwen, Gemma, and Inkling families were rendering as raw FQNs such as `system.ai.gemini-3-5-flash` in the agent model picker. #6918 surfaces these models, but the capability manifest carried no records for most of them and the registry-label path could not strip their Unity Catalog or `goose-` prefixes.

I added a display-only `label_family_tokens` list and `databricks_v2` exact records for the sixteen previously unlabeled endpoint stems. All 26 target FQNs and their `goose-` aliases now resolve to curated labels through `databricks_registry_label`, while capability resolution continues to use only the existing `family_tokens` (`claude-`, `gpt-`, and `kimi-`). This keeps label discovery from changing capability profiles for unrelated model IDs.

Each new record includes reconciliation metadata against the pinned [models.dev catalog](https://models.dev/api.json). Nine records adopt first-party effort evidence that the Databricks MLflow Chat transport can express: Gemini 3.5 Flash, Gemini 3.5 Flash Lite, Gemini 3.6 Flash, Gemini 3 Pro Image, DeepSeek V4 Flash, DeepSeek V4 Pro, GLM-5.3 Flash, Grok 4.6, and Inkling. The remaining seven deliberately retain the `databricks_v2/concrete_unknown` fallback because upstream evidence is absent, identifies a non-reasoning model, or provides only toggle/token-budget controls that `reasoning_effort` cannot represent.

The normative corpus adds the sixteen exact records, four Unity Catalog alias probes, and two capability-isolation probes. Existing base vectors remain unchanged, and Rust and TypeScript consume the same strict manifest and corpus.

Related: #6918
