### PR TITLE
fix(desktop): hide resting markdown link underlines

### DIFF
--- a/desktop/src/shared/ui/markdown/ExternalLinkAnchor.test.mjs
+++ b/desktop/src/shared/ui/markdown/ExternalLinkAnchor.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { TooltipProvider } from "../tooltip.tsx";
+import { ExternalLinkAnchor } from "./ExternalLinkAnchor.tsx";
+
+test("external markdown links rest without an underline", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(
+      TooltipProvider,
+      null,
+      React.createElement(
+        ExternalLinkAnchor,
+        {
+          anchorProps: {},
+          href: "https://example.com/tasks/t_5873512f",
+          isLinearLink: false,
+          label: "t_5873512f",
+        },
+        "t_5873512f",
+      ),
+    ),
+  );
+
+  const className = html.match(/<a[^>]*class="([^"]+)"/)?.[1] ?? "";
+  assert.match(className, /(?:^| )no-underline(?: |$)/);
+  assert.match(className, /(?:^| )hover:underline(?: |$)/);
+  assert.doesNotMatch(className, /(?:^| )underline(?: |$)/);
+});

--- a/desktop/src/shared/ui/markdown/ExternalLinkAnchor.tsx
+++ b/desktop/src/shared/ui/markdown/ExternalLinkAnchor.tsx
@@ -42,7 +42,7 @@ export function ExternalLinkAnchor({
     <a
       {...anchorProps}
       className={cn(
-        "font-medium underline underline-offset-4 transition-colors",
+        "font-medium no-underline underline-offset-4 transition-colors hover:underline",
         isLinearLink ? "linear-link" : "text-primary hover:text-primary/80",
       )}
       href={href}


### PR DESCRIPTION
## Summary
- remove the always-on underline from external Markdown links
- retain an underline on hover for pointer users
- prevent the blue task-ID underline seen in the mobile timeline

## Verification
- `node --import ./test-loader.mjs --experimental-strip-types --test src/shared/ui/markdown/ExternalLinkAnchor.test.mjs`
- `pnpm exec biome check src/shared/ui/markdown/ExternalLinkAnchor.tsx src/shared/ui/markdown/ExternalLinkAnchor.test.mjs`
- `pnpm typecheck`
- `pnpm build`