### PR TITLE
fix(pair-relay): bind to :18765 by default instead of :5000

### DIFF
--- a/crates/buzz-pair-relay/src/main.rs
+++ b/crates/buzz-pair-relay/src/main.rs
@@ -7,7 +7,7 @@ use tokio::net::TcpListener;
 #[tokio::main]
 async fn main() {
     let addr_raw =
-        std::env::var("BUZZ_PAIR_RELAY_BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:5000".to_string());
+        std::env::var("BUZZ_PAIR_RELAY_BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:18765".to_string());
     let addr: SocketAddr = match addr_raw.parse() {
         Ok(addr) => addr,
         Err(e) => {

--- a/deploy/charts/buzz/README.md
+++ b/deploy/charts/buzz/README.md
@@ -180,7 +180,7 @@ pairingRelay:
 `pairingRelay.url` is advertised in the main relay's NIP-11 document so Buzz
 clients connect directly to the dedicated endpoint. The chart does not create
 an Ingress or HTTPRoute for the pairing Service; route the public hostname to
-`<release>-buzz-pairing:5000` with your platform's ingress configuration.
+`<release>-buzz-pairing:18765` with your platform's ingress configuration.
 
 ## HA (production)
 

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -219,7 +219,7 @@ pairingRelay:
   replicaCount: 1
   service:
     type: ClusterIP
-    port: 5000
+    port: 18765
     annotations: {}
   podAnnotations: {}
   podLabels: {}

--- a/desktop/src-tauri/src/commands/pairing_relay_tests.rs
+++ b/desktop/src-tauri/src/commands/pairing_relay_tests.rs
@@ -19,7 +19,7 @@ async fn live_nip11_probe_discovers_configured_pairing_relay() {
             .to_ascii_lowercase()
             .contains("accept: application/nostr+json"));
 
-        let body = r#"{"pairing_relay_url":"ws://127.0.0.1:5000"}"#;
+        let body = r#"{"pairing_relay_url":"ws://127.0.0.1:18765"}"#;
         let response = format!(
                 "HTTP/1.1 200 OK\r\nContent-Type: application/nostr+json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
                 body.len()
@@ -32,7 +32,7 @@ async fn live_nip11_probe_discovers_configured_pairing_relay() {
 
     assert_eq!(
         probe_pairing_relay(&format!("ws://{addr}")).await,
-        PairingRelay::Configured("ws://127.0.0.1:5000".to_string())
+        PairingRelay::Configured("ws://127.0.0.1:18765".to_string())
     );
     server.await.expect("NIP-11 server task");
 }


### PR DESCRIPTION
## Summary
- Default `BUZZ_PAIR_RELAY_BIND_ADDR` is now `127.0.0.1:18765` instead of `:5000`.
- macOS AirPlay Receiver owns port 5000, so a local pair-relay never bound and clients got a misleading empty 403 from ControlCenter.
- Helm pairing service port and README ingress example updated to match.

Fixes #7008.

## Test plan
- [x] `./bin/cargo test -p buzz-pair-relay --lib`
- [ ] On macOS with AirPlay Receiver enabled: start pair-relay with no env override and confirm it binds (no AirPlay 403)

