### PR TITLE
fix(cli): reject invalid moderation report statuses

### DIFF
--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -1908,7 +1908,7 @@ pub enum ModerationCmd {
     )]
     Reports {
         /// Filter by status: open | resolved | dismissed | escalated (default: all)
-        #[arg(long)]
+        #[arg(long, value_parser = ["open", "resolved", "dismissed", "escalated"])]
         status: Option<String>,
         /// Maximum number of reports to return
         #[arg(long, default_value_t = 50)]
@@ -2153,6 +2153,16 @@ mod tests {
     #[test]
     fn cli_definition_is_valid() {
         Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn moderation_reports_rejects_unknown_status() {
+        assert!(
+            Cli::try_parse_from(["buzz", "moderation", "reports", "--status", "open",]).is_ok()
+        );
+        assert!(
+            Cli::try_parse_from(["buzz", "moderation", "reports", "--status", "opne",]).is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Reject unknown values for `buzz moderation reports --status` before a request is made.

### Related issue

Fixes #7009.

No duplicate pull request was open when this PR was created.

## Problem

A typo such as `--status opne` was forwarded to the relay and looked like a successful empty moderation queue, which can hide open reports from moderators and agents.

## Fix

Use clap's existing allow-list pattern to accept only `open`, `resolved`, `dismissed`, or `escalated`. The parser regression verifies that a supported value parses and a typo is rejected before dispatch.

## User impact

Invalid report-status filters now produce a CLI usage error instead of an indistinguishable empty result. Valid commands and request behavior are unchanged.

## Verification

- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `cargo test -p buzz-cli moderation_reports_rejects_unknown_status --lib` and `cargo check -p buzz-cli` — could not link locally because this Windows host lacks MSVC `link.exe`; GitHub CI will run the test matrix.