### PR TITLE
perf(mobile): pace startup subscriptions

### DIFF
--- a/mobile/lib/features/channels/channel_directory.dart
+++ b/mobile/lib/features/channels/channel_directory.dart
@@ -485,3 +485,86 @@ extension _ObservedUnreadRecording on ChannelsNotifier {
     }
   }
 }
+
+/// Scope-owned live events received before the initial list is published.
+class _BootstrapLiveEventBuffer {
+  _BootstrapLiveEventBuffer(this.fence);
+
+  final _ChannelRefreshFence fence;
+  final Map<String, NostrEvent> events = {};
+}
+
+extension _ChannelBootstrapMerging on ChannelsNotifier {
+  void _cacheMemberSnapshots(
+    Iterable<NostrEvent> events, {
+    bool replaceAll = false,
+  }) {
+    final latestByChannelId = <String, NostrEvent>{};
+    for (final event in events) {
+      final channelId = event.getTagValue('d');
+      if (channelId == null) continue;
+      final current = latestByChannelId[channelId];
+      if (current == null || event.createdAt > current.createdAt) {
+        latestByChannelId[channelId] = event;
+      }
+    }
+
+    final snapshots = replaceAll
+        ? <String, List<ChannelMember>>{}
+        : Map<String, List<ChannelMember>>.of(_memberSnapshotsByChannelId);
+    snapshots.addAll({
+      for (final entry in latestByChannelId.entries)
+        entry.key: List.unmodifiable([
+          for (final member in membersFromEvent(entry.value))
+            ChannelMember(
+              pubkey: member.pubkey,
+              role: member.role,
+              joinedAt: DateTime.fromMillisecondsSinceEpoch(
+                entry.value.createdAt * 1000,
+                isUtc: true,
+              ),
+            ),
+        ]),
+    });
+    _memberSnapshotsByChannelId = Map.unmodifiable(snapshots);
+  }
+
+  List<NostrFilter> _lastMessageFilters(List<Channel> channels) => [
+    for (final channel in channels)
+      NostrFilter(
+        kinds: EventKind.channelMessageEventKinds,
+        tags: {
+          '#h': [channel.id],
+        },
+        limit: channel.isDm ? 1 : 20,
+      ),
+  ];
+
+  void _mergeLastMessageEvents(
+    Map<String, int> lastMessageMap,
+    Iterable<NostrEvent> events, {
+    required Map<String, Channel> channelById,
+    required String myPk,
+    required Set<String> mutedChannelIds,
+  }) {
+    for (final event in events) {
+      final channelId = event.channelId;
+      if (channelId == null) continue;
+      final channel = channelById[channelId];
+      if (channel == null) continue;
+      if (!channel.isDm &&
+          !shouldNotifyForEvent(
+            event,
+            myPk,
+            mutedChannelIds: mutedChannelIds,
+            channelId: channelId,
+          )) {
+        continue;
+      }
+      final current = lastMessageMap[channelId];
+      if (current == null || event.createdAt > current) {
+        lastMessageMap[channelId] = event.createdAt;
+      }
+    }
+  }
+}

--- a/mobile/lib/features/channels/channel_sync.dart
+++ b/mobile/lib/features/channels/channel_sync.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+import 'dart:math';
+
+const channelQueryBatchSize = 100;
+const liveSubscriptionMaxConcurrent = 4;
+const liveSubscriptionStartInterval = Duration(milliseconds: 125);
+
+typedef TaskDelay = Future<void> Function(Duration duration);
+
+List<List<T>> chunkChannelQueryItems<T>(List<T> items) => [
+  for (var start = 0; start < items.length; start += channelQueryBatchSize)
+    items.sublist(start, min(start + channelQueryBatchSize, items.length)),
+];
+
+/// Runs tasks through one globally serialized admission chain.
+///
+/// The relay bills each REQ against a 50-per-five-second budget. A 125 ms
+/// interval admits at most 40 requests in a half-open five-second window, while
+/// the worker ceiling limits outstanding readiness waits when the relay stalls.
+Future<void> runPacedTasks(
+  List<Future<void> Function()> tasks, {
+  required int maxConcurrent,
+  required Duration startInterval,
+  required bool Function() isCancelled,
+  TaskDelay delay = defaultTaskDelay,
+  void Function(Object error)? onError,
+}) async {
+  if (maxConcurrent < 1) throw ArgumentError.value(maxConcurrent);
+  var nextTask = 0;
+  var firstStart = true;
+  Future<void> startPermit = Future.value();
+
+  Future<bool> acquireStartPermit() async {
+    if (firstStart) {
+      firstStart = false;
+    } else {
+      startPermit = startPermit.then((_) => delay(startInterval));
+      await startPermit;
+    }
+    return !isCancelled();
+  }
+
+  Future<void> worker() async {
+    while (true) {
+      final index = nextTask++;
+      if (index >= tasks.length) return;
+      if (!await acquireStartPermit()) return;
+      try {
+        await tasks[index]();
+      } catch (error) {
+        onError?.call(error);
+      }
+    }
+  }
+
+  await Future.wait([
+    for (var i = 0; i < min(maxConcurrent, tasks.length); i++) worker(),
+  ]);
+}
+
+Future<void> defaultTaskDelay(Duration duration) =>
+    Future<void>.delayed(duration);

--- a/mobile/lib/features/channels/channels_provider.dart
+++ b/mobile/lib/features/channels/channels_provider.dart
@@ -24,6 +24,9 @@ part 'channels_provider_lifecycle.dart';
 
 const _channelTypeOrder = {'stream': 0, 'forum': 1, 'dm': 2};
 const _unreadCatchUpLimit = 1000;
+const _latestMessageQueryBatchSize = 128;
+const _latestMessageQueryDeadline = Duration(seconds: 8);
+const _liveSubscriptionStartInterval = Duration(milliseconds: 125);
 const _participatedRootIdsPrefix = 'buzz-thread-participation.v1';
 const _authoredRootIdsPrefix = 'buzz-thread-authored.v1';
 
@@ -46,6 +49,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
   int _subscriptionVersion = 0;
   String? _subscriptionRelayBaseUrl;
   Timer? _backstopTimer;
+  _BootstrapLiveEventBuffer? _bootstrapLiveEventBuffer;
   final Map<String, int> _latestObservedByChannel = {};
   final Map<String, Map<String, ObservedUnreadEvent>>
   _observedUnreadEventsByChannel = {};
@@ -128,6 +132,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       _observedUnreadEventsByChannel.clear();
       _backstopTimer?.cancel();
       _backstopTimer = null;
+      _bootstrapLiveEventBuffer = null;
     });
 
     if (sessionState.status != SessionStatus.connected) {
@@ -291,11 +296,17 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       }
     }
 
