### PR TITLE
Reduce idle ACP worker fan-out

### DIFF
--- a/desktop/src-tauri/src/managed_agents/agent_env.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_env.rs
@@ -15,6 +15,11 @@ use base64::Engine as _;
 /// normal back-and-forth but a truly quiet harness stops paying for workers.
 const IDLE_POOL_SLEEP_SECS: &str = "900";
 
+/// Seconds a manually started harness may remain quiet before the whole
+/// process exits. Auto-start agents deliberately keep their relay listener;
+/// manual-start agents are demand-scoped and should not retain one forever.
+const MANUAL_HARNESS_IDLE_EXIT_SECS: &str = "900";
+
 /// Value for `BUZZ_ACP_IDLE_POOL_SLEEP`. Idle re-sleep is only meaningful for
 /// lazy harnesses (the harness ignores it otherwise); gate to `lazy` here so
 /// the env reads inert (`"0"` = disabled) for eager harnesses. This is a
@@ -25,6 +30,33 @@ pub(super) fn idle_pool_sleep_env(lazy: bool) -> &'static str {
     } else {
         "0"
     }
+}
+
+/// Value for `BUZZ_ACP_EXIT_AFTER_INACTIVITY`.
+///
+/// The inactivity reaper is only enabled for lazy, manual-start agents. An
+/// auto-start agent's contract is continuous relay availability, while an
+/// eager harness may have been launched for setup or another bounded flow
+/// whose lifetime is owned by its caller.
+pub(super) fn exit_after_inactivity_env(lazy: bool, start_on_app_launch: bool) -> &'static str {
+    if lazy && !start_on_app_launch {
+        MANUAL_HARNESS_IDLE_EXIT_SECS
+    } else {
+        "0"
+    }
+}
+
+/// Apply Desktop-owned ACP harness lifetime policy to a child process.
+pub(super) fn apply_harness_lifecycle_env(
+    command: &mut std::process::Command,
+    lazy: bool,
+    start_on_app_launch: bool,
+) {
+    command.env("BUZZ_ACP_IDLE_POOL_SLEEP", idle_pool_sleep_env(lazy));
+    command.env(
+        "BUZZ_ACP_EXIT_AFTER_INACTIVITY",
+        exit_after_inactivity_env(lazy, start_on_app_launch),
+    );
 }
 
 /// Return the baked-in build-time env pairs as a map.
@@ -141,8 +173,18 @@ pub(crate) fn parse_agent_env_lines(raw: &str) -> Vec<(&str, &str)> {
 mod tests {
     use super::{
         baked_build_env, build_buzz_agent_provider_defaults, build_env_map,
-        discovery_env_with_baked_floor, parse_agent_env_lines,
+        discovery_env_with_baked_floor, exit_after_inactivity_env, idle_pool_sleep_env,
+        parse_agent_env_lines,
     };
+
+    #[test]
+    fn lazy_manual_harnesses_reap_but_auto_start_harnesses_keep_listening() {
+        assert_eq!(exit_after_inactivity_env(true, false), "900");
+        assert_eq!(exit_after_inactivity_env(true, true), "0");
+        assert_eq!(exit_after_inactivity_env(false, false), "0");
+        assert_eq!(idle_pool_sleep_env(true), "900");
+        assert_eq!(idle_pool_sleep_env(false), "0");
+    }
 
     #[test]
     fn buzz_agent_provider_defaults_empty_in_oss_build() {

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use tauri::AppHandle;
 
-use super::agent_env::{build_buzz_agent_provider_defaults, idle_pool_sleep_env};
+use super::agent_env::{apply_harness_lifecycle_env, build_buzz_agent_provider_defaults};
 
 use crate::{
     managed_agents::{
@@ -533,7 +533,7 @@ pub fn spawn_agent_child(
     command.env("BUZZ_PRIVATE_KEY", &record.private_key_nsec);
     command.env("BUZZ_RELAY_URL", &effective_relay_url);
     command.env("BUZZ_ACP_LAZY_POOL", if lazy { "true" } else { "false" });
-    command.env("BUZZ_ACP_IDLE_POOL_SLEEP", idle_pool_sleep_env(lazy));
+    apply_harness_lifecycle_env(&mut command, lazy, record.start_on_app_launch);
     command.env("BUZZ_ACP_AGENT_COMMAND", &resolved_agent_command);
     command.env("BUZZ_ACP_AGENT_ARGS", agent_args.join(","));
     match &resolved_mcp_command {

--- a/desktop/src/features/agents/lib/instanceInputForDefinition.test.mjs
+++ b/desktop/src/features/agents/lib/instanceInputForDefinition.test.mjs
@@ -153,13 +153,13 @@ test("mapping carries the runtime and definition fields", async () => {
   assert.equal(input.model, undefined);
   assert.equal(input.provider, undefined);
   assert.equal(input.spawnAfterCreate, true);
-  assert.equal(input.startOnAppLaunch, true);
+  assert.equal(input.startOnAppLaunch, false);
   assert.deepEqual(input.backend, { type: "local" });
 });
 
-test("no backend intent is byte-identical to the pre-intent mapping", async () => {
-  // The 3 pre-B5 call sites (useManagedAgentActions, usePersonaActions,
-  // UserProfilePanel) pass no intent; their output must not move.
+test("no backend intent starts locally without opting into launch fan-out", async () => {
+  // The 3 ordinary local call sites (useManagedAgentActions,
+  // usePersonaActions, UserProfilePanel) pass no backend intent.
   // B-5: agentArgs is [] — args are NOT seeded from the definition at create
   // time. Spawn reads live args from the definition on every start.
   const input = await buildInstanceInputForDefinition(persona(), gooseRuntime);
@@ -176,7 +176,7 @@ test("no backend intent is byte-identical to the pre-intent mapping", async () =
     model: undefined,
     provider: undefined,
     spawnAfterCreate: true,
-    startOnAppLaunch: true,
+    startOnAppLaunch: false,
     backend: { type: "local" },
   });
 });
@@ -194,7 +194,7 @@ test("Buzz shared compute definition carries native provider and auto model", as
   assert.equal(input.provider, "relay-mesh");
   assert.equal(input.model, "auto");
   assert.equal(input.spawnAfterCreate, true);
-  assert.equal(input.startOnAppLaunch, true);
+  assert.equal(input.startOnAppLaunch, false);
 });
 
 test("provider intent forces startOnAppLaunch off and omits local commands", async () => {

--- a/desktop/src/features/agents/lib/instanceInputForDefinition.ts
+++ b/desktop/src/features/agents/lib/instanceInputForDefinition.ts
@@ -68,8 +68,8 @@ export function resolveStartRuntimeForDefinition(
 
 /**
  * Where the started instance should run when the user picked something other
- * than plain local in the definition-create flow (B5). Absent intent =
- * today's local mapping, byte-identical.
+ * than plain local in the definition-create flow (B5). Absent intent uses the
+ * local mapping below: start now, with future launch-time fan-out opt-in.
  *
  * - `provider`: remote backend. Mirrors the legacy provider-mode create:
  *   no local ACP/agent/MCP commands are spawned, so none are set;
@@ -155,7 +155,9 @@ export async function buildInstanceInputForDefinition(
     model: persona.model ?? undefined,
     provider: persona.provider ?? undefined,
     spawnAfterCreate: true,
-    startOnAppLaunch: true,
+    // Start this deployment now, but require an explicit opt-in before every
+    // future Desktop launch retains a relay-listener process for it.
+    startOnAppLaunch: false,
     backend: { type: "local" },
   };
 }


### PR DESCRIPTION
## Summary
- keep newly created local agents immediate-start, but make future launch-time listening opt-in
- reap manually started lazy ACP harnesses after 15 minutes of inactivity
- preserve existing Auto-start preferences and continuous listeners for explicitly opted-in agents

## Root cause
Desktop eagerly launched one lazy `buzz-acp` harness for every Auto-start agent/community pair. Lazy pooling deferred the model subprocess, but the outer harness and relay socket stayed resident indefinitely, so idle configurations fanned out into dozens of processes.

## Behavior notes
- Existing Auto-start settings are unchanged; there is no migration.
- Explicit Auto-start agents retain instant remote-mention behavior.
- Eager/setup-owned harness lifetimes remain caller-owned.

## Validation
- `just ci` on commit `3cd4d1ab74d2bc4d574ef59cb0976f7d259861de`
- complete Desktop JavaScript suite passed
- Desktop Rust main crate: 2,980 passed, 18 ignored; integration targets passed
- Mobile: 1,896 passed
- workspace lint, formatting, builds, unit suites, file-size enforcement, web build, and mobile analysis passed

Buzz origin channel: `b97e1d62-f607-5ab9-89f8-3ae4363fd9d5`