-    // Step 3: fetch the most recent message per channel to populate lastMessageAt.
-    // kind:39000 metadata doesn't carry message timestamps, so channels load with
-    // lastMessageAt: null. Without this, unread detection and badge computation
-    // see every channel as having no messages. Skipped on backstop refreshes since
-    // live subscriptions keep lastMessageAt current after the initial load.
+    final bootstrapBuffer = subscribeLive && !_hasLoaded
+        ? _BootstrapLiveEventBuffer(fence)
+        : null;
+    if (bootstrapBuffer != null) {
+      _bootstrapLiveEventBuffer = bootstrapBuffer;
+      fence.ensureCurrent();
+      unawaited(_subscribeLive(channels, fence));
+    }
+
+    // Fetch a bounded latest-message snapshot while initial live subscriptions
+    // are admitted in the background. Batches share one total startup deadline.
     if (fetchLastMessage) {
       final activeChannels = [
         for (final channel in channels)
@@ -304,29 +315,38 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       final channelById = {
         for (final channel in activeChannels) channel.id: channel,
       };
-      final events = await _fenced(
-        fence,
-        _fetchLastMessageEvents(session, activeChannels),
-      );
       final lastMessageMap = <String, int>{};
       final mutedChannelIds = _mutedChannelIds();
-      for (final event in events) {
-        final channelId = event.channelId;
-        if (channelId == null) continue;
-        final channel = channelById[channelId];
-        if (channel == null) continue;
-        if (!channel.isDm &&
-            !shouldNotifyForEvent(
-              event,
-              myPk,
-              mutedChannelIds: mutedChannelIds,
-              channelId: channelId,
-            )) {
-          continue;
-        }
-        final current = lastMessageMap[channelId];
-        if (current == null || event.createdAt > current) {
-          lastMessageMap[channelId] = event.createdAt;
+      final stopwatch = Stopwatch()..start();
+      for (
+        var start = 0;
+        start < activeChannels.length;
+        start += _latestMessageQueryBatchSize
+      ) {
+        final remaining = _latestMessageQueryDeadline - stopwatch.elapsed;
+        if (remaining <= Duration.zero) break;
+        final end = min(
+          start + _latestMessageQueryBatchSize,
+          activeChannels.length,
+        );
+        try {
+          final events = await _fenced(
+            fence,
+            session.queryRelay(
+              _lastMessageFilters(activeChannels.sublist(start, end)),
+              timeout: remaining,
+            ),
+          );
+          _mergeLastMessageEvents(
+            lastMessageMap,
+            events,
+            channelById: channelById,
+            myPk: myPk,
+            mutedChannelIds: mutedChannelIds,
+          );
+        } catch (error) {
+          if (error is _StaleChannelRefresh) rethrow;
+          debugPrint('[ChannelsNotifier] last-message batch failed: $error');
         }
       }
 
@@ -378,7 +398,18 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       }
     }
 
-    if (subscribeLive) {
+    if (bootstrapBuffer != null) {
+      if (!identical(_bootstrapLiveEventBuffer, bootstrapBuffer)) {
+        throw const _StaleChannelRefresh();
+      }
+      for (final event in bootstrapBuffer.events.values) {
+        _mergeLiveEventIntoChannels(channels, event);
+      }
+      // Publish while the buffer is still authoritative. No asynchronous
+      // callback can interleave between this write and the handoff below.
+      state = AsyncData(channels);
+      _bootstrapLiveEventBuffer = null;
+    } else if (subscribeLive) {
       // Subscriptions are shared relay state, so a retired refresh must not
       // install them even though its channel list is already built.
       fence.ensureCurrent();
@@ -388,68 +419,6 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     // caller assigns whatever this returns, so the last check belongs here.
     fence.ensureCurrent();
     return channels;
-  }
-
-  void _cacheMemberSnapshots(
-    Iterable<NostrEvent> events, {
-    bool replaceAll = false,
-  }) {
-    final latestByChannelId = <String, NostrEvent>{};
-    for (final event in events) {
-      final channelId = event.getTagValue('d');
-      if (channelId == null) continue;
-      final current = latestByChannelId[channelId];
-      if (current == null || event.createdAt > current.createdAt) {
-        latestByChannelId[channelId] = event;
-      }
-    }
-
-    final snapshots = replaceAll
-        ? <String, List<ChannelMember>>{}
-        : Map<String, List<ChannelMember>>.of(_memberSnapshotsByChannelId);
-    snapshots.addAll({
-      for (final entry in latestByChannelId.entries)
-        entry.key: List.unmodifiable([
-          for (final member in membersFromEvent(entry.value))
-            ChannelMember(
-              pubkey: member.pubkey,
-              role: member.role,
-              joinedAt: DateTime.fromMillisecondsSinceEpoch(
-                entry.value.createdAt * 1000,
-                isUtc: true,
-              ),
-            ),
-        ]),
-    });
-    _memberSnapshotsByChannelId = Map.unmodifiable(snapshots);
-  }
-
-  /// Fetches each channel's independent latest-message window in one HTTP
-  /// bridge request. The relay preserves NIP-01 per-filter limits while
-  /// executing the filters with bounded concurrency, avoiding an unbounded
-  /// burst of websocket REQs on communities with many channels.
-  Future<List<NostrEvent>> _fetchLastMessageEvents(
-    RelaySessionNotifier session,
-    List<Channel> channels,
-  ) async {
-    if (channels.isEmpty) return const [];
-
-    final filters = [
-      for (final channel in channels)
-        NostrFilter(
-          kinds: EventKind.channelMessageEventKinds,
-          tags: {
-            '#h': [channel.id],
-          },
-          limit: channel.isDm ? 1 : 20,
-        ),
-    ];
-
-    return _fetchChannelHistoryBatch(
-      session,
-      filters,
-      operation: 'latest-message query',
-    );
   }
 
   Future<List<NostrEvent>> _fetchChannelHistoryBatch(
@@ -604,11 +573,16 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       entry.value();
     }
 
-    for (final channelId in channelIds) {
+    final pendingChannelIds = channelIds.toList();
+    for (var index = 0; index < pendingChannelIds.length; index++) {
+      final channelId = pendingChannelIds[index];
       if (ref.read(relaySessionProvider).status != SessionStatus.connected) {
         return;
       }
       if (_unsubscribersByChannel.containsKey(channelId)) continue;
+      if (subscriptionVersion != _subscriptionVersion || !fence.isCurrent) {
+        return;
+      }
       try {
         final unsubscribe = await session.subscribe(
           NostrFilter(
@@ -638,6 +612,9 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
           continue;
         }
         _unsubscribersByChannel[channelId] = unsubscribe;
+        if (index + 1 < pendingChannelIds.length) {
+          await Future<void>.delayed(_liveSubscriptionStartInterval);
+        }
       } on _StaleChannelRefresh {
         rethrow;
       } catch (error) {
@@ -778,48 +755,53 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
   }
 
   void _handleLiveEvent(NostrEvent event) {
-    final channelId = event.channelId;
-    if (channelId == null) return;
-
-    final myPk = ref.read(myPubkeyProvider);
-    final mutedChannelIds = _mutedChannelIds();
+    final bootstrapBuffer = _bootstrapLiveEventBuffer;
+    if (bootstrapBuffer != null) {
+      if (bootstrapBuffer.fence.isCurrent) {
+        bootstrapBuffer.events[event.id] = event;
+      }
+      return;
+    }
+    if (event.channelId == null) return;
 
     state = state.whenData((channels) {
-      final idx = channels.indexWhere((c) => c.id == channelId);
-      if (idx == -1) {
-        refresh();
-        return channels;
-      }
       final updated = List<Channel>.of(channels);
-      final channel = updated[idx];
-
-      if (myPk != null && event.pubkey.toLowerCase() == myPk.toLowerCase()) {
-        _recordSelfThreadInterest(event, myPk);
-      }
-
-      if (myPk != null &&
-          shouldNotifyForEvent(
-            event,
-            myPk,
-            participatedRootIds: _participatedRootIds,
-            followedRootIds: _followedRootIds(),
-            authoredRootIds: _authoredRootIds,
-            mutedChannelIds: mutedChannelIds,
-            channelId: channel.id,
-          )) {
-        _recordUnreadEvent(channel, event, myPk);
-        final eventTime = DateTime.fromMillisecondsSinceEpoch(
-          event.createdAt * 1000,
-          isUtc: true,
-        );
-        if (channel.lastMessageAt == null ||
-            eventTime.isAfter(channel.lastMessageAt!)) {
-          updated[idx] = channel.copyWith(lastMessageAt: eventTime);
-        }
-      }
-
+      _mergeLiveEventIntoChannels(updated, event);
       return updated;
     });
+  }
+
+  void _mergeLiveEventIntoChannels(List<Channel> channels, NostrEvent event) {
+    final channelId = event.channelId;
+    if (channelId == null) return;
+    final idx = channels.indexWhere((channel) => channel.id == channelId);
+    if (idx == -1) return;
+    final myPk = ref.read(myPubkeyProvider);
+    final channel = channels[idx];
+    if (myPk != null && event.pubkey.toLowerCase() == myPk.toLowerCase()) {
+      _recordSelfThreadInterest(event, myPk);
+    }
+    if (myPk == null ||
+        !shouldNotifyForEvent(
+          event,
+          myPk,
+          participatedRootIds: _participatedRootIds,
+          followedRootIds: _followedRootIds(),
+          authoredRootIds: _authoredRootIds,
+          mutedChannelIds: _mutedChannelIds(),
+          channelId: channel.id,
+        )) {
+      return;
+    }
+    _recordUnreadEvent(channel, event, myPk);
+    final eventTime = DateTime.fromMillisecondsSinceEpoch(
+      event.createdAt * 1000,
+      isUtc: true,
+    );
+    if (channel.lastMessageAt == null ||
+        eventTime.isAfter(channel.lastMessageAt!)) {
+      channels[idx] = channel.copyWith(lastMessageAt: eventTime);
+    }
   }
 
   Set<String> _mutedChannelIds() => {

--- a/mobile/lib/features/channels/channels_provider.dart
+++ b/mobile/lib/features/channels/channels_provider.dart
@@ -387,6 +387,13 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     final prevById = <String, Channel>{
       for (final c in state.value ?? const <Channel>[]) c.id: c,
     };
+    for (var i = 0; i < channels.length; i++) {
+      final previous = prevById[channels[i].id]?.lastMessageAt;
+      if (previous != null &&
+          (channels[i].lastMessageAt?.isBefore(previous) ?? true)) {
+        channels[i] = channels[i].copyWith(lastMessageAt: previous);
+      }
+    }
     for (final channel in channels) {
       final prev = prevById[channel.id];
       if (prev != null && prev.isArchived != channel.isArchived) {
@@ -881,7 +888,6 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     }
   }
 
-  /// Backstop refresh that preserves existing state on transient failure.
   Future<void> _backstopRefresh() async {
     try {
       final sessionState = ref.read(relaySessionProvider);

--- a/mobile/lib/features/channels/channels_provider.dart
+++ b/mobile/lib/features/channels/channels_provider.dart
@@ -378,10 +378,8 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     // Scoped narrowly to the archived flip — broader metadata staleness
     // (renames, topic changes, etc.) is a separate, pre-existing concern that
     // already affects this provider for other reasons.
-    // Re-check before the first write that other providers can observe. Every
     // await above is fenced, but the switch can also land in the synchronous
-    // gap, so the guard sits immediately before the write rather than only
-    // after the await.
+    // gap, so the guard sits immediately before the write.
     fence.ensureCurrent();
 
     final prevById = <String, Channel>{
@@ -390,7 +388,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     for (var i = 0; i < channels.length; i++) {
       final previous = prevById[channels[i].id]?.lastMessageAt;
       if (previous != null &&
-          (channels[i].lastMessageAt?.isBefore(previous) ?? true)) {
+          previous.isAfter(channels[i].lastMessageAt ?? DateTime(0))) {
         channels[i] = channels[i].copyWith(lastMessageAt: previous);
       }
     }

--- a/mobile/lib/features/channels/channels_provider.dart
+++ b/mobile/lib/features/channels/channels_provider.dart
@@ -9,6 +9,7 @@ import '../../shared/relay/relay.dart';
 import '../../shared/theme/theme_provider.dart';
 import '../../shared/utils/string_utils.dart';
 import 'channel.dart';
+import 'channel_sync.dart';
 import 'channel_management_provider.dart'
     show ChannelMember, channelDetailsProvider;
 import 'channel_mutes/channel_mutes_provider.dart';
@@ -24,9 +25,7 @@ part 'channels_provider_lifecycle.dart';
 
 const _channelTypeOrder = {'stream': 0, 'forum': 1, 'dm': 2};
 const _unreadCatchUpLimit = 1000;
-const _latestMessageQueryBatchSize = 128;
 const _latestMessageQueryDeadline = Duration(seconds: 8);
-const _liveSubscriptionStartInterval = Duration(milliseconds: 125);
 const _participatedRootIdsPrefix = 'buzz-thread-participation.v1';
 const _authoredRootIdsPrefix = 'buzz-thread-authored.v1';
 
@@ -321,14 +320,11 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       for (
         var start = 0;
         start < activeChannels.length;
-        start += _latestMessageQueryBatchSize
+        start += channelQueryBatchSize
       ) {
         final remaining = _latestMessageQueryDeadline - stopwatch.elapsed;
         if (remaining <= Duration.zero) break;
-        final end = min(
-          start + _latestMessageQueryBatchSize,
-          activeChannels.length,
-        );
+        final end = min(start + channelQueryBatchSize, activeChannels.length);
         try {
           final events = await _fenced(
             fence,
@@ -425,11 +421,12 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     RelaySessionNotifier session,
     List<NostrFilter> filters, {
     required String operation,
+    Duration timeout = const Duration(seconds: 8),
   }) async {
     if (filters.isEmpty) return const [];
 
     try {
-      return await session.queryRelay(filters);
+      return await session.queryRelay(filters, timeout: timeout);
     } catch (error) {
       debugPrint(
         '[ChannelsNotifier] batched $operation failed; '
@@ -546,7 +543,8 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     _ChannelRefreshFence fence,
   ) async {
     fence.ensureCurrent();
-    if (ref.read(relaySessionProvider).status != SessionStatus.connected) {
+    if (!ref.mounted ||
+        ref.read(relaySessionProvider).status != SessionStatus.connected) {
       return;
     }
 
@@ -573,58 +571,64 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       entry.value();
     }
 
-    final pendingChannelIds = channelIds.toList();
-    for (var index = 0; index < pendingChannelIds.length; index++) {
-      final channelId = pendingChannelIds[index];
-      if (ref.read(relaySessionProvider).status != SessionStatus.connected) {
-        return;
-      }
-      if (_unsubscribersByChannel.containsKey(channelId)) continue;
-      if (subscriptionVersion != _subscriptionVersion || !fence.isCurrent) {
-        return;
-      }
-      try {
-        final unsubscribe = await session.subscribe(
-          NostrFilter(
-            kinds: EventKind.channelEventKinds,
-            tags: {
-              '#h': [channelId],
-            },
-            limit: 0,
-          ),
-          _handleLiveEvent,
-        );
-        if (!fence.isCurrent) {
-          unsubscribe();
-          throw const _StaleChannelRefresh();
-        }
-        if (subscriptionVersion != _subscriptionVersion ||
-            ref.read(relaySessionProvider).status != SessionStatus.connected ||
-            !_desiredLiveChannelIds.contains(channelId) ||
-            ref.read(relayConfigProvider).baseUrl != relayBaseUrl ||
-            _subscriptionRelayBaseUrl != relayBaseUrl) {
-          unsubscribe();
-          return;
-        }
-        final replaced = _unsubscribersByChannel[channelId];
-        if (replaced != null) {
-          unsubscribe();
-          continue;
-        }
-        _unsubscribersByChannel[channelId] = unsubscribe;
-        if (index + 1 < pendingChannelIds.length) {
-          await Future<void>.delayed(_liveSubscriptionStartInterval);
-        }
-      } on _StaleChannelRefresh {
-        rethrow;
-      } catch (error) {
-        debugPrint(
-          '[ChannelsNotifier] live subscription failed for $channelId: $error',
-        );
-      }
-    }
+    final pendingChannelIds = [
+      for (final channelId in channelIds)
+        if (!_unsubscribersByChannel.containsKey(channelId)) channelId,
+    ];
+    await runPacedTasks(
+      [
+        for (final channelId in pendingChannelIds)
+          () async {
+            if (subscriptionVersion != _subscriptionVersion ||
+                !fence.isCurrent ||
+                ref.read(relaySessionProvider).status !=
+                    SessionStatus.connected) {
+              return;
+            }
+            final unsubscribe = await session.subscribeWithStatus(
+              NostrFilter(
+                kinds: EventKind.channelEventKinds,
+                tags: {
+                  '#h': [channelId],
+                },
+                limit: 0,
+              ),
+              _handleLiveEvent,
+              onStatusChanged: (_) {},
+            );
+            if (subscriptionVersion != _subscriptionVersion ||
+                !fence.isCurrent ||
+                ref.read(relaySessionProvider).status !=
+                    SessionStatus.connected ||
+                !_desiredLiveChannelIds.contains(channelId) ||
+                ref.read(relayConfigProvider).baseUrl != relayBaseUrl ||
+                _subscriptionRelayBaseUrl != relayBaseUrl) {
+              unsubscribe();
+              return;
+            }
+            final replaced = _unsubscribersByChannel[channelId];
+            if (replaced != null) {
+              unsubscribe();
+              return;
+            }
+            _unsubscribersByChannel[channelId] = unsubscribe;
+          },
+      ],
+      maxConcurrent: liveSubscriptionMaxConcurrent,
+      startInterval: liveSubscriptionStartInterval,
+      isCancelled: () =>
+          subscriptionVersion != _subscriptionVersion ||
+          !fence.isCurrent ||
+          ref.read(relaySessionProvider).status != SessionStatus.connected ||
+          ref.read(relayConfigProvider).baseUrl != relayBaseUrl,
+      delay: ref.read(channelsLiveSubscriptionDelayProvider),
+      onError: (error) {
+        debugPrint('[ChannelsNotifier] live subscription failed: $error');
+      },
+    );
 
-    if (ref.read(relaySessionProvider).status != SessionStatus.connected) {
+    if (!ref.mounted ||
+        ref.read(relaySessionProvider).status != SessionStatus.connected) {
       return;
     }
 
@@ -702,11 +706,20 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     ];
 
     try {
-      final events = await _fetchChannelHistoryBatch(
-        session,
-        filters,
-        operation: 'unread catch-up',
-      );
+      final events = <NostrEvent>[];
+      final stopwatch = Stopwatch()..start();
+      for (final batch in chunkChannelQueryItems(filters)) {
+        final remaining = _latestMessageQueryDeadline - stopwatch.elapsed;
+        if (remaining <= Duration.zero) break;
+        events.addAll(
+          await _fetchChannelHistoryBatch(
+            session,
+            batch,
+            operation: 'unread catch-up',
+            timeout: remaining,
+          ),
+        );
+      }
       // The relay round-trip above is the window Jed's probes park in: a newer
       // refresh, a community switch or an identity switch here means every
       // write below belongs to a channel list the user has left.
@@ -974,4 +987,8 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
 
 final channelsProvider = AsyncNotifierProvider<ChannelsNotifier, List<Channel>>(
   ChannelsNotifier.new,
+);
+
+final channelsLiveSubscriptionDelayProvider = Provider<TaskDelay>(
+  (_) => defaultTaskDelay,
 );

--- a/mobile/lib/features/channels/channels_provider.dart
+++ b/mobile/lib/features/channels/channels_provider.dart
@@ -55,6 +55,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
   Set<String> _participatedRootIds = {};
   Set<String> _authoredRootIds = {};
   String? _threadInterestPubkey;
+  String? _publishedChannelScope;
   bool _hasLoaded = false;
   String? _memberSnapshotRelayBaseUrl;
   String? _memberSnapshotPubkey;
@@ -62,7 +63,6 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
   List<NostrEvent> _directoryMetas = const [];
   Set<String> _hiddenDmIds = const {};
 
-  /// Fences directory responses to the relay and identity that requested them.
   late final _ChannelRefreshCoordinator _refreshCoordinator =
       _ChannelRefreshCoordinator.forRef(ref);
 
@@ -378,13 +378,13 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     // Scoped narrowly to the archived flip — broader metadata staleness
     // (renames, topic changes, etc.) is a separate, pre-existing concern that
     // already affects this provider for other reasons.
-    // await above is fenced, but the switch can also land in the synchronous
-    // gap, so the guard sits immediately before the write.
     fence.ensureCurrent();
 
-    final prevById = <String, Channel>{
-      for (final c in state.value ?? const <Channel>[]) c.id: c,
-    };
+    final prevById = _publishedChannelScope == fence.scope
+        ? <String, Channel>{
+            for (final c in state.value ?? const <Channel>[]) c.id: c,
+          }
+        : const <String, Channel>{};
     for (var i = 0; i < channels.length; i++) {
       final previous = prevById[channels[i].id]?.lastMessageAt;
       if (previous != null &&
@@ -419,6 +419,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     // Guard the provider-state write in `retryDirectory` and `build`: the
     // caller assigns whatever this returns, so the last check belongs here.
     fence.ensureCurrent();
+    _publishedChannelScope = fence.scope;
     return channels;
   }
 

--- a/mobile/lib/shared/relay/relay_closed_policy.dart
+++ b/mobile/lib/shared/relay/relay_closed_policy.dart
@@ -3,6 +3,9 @@ enum RelayClosedClass {
   /// A transient failure that may recover when the same REQ is retried.
   retryable,
 
+  /// Relay capacity exhaustion that may recover after another REQ closes.
+  capacity,
+
   /// Relay back-pressure that must also arm the shared request gate.
   rateLimited,
 
@@ -16,6 +19,9 @@ RelayClosedClass classifyRelayClosed(String message) {
   if (normalized.startsWith('rate-limited:')) {
     return RelayClosedClass.rateLimited;
   }
+  if (normalized.startsWith('error: too many subscriptions')) {
+    return RelayClosedClass.capacity;
+  }
   if (normalized.startsWith('restricted:') ||
       normalized.startsWith('auth-required:') ||
       normalized.startsWith('blocked:') ||
@@ -23,8 +29,7 @@ RelayClosedClass classifyRelayClosed(String message) {
       normalized.startsWith('pow:') ||
       normalized.startsWith('duplicate:') ||
       normalized.startsWith('unsupported:') ||
-      normalized.startsWith('error: mixed search') ||
-      normalized.startsWith('error: too many subscriptions')) {
+      normalized.startsWith('error: mixed search')) {
     return RelayClosedClass.terminal;
   }
   return RelayClosedClass.retryable;

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -154,6 +154,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     List<NostrFilter> filters, {
     Duration timeout = const Duration(seconds: 8),
   }) async {
+    if (_rateLimitGate.isActive) await _rateLimitGate.wait();
     final config = ref.read(relayConfigProvider);
     final url = Uri.parse(config.baseUrl).resolve('/query').toString();
     final bodyBytes = utf8.encode(

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -748,6 +748,8 @@ class RelaySessionNotifier extends Notifier<SessionState> {
             ? fallbackMs
             : _rateLimitGate.remainingMs(),
       );
+    } else if (closedClass == RelayClosedClass.capacity) {
+      delayMs = max(backoffMs, RelayRateLimitGate.defaultRetrySeconds * 1000);
     }
 
     liveSub.closedRetryAttempt = attempt + 1;

--- a/mobile/test/features/channels/channel_sync_test.dart
+++ b/mobile/test/features/channels/channel_sync_test.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+
+import 'package:buzz/features/channels/channel_sync.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('query chunks preserve exact 100 boundary', () {
+    expect(
+      chunkChannelQueryItems(List.generate(100, (i) => i)).map((b) => b.length),
+      [100],
+    );
+    expect(
+      chunkChannelQueryItems(List.generate(129, (i) => i)).map((b) => b.length),
+      [100, 29],
+    );
+  });
+
+  test('paced admission captures one shared 125 ms interval', () async {
+    final delays = <Duration>[];
+    final starts = <int>[];
+    await runPacedTasks(
+      [for (var i = 0; i < 6; i++) () async => starts.add(i)],
+      maxConcurrent: liveSubscriptionMaxConcurrent,
+      startInterval: liveSubscriptionStartInterval,
+      isCancelled: () => false,
+      delay: (duration) async => delays.add(duration),
+    );
+    expect(starts.toSet(), {0, 1, 2, 3, 4, 5});
+    expect(delays, List.filled(5, const Duration(milliseconds: 125)));
+  });
+
+  test('start permits are globally serialized across workers', () async {
+    final pendingDelays = <Completer<void>>[];
+    var activeDelays = 0;
+    var peakActiveDelays = 0;
+    final run = runPacedTasks(
+      [for (var i = 0; i < 6; i++) () async {}],
+      maxConcurrent: liveSubscriptionMaxConcurrent,
+      startInterval: liveSubscriptionStartInterval,
+      isCancelled: () => false,
+      delay: (_) {
+        activeDelays++;
+        peakActiveDelays = activeDelays > peakActiveDelays
+            ? activeDelays
+            : peakActiveDelays;
+        final pending = Completer<void>();
+        pendingDelays.add(pending);
+        return pending.future.whenComplete(() => activeDelays--);
+      },
+    );
+
+    for (var completed = 0; completed < 5; completed++) {
+      await _waitUntil(() => pendingDelays.length == completed + 1);
+      expect(activeDelays, 1);
+      pendingDelays[completed].complete();
+    }
+    await run;
+    expect(peakActiveDelays, 1);
+  });
+
+  test('slow tasks never exceed four in flight', () async {
+    var inFlight = 0;
+    var peakInFlight = 0;
+    final releases = <Completer<void>>[];
+    final run = runPacedTasks(
+      [
+        for (var i = 0; i < 12; i++)
+          () async {
+            inFlight++;
+            if (inFlight > peakInFlight) peakInFlight = inFlight;
+            final release = Completer<void>();
+            releases.add(release);
+            await release.future;
+            inFlight--;
+          },
+      ],
+      maxConcurrent: liveSubscriptionMaxConcurrent,
+      startInterval: liveSubscriptionStartInterval,
+      isCancelled: () => false,
+      delay: (_) async {},
+    );
+    await _waitUntil(() => releases.length == 4);
+    expect(peakInFlight, 4);
+    while (releases.length < 12) {
+      final count = releases.length;
+      for (final release in releases.take(count).where((c) => !c.isCompleted)) {
+        release.complete();
+      }
+      await _waitUntil(() => releases.length > count || releases.length == 12);
+    }
+    for (final release in releases.where((c) => !c.isCompleted)) {
+      release.complete();
+    }
+    await run;
+    expect(peakInFlight, 4);
+  });
+}
+
+Future<void> _waitUntil(bool Function() predicate) async {
+  for (var i = 0; i < 100; i++) {
+    if (predicate()) return;
+    await Future<void>.delayed(Duration.zero);
+  }
+  fail('condition did not become true');
+}

--- a/mobile/test/features/channels/channel_sync_test.dart
+++ b/mobile/test/features/channels/channel_sync_test.dart
@@ -79,7 +79,7 @@ void main() {
       isCancelled: () => false,
       delay: (_) async {},
     );
-    await _waitUntil(() => releases.length == 4);
+    await _waitUntil(() => releases.length >= 4);
     expect(peakInFlight, 4);
     while (releases.length < 12) {
       final count = releases.length;

--- a/mobile/test/features/channels/channels_provider_test.dart
+++ b/mobile/test/features/channels/channels_provider_test.dart
@@ -2024,9 +2024,16 @@ void main() {
       final container = _buildContainer(session: session);
       addTearDown(container.dispose);
 
+      final stopwatch = Stopwatch()..start();
       await container.read(channelsProvider.future);
       await _waitUntil(() => session.queryBatches.length == 2);
+      stopwatch.stop();
 
+      expect(
+        stopwatch.elapsed,
+        greaterThanOrEqualTo(const Duration(milliseconds: 450)),
+      );
+      expect(stopwatch.elapsed, lessThan(const Duration(seconds: 2)));
       expect(session.peakNeverEoseSubscriptions, 4);
       expect(session.totalSubscribeCount, 5);
       expect(session.activeChannels, ids.toSet());

--- a/mobile/test/features/channels/channels_provider_test.dart
+++ b/mobile/test/features/channels/channels_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/features/channels/channels_provider.dart';
+import 'package:buzz/features/channels/channel_sync.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
 /// Tests for [ChannelsNotifier] in the pure-Nostr world.
@@ -1656,6 +1657,35 @@ void main() {
       expect(session.totalSubscribeCount, initialSubscribeCount);
       expect(session.unsubscribeCount, 0);
       expect(session.subscribeFilters, hasLength(2));
+
+      session.emit(
+        const NostrEvent(
+          id: 'retained-live-event',
+          pubkey: 'alice',
+          createdAt: 20,
+          kind: EventKind.streamMessageV2,
+          tags: [
+            ['h', _channelA],
+          ],
+          content: 'after unchanged refresh',
+          sig: 'sig',
+        ),
+      );
+
+      final channelA = container
+          .read(channelsProvider)
+          .requireValue
+          .firstWhere((channel) => channel.id == _channelA);
+      expect(
+        channelA.lastMessageAt,
+        DateTime.fromMillisecondsSinceEpoch(20 * 1000, isUtc: true),
+      );
+      expect(
+        container
+            .read(channelsProvider.notifier)
+            .observedUnreadEventsByChannel[_channelA],
+        contains('retained-live-event'),
+      );
     },
   );
 
@@ -1676,6 +1706,7 @@ void main() {
       addTearDown(container.dispose);
 
       await container.read(channelsProvider.future);
+      await _waitUntil(() => session.activeSubscriptionCount == 2);
       session.memberships = [
         _membership(_channelB, myPk),
         _membership(_channelD, myPk),
@@ -1903,6 +1934,37 @@ void main() {
       expect(
         channels.firstWhere((channel) => channel.id == _channelB).lastMessageAt,
         DateTime.fromMillisecondsSinceEpoch(40 * 1000, isUtc: true),
+      );
+    },
+  );
+
+  test(
+    'chunks latest-message and unread queries at 100 for 129 channels',
+    () async {
+      final ids = [for (var i = 0; i < 129; i++) 'channel-$i'];
+      final session = _FakeRelaySession(
+        memberships: [for (final id in ids) _membership(id, myPk)],
+        metadata: [for (final id in ids) _meta(id: id, name: id)],
+      );
+      final container = _buildContainer(session: session);
+      addTearDown(container.dispose);
+
+      await container.read(channelsProvider.future);
+      await _waitUntil(() => session.queryBatches.length == 4);
+
+      expect(session.queryBatches.map((batch) => batch.length), [
+        100,
+        29,
+        100,
+        29,
+      ]);
+      expect(
+        session.historyFilters.where(
+          (filter) => filter.kinds.toSet().containsAll(
+            EventKind.channelMessageEventKinds,
+          ),
+        ),
+        isEmpty,
       );
     },
   );
@@ -2426,7 +2488,10 @@ NostrEvent _meta({
   sig: 'sig',
 );
 
-ProviderContainer _buildContainer({required _FakeRelaySession session}) {
+ProviderContainer _buildContainer({
+  required _FakeRelaySession session,
+  TaskDelay liveSubscriptionDelay = _noDelay,
+}) {
   return ProviderContainer(
     retry: (_, _) => null,
     overrides: [
@@ -2435,6 +2500,9 @@ ProviderContainer _buildContainer({required _FakeRelaySession session}) {
       // Route the pubkey through a mutable notifier so tests can switch the
       // signing identity mid-flight the way an account change does at runtime.
       myPubkeyProvider.overrideWith((ref) => ref.watch(_testPubkeyProvider)),
+      channelsLiveSubscriptionDelayProvider.overrideWithValue(
+        liveSubscriptionDelay,
+      ),
     ],
   );
 }
@@ -2929,6 +2997,14 @@ class _FakeRelaySession extends RelaySessionNotifier {
   }
 
   @override
+  Future<void Function()> subscribeWithStatus(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String message)? onClosed,
+    required void Function(RelaySubscriptionStatus status) onStatusChanged,
+  }) => subscribe(filter, onEvent, onClosed: onClosed);
+
+  @override
   Future<void Function()> subscribe(
     NostrFilter filter,
     void Function(NostrEvent) onEvent, {
@@ -2969,3 +3045,5 @@ class _FakeAppLifecycleNotifier extends AppLifecycleNotifier {
   @override
   AppLifecycleState build() => AppLifecycleState.resumed;
 }
+
+Future<void> _noDelay(Duration _) async {}

--- a/mobile/test/features/channels/channels_provider_test.dart
+++ b/mobile/test/features/channels/channels_provider_test.dart
@@ -1938,6 +1938,106 @@ void main() {
     },
   );
 
+  test('loaded refresh preserves a newer live timestamp', () async {
+    final session = _FakeRelaySession(
+      memberships: [_membership(_channelA, myPk)],
+      metadata: [_meta(id: _channelA, name: 'general')],
+      recentMessages: [
+        NostrEvent(
+          id: 'snapshot',
+          pubkey: 'alice',
+          createdAt: 10,
+          kind: EventKind.streamMessageV2,
+          tags: const [
+            ['h', _channelA],
+          ],
+          content: 'snapshot',
+          sig: 'sig',
+        ),
+      ],
+    );
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+
+    await container.read(channelsProvider.future);
+    await _waitUntil(() => session.activeSubscriptionCount == 1);
+    session.pauseNextLatestMessageQuery();
+    final refresh = container.read(channelsProvider.notifier).refresh();
+    await session.nextLatestMessageQueryStarted;
+    session.emit(
+      NostrEvent(
+        id: 'live',
+        pubkey: 'alice',
+        createdAt: 50,
+        kind: EventKind.streamMessageV2,
+        tags: const [
+          ['h', _channelA],
+        ],
+        content: 'live',
+        sig: 'sig',
+      ),
+    );
+    session.resumePausedLatestMessageQuery();
+    await refresh;
+
+    expect(
+      container.read(channelsProvider).value!.single.lastMessageAt,
+      DateTime.fromMillisecondsSinceEpoch(50 * 1000, isUtc: true),
+    );
+  });
+
+  test(
+    'chunks latest-message and unread queries at exactly 100 channels',
+    () async {
+      final ids = [for (var i = 0; i < 100; i++) 'channel-$i'];
+      final session = _FakeRelaySession(
+        memberships: [for (final id in ids) _membership(id, myPk)],
+        metadata: [for (final id in ids) _meta(id: id, name: id)],
+      );
+      final container = _buildContainer(session: session);
+      addTearDown(container.dispose);
+
+      await container.read(channelsProvider.future);
+      await _waitUntil(() => session.queryBatches.length == 2);
+
+      expect(session.queryBatches.map((batch) => batch.length), [100, 100]);
+      expect(
+        session.queryBatches.first.every((filter) => filter.since == null),
+        isTrue,
+      );
+      expect(
+        session.queryBatches.last.every((filter) => filter.since != null),
+        isTrue,
+      );
+    },
+  );
+
+  test(
+    'never-EOSE workers release and allow later subscriptions and catch-up',
+    () async {
+      final ids = [for (var i = 0; i < 5; i++) 'channel-$i'];
+      final session = _FakeRelaySession(
+        memberships: [for (final id in ids) _membership(id, myPk)],
+        metadata: [for (final id in ids) _meta(id: id, name: id)],
+        neverEoseSubscribeCount: 4,
+      );
+      final container = _buildContainer(session: session);
+      addTearDown(container.dispose);
+
+      await container.read(channelsProvider.future);
+      await _waitUntil(() => session.queryBatches.length == 2);
+
+      expect(session.peakNeverEoseSubscriptions, 4);
+      expect(session.totalSubscribeCount, 5);
+      expect(session.activeChannels, ids.toSet());
+      expect(session.queryBatches.last, hasLength(5));
+      expect(
+        session.queryBatches.last.every((filter) => filter.since != null),
+        isTrue,
+      );
+    },
+  );
+
   test(
     'chunks latest-message and unread queries at 100 for 129 channels',
     () async {
@@ -2551,6 +2651,7 @@ class _FakeRelaySession extends RelaySessionNotifier {
     this.huddleStarts = const [],
     this.recentMessages = const [],
     this.membershipFailures = 0,
+    this.neverEoseSubscribeCount = 0,
   });
 
   List<NostrEvent> memberships;
@@ -2566,6 +2667,10 @@ class _FakeRelaySession extends RelaySessionNotifier {
   final List<NostrEvent> huddleStarts;
   List<NostrEvent> recentMessages;
   int membershipFailures;
+  final int neverEoseSubscribeCount;
+  int activeNeverEoseSubscriptions = 0;
+  int peakNeverEoseSubscriptions = 0;
+  int statusSubscribeAttempts = 0;
   Completer<void>? _pausedLatestMessageQuery;
   Completer<void>? _latestMessageQueryStarted;
   int directoryFailures = 0;
@@ -3002,7 +3107,19 @@ class _FakeRelaySession extends RelaySessionNotifier {
     void Function(NostrEvent) onEvent, {
     void Function(String message)? onClosed,
     required void Function(RelaySubscriptionStatus status) onStatusChanged,
-  }) => subscribe(filter, onEvent, onClosed: onClosed);
+  }) async {
+    final shouldAwaitReadiness =
+        statusSubscribeAttempts++ < neverEoseSubscribeCount;
+    if (shouldAwaitReadiness) {
+      activeNeverEoseSubscriptions++;
+      if (activeNeverEoseSubscriptions > peakNeverEoseSubscriptions) {
+        peakNeverEoseSubscriptions = activeNeverEoseSubscriptions;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      activeNeverEoseSubscriptions--;
+    }
+    return subscribe(filter, onEvent, onClosed: onClosed);
+  }
 
   @override
   Future<void Function()> subscribe(

--- a/mobile/test/features/channels/channels_provider_test.dart
+++ b/mobile/test/features/channels/channels_provider_test.dart
@@ -1593,6 +1593,7 @@ void main() {
       addTearDown(container.dispose);
 
       await container.read(channelsProvider.future);
+      await _waitUntil(() => session.activeSubscriptionCount == 2);
 
       // One subscription per joined, non-archived channel.
       expect(session.subscribeFilters, hasLength(2));
@@ -1643,6 +1644,11 @@ void main() {
       addTearDown(container.dispose);
 
       await container.read(channelsProvider.future);
+      await _waitUntil(() => session.activeSubscriptionCount == 2);
+      // Active fake subscriptions become visible just before the notifier
+      // records their unsubscribe handles. Let that synchronous handoff settle
+      // before testing an unchanged refresh.
+      await Future<void>.delayed(const Duration(milliseconds: 10));
       final initialSubscribeCount = session.totalSubscribeCount;
 
       await container.read(channelsProvider.notifier).refresh();
@@ -1709,6 +1715,7 @@ void main() {
       addTearDown(container.dispose);
 
       await container.read(channelsProvider.future);
+      await _waitUntil(() => session.activeSubscriptionCount == 2);
       session.memberships = [];
       session.metadata = [];
 
@@ -1899,6 +1906,58 @@ void main() {
       );
     },
   );
+
+  test('initial list retains a live event overlapping its snapshot', () async {
+    final session = _FakeRelaySession(
+      memberships: [_membership(_channelA, myPk)],
+      metadata: [_meta(id: _channelA, name: 'general')],
+      recentMessages: [
+        NostrEvent(
+          id: 'snapshot',
+          pubkey: 'alice',
+          createdAt: 10,
+          kind: EventKind.streamMessageV2,
+          tags: const [
+            ['h', _channelA],
+          ],
+          content: 'snapshot',
+          sig: 'sig',
+        ),
+      ],
+    )..pauseNextLatestMessageQuery();
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+
+    final channelsFuture = container.read(channelsProvider.future);
+    await session.nextLatestMessageQueryStarted;
+    await _waitUntil(() => session.activeSubscriptionCount == 1);
+    final live = NostrEvent(
+      id: 'live',
+      pubkey: 'alice',
+      createdAt: 20,
+      kind: EventKind.streamMessageV2,
+      tags: const [
+        ['h', _channelA],
+      ],
+      content: 'live',
+      sig: 'sig',
+    );
+    session.emit(live);
+    session.emit(live);
+    session.resumePausedLatestMessageQuery();
+
+    final channels = await channelsFuture;
+    expect(
+      channels.single.lastMessageAt,
+      DateTime.fromMillisecondsSinceEpoch(20 * 1000, isUtc: true),
+    );
+    expect(
+      container
+          .read(channelsProvider.notifier)
+          .observedUnreadEventsByChannel[_channelA],
+      contains('live'),
+    );
+  });
 
   test('ephemeral (TTL) channels appear in the list', () async {
     // Regression: previously the provider unconditionally dropped any channel
@@ -2402,7 +2461,7 @@ Future<void> _settle() async {
 Future<void> _waitUntil(bool Function() predicate) async {
   for (var i = 0; i < 100; i++) {
     if (predicate()) return;
-    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(const Duration(milliseconds: 5));
   }
   fail('Timed out waiting for asynchronous provider work');
 }
@@ -2439,6 +2498,8 @@ class _FakeRelaySession extends RelaySessionNotifier {
   final List<NostrEvent> huddleStarts;
   List<NostrEvent> recentMessages;
   int membershipFailures;
+  Completer<void>? _pausedLatestMessageQuery;
+  Completer<void>? _latestMessageQueryStarted;
   int directoryFailures = 0;
   bool failClaimedMemberCountQuery = false;
   bool failClaimedUnreadCatchUpQuery = false;
@@ -2483,6 +2544,21 @@ class _FakeRelaySession extends RelaySessionNotifier {
       throw StateError('No paused subscription is pending');
     }
     await started.future;
+  }
+
+  Future<void> get nextLatestMessageQueryStarted async {
+    final started = _latestMessageQueryStarted;
+    if (started == null) throw StateError('No latest-message query pending');
+    await started.future;
+  }
+
+  void pauseNextLatestMessageQuery() {
+    _pausedLatestMessageQuery = Completer<void>();
+    _latestMessageQueryStarted = Completer<void>();
+  }
+
+  void resumePausedLatestMessageQuery() {
+    _pausedLatestMessageQuery!.complete();
   }
 
   void pauseNextSubscribe() {
@@ -2793,6 +2869,16 @@ class _FakeRelaySession extends RelaySessionNotifier {
       return filter.until == null ? directorySnapshot : const [];
     }
     queryBatches.add(filters);
+    final isLatestMessage =
+        filters.isNotEmpty && filters.every((filter) => filter.since == null);
+    if (isLatestMessage && _pausedLatestMessageQuery != null) {
+      final messages = List<NostrEvent>.of(recentMessages);
+      _latestMessageQueryStarted!.complete();
+      await _pausedLatestMessageQuery!.future;
+      _pausedLatestMessageQuery = null;
+      _latestMessageQueryStarted = null;
+      return _matchingMessages(filters, messages);
+    }
     // The unread catch-up is the only batch that carries `since` on every
     // filter; the latest-message batch leaves it null. Snapshot the messages at
     // request time so a parked response reflects the scope that asked for it.
@@ -2814,7 +2900,14 @@ class _FakeRelaySession extends RelaySessionNotifier {
         }
       }
     }
-    return messageSnapshot.where((event) {
+    return _matchingMessages(filters, messageSnapshot);
+  }
+
+  List<NostrEvent> _matchingMessages(
+    List<NostrFilter> filters,
+    List<NostrEvent> messages,
+  ) {
+    return messages.where((event) {
       return filters.any((filter) {
         if (!filter.kinds.contains(event.kind)) return false;
         for (final entry in filter.tags.entries) {

--- a/mobile/test/features/channels/channels_provider_test.dart
+++ b/mobile/test/features/channels/channels_provider_test.dart
@@ -2429,6 +2429,54 @@ void main() {
   );
 
   test(
+    'same channel id does not inherit a timestamp across communities',
+    () async {
+      final session = _FakeRelaySession(
+        memberships: [_membership(_channelA, myPk)],
+        metadata: [_meta(id: _channelA, name: 'community-a')],
+        recentMessages: [
+          _message(id: 'a-message', channelId: _channelA, createdAt: 50),
+        ],
+      );
+      final container = _buildContainer(session: session);
+      addTearDown(container.dispose);
+
+      expect(
+        (await container.read(
+          channelsProvider.future,
+        )).single.lastMessageAt?.millisecondsSinceEpoch,
+        50 * 1000,
+      );
+
+      session.setStatus(SessionStatus.disconnected);
+      session.metadata = [_meta(id: _channelA, name: 'community-b')];
+      session.recentMessages = [
+        _message(id: 'b-message', channelId: _channelA, createdAt: 10),
+      ];
+      container
+          .read(relayConfigProvider.notifier)
+          .update(baseUrl: 'https://new-community.example');
+      await Future<void>.delayed(Duration.zero);
+      session.setStatus(SessionStatus.connected);
+      await _waitUntil(
+        () =>
+            container.read(channelsProvider).value?.single.name ==
+            'community-b',
+      );
+
+      expect(
+        container
+            .read(channelsProvider)
+            .value!
+            .single
+            .lastMessageAt
+            ?.millisecondsSinceEpoch,
+        10 * 1000,
+      );
+    },
+  );
+
+  test(
     'refreshes cached channels after a disconnected community switch',
     () async {
       final session = _FakeRelaySession(
@@ -2561,6 +2609,22 @@ NostrEvent _hiddenDms(List<String> channelIds, {required String pubkey}) =>
       content: '',
       sig: 'sig',
     );
+
+NostrEvent _message({
+  required String id,
+  required String channelId,
+  required int createdAt,
+}) => NostrEvent(
+  id: id,
+  pubkey: 'alice',
+  createdAt: createdAt,
+  kind: EventKind.streamMessageV2,
+  tags: [
+    ['h', channelId],
+  ],
+  content: 'message',
+  sig: 'sig',
+);
 
 /// Build a kind:39000 channel metadata event.
 NostrEvent _meta({

--- a/mobile/test/shared/relay/relay_closed_policy_test.dart
+++ b/mobile/test/shared/relay/relay_closed_policy_test.dart
@@ -15,7 +15,7 @@ void main() {
       'duplicate: subscription already exists': RelayClosedClass.terminal,
       'unsupported: filter extension': RelayClosedClass.terminal,
       'error: mixed search and channel filter': RelayClosedClass.terminal,
-      'error: too many subscriptions': RelayClosedClass.terminal,
+      'error: too many subscriptions': RelayClosedClass.capacity,
       'error: relay temporarily unavailable': RelayClosedClass.retryable,
       'subscription closed by relay': RelayClosedClass.retryable,
     };

--- a/mobile/test/shared/relay/relay_session_test.dart
+++ b/mobile/test/shared/relay/relay_session_test.dart
@@ -699,6 +699,26 @@ void main() {
     unsubscribe();
   });
 
+  test(
+    'live subscribe without EOSE releases readiness after its bound',
+    () async {
+      final socket = _RecordingRelaySocket();
+      final session = RelaySessionNotifier();
+      session.debugAttachSocketForTest(socket);
+      final stopwatch = Stopwatch()..start();
+
+      final unsubscribe = await session.subscribe(_channelFilter, (_) {});
+
+      expect(
+        stopwatch.elapsed,
+        greaterThanOrEqualTo(const Duration(milliseconds: 450)),
+      );
+      expect(stopwatch.elapsed, lessThan(const Duration(seconds: 2)));
+      expect(_reqs(socket), hasLength(1));
+      unsubscribe();
+    },
+  );
+
   test('terminal CLOSED fails a live subscribe before ready', () async {
     final session = RelaySessionNotifier();
     const filter = NostrFilter(kinds: [EventKind.agentObserverFrame], limit: 0);
@@ -997,6 +1017,44 @@ void main() {
     session.debugDispose();
     expect(disposeTimer.isActive, isFalse);
   });
+
+  test(
+    'capacity CLOSED retries after ten seconds without arming gate',
+    () async {
+      final retryTimers = <_ManualTimer>[];
+      final gateTimers = <_ManualTimer>[];
+      final gate = RelayRateLimitGate(
+        timerFactory: (duration, callback) {
+          final timer = _ManualTimer(duration, callback);
+          gateTimers.add(timer);
+          return timer;
+        },
+      );
+      final session = RelaySessionNotifier(
+        rateLimitGate: gate,
+        retryTimerFactory: (duration, callback) {
+          final timer = _ManualTimer(duration, callback);
+          retryTimers.add(timer);
+          return timer;
+        },
+      );
+      final socket = _RecordingRelaySocket();
+      session.debugAttachSocketForTest(socket);
+      final subscribe = session.subscribe(_channelFilter, (_) {});
+      session.debugHandleMessage(['EOSE', 'l-1']);
+      final unsubscribe = await subscribe;
+
+      session.debugHandleMessage([
+        'CLOSED',
+        'l-1',
+        'error: too many subscriptions',
+      ]);
+
+      expect(retryTimers.single.duration, const Duration(seconds: 10));
+      expect(gateTimers, isEmpty);
+      unsubscribe();
+    },
+  );
 
   test('rate-limited live CLOSED honours the gate floor', () async {
     final retryTimers = <_ManualTimer>[];

--- a/mobile/test/shared/relay/relay_session_test.dart
+++ b/mobile/test/shared/relay/relay_session_test.dart
@@ -331,7 +331,7 @@ void main() {
     expect(gate.isActive, isFalse);
   });
 
-  test('queryRelay does not wait for an active rate-limit gate', () async {
+  test('queryRelay waits for an active rate-limit gate', () async {
     final gate = RelayRateLimitGate(
       now: () => DateTime(2026),
       timerFactory: _ManualTimer.new,
@@ -356,10 +356,10 @@ void main() {
     final query = harness.session.queryRelay(const []);
     await Future<void>.delayed(Duration.zero);
 
-    expect(requestCount, 1);
+    expect(requestCount, 0);
+    gate.reset();
     expect(await query, isEmpty);
-    // Still armed: the read must neither wait on the gate nor clear it.
-    expect(gate.isActive, isTrue);
+    expect(requestCount, 1);
   });
 
   test(


### PR DESCRIPTION
### What changed?

Mobile startup now chunks latest-message and unread catch-up queries at 100, retries relay subscription-capacity errors without arming the rate-limit gate, and admits live subscriptions through one globally serialized 125 ms pacer with at most four active readiness waits. Readiness remains cancellable and bounded when a relay never sends EOSE.

Channel refreshes preserve newer live timestamps only within the same relay-and-identity scope, preventing cached state from crossing community or account boundaries.

### Why?

This reduces startup subscription pressure while preserving relay pacing, recovery, and tenant-isolation guarantees.

### How is it tested?

Build and run.

Added tests:

- Query chunking at exact and over-limit channel counts
- Serialized pacing, four-worker admission, cancellation, and never-EOSE readiness release
- Capacity-error retry without rate-limit-gate activation
- Same-scope timestamp preservation and cross-community isolation
